### PR TITLE
Autotype fixes for conflicts with browser autofill

### DIFF
--- a/help/default/html/autotype.html
+++ b/help/default/html/autotype.html
@@ -102,6 +102,17 @@ and then emit the letter '0', which is probably not what you intended (\W5 would
 non-Latin characters incorrectly, but can make AutoType work on certain problematical web sites.
 If you find that AutoType does not work properly on a particular web site, try this code in the
 AutoType command field.</li>
+<li><b>\c</b> generates the key events that cause a platform-specific Select-All command. It is
+useful when autotype conflicts with browser's autofill, where the two texts combine instead of
+autotype'd text replacing the auto-filled text.  Generating a <b>\c</b> at the start of autotyping
+inside a field (at the very beginning of autotype string, or just after a <b>\t</b>) ensures that
+the autofill'ed text gets replaced by the autotype'd text. For some sites, you might also
+need to autotype <i>slowly</i>, for which put <b>\d100</b> at the begining of your autotype string.
+So your autotype string could look like <pre>\d100\c\u\t\c\p\n</pre>.
+</li>
+<li><b>\j</b> starts generating independent key events for modifier keys like ALT, SHIFT, etc.</li>
+<li><b>\k</b> stops generating independent keystrokes for modifier keys and only simulates the modifications (like making things uppercase) with flags to main key events.</li>
+<li> <b>\j</b> and <b>\k</b> could be useful when you find that autotype is not maintaining case-sensitivity of autotyped text, or is producing the lower keys (3 instead of #).</li>
 <li>All other text is typed as-is.</li>
 </ul>
 

--- a/src/core/PWSAuxParse.cpp
+++ b/src/core/PWSAuxParse.cpp
@@ -381,6 +381,9 @@ StringX PWSAuxParse::GetAutoTypeString(const StringX &sx_in_autotype,
         // Copy them to output string unchanged.
         case TCHAR('b'):  // backspace!
         case TCHAR('z'):  // Use older method
+        case TCHAR('c'):  // select-all
+        case TCHAR('j'):  // modifier emulation on
+        case TCHAR('k'):  // modifier emulation off
           vactionverboffsets.push_back(sxtmp.length());
           sxtmp += _T("\\");
           sxtmp += curChar;

--- a/src/os/KeySend.h
+++ b/src/os/KeySend.h
@@ -34,6 +34,9 @@ public:
 #ifdef __PWS_MACINTOSH__  
   bool SimulateApplicationSwitch();
 #endif  
+  void SelectAll() const;
+  void EmulateMods(bool emulate);
+  bool IsEmulatingMods() const;
 private:
   unsigned m_delayMS; //delay between keystrokes in milliseconds
   CKeySendImpl *m_impl;

--- a/src/os/linux/xsendstring.cpp
+++ b/src/os/linux/xsendstring.cpp
@@ -27,6 +27,9 @@
 #include <errno.h>
 #include <limits.h>
 
+#include <memory>
+#include <algorithm>
+#include <functional>
 
 #include <X11/Intrinsic.h> // in libxt-dev
 #include <X11/keysym.h>
@@ -38,19 +41,20 @@
 #include "../../core/StringX.h"
 #include "./unicode2keysym.h"
 
-namespace { // anonymous namespace for hiding
-  //           local variables and functions
+// We convert all chars in a string to a keycode and a set of modifier keys (like Shift)
 typedef struct _KeyPress {
   KeyCode code;
   unsigned int state;
 } KeyPressInfo;
 
+// X errors are reported via asynchronous callbacks, which we store here
 struct AutotypeGlobals
 {
   Boolean      error_detected;
   char      errorString[1024];
 } atGlobals  = { False, {0} };
 
+// We throw this exception when we detect something in atGlobals above
 class autotype_exception: public std::exception
 {
   public:
@@ -75,94 +79,303 @@ int ErrorHandler(Display *my_dpy, XErrorEvent *event)
 
 
 
-
-void XTest_SendEvent(XKeyEvent *event)
-{
-  XTestFakeKeyEvent(event->display, event->keycode, event->type == KeyPress, 0);
-}
-
-void XSendKeys_SendEvent(XKeyEvent *event)
-{
-    XSendEvent(event->display, event->window, TRUE, KeyPressMask, reinterpret_cast<XEvent *>(event));
-}
-
-void XSendKeys_SendKeyEvent(XKeyEvent* event)
-{
-  event->type = KeyPress;
-  XSendKeys_SendEvent(event);
-
-  event->type = KeyRelease;
-  XSendKeys_SendEvent(event);
-
-  XFlush(event->display);
-}
-
-
-void XTest_SendKeyEvent(XKeyEvent* event)
-{
-  XKeyEvent shiftEvent;
-
-  /* must simulate the shift-press for CAPS and shifted keypresses manually */
-  if (event->state & ShiftMask) {
-    memcpy(&shiftEvent, event, sizeof(shiftEvent));
-
-    shiftEvent.keycode = XKeysymToKeycode(event->display, XK_Shift_L);
-    shiftEvent.type = KeyPress;
-
-    XTest_SendEvent(&shiftEvent);
-  }
-
-  event->type = KeyPress;
-  XTest_SendEvent(event);
-
-  event->type = KeyRelease;
-  XTest_SendEvent(event);
-
-  if (event->state & ShiftMask) {
-    shiftEvent.type = KeyRelease;
-    XTest_SendEvent(&shiftEvent);
-  }
-
-  XFlush(event->display);
-
-}
-
-Bool UseXTest(Display* disp)
-{
-  int major_opcode, first_event, first_error;
-  static Bool useXTest;
-  static int checked = 0;
-
-  if (!checked) {
-    useXTest = XQueryExtension(disp, "XTEST", &major_opcode, &first_event, &first_error);
-    checked = 1;
-  }
-  return useXTest;
-}
-
+// A simple helper class
 class AutotypeEvent: public XKeyEvent {
 public:
-  AutotypeEvent()
+  AutotypeEvent(Display *disp)
   {
-    display = XOpenDisplay(NULL);
-    if (display) {
-      int    revert_to;
-      XGetInputFocus(display, &window, &revert_to);
-      subwindow = None;
-      x = y = x_root = y_root = 1;
-      same_screen = True;
+    display = disp;
+    int    revert_to;
+    XGetInputFocus(display, &window, &revert_to);
+    subwindow = None;
+    x = y = x_root = y_root = 1;
+    same_screen = True;
+  }
+};
+
+//////////////////////////////////////////////////////////////////////////////////////
+// AutotypeMethodBase
+//
+// Base class for the various ways to emulate keystrokes that result in a keyboard
+// event interpreted by the receiving application as the intended character.
+//
+// This class takes care of wchar_t => KeySym => (KeyCode, Modifiers) combination, and
+// generates the key-up & key-down events in the required order to generate the
+// character being auto-typed.  The derived classes only need to implement the
+// virtual GenerateKeyEvent() member that emulates a single keystroke
+
+class AutotypeMethodBase
+{
+  // We use this array to look up modifier keycodes from modifier masks
+  struct ModInfo {
+    // These enums are uses as array index in SetModifiers() method below
+    // Don't change their values!!
+    enum ModType {Shift /*press and hold*/, Lock, Latch, Unknown};
+
+    int mask;
+    int ModMapIndex;
+    KeySym sym;
+    KeyCode key;
+    ModType type;
+
+  }  m_mods[8] =    {{ShiftMask,   ShiftMapIndex,   XK_Shift_L,   0, ModInfo::Shift},
+                     {LockMask,    LockMapIndex,    XK_Caps_Lock, 0, ModInfo::Lock},
+                     {ControlMask, ControlMapIndex, XK_Control_L, 0, ModInfo::Shift},
+                     {Mod1Mask,    Mod1MapIndex,    NoSymbol,     0, ModInfo::Unknown},
+                     {Mod2Mask,    Mod2MapIndex,    NoSymbol,     0, ModInfo::Unknown},
+                     {Mod3Mask,    Mod3MapIndex,    NoSymbol,     0, ModInfo::Unknown},
+                     {Mod4Mask,    Mod4MapIndex,    NoSymbol,     0, ModInfo::Unknown},
+                     {Mod5Mask,    Mod5MapIndex,    NoSymbol,     0, ModInfo::Unknown},
+                   };
+
+  void InitModInfo();
+
+protected:
+  Display *m_display;
+  bool     m_emulateMods = true;
+
+public:
+  AutotypeMethodBase(Display *display, bool emulateMods):
+			m_display(display), m_emulateMods(emulateMods) {
+	XSetErrorHandler(ErrorHandler);
+	atGlobals.error_detected = false;
+  InitModInfo();
+  }
+
+  // virtual, because derived classes will have clean-ups of their own
+  virtual ~AutotypeMethodBase() {
+	  XSetErrorHandler(NULL);
+  }
+
+  // This function does the most heavy lifting, using the bare minimum api-specific
+  // support from derived classes implemented by overriding GenerateKeyEvent
+  void operator()(unsigned int keycode, unsigned int state, Time event_time = CurrentTime);
+  void operator()(XKeyEvent &ev);
+
+  bool EmulatesMods() const { return m_emulateMods; }
+  void EmulateMods(bool emulate) { m_emulateMods = emulate; }
+
+protected:
+  // This is not exposed as it will probably not do what you think.  Use SendKeyEvent above
+  virtual void GenerateKeyEvent(XKeyEvent *ev) = 0;
+
+  void PressModifiers(int masks) { SetModifiers(masks, true); }
+  void ReleaseModifiers(int masks) { SetModifiers(masks, false); }
+  void SetModifiers(int masks, bool set);
+};
+
+///////////////////////////////////////////////////////////////////////
+// For each modifier, finds the keycode that generates that modifier
+// and the type (shift, latch, etc) because that dictates what kind
+// of key events are required to use that modifier.
+//
+// The KeySym is generated in the process and is needed for initialization,
+// but is not used afterwards
+void AutotypeMethodBase::InitModInfo()
+{
+  XModifierKeymap* modmap = XGetModifierMapping(m_display);
+  if (modmap) {
+    for(auto& m: m_mods) {
+      if (m.key == 0) {
+        if (m.sym != NoSymbol) {
+          // If we know the KeySym associated with the modifier, things are easy
+          m.key = XKeysymToKeycode(m_display, m.sym);
+        }
+        if (!m.key) {
+          // Either the KeySym is unknown, or XKeysymToKeycode failed above
+          // Look up the KeyCode in the XModifierKeymap
+          const auto keys = modmap->modifiermap + m.ModMapIndex*modmap->max_keypermod;
+          const auto keyptr = std::find_if(keys, keys + modmap->max_keypermod, [](KeyCode k){ return k != 0; });
+          m.key = (keyptr == keys + modmap->max_keypermod? 0: *keyptr);
+        }
+      }
+
+      if (m.sym == NoSymbol && m.key != 0) {
+        // We know the KeyCode.  Now we need the KeySym to know what kind of key events
+        // to generate with that KeyCode
+        int keysyms_per_keycode = 0;
+        KeySym* symlist = XGetKeyboardMapping(m_display, m.key, 1, &keysyms_per_keycode);
+        if (symlist) {
+          // The keysym for a modifier must not require a modifier itself, so the first
+          // KeySym must not be empty
+          assert(symlist[0] != NoSymbol);
+          m.sym = symlist[0];
+          XFree(symlist);
+        }
+      }
+      if (m.type == ModInfo::Unknown && m.sym != NoSymbol) {
+        // The modifier "type" tells us the sequence of up or down key events
+        // to generate for that modifier
+        switch (m.sym) {
+          // These are known
+          case XK_Meta_L: case XK_Meta_R: case XK_Alt_L: case XK_Alt_R:
+          case XK_Super_L: case XK_Super_R: case XK_Hyper_L: case XK_Hyper_R:
+            m.type = ModInfo::Shift;
+            break;
+          default:
+          // Now we go by what it "sounds" like
+            const char *symstr = XKeysymToString(m.sym);
+            if (symstr) {
+              const size_t s_len = strlen(symstr);
+              auto ends_with = [symstr, s_len](const char* e, size_t e_len) {
+                return s_len >= e_len && strncmp(symstr + s_len - e_len, e, e_len) == 0;
+              };
+              m.type =  ends_with("Latch", 5)? ModInfo::Latch
+                       : ends_with("Lock", 4)? ModInfo::Lock
+                       : ends_with("Shift", 5) || ends_with("Switch", 6)? ModInfo::Shift
+                       : ModInfo::Unknown;
+            }
+            break;
+        }
+      }
+    }
+    XFreeModifiermap(modmap);
+  }
+  // Note that we may not have initialized every Modifier, but that may be ok
+  // because we may not actually use that modifier.  We can only tell while'
+  // autotyping
+}
+
+void AutotypeMethodBase::operator()(unsigned int keycode, unsigned int state,
+							Time event_time /*= CurrentTime*/)
+{
+	XKeyEvent ev;
+	ev.display = m_display;
+	ev.keycode = keycode;
+	ev.state = state;
+	ev.time = event_time;
+	operator()(ev);
+}
+
+void AutotypeMethodBase::operator()(XKeyEvent &ev)
+{
+  if (!ev.display)
+    ev.display = m_display;
+  else {
+    assert( ev.display == m_display);
+  }
+
+  if (m_emulateMods && ev.state) {
+    PressModifiers(ev.state);
+  }
+
+	ev.type = KeyPress;
+	GenerateKeyEvent(&ev);
+	ev.type = KeyRelease;
+	GenerateKeyEvent(&ev);
+
+  if (m_emulateMods && ev.state) {
+    ReleaseModifiers(ev.state);
+  }
+
+  XFlush(m_display);
+}
+
+///////////////////////////////////////////////////////////
+// Generate the modifier key events for all the modifier masks
+// (one event per mask).  For each mask, generate the keystrokes
+// (up, down, both, etc) for the keycodes corresponding to that
+// modifier based on the "type" of the modifier
+void AutotypeMethodBase::SetModifiers(int masks, bool set)
+{
+  // Shift modifiers require you to press the key for setting it, or release
+  // while unsetting
+  const int shift_events[] =  { (set? KeyPress: KeyRelease), 0};
+
+  // Lock modifiers (like CAPSLOCK) require you to press and release the key
+  // for both setting & unsetting
+  const int lock_events[] = {KeyPress, KeyRelease, 0};
+
+  // Latch modifiers require you to press and release the key for setting it
+  // it unsets itself as soon as any other key is pressed
+  const int latch_events[] = {KeyPress, KeyRelease, KeyPress, KeyRelease, 0};
+
+  // Note that these are indexed by the ModInfo::ModType enum values
+  const int* key_event_types[] = {shift_events, lock_events, latch_events, shift_events /*Unknown*/};
+
+  for (auto mod: m_mods) {
+    if (mod.mask & masks) {
+      const auto *events = key_event_types[mod.type];
+      for( const auto *e = events; *e; e++) {
+        XKeyEvent ev{};
+        ev.type = *e;
+        ev.display = m_display;
+        ev.keycode = mod.key;
+        ev.time = CurrentTime;
+        GenerateKeyEvent(&ev);
+      }
     }
   }
+}
 
-  ~AutotypeEvent() {
-    if (display)
-      XCloseDisplay(display);
+//////////////////////////////////////////////////////////////////////////
+// AutotypeMethodXTEST
+//
+// Emulates keystrokes using the XTEST extension.
+//
+class AutotypeMethodXTEST: public AutotypeMethodBase
+{
+public:
+	AutotypeMethodXTEST(Display *display, bool emulateMods):
+	AutotypeMethodBase(display, emulateMods){ XTestGrabControl(display, true); }
+	~AutotypeMethodXTEST() { XTestGrabControl(m_display, false); }
+
+protected:
+  virtual void GenerateKeyEvent(XKeyEvent *ev) {
+    XTestFakeKeyEvent(ev->display, ev->keycode, ev->type == KeyPress, CurrentTime);
   }
 
-  bool operator !() const { return display == NULL; }
+};
+
+//////////////////////////////////////////////////////////////////////////
+// AutotypeMethodSendKeys
+//
+// Emulates keystrokes using the XSendEvent method
+//
+class AutotypeMethodSendKeys: public AutotypeMethodBase
+{
+public:
+	AutotypeMethodSendKeys(Display *display, bool emulateMods):
+				AutotypeMethodBase(display, emulateMods){}
+	~AutotypeMethodSendKeys() { XSync(m_display, False); }
+protected:
+  virtual void GenerateKeyEvent(XKeyEvent *ev) {
+	XSendEvent(ev->display, ev->window, TRUE,
+					ev->type == KeyPress? KeyPressMask: KeyReleaseMask, 
+					reinterpret_cast<XEvent *>(ev));
+  }
 };
 
 
+//////////////////////////////////////////////////////////////////////////
+// Factory method for generating the correct type of autotype method, based
+// on
+//   1. User preference
+//   2. XTEST extension availability
+//
+AutotypeMethodBase* GetAutotypeMethod(Display* disp,
+									pws_os::AutotypeMethod method_preference)
+{
+  int major_opcode, first_event, first_error;
+  AutotypeMethodBase *method_ptr = nullptr;
+  if (method_preference != pws_os::ATMETHOD_XSENDKEYS &&
+			XQueryExtension(disp, "XTEST", &major_opcode, &first_event, &first_error)) {
+    method_ptr = new AutotypeMethodXTEST(disp, true); // true => emulate modifiers independently
+  }
+  else {
+	method_ptr = new AutotypeMethodSendKeys(disp, false); // false => no emulation for modifier keys
+  }
+  return method_ptr;
+}
+
+// Helper method to check if an X extension is available
+bool XExtensionAvailable(Display *disp, const char* ext)
+{
+  int major_opcode, first_event, first_error;
+  return XQueryExtension(disp, ext, &major_opcode, &first_event, &first_error) == True;
+}
+
+// Calculates the masks (actually, shifts) used by the modifier with the KeySym "sym"
 int FindModifierMask(Display* disp, KeySym sym)
 {
   int modmask = 0;
@@ -191,48 +404,39 @@ int FindModifierMask(Display* disp, KeySym sym)
       }
     }
     XFreeModifiermap(modmap);
-    assert( modmask >= 3 && modmask <= 7);
   }
-  return 1 << modmask;
+  return modmask;
 }
 
 int CalcModifiersForKeysym(KeyCode code, KeySym sym, Display* disp)
 {
+  int modifiers = 0;
   int keysyms_per_keycode = 0;
-  const KeySym* symlist = XGetKeyboardMapping(disp, code, 1, &keysyms_per_keycode);
+  KeySym* symlist = XGetKeyboardMapping(disp, code, 1, &keysyms_per_keycode);
   if (symlist != NULL && keysyms_per_keycode > 0) {
-    const int ModeSwitchMask = FindModifierMask(disp, XK_Mode_switch);
-    const int Level3ShiftMask = FindModifierMask(disp, XK_ISO_Level3_Shift);
-    int mods[] = {
-      0,                  //none
-      ShiftMask,
-      ModeSwitchMask,
-      ShiftMask | ModeSwitchMask,
-      // beyond this, its all guesswork since there's no documentation, but see this:
-      //
-      //     http://superuser.com/questions/189869/xmodmap-six-characters-to-one-key
-      //
-      // Also, if you install mulitple keyboard layouts the number of keysyms-per-keycode
-      // will keep increasing to a max of 16 (up to 4 layouts can be installed together
-      // in Ubuntu 11.04).  For some keycodes, you will actually have non-NoSymbol
-      // keysyms beyond the first four
-      //
-      // We probably shouldn't go here if Mode_switch and ISO_Level3_Shift are assigned to
-      // the same modifier mask
-      Level3ShiftMask,
-      ShiftMask | Level3ShiftMask,
-      ModeSwitchMask | Level3ShiftMask,
-      ShiftMask | ModeSwitchMask | Level3ShiftMask,
-    };
-    const int max_keysym_index = std::min(int(NumberOf(mods)), keysyms_per_keycode);
-    for (int idx = 0; idx < max_keysym_index; ++idx) {
-      if (symlist[idx] == sym)
-        return mods[idx];
+    // Supported everywhere.  Note: order is important
+    std::vector<int> masks = {0, ShiftMask};
+    // These aren't necessarily supported in all systems.  Once again, order is important
+    for ( const auto s: {XK_Mode_switch, XK_ISO_Level3_Shift}) {
+      const int modshift = FindModifierMask(disp, s);
+      // May repeat.  Only consider it if we haven't added it already
+      if (modshift && std::find(masks.begin(), masks.end(), 1 << modshift) == masks.end()) {
+        std::vector<int> extra_masks;
+        // OR each element of mask with "1 << modshift" & insert the result in mask
+        std::transform(masks.begin(), masks.end(), std::back_inserter(extra_masks),
+                        std::bind(std::bit_or<int>(), std::placeholders::_1, 1 << modshift));
+        masks.insert(masks.end(), extra_masks.begin(), extra_masks.end());
+      }
     }
+    // Get the index of the symbol we are searching for
+    const auto max_keysym_index = std::min(masks.size(), static_cast<size_t>(keysyms_per_keycode));
+    // return the modifiers at the same index
+    const size_t match_index = std::find(symlist, symlist + max_keysym_index, sym) - symlist;
+    if ( match_index != max_keysym_index)
+        modifiers = masks[match_index];
+    XFree(symlist);
   }
-  // we should at least find the keysym without any mods (index 0)
-  assert(0);
-  return 0;
+  return modifiers;
 }
 
 KeySym wchar2keysym(wchar_t wc)
@@ -291,19 +495,12 @@ public:
  * Some escape sequences can be converted to the appropriate KeyCodes
  * by this function.  See the code below for details
  */
-void DoSendString(const StringX& str, pws_os::AutotypeMethod method, unsigned delayMS)
+void CKeySendImpl::DoSendString(const StringX& str, unsigned delayMS, bool emulateMods)
 {
   atGlobals.error_detected = false;
   atGlobals.errorString[0] = 0;
 
-  AutotypeEvent event;
-  if (!event) {
-    if (!atGlobals.error_detected)
-      atGlobals.error_detected = true;
-    if (!atGlobals.errorString[0])
-      strncpy(atGlobals.errorString, "Could not open X display for autotyping", NumberOf(atGlobals.errorString));
-    throw autotype_exception();
-  }
+  AutotypeEvent event(m_display);
 
   // convert all the chars into keycodes and required shift states first
   // Abort if any of the characters cannot be converted
@@ -344,19 +541,7 @@ void DoSendString(const StringX& str, pws_os::AutotypeMethod method, unsigned de
     }
   }
 
-  XSetErrorHandler(ErrorHandler);
-  atGlobals.error_detected = False;
-
-  bool useXTEST = (UseXTest(event.display) && method != pws_os::ATMETHOD_XSENDKEYS);
-  void (*KeySendFunction)(XKeyEvent*);
-
-  if ( useXTEST) {
-    KeySendFunction = XTest_SendKeyEvent;
-    XTestGrabControl(event.display, True);
-  }
-  else {
-    KeySendFunction = XSendKeys_SendKeyEvent;
-  }
+  m_method->EmulateMods(emulateMods);
 
   for (KeyPressInfoVector::const_iterator itr = keypresses.begin(); itr != keypresses.end()
                               && !atGlobals.error_detected; ++itr) {
@@ -364,36 +549,50 @@ void DoSendString(const StringX& str, pws_os::AutotypeMethod method, unsigned de
     event.state = itr->state;
     event.time = CurrentTime;
 
-    KeySendFunction(&event);
+    (*m_method)(event);
     pws_os::sleep_ms(delayMS);
   }
-
-  if (useXTEST) {
-    XTestGrabControl(event.display, False);
-  }
-  else {
-    XSync(event.display, False);
-  }
-
-  XSetErrorHandler(NULL);
 }
 
-} // anonymous namespace
 
-/*
- * SendString - The interface method for CKeySend
- *
- * The actual work is done by DoSendString above. This function just
- * just throws an exception if DoSendString encounters an error.
- *
- */
-void pws_os::SendString(const StringX& str, AutotypeMethod method, unsigned delayMS)
+void CKeySendImpl::SendString(const StringX& str, unsigned delayMS)
 {
   atGlobals.error_detected = false;
   atGlobals.errorString[0] = 0;
 
-  DoSendString(str, method, delayMS);
+  DoSendString(str, delayMS, m_emulateModsSeparately);
 
   if (atGlobals.error_detected)
     throw autotype_exception();
+}
+
+void CKeySendImpl::SelectAll(unsigned delayMS)
+{
+  AutotypeEvent event(m_display);
+  event.keycode = XKeysymToKeycode(event.display, XK_a);
+  event.state = ControlMask;
+  event.time = CurrentTime;
+  (*m_method)(event);
+  pws_os::sleep_ms(delayMS);
+}
+
+CKeySendImpl::CKeySendImpl(pws_os::AutotypeMethod method): m_display(XOpenDisplay(NULL))
+{
+  if (m_display) {
+    m_method = GetAutotypeMethod(m_display, method);
+  }
+  else {
+    if (!atGlobals.error_detected)
+      atGlobals.error_detected = true;
+    if (!atGlobals.errorString[0])
+      strncpy(atGlobals.errorString, "Could not open X display for autotyping", NumberOf(atGlobals.errorString));
+
+    throw autotype_exception();
+  }
+}
+
+CKeySendImpl::~CKeySendImpl()
+{
+  delete m_method;
+  XCloseDisplay(m_display);
 }

--- a/src/os/linux/xsendstring.h
+++ b/src/os/linux/xsendstring.h
@@ -19,8 +19,41 @@
 namespace pws_os {
   /* Set the method to AUTO if you're not sure what it should be */
   typedef enum { ATMETHOD_AUTO, ATMETHOD_XTEST, ATMETHOD_XSENDKEYS } AutotypeMethod;
-  
-  void SendString(const StringX& str, AutotypeMethod method, unsigned delayMS);
 }
+
+/////////////////////////////////////////////////////////////////////
+// CKeySendImpl - Linux specific bits
+///////////////
+
+// This is to keep Xlib headers in xsendstring.cpp only
+class AutotypeMethodBase;
+struct _XDisplay;
+
+class CKeySendImpl
+{
+    // This takes effect the next time SendString is called
+    bool m_emulateModsSeparately = true;
+
+    // The ctor throws if it can create this, because all X functions need it
+    _XDisplay *m_display;
+
+    // Can't change autotype method in the middle of an autotype session
+    AutotypeMethodBase *m_method;
+
+    // Does the actual autotype work with the help of m_method
+    void DoSendString(const StringX& str, unsigned delayMS, bool emulateMods);
+  public:
+
+    CKeySendImpl(pws_os::AutotypeMethod method);
+    ~CKeySendImpl();
+
+    // Autotypes all chars in data "delay" ms in between
+    void SendString(const StringX &data, unsigned delay);
+    void EmulateMods(bool emulate) { m_emulateModsSeparately = emulate; }
+    bool IsEmulatingMods() const { return m_emulateModsSeparately; }
+    // Autotypes a Ctrl-A
+    void SelectAll(unsigned delayMS);
+};
+
 #endif
 

--- a/src/os/mac/KeySend.cpp
+++ b/src/os/mac/KeySend.cpp
@@ -71,3 +71,19 @@ bool CKeySend::SimulateApplicationSwitch(void)
 }
 #endif
 
+
+void CKeySend::SelectAll() const
+{
+  const bool selectedAll = pws_os::SelectAll();
+  VERIFY(selectedAll);
+}
+
+void CKeySend::EmulateMods(bool /*emulate*/)
+{
+  // I just don't know how to do it!
+}
+
+bool CKeySend::IsEmulatingMods() const
+{
+  return false;
+}

--- a/src/os/mac/macsendstring.h
+++ b/src/os/mac/macsendstring.h
@@ -20,6 +20,7 @@
 namespace pws_os {
   void SendString(const char* str, unsigned delayMS);
   bool MacSimulateApplicationSwitch(unsigned delayMS);
+  bool SelectAll();
 };
 #endif
 

--- a/src/os/windows/KeySend.cpp
+++ b/src/os/windows/KeySend.cpp
@@ -307,3 +307,16 @@ void CKeySend::BlockInput(bool bi) const
 {
   ::BlockInput(bi ? TRUE : FALSE);
 }
+
+void CKeySend::SelectAll() const
+{
+}
+
+void CKeySend::EmulateMods(bool /*emulate*/)
+{
+}
+
+bool CKeySend::IsEmulatingMods() const
+{
+  return false;
+}

--- a/src/ui/wxWidgets/mainEdit.cpp
+++ b/src/ui/wxWidgets/mainEdit.cpp
@@ -632,6 +632,29 @@ void PasswordSafeFrame::DoAutotype(const StringX& sx_autotype,
 
           break; // case 'd', 'w' & 'W'
         }
+        case L'c':
+          if (std::find(vactionverboffsets.begin(), vactionverboffsets.end(), n - 1) ==
+              vactionverboffsets.end()) {
+            // Not in the list of found action verbs - treat as-is
+            sxtmp += L'\\';
+            sxtmp += curChar;
+          }
+          else {
+            ks.SelectAll();
+          }
+          break;
+        case L'j':
+        case L'k':
+          if (std::find(vactionverboffsets.begin(), vactionverboffsets.end(), n - 1) ==
+              vactionverboffsets.end()) {
+            // Not in the list of found action verbs - treat as-is
+            sxtmp += L'\\';
+            sxtmp += curChar;
+          }
+          else {
+            ks.EmulateMods(curChar == L'j');
+          }
+          break;
         case L'z':
           if (std::find(vactionverboffsets.begin(), vactionverboffsets.end(), n - 1) ==
               vactionverboffsets.end()) {


### PR DESCRIPTION
I have been using this code for some time now and works well on Linux.  I squashed all the changes from linux-autotype-fixes branch in master.  Also added documentation :-)

Squashed commit of the following:

commit 2a70e17f92f48ec23955aa00780eb5fb2681a7d7
Author: saurav <sauravg@users.sf.net>
Date:   Thu Aug 27 16:24:31 2015 +0530

    Update docs with new autotype meta-characters

commit 39d69500e37482318d248f447ccfeabffa4043fb
Author: saurav <sauravg@users.sf.net>
Date:   Mon Aug 17 12:23:22 2015 +0530

    Add dummy methods to windows/Keysend.cpp to keep compiling

commit c0b0112f81760f9308d9dba1ef18a82946f9f586
Author: saurav <sauravg@users.sf.net>
Date:   Wed Aug 12 12:44:19 2015 +0530

    Remove whitespace diffs

commit c4cc471d1153d789f6c9113946023852894bcefd
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Thu Aug 6 17:21:45 2015 +0530

    Add comments

commit efa8cbafa59231c89ebb0285641a41bdfbc5835c
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Tue Apr 14 15:35:36 2015 +0530

    wx-autotype: select-all & mod-emulate are no longer sticky

commit 20d8f1c96e6e76474d34e6003eecace851687182
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Thu Apr 9 10:21:48 2015 +0530

    Removed a redundant layer of code

    CKeySendImpl is now really the platform-specific implementation.
    No more global functions.

commit 5f9cdda62ed4c3f159c62ecc2123f7f9cd97fb58
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Fri Apr 3 21:48:48 2015 +0530

    Added SelectAll & EmulateMods for OSX

commit 37424c55dc1329ba85c9ef2571f32bddc0b58a1d
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Thu Apr 2 16:21:51 2015 +0530

    Autotype string controls SelectAll & mod emulation

    But the implementation is hacky in order to minimize code changes
    before further testing.  Select-All only happens just before the
    next char is autotyped (it might impact the next field), and is
    "sticky".

commit eda8e81a2bac90629a69cfab4a4f836910353a75
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Tue Mar 24 15:29:40 2015 +0530

    Erase-all and emulate-mods while autotyping by default

commit e09c4248b6510646db9e272eba9e4a573048b71e
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Tue Mar 24 15:18:36 2015 +0530

    wx-linux: create select-all keysequence in one place

commit ca3a9c4914db9c8732b528b1afb6d96c0f88edd1
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Tue Mar 24 15:16:57 2015 +0530

    wx-linux: use CurrentTime to type key immediately

commit d701ad927e1be3ac11e23e5a9be2e1c30c76d15b
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Tue Mar 24 14:40:00 2015 +0530

    wx-linux: SelectAll before autotyping only if user wanted that

commit 9924071f523976ee68912a7d70013bb9a6aec429
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Tue Mar 24 14:38:34 2015 +0530

    wx-linux: Convert Xk_a to KeyCode to type Ctrl-A

commit b1c075c9b3a24239f8dda3abc8bbd666a0463978
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Tue Mar 24 11:56:25 2015 +0530

    wx-linux: autotype improvements

    1. Can auto-select existing text before typing
    2. Independent emulation of modifier keys can be turned on/off

commit 1c1cf0b3c590782377ac0fbaecdcd6776d1953da
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Tue Mar 24 11:35:39 2015 +0530

    wx-linux: AutotypeMethod only works with the display it was initialized with

commit 5002907558f927070151f939ddcaf7e2dea1400e
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Mon Mar 9 12:18:50 2015 +0530

    Encapsulated XTEST and XSendKeys into C++ classes

    This will help with better re-use and further
    refactoring when we implement "Select-All before autotype"

    Didn't remove all the trailing spaces as this gives a
    better sense of exactly changed.  Removing the spaces
    totally clobbers the context.

commit 50b77f38ae2c7b76ed3eb8b6bdda690ff64bc916
Author: Saurav Ghosh <sauravg@users.sourceforge.net>
Date:   Thu Jan 8 17:12:18 2015 +0530

    linux: Fixed crash while autotyping (debug only)

    Happens on systems with limited keyboard symbol support, like
    XQuartz on Darwin, because we were asserting for presence of
    modifiers that are not supported