### PR TITLE
Generate position independent code.  This fixes FTBFS on Debian

### DIFF
--- a/src/core/Makefile
+++ b/src/core/Makefile
@@ -43,7 +43,7 @@ LIBOBJ    = $(addprefix $(OBJPATH)/,$(subst .cpp,.o,$(LIBSRC)))
 LIB       = $(LIBPATH)/libcore.a
 OBJ       = $(LIBOBJ)
 
-CPPFLAGS := $(CXXFLAGS) -Wall -I.. -DLINUX $(CPPFLAGS)
+CPPFLAGS := $(CXXFLAGS) -fPIC -Wall -I.. -DLINUX $(CPPFLAGS)
 
 ifeq ($(CONFIG),debug)
 CPPFLAGS += -O0 -g -ggdb -D_DEBUG -DDEBUG

--- a/src/os/linux/Makefile
+++ b/src/os/linux/Makefile
@@ -48,7 +48,7 @@ LIBOBJ    = $(addprefix $(OBJPATH)/,$(subst .cpp,.o,$(LIBSRC)))
 LIB       = $(LIBPATH)/libos.a
 OBJ       = $(LIBOBJ)
 
-CPPFLAGS := $(CXXFLAGS) -Wall -I../../core -I../.. $(CPPINC) $(YBPERSFLAGS) \
+CPPFLAGS := $(CXXFLAGS) -fPIC -Wall -I../../core -I../.. $(CPPINC) $(YBPERSFLAGS) \
                 $(CPPFLAGS)
 
 ifeq ($(CONFIG),debug)

--- a/src/ui/wxWidgets/Makefile
+++ b/src/ui/wxWidgets/Makefile
@@ -49,7 +49,7 @@ OPTFLAGS=-O0
 DEBUGFLAGS=-ggdb -D_DEBUG
 LIBPATH=../../../lib/debug
 CPPINC=`$(WX_CONFIG) --debug=yes --unicode=no --inplace --cxxflags`
-GCCFLAGS=
+GCCFLAGS=-fPIC
 RESPATH=--include-dir "$(WXWIN)/include" --include-dir "$(WXWIN)/contrib/include" --include-dir "$(WXWIN)/GCCBuildDebugGTK2/lib/wx/include/gtk2-ansi-debug-static-2.6"
 MACPACKAGEINFO=
 
@@ -76,7 +76,7 @@ OPTFLAGS=-O
 DEBUGFLAGS=
 LIBPATH=../../../lib/release
 CPPINC=`$(WX_CONFIG) --debug=no --unicode=no --inplace --cxxflags` -DNDEBUG
-GCCFLAGS=
+GCCFLAGS=-fPIC
 RESPATH=--include-dir "$(WXWIN)/include" --include-dir "$(WXWIN)/contrib/include" --include-dir "$(WXWIN)/GCCBuildReleaseGTK2/lib/wx/include/gtk2-ansi-release-static-2.6"
 MACPACKAGEINFO=
 
@@ -105,7 +105,7 @@ LIBPATH=../../../lib/unicodedebug
 CPPINC=`$(WX_CONFIG) --debug=yes --unicode=yes --inplace --cxxflags` -DUNICODE
 XERCESCPPFLAGS=-DUSE_XML_LIBRARY=XERCES -DWCHAR_INCOMPATIBLE_XMLCH
 XERCESLIBFLAGS=-lxerces-c
-GCCFLAGS=
+GCCFLAGS=-fPIC
 RESPATH=--include-dir "$(WXWIN)/include" --include-dir "$(WXWIN)/contrib/include" --include-dir "$(WXWIN)/GCCBuildDebugGTK2Unicode/lib/wx/include/gtk2-unicode-debug-static-2.6"
 MACPACKAGEINFO=
 
@@ -133,7 +133,7 @@ LIBPATH=../../../lib/unicoderelease
 CPPINC=`$(WX_CONFIG) --debug=no --unicode=yes --inplace --cxxflags` -DUNICODE -DNDEBUG
 XERCESCPPFLAGS=-DUSE_XML_LIBRARY=XERCES -DWCHAR_INCOMPATIBLE_XMLCH
 XERCESLIBFLAGS=-lxerces-c
-GCCFLAGS=
+GCCFLAGS=-fPIC
 LDFLAGS:=$(LIBS) -L$(LIBPATH) $(LINKERFLAGS) $(LDFLAGS)
 RESPATH=--include-dir "$(WXWIN)/include" --include-dir "$(WXWIN)/contrib/include" --include-dir "$(WXWIN)/GCCBuildReleaseGTK2Unicode/lib/wx/include/gtk2-unicode-release-static-2.6"
 MACPACKAGEINFO=


### PR DESCRIPTION
0.95 and later fails to build from source on Debian systems.  Enabling position independent code (-fPIC) resolves the issue.