### PR TITLE
Encryption Changes

### DIFF
--- a/src/core/BlowFish.cpp
+++ b/src/core/BlowFish.cpp
@@ -301,7 +301,7 @@ const uint32 BlowFish::tempbf_S[4][256] =
 };
 
 void BlowFish::Blowfish_encipher(uint32 *xl,
-                                 uint32 *xr)
+                                 uint32 *xr) const
 {
   union aword Xl;
   union aword Xr;
@@ -325,7 +325,7 @@ void BlowFish::Blowfish_encipher(uint32 *xl,
 }
 
 void BlowFish::Blowfish_decipher(uint32 *xl,
-                                 uint32 *xr)
+                                 uint32 *xr) const
 {
   union aword Xl;
   union aword Xr;
@@ -424,7 +424,7 @@ BlowFish::~BlowFish()
   trashMemory(bf_S, sizeof(bf_S));
 }
 
-void BlowFish::Encrypt(const unsigned char *in, unsigned char *out)
+void BlowFish::Encrypt(const unsigned char *in, unsigned char *out) const
 {
   for (int x = 0; x < 8; x++)
     out[x] = in[x];
@@ -432,7 +432,7 @@ void BlowFish::Encrypt(const unsigned char *in, unsigned char *out)
     reinterpret_cast<uint32 *>(out + sizeof(uint32)));
 }
 
-void BlowFish::Decrypt(const unsigned char *in, unsigned char *out)
+void BlowFish::Decrypt(const unsigned char *in, unsigned char *out) const
 {
   for (int x = 0; x < 8; x++)
     out[x] = in[x];

--- a/src/core/BlowFish.h
+++ b/src/core/BlowFish.h
@@ -22,10 +22,10 @@ public:
   enum {BLOCKSIZE = 8};
 
   BlowFish(const unsigned char* key, int keylen);
-  virtual ~BlowFish();
-  virtual void Encrypt(const unsigned char *in, unsigned char *out);
-  virtual void Decrypt(const unsigned char *in, unsigned char *out);
-  virtual unsigned int GetBlockSize() const {return BLOCKSIZE;}
+  ~BlowFish();
+  void Encrypt(const unsigned char *in, unsigned char *out) const;
+  void Decrypt(const unsigned char *in, unsigned char *out) const;
+  unsigned int GetBlockSize() const {return BLOCKSIZE;}
 
 private:
   enum {bf_N = 16};
@@ -33,8 +33,8 @@ private:
   uint32 bf_P[bf_N + 2];
   static const uint32 tempbf_S[4][256];
   static const uint32 tempbf_P[bf_N + 2];
-  void Blowfish_encipher(uint32* xl, uint32* xr);
-  void Blowfish_decipher(uint32* xl, uint32* xr);
+  void Blowfish_encipher(uint32* xl, uint32* xr) const;
+  void Blowfish_decipher(uint32* xl, uint32* xr) const;
   void InitializeBlowfish(const unsigned char key[], short keybytes);
 };
 #endif /* __BLOWFISH_H */

--- a/src/core/Fish.h
+++ b/src/core/Fish.h
@@ -23,8 +23,8 @@ public:
   virtual unsigned int GetBlockSize() const = 0;
   // Following encrypt/decrypt a single block
   // (blocksize dependent on cipher)
-  virtual void Encrypt(const unsigned char *pt, unsigned char *ct) = 0;
-  virtual void Decrypt(const unsigned char *ct, unsigned char *pt) = 0;
+  virtual void Encrypt(const unsigned char *pt, unsigned char *ct) const = 0;
+  virtual void Decrypt(const unsigned char *ct, unsigned char *pt) const = 0;
 };
 
 #endif /* __FISH_H */

--- a/src/core/ItemData.h
+++ b/src/core/ItemData.h
@@ -367,6 +367,8 @@ private:
   EntryType m_entrytype;
   EntryStatus m_entrystatus;
 
+  mutable BlowFish * m_blowfish = nullptr;
+  
   // random key for storing stuff in memory, just to remove dependence
   // on passphrase
   static bool IsSessionKeySet;
@@ -386,7 +388,7 @@ private:
   bool SetTime(const int whichtime, const stringT &time_str); // V30
 
   // Create local Encryption/Decryption object
-  BlowFish *MakeBlowFish(bool noData = false) const;
+  const BlowFish *MakeBlowFish(bool noData = false) const;
   // Laziness is a Virtue:
   StringX GetField(FieldType ft) const;
   StringX GetField(const CItemField &field) const;

--- a/src/core/ItemField.cpp
+++ b/src/core/ItemField.cpp
@@ -61,7 +61,7 @@ void CItemField::Empty()
 }
 
 void CItemField::Set(const unsigned char* value, size_t length,
-                     Fish *bf, unsigned char type)
+                     const Fish *bf, unsigned char type)
 {
   size_t BlockLength;
 
@@ -97,7 +97,7 @@ void CItemField::Set(const unsigned char* value, size_t length,
     m_Type = type;
 }
 
-void CItemField::Set(const StringX &value, Fish *bf, unsigned char type)
+void CItemField::Set(const StringX &value, const Fish *bf, unsigned char type)
 {
   const LPCTSTR plainstr = value.c_str();
 
@@ -105,7 +105,7 @@ void CItemField::Set(const StringX &value, Fish *bf, unsigned char type)
       value.length() * sizeof(*plainstr), bf, type);
 }
 
-void CItemField::Get(unsigned char *value, size_t &length, Fish *bf) const
+void CItemField::Get(unsigned char *value, size_t &length, const Fish *bf) const
 {
   // Sanity check: length is 0 iff data ptr is NULL
   ASSERT((m_Length == 0 && m_Data == NULL) ||
@@ -136,7 +136,7 @@ void CItemField::Get(unsigned char *value, size_t &length, Fish *bf) const
   }
 }
 
-void CItemField::Get(StringX &value, Fish *bf) const
+void CItemField::Get(StringX &value, const Fish *bf) const
 {
   // Sanity check: length is 0 iff data ptr is NULL
   ASSERT((m_Length == 0 && m_Data == NULL) ||

--- a/src/core/ItemField.h
+++ b/src/core/ItemField.h
@@ -33,11 +33,11 @@ public:
 
   CItemField &operator=(const CItemField &that);
 
-  void Set(const StringX &value, Fish *bf, unsigned char type = 0xff);
-  void Set(const unsigned char* value, size_t length, Fish *bf, unsigned char type = 0xff);
+  void Set(const StringX &value, const Fish *bf, unsigned char type = 0xff);
+  void Set(const unsigned char* value, size_t length, const Fish *bf, unsigned char type = 0xff);
 
-  void Get(StringX &value, Fish *bf) const;
-  void Get(unsigned char *value, size_t &length, Fish *bf) const;
+  void Get(StringX &value, const Fish *bf) const;
+  void Get(unsigned char *value, size_t &length, const Fish *bf) const;
   unsigned char GetType() const {return m_Type;}
   size_t GetLength() const {return m_Length;}
   bool IsEmpty() const {return m_Length == 0;}

--- a/src/core/TwoFish.cpp
+++ b/src/core/TwoFish.cpp
@@ -477,12 +477,13 @@ int twofish_setup(const unsigned char *key, int keylen, int num_rounds, twofish_
   @param skey The key as scheduled
 */
 #ifdef LTC_CLEAN_STACK
-static void _twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, twofish_key *skey)
+static void _twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const twofish_key *skey)
 #else
 static void twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, twofish_key *skey)
 #endif
 {
-  uint32 a,b,c,d,ta,tb,tc,td,t1,t2, *k;
+  uint32 a,b,c,d,ta,tb,tc,td,t1,t2;
+  uint32 const *k;
   int r;
 #if !defined(TWOFISH_SMALL) && !defined(__GNUC__)
   uint32 *S1, *S2, *S3, *S4;
@@ -532,7 +533,7 @@ static void twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, twof
 }
 
 #ifdef LTC_CLEAN_STACK
-static void twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, twofish_key *skey)
+static void twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, const twofish_key *skey)
 {
   _twofish_ecb_encrypt(pt, ct, skey);
   burnStack(sizeof(uint32) * 10 + sizeof(uint32));
@@ -546,12 +547,13 @@ static void twofish_ecb_encrypt(const unsigned char *pt, unsigned char *ct, twof
   @param skey The key as scheduled 
 */
 #ifdef LTC_CLEAN_STACK
-static void _twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, twofish_key *skey)
+static void _twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const twofish_key *skey)
 #else
 static void twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, twofish_key *skey)
 #endif
 {
-  uint32 a,b,c,d,ta,tb,tc,td,t1,t2, *k;
+  uint32 a,b,c,d,ta,tb,tc,td,t1,t2;
+  uint32 const *k;
   int r;
 #if !defined(TWOFISH_SMALL) && !defined(__GNUC__)
   uint32 *S1, *S2, *S3, *S4;
@@ -604,7 +606,7 @@ static void twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, twof
 }
 
 #ifdef LTC_CLEAN_STACK
-static void twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, twofish_key *skey)
+static void twofish_ecb_decrypt(const unsigned char *ct, unsigned char *pt, const twofish_key *skey)
 {
   _twofish_ecb_decrypt(ct, pt, skey);
   burnStack(sizeof(uint32) * 10 + sizeof(uint32));
@@ -625,12 +627,12 @@ TwoFish::~TwoFish()
   trashMemory(&key_schedule, sizeof(key_schedule));
 }
 
-void TwoFish::Encrypt(const unsigned char *in, unsigned char *out)
+void TwoFish::Encrypt(const unsigned char *in, unsigned char *out) const
 {
   twofish_ecb_encrypt(in, out, &key_schedule);
 }
 
-void TwoFish::Decrypt(const unsigned char *in, unsigned char *out)
+void TwoFish::Decrypt(const unsigned char *in, unsigned char *out) const
 {
   twofish_ecb_decrypt(in, out, &key_schedule);
 }

--- a/src/core/TwoFish.h
+++ b/src/core/TwoFish.h
@@ -31,10 +31,10 @@ class TwoFish : public Fish
 public:
   enum {BLOCKSIZE=16};
   TwoFish(const unsigned char* key, int keylen);
-  virtual ~TwoFish();
-  virtual void Encrypt(const unsigned char *in, unsigned char *out);
-  virtual void Decrypt(const unsigned char *in, unsigned char *out);
-  virtual unsigned int GetBlockSize() const {return BLOCKSIZE;}
+  ~TwoFish();
+  void Encrypt(const unsigned char *in, unsigned char *out) const;
+  void Decrypt(const unsigned char *in, unsigned char *out) const;
+  unsigned int GetBlockSize() const {return BLOCKSIZE;}
 
 private:
   twofish_key key_schedule;


### PR DESCRIPTION
This includes two commits for performance enhancements.

The first one https://github.com/pwsafe/pwsafe/commit/b88f60487806bcfddf2e22846e6622d7a470db8e simply adds syntax changes to avoid useless virtual indirection in leaf classes and adds const markers to the encryptors methods which effectively do not change its internal state. This last change will be needed on the next commit.

The second one https://github.com/pwsafe/pwsafe/commit/198b6cdb33d3dc501220c557252794bab5df54f6 has been made due to a finding in the profiler, which showed that most of the CPU time spent opening huge safes was creating and destroying equivalent Blowfish objects. On an iPhone 4s this change make a 1500-entries safe open in 0,5 seconds instead of 2,5, which is a huge UX gain.