### PR TITLE
V4/2015 10 12

### DIFF
--- a/README.WINDOWS.DEVELOPERS.html
+++ b/README.WINDOWS.DEVELOPERS.html
@@ -18,6 +18,7 @@ wishing to compile PasswordSafe for Windows. Linux developers should read the fi
 <li><a href="#Introduction">Introduction</a></li>
 <li><a href="README.WINDOWS.DEVELOPERS.html#Software_Requirements">Software Requirements</a></li>
 <li><a href="README.WINDOWS.DEVELOPERS.html#XML_Processing">XML Processing</a></li>
+<li><a href="README.WINDOWS.DEVELOPERS.html#Gtest">Gtest</a></li>
 <li><a href="README.WINDOWS.DEVELOPERS.html#Minidump_Production">Minidumps</a></li>
 </ol>
 
@@ -319,48 +320,64 @@ ensures that the data eventually hitting the SAX2 content handlers is
 correct and just needs placing in the appropriate fields.</p>
 
 <h3><a name="Gtest"></a> Gtest framework</h3>
-PasswordSafe uses the <a href="https://github.com/google/googletest" target="_blank">gtest</a> framework
-in the DebugM build - specifically the DebugM build of the coretest project.
-<br>
-(The following instructions were written for version 1.7 of gtest.)
-<br>
-To generate the required library, open gtest.sln in the "msvc" sub-directory in the gtest directory.
-<br>
-You only need to build the Debug version of gtest library (gtestd.lib) in the gtest project of the
+
+<p>The following instructions were written for version 1.7.0 of gtest.</p>
+
+<p>PasswordSafe uses the <a href="https://github.com/google/googletest" target="_blank">gtest</a>
+framework in the DebugM build - specifically the DebugM build of the coretest project.</p>
+
+<p>To generate the required library, open gtest.sln in the "msvc" sub-directory in the gtest
+directory.</p>
+<p>You only need to build the Debug version of gtest library (gtestd.lib) in the gtest project of the
 solution "gtest.sln". PasswordSafe does not use the "gtest-md.sln" solution nor following projects
-in gtest.sln:
+in gtest.sln:</p>
 <ol type="a">
  <li>gtest_main</li>
  <li>gtest_prod_test</li>
  <li>gtest_unittest</li>
 </ol> 
-However, you can also make the similar changes to the following in these project if you wish to
-run the gtest Test programs.
-
-The following changes should be made to the (converted) project file:
+<p>The following changes should be made to the (converted) project file:</p>
 <ol>
-<li> Configuration Properties: General: (NN is 12 for VS2013 & 14 for VS2015)
-	 <ol type="a">
-	 	 <li> All configurations:<br>
-  		 	  Output directory:       ..\build-vcNN/$(Configuration)\<br>
-			  Intermediate Directory: $(Configuration)/$(ProjectName)\</li>
-  		 <li>Debug configuration:<br>
-		     Target Name:            $(ProjectName)d</li>
-		 <li>Release configuration (not used by PasswordSafe):<br>
-		     Target Name:            $(ProjectName)</li>
-	</ol></li>
+  <li> Configuration Properties: General: (where NN is 12 for VS2013 & 14 for VS2015)
+    <ul>
+      <li> All configurations:<br>
+          Output directory:       ..\build-vcNN/$(Configuration)\<br>
+          Intermediate Directory: $(Configuration)/$(ProjectName)\
+      </li>
+      <li>Debug configuration:<br>
+         Target Name:            $(ProjectName)d
+      </li>
+      <li>Release configuration (not used by PasswordSafe):<br>
+         Target Name:            $(ProjectName)
+      </li>
+    </ul>
+  </li>
 
-<li>Configuration Properties: C/C++: Output Files
-	<ol type="a">
-  		<li>Debug configuration:<br>
-		    Program Database File Name: $(OutDir)\$(ProjectName)d.pdb</li>
-		<li>Release configuration(not used by PasswordSafe):<br>
-		    Program Database File Name: $(OutDir)\$(ProjectName).pdb</li>
-			</ol></li>
+  <li>Configuration Properties: C/C++: General
+    <ul>
+      <li>Debug configuration:<br>
+          Debug Information Format: Program Database (/Zi)
+      </li>
+    </ul>
+  </li>
+    
+  <li>Configuration Properties: C/C++: Output Files
+    <ul>
+      <li>Debug configuration:<br>
+          Program Database File Name: $(OutDir)\$(ProjectName)d.pdb
+      </li>
+      <li>Release configuration (not used by PasswordSafe):<br>
+          Program Database File Name: $(OutDir)\$(ProjectName).pdb
+      </li>
+    </ul>
+  </li>
 </ol>
-Please remember to (re-)run the PasswordSafe configure-12.vbs or configure-14.vbs script to set the necessary gtest
-include and library directories.  These would normally be the subdirectories "include" and either
-"build-vc12" or "build-vc14" of the "gtest-1.7.0" directory.
+<p>Please remember to (re-)run the PasswordSafe configure-12.vbs or configure-14.vbs script to set
+the necessary gtest include and library directories.  These would normally be the subdirectories
+"include" and either "build-vc12" or "build-vc14" of the "gtest-1.7.0" directory.</p>
+
+<p>Note: you can also make the similar changes to those above in the projects not used by
+PasswordSafe in gtest.sln  if you wish to run the gtest Test programs.</p>
 
 <h3><a name="Minidump_Production"></a>Minidump Production (Windows only)</h3>
 

--- a/src/core/ItemData.cpp
+++ b/src/core/ItemData.cpp
@@ -524,7 +524,7 @@ void CItemData::GetUUID(uuid_array_t &uuid_array, FieldType ft) const
       ASSERT(0);
     }
   if (fiter == m_fields.end()) {
-    pws_os::Trace(_T("CItemData::GetUUID(uuid_array_t) - no UUID found!"));
+    pws_os::Trace(_T("CItemData::GetUUID(uuid_array_t) - no UUID found!\n"));
     memset(uuid_array, 0, length);
   } else
     CItem::GetField(fiter->second,

--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -492,6 +492,9 @@ void PWScore::NewFile(const StringX &passkey)
 struct RecordWriter {
   RecordWriter(PWSfile *pout, PWScore *pcore, PWSfile::VERSION version)
     : m_pout(pout), m_pcore(pcore), m_version(version) {}
+
+  RecordWriter& operator=(const RecordWriter&); // Do not implement
+
   void operator()(std::pair<CUUID const, CItemData> &p)
   {
     if (p.second.IsAlias() && m_version < PWSfile::V30) {

--- a/src/core/PWSfileV4.cpp
+++ b/src/core/PWSfileV4.cpp
@@ -424,6 +424,9 @@ const short VersionNum = 0x0400;
 
 struct PWSfileV4::CKeyBlocks::KeyBlockFinder {
   KeyBlockFinder(const StringX &passkey) : passkey(passkey) {}
+
+  KeyBlockFinder& operator=(const KeyBlockFinder&); // Do not implement
+
   bool operator()(const KeyBlock &kb) {
     unsigned char Ptag[SHA256::HASHLEN];
     unsigned char K[PWSfileV4::KLEN];

--- a/src/core/core-12.vcxproj
+++ b/src/core/core-12.vcxproj
@@ -573,6 +573,7 @@
     <ClInclude Include="ExpiredList.h" />
     <ClInclude Include="Fish.h" />
     <ClInclude Include="hmac.h" />
+    <ClInclude Include="Item.h" />
     <ClInclude Include="ItemAtt.h" />
     <ClInclude Include="ItemData.h" />
     <ClInclude Include="ItemField.h" />

--- a/src/core/core-12.vcxproj.filters
+++ b/src/core/core-12.vcxproj.filters
@@ -349,5 +349,8 @@
     <ClInclude Include="ItemAtt.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Item.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/core/hmac.h
+++ b/src/core/hmac.h
@@ -54,6 +54,7 @@ public:
   }
 
   HMAC(const HMAC &hmac) {
+    delete Hash;
     Hash = new H;
     *Hash = *hmac.Hash;
     memcpy(K, hmac.K, BLOCKSIZE);
@@ -61,6 +62,7 @@ public:
 
   HMAC &operator=(const HMAC &that) {
     if (this != &that) {
+      delete Hash;
       Hash = new H;
       *Hash = *that.Hash;
       memcpy(K, that.K, BLOCKSIZE);

--- a/src/test/ItemAttTest.cpp
+++ b/src/test/ItemAttTest.cpp
@@ -152,9 +152,13 @@ TEST_F(ItemAttTest, Getters_n_Setters)
   EXPECT_EQ(title, ai.GetTitle());
   EXPECT_EQ(cTime, ai.GetCTime(tVal));
   ASSERT_EQ(sizeof(content), ai.GetContentLength());
+
   size_t contentSize = ai.GetContentSize();
   contentVal = new unsigned char[contentSize];
+
   EXPECT_FALSE(ai.GetContent(contentVal, contentSize - 1));
   EXPECT_TRUE(ai.GetContent(contentVal, contentSize));
   EXPECT_EQ(0, memcmp(content, contentVal, sizeof(content)));
+
+  delete[] contentVal;
 }

--- a/src/test/coretest.cpp
+++ b/src/test/coretest.cpp
@@ -27,15 +27,7 @@ int main(int argc, char **argv)
   system("read");
 #endif
 
-  /* 
-     Tidy up some memory leaks - at least 85 left!
-     These are all probably caused in core/hmac.h
-     line 57 & 64 "Hash = new H" leaving any
-     exising H that was in Hash in limbo.
-
-     Leave to Rony to fix :-)
-  */
-
+  // Need to find these in order to delete them
   PWSLog *pwslog = PWSLog::GetLog();
   PWSprefs *pwsprefs = PWSprefs::GetInstance();
   PWSrand *pwsrand = PWSrand::GetInstance();

--- a/src/ui/wxWidgets/passwordsafeframe.cpp
+++ b/src/ui/wxWidgets/passwordsafeframe.cpp
@@ -3046,7 +3046,7 @@ void PasswordSafeFrame::OnExportVx(wxCommandEvent& evt)
       return;
 
     newfile = tostringx(fd.GetPath());
-    rc = m_core.WriteFile(newfile, ver);
+    rc = m_core.WriteFile(newfile, true, ver);
   } else { // internal error
     wxFAIL_MSG(_("Could not figure out why PasswordSafeFrame::OnExportVx was invoked"));
   }


### PR DESCRIPTION
Please review:
1. Change to hmac.h,
2. Why there is an access violation deleting pcmd1 in coretest/CommandTest.cpp [TEST_F(CommandsTest, CreateShortcutEntry)] but no memory leaks if pcmd1 is not deleted.