### PR TITLE
1193: Ctrl-F would set focus to search textbox if searchbar is already visible

### DIFF
--- a/CodeLite/exec-wx3-config
+++ b/CodeLite/exec-wx3-config
@@ -2,6 +2,9 @@
 
 ORIG_ARGS="$@"
 
+if [ -z "$WX3_CONFIG_DEBUG" ]; then WX3_CONFIG_DEBUG=$(which wx-config); fi
+if [ -z "$WX3_CONFIG_RELEASE" ]; then WX3_CONFIG_RELEASE=$(which wx-config); fi
+
 while [ -n "$1" ]
 do
 	case "$1" in

--- a/CodeLite/pwsafe.project
+++ b/CodeLite/pwsafe.project
@@ -228,6 +228,7 @@
         <Library Value="uuid"/>
         <Library Value="Xtst"/>
         <Library Value="xerces-c"/>
+        <Library Value="X11"/>
       </Linker>
       <ResourceCompiler Options="$(shell wx-config --rcflags)" Required="no"/>
       <General OutputFile="$(IntermediateDirectory)/$(ProjectName)" IntermediateDirectory="./DebugX" Command="./$(ProjectName)" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
@@ -336,6 +337,7 @@ dir /usr/src/gtk+2.0-2.18.3/gdk
         <Library Value="uuid"/>
         <Library Value="Xtst"/>
         <Library Value="xerces-c"/>
+        <Library Value="X11"/>
       </Linker>
       <ResourceCompiler Options="$(shell wx-config --rcflags)" Required="no"/>
       <General OutputFile="$(IntermediateDirectory)/$(ProjectName)" IntermediateDirectory="./ReleaseX" Command="./$(ProjectName)" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>

--- a/src/ui/wxWidgets/PasswordSafeSearch.cpp
+++ b/src/ui/wxWidgets/PasswordSafeSearch.cpp
@@ -438,7 +438,10 @@ void PasswordSafeSearch::Activate(void)
   if (!m_toolbar)
     CreateSearchBar();
   else {
-    if (m_toolbar->Show(true)) {
+    if ( m_toolbar->IsShownOnScreen() ) {
+        m_toolbar->FindControl(ID_FIND_EDITBOX)->SetFocus();
+    }
+    else if (m_toolbar->Show(true)) {
       wxSize srchCtrlSize(m_parentFrame->GetSize().GetWidth()/5, wxDefaultSize.GetHeight());
       m_toolbar->FindControl(ID_FIND_EDITBOX)->SetSize(srchCtrlSize);
       m_parentFrame->GetSizer()->Layout();


### PR DESCRIPTION
Only 233c37c is required to fix the focus issue.  The rest are required to build with CodeLite IDE (I guess I alone use it).