### PR TITLE
Hide/Unhide pwsafe during autotype using timers

### DIFF
--- a/CodeLite/pwsafe.project
+++ b/CodeLite/pwsafe.project
@@ -128,6 +128,8 @@
     <File Name="../src/ui/wxWidgets/mainManage.cpp"/>
     <File Name="../src/ui/wxWidgets/SelectionCriteria.h"/>
     <File Name="../src/ui/wxWidgets/SelectionCriteria.cpp"/>
+    <File Name="../src/ui/wxWidgets/TimedTaskChain.cpp"/>
+    <File Name="../src/ui/wxWidgets/TimedTaskChain.h"/>
   </VirtualDirectory>
   <Dependencies Name="Release">
     <Project Name="core"/>

--- a/src/core/PWSprefs.cpp
+++ b/src/core/PWSprefs.cpp
@@ -168,6 +168,7 @@ const PWSprefs::intPref PWSprefs::m_int_prefs[NumIntPrefs] = {
   {_T("DefaultAutotypeDelay"), 10, ptApplication,
                             1, 60000},                              // application
   {_T("DlgOrientation"), AUTO, ptApplication, AUTO, WIDE},         // application
+  {_T("TimedTaskChainDelay"), 100, ptApplication, -1, -1},         // application
 };
 
 const PWSprefs::stringPref PWSprefs::m_string_prefs[NumStringPrefs] = {
@@ -195,6 +196,7 @@ const PWSprefs::stringPref PWSprefs::m_string_prefs[NumStringPrefs] = {
   {_T("DefaultSymbols"), _T(""), ptDatabase},                       // database
   {_T("NotesFont"), _T(""), ptApplication},                         // application
   {_T("NotesSampleText"), _T("AaBbYyZz 0O1IlL"), ptApplication},    // application
+  {_T("AutotypeTaskDelays"), _T("100,100,100"), ptApplication},     // application
 };
 
 PWSprefs *PWSprefs::GetInstance()

--- a/src/core/PWSprefs.h
+++ b/src/core/PWSprefs.h
@@ -132,7 +132,7 @@ public:
     PreExpiryWarnDays, ClosedTrayIconColour, PWDigitMinLength,
     PWLowercaseMinLength, PWSymbolMinLength, PWUppercaseMinLength,
     OptShortcutColumnWidth, ShiftDoubleClickAction, DefaultAutotypeDelay,
-    DlgOrientation,
+    DlgOrientation, TimedTaskChainDelay,
     NumIntPrefs};
 
   enum StringPrefs {CurrentBackup, CurrentFile, LastView, DefaultUsername,
@@ -140,7 +140,7 @@ public:
     ColumnWidths, DefaultAutotypeString, AltBrowserCmdLineParms,
     MainToolBarButtons, PasswordFont, TreeListSampleText, PswdSampleText,
     LastUsedKeyboard, VKeyboardFontName, VKSampleText, AltNotesEditor,
-    LanguageFile, DefaultSymbols, NotesFont, NotesSampleText,
+    LanguageFile, DefaultSymbols, NotesFont, NotesSampleText, AutotypeTaskDelays,
     NumStringPrefs};
 
   // for DoubleClickAction and ShiftDoubleClickAction

--- a/src/ui/wxWidgets/Makefile
+++ b/src/ui/wxWidgets/Makefile
@@ -178,7 +178,8 @@ SOURCES= passwordsafeframe.cpp \
 	wxutils.cpp ComparisonGridTable.cpp SizeRestrictedPanel.cpp \
 	fieldselectionpanel.cpp fieldselectiondlg.cpp pwsmenushortcuts.cpp \
 	$(YUBI_SRC) \
-	ManagePwdPolicies.cpp PasswordPolicy.cpp SelectionCriteria.cpp
+	ManagePwdPolicies.cpp PasswordPolicy.cpp SelectionCriteria.cpp \
+	TimedTaskChain.cpp
 
 
 OBJECTS=$(SOURCES:%.cpp=$(OBJECTPATH)/%.o)

--- a/src/ui/wxWidgets/TimedTaskChain.cpp
+++ b/src/ui/wxWidgets/TimedTaskChain.cpp
@@ -1,0 +1,165 @@
+#include "./TimedTaskChain.h"
+
+#ifndef __TESTING_TIMEDTASKCHAIN__
+#include "../../core/PWSprefs.h"
+#endif
+
+// static
+int TimedTaskChain::DefaultTaskDelay()
+{
+#ifndef __TESTING_TIMEDTASKCHAIN__
+    static const int defaultDelay = PWSprefs::GetInstance()->GetPref(PWSprefs::TimedTaskChainDelay);
+#else
+    static const int defaultDelay = 100;
+#endif
+    return defaultDelay;
+}
+
+
+// static
+TimedTaskChain& TimedTaskChain::CreateTaskChain(std::initializer_list<TaskType> tasks)
+{
+    return *new TimedTaskChain(tasks);
+}
+
+// static
+TimedTaskChain& TimedTaskChain::CreateTaskChain(const TaskType &task)
+{
+    return CreateTaskChain({task});
+}
+
+//static
+TimedTaskChain& TimedTaskChain::CreateTaskChain(std::initializer_list<TaskWithInterval> tasks)
+{
+    return *new TimedTaskChain(tasks);
+}
+
+
+TimedTaskChain::TimedTaskChain(std::initializer_list<TaskType> tasks):   m_errorHandler(nullptr)
+{
+    for (auto t: tasks)
+        m_tasks.push_back({t, DefaultTaskDelay()});
+
+    // even if m_tasks is empty
+    m_nextTask = m_tasks.begin();
+
+    // if m_tasks is empty, it would get destructed in the next timer callback
+    Next();
+}
+
+TimedTaskChain::TimedTaskChain(std::initializer_list<TaskWithInterval> tasks): m_errorHandler{nullptr},
+                                                                            m_tasks{tasks},
+                                                                            m_nextTask{m_tasks.begin()}
+{
+    Next();
+}
+
+void TimedTaskChain::Next()
+{
+    Start(m_nextTask->second, wxTIMER_ONE_SHOT);
+}
+
+void TimedTaskChain::RunTask()
+{
+    if (m_nextTask != m_tasks.end()) {
+        try {
+            m_nextTask->first();
+            m_nextTask++;
+        }
+        catch(std::exception& e) {
+            if (m_errorHandler)
+                m_errorHandler(e);
+
+            m_nextTask = m_tasks.end();
+        }
+        Next();
+    }
+    else {
+        delete this;
+    }
+}
+
+void TimedTaskChain::Notify()
+{
+    RunTask();
+}
+
+
+
+#ifdef __TESTING_TIMEDTASKCHAIN__
+#include <wx/app.h>
+#include <iostream>
+
+/*
+ * Use this to compile from vim
+ *
+ *      set makeprg=g++\ -std=c++11\ %\ `wx-config\ --cxxflags`\ `wx-config\ --libs`
+ *
+ * And this to run it from command-line
+ *
+ *      g++ -D__TESTING_TIMEDTASKCHAIN__ TimedTaskChain.cpp -std=c++11 `wx-config --cxxflags --libs`
+ *
+ *
+ */
+
+
+class TaskApp: public wxApp
+{
+    const char *errmsg{"Here we throw!"};
+    int total{0};
+    wxStopWatch watch;
+
+    void Quit()
+    {
+        static int testsRunning = TestsToRun.size();
+        if (--testsRunning == 0)
+            ExitMainLoop();
+    }
+
+    void TestSequentialExecution()
+    {
+		TimedTaskChain::CreateTaskChain( [this]() { total = 10; } )
+                                .then( [this]() { assert(total == 10); total *= 2; })
+								.then( [this]() { assert(total == 20); total += 3; })
+								.then( [this]() { assert(total == 23); total += 34; })
+                                .then( [this]() { assert(total == 57); Quit(); });
+    }
+
+    void TestErrorHandling()
+    {
+		TimedTaskChain::CreateTaskChain( [](void) {  } )
+                                .then( []() {  })
+								.then( [this]() { throw std::logic_error(this->errmsg); })
+								.then( []() { assert(!!"Task executed after exception was thrown!" ); })
+                                .OnError( [this](const std::exception& e) { assert(strcmp(e.what(), this->errmsg) == 0); Quit(); } );
+    }
+
+    void TestTaskDelays()
+    {
+        watch.Start();
+        TimedTaskChain::CreateTaskChain( {{[this](){ watch.Pause(); assert(watch.Time() >= 100); watch.Resume();}, 100}} )
+                                .then( [this](){ watch.Pause(); assert(watch.Time() >= 500); watch.Resume();}, 500 )
+                                .then( [this](){ watch.Pause(); assert(watch.Time() >= 50);  watch.Resume();}, 50  )
+                                .then( [this](){ watch.Pause(); assert(watch.Time() >= 300); Quit();}, 300 );
+    }
+
+    typedef std::mem_fun_t<void, TaskApp> TestFunction;
+    std::array<TestFunction, 3> TestsToRun ={ { std::mem_fun(&TaskApp::TestSequentialExecution),
+                                                std::mem_fun(&TaskApp::TestErrorHandling),
+                                                std::mem_fun(&TaskApp::TestTaskDelays)
+                                              }
+    };
+
+public:
+	bool OnInit()
+	{
+        for ( auto t: TestsToRun )
+            t(this);
+
+		return true;
+	}
+};
+
+wxIMPLEMENT_APP(TaskApp);
+
+#endif //__TESTING_TIMEDTASKCHAIN__

--- a/src/ui/wxWidgets/TimedTaskChain.h
+++ b/src/ui/wxWidgets/TimedTaskChain.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2003-2015 Rony Shapiro <ronys@users.sourceforge.net>.
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+
+////////////////////////////////////////////////////////////////////
+// TimedTaskChain.h - A timer driven single-threaded task chain,
+// somewhat like JavaScript promises. Each task is kicked off on receiving
+// a timer event. The current default is 100ms
+//
+// Basically, you can do this
+//
+// new TimedTaskChain( {task1, task2, task3...} )
+// 		.then( task )
+// 		.then( task )
+// 		.then( task )
+// 		...
+// 		.error( error_handler_functor );
+//
+// Each task is only invoked after the next timer event has been received
+// effectively ensuring that the current iteration of event loop has unwound.
+// Error handler (if set) is called as soon as an error happens.
+//
+// The purpose is similar to that of wxEvtHandler::CallAfter(), but
+// I have seen at least one instance where CallAfter didn't help:
+//
+// #1178 Linux autotype fails when "Minimize after Autotype" is not checked
+//
+// Somehow, pwsafe needs time to minimize itself, and not just unwind from
+// the current iteration of event loop. There could be other instances where
+// You might really need to wait for a finite amount of time, and not just
+// post a callback event to yourself.
+//
+// Note that the TimedTaskChain object must be created on the heap, so that
+// it does not get destroyed as the current call stack unwinds. Similarly,
+// it cannot be destructed at will. It will autodestruct once it finishes
+// executing all its tasks. Therefore, the ctor and dtor are private, and
+// it must be constructed via a public static funciton.
+//
+// Each task is a functor (regular function, lambda or a functor) that takes
+// and returns void. The error handler functor should take a std::exception
+// derived class as argument. Its is only invoked if any of the functions in
+// the task chain throws, in which case the rest of the tasks in the chain
+// are not invoked.
+
+
+#ifndef __TIMEDTASKCHAIN_H__
+#define __TIMEDTASKCHAIN_H__
+
+#include <list>
+#include <functional>
+#include <wx/timer.h>
+
+class TimedTaskChain: public wxTimer
+{
+	typedef std::function<void(void)> TaskType;
+    typedef std::pair<TaskType, int> TaskWithInterval;
+	typedef std::list<TaskWithInterval> TaskList;
+
+	typedef std::function<void(const std::exception&)> ErrorHandlerType;
+
+	ErrorHandlerType m_errorHandler;
+	TaskList m_tasks;
+	TaskList::iterator m_nextTask;
+
+	TimedTaskChain(std::initializer_list<TaskWithInterval> tasks);
+	TimedTaskChain(std::initializer_list<TaskType> tasks);
+    ~TimedTaskChain() {}
+
+    static int DefaultTaskDelay();
+
+public:
+	static TimedTaskChain& CreateTaskChain(std::initializer_list<TaskWithInterval> tasks);
+    static TimedTaskChain& CreateTaskChain(std::initializer_list<TaskType> tasks);
+    static TimedTaskChain& CreateTaskChain(const TaskType &tasks);
+
+	TimedTaskChain& then(const TaskType& task, int delay = DefaultTaskDelay() ) { m_tasks.push_back({task, delay}); return *this; }
+
+	void OnError(ErrorHandlerType errHandler) { m_errorHandler = errHandler; }
+
+    // overriden from wxTimer
+    void Notify();
+
+private:
+	void RunTask();
+	void Next();
+};
+
+
+
+#endif
+

--- a/src/ui/wxWidgets/passwordsafeframe.h
+++ b/src/ui/wxWidgets/passwordsafeframe.h
@@ -507,6 +507,10 @@ public:
   void DoRun(CItemData &item);
   void DoEmail(CItemData &item);
 
+  // These 3 fns are called via wxEvtHandler::CallAfter in sequence for autotyping
+  void MinimizeOrHideBeforeAutotyping();
+  void MaybeRestoreUI(bool autotype_err, wxString autotype_err_msg);
+
   template <class ExportType>
   void DoExportText();
 


### PR DESCRIPTION
This should fix http://sourceforge.net/p/passwordsafe/bugs/1178/. However, I don't know what broke it in the first place, even after debugging. The hiding/unhiding code has undergone a lot of changes by multiple authors and I even see use of mutexes in some places. However, I could find no difference between pwsafe's code flow and a simple test app. The test app worked (it could hide itself) but pwsafe didn't, with exactly the same set of function calls.

So this new code doesn't really fix what's broken (I don't even know  the what/when of it), but rather somehow ensures that the breakage cannot keep pwsafe from hiding itself.
