### PR TITLE
Fix autofocus on master password field in the startup dialog on Mac.

### DIFF
--- a/src/ui/wxWidgets/safecombinationentry.cpp
+++ b/src/ui/wxWidgets/safecombinationentry.cpp
@@ -66,6 +66,8 @@ IMPLEMENT_CLASS( CSafeCombinationEntry, wxDialog )
 BEGIN_EVENT_TABLE( CSafeCombinationEntry, wxDialog )
 
 ////@begin CSafeCombinationEntry event table entries
+  EVT_ACTIVATE( CSafeCombinationEntry::OnActivate )
+
   EVT_BUTTON( ID_ELLIPSIS, CSafeCombinationEntry::OnEllipsisClick )
 
   EVT_BUTTON( ID_NEWDB, CSafeCombinationEntry::OnNewDbClick )
@@ -163,6 +165,7 @@ void CSafeCombinationEntry::Init()
   m_YubiBtn = NULL;
   m_yubiStatusCtrl = NULL;
 #endif
+  m_postInitDone = false;
 ////@end CSafeCombinationEntry member initialisation
 }
 
@@ -272,13 +275,19 @@ void CSafeCombinationEntry::CreateControls()
   //  to hand back the string we just added
   wxCommandEvent cmdEvent(wxEVT_COMMAND_COMBOBOX_SELECTED, m_filenameCB->GetId());
   GetEventHandler()->AddPendingEvent(cmdEvent);
-  // if filename field not empty, set focus to password:
-  if (!m_filename.empty()) {
-    FindWindow(ID_COMBINATION)->SetFocus();
-  }
   SetIcons(wxGetApp().GetAppIcons());
 }
 
+void CSafeCombinationEntry::OnActivate( wxActivateEvent& event )
+{
+  if (!m_postInitDone) {
+    // if filename field not empty, set focus to password:
+    if (!m_filename.empty()) {
+      FindWindow(ID_COMBINATION)->SetFocus();
+    }
+    m_postInitDone = true;
+  }
+}
 
 /*!
  * Should we show tooltips?

--- a/src/ui/wxWidgets/safecombinationentry.h
+++ b/src/ui/wxWidgets/safecombinationentry.h
@@ -95,6 +95,9 @@ public:
 
   ////@begin CSafeCombinationEntry event handler declarations
 
+  /// wxEVT_ACTIVATE event handler to do post initialization
+  void OnActivate( wxActivateEvent& event );
+
   /// wxEVT_COMMAND_BUTTON_CLICKED event handler for ID_ELLIPSIS
   void OnEllipsisClick( wxCommandEvent& event );
 
@@ -151,6 +154,7 @@ private:
   bool m_readOnly;
   PWScore &m_core;
   unsigned m_tries;
+  bool m_postInitDone;
 
 #ifndef NO_YUBI
   wxTimer* m_pollingTimer; // for Yubi, but can't go into mixin :-(


### PR DESCRIPTION
wxWindow->SetFocus on Mac OS X works only if window already visible on screen.
So:
- move code for autoselect the master password field to EVT_ACTIVATE event handler for the dialog.
- guard the code to be called only once (in case user will change focus and switch between applications).