### PR TITLE
Fix window visibility on initial open, fix showing of system tray icon

### DIFF
--- a/src/ui/wxWidgets/passwordsafeframe.cpp
+++ b/src/ui/wxWidgets/passwordsafeframe.cpp
@@ -2618,6 +2618,16 @@ void PasswordSafeFrame::SetTrayStatus(bool locked)
   m_sysTray->SetTrayStatus(locked ? SystemTray::TRAY_LOCKED : SystemTray::TRAY_UNLOCKED);
 }
 
+void PasswordSafeFrame::SetTrayClosed()
+{
+  m_sysTray->SetTrayStatus(SystemTray::TRAY_CLOSED);
+}
+
+void PasswordSafeFrame::ShowTrayIcon()
+{
+  if (m_sysTray)
+    m_sysTray->ShowIcon();
+}
 
 void PasswordSafeFrame::OnOpenRecentDB(wxCommandEvent& evt)
 {

--- a/src/ui/wxWidgets/passwordsafeframe.h
+++ b/src/ui/wxWidgets/passwordsafeframe.h
@@ -438,6 +438,8 @@ public:
   wxString GetCurrentSafe() const { return towxstring(m_core.GetCurFile()); }
 
   void SetTrayStatus(bool locked);
+  void SetTrayClosed();
+  void ShowTrayIcon();
 
   ////@begin PasswordSafeFrame member variables
   PWSGrid* m_grid;

--- a/src/ui/wxWidgets/pwsafeapp.cpp
+++ b/src/ui/wxWidgets/pwsafeapp.cpp
@@ -437,7 +437,8 @@ bool PwsafeApp::OnInit()
   }
 
   RestoreFrameCoords();
-  m_frame->Show();
+  if (!cmd_silent)
+    m_frame->Show();
   if (cmd_minimized)
     m_frame->Iconize();
   else if (cmd_silent) {
@@ -452,10 +453,13 @@ bool PwsafeApp::OnInit()
     }
     else {
        m_core.SetCurFile(L"");
+       m_frame->SetTrayClosed();
     }
   } else {
     SetTopWindow(m_frame);
   }
+  if (PWSprefs::GetInstance()->GetPref(PWSprefs::UseSystemTray))
+    m_frame->ShowTrayIcon();
   return true;
 }
 


### PR DESCRIPTION
Issue #45
When using the -s switch, don't show the main window. This fixes the problem of the main window sometimes remaining visible when the program starts.
If the systray is being used, show the tray icon after all other initialization is done. This insures the tray icon's visible from the start even if the main window is never shown, rather than only being shown after the main window is closed for the first time.