### PR TITLE
Fix D&D involving Empty Groups

### DIFF
--- a/src/ui/Windows/PWTreeCtrl.h
+++ b/src/ui/Windows/PWTreeCtrl.h
@@ -141,7 +141,8 @@ private:
   
   CSecString m_eLabel; // label at start of edit, if we need to revert
 
-  bool MoveItem(MultiCommands *pmulticmds, HTREEITEM hitem, HTREEITEM hNewParent);
+  bool MoveItem(MultiCommands *pmulticmds, HTREEITEM hitem, HTREEITEM hNewParent,
+    const StringX &sxPprefix);
   bool CopyItem(HTREEITEM hitem, HTREEITEM hNewParent, const CSecString &prefix);
   bool IsChildNodeOf(HTREEITEM hitemChild, HTREEITEM hitemSuspectedParent) const;
   bool ExistsInTree(HTREEITEM &node, const CSecString &s, HTREEITEM &si) const; 


### PR DESCRIPTION
Note: Only tested D&D within the same instance so far but might work between instances too.