### PR TITLE
Fix errors in ::GetFileTimes for Mac OS X

### DIFF
--- a/src/os/mac/file.cpp
+++ b/src/os/mac/file.cpp
@@ -366,17 +366,17 @@ ulong64 pws_os::fileLength(std::FILE *fp)
 bool pws_os::GetFileTimes(const stringT &filename,
 			time_t &ctime, time_t &mtime, time_t &atime)
 {
-  struct stat info;
+  struct stat statbuf;
   int status;
   size_t N = wcstombs(NULL, filename.c_str(), 0) + 1;
   char *fn = new char[N];
   wcstombs(fn, filename.c_str(), N);
-  int status = ::stat(fn, &statbuf);
+  status = ::stat(fn, &statbuf);
   delete[] fn;
   if (status == 0) {
-    ctime = info.st_ctime;
-    mtime = info.st_mtime;
-        atime = info.st_atime;
+    ctime = statbuf.st_ctime;
+    mtime = statbuf.st_mtime;
+    atime = statbuf.st_atime;
     return true;
   } else {
     return false;


### PR DESCRIPTION
Parallel other use of 'statbuf' rather than 'info' in
::(fn, &statbuf)



As described in [Ticket #1321](https://sourceforge.net/p/passwordsafe/bugs/1321/), *src/os/mac/file.cpp* does not compile under Mac OS X 10.11.2 with Xcode 7.2
* *&statbuf* is not defined
* *status* is declared twice

This change allows this specific file to compile.

Not that I cannot yet verify the functionality as the project does not successfully build. *Generate version.h* does not appear to run, causing problems with *About.cpp* missing *version.h*
