### PR TITLE
Fix cmake build on Linux without yubikey lib (NO_YUBI option)

### DIFF
--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -46,7 +46,6 @@ if (WIN32)
   elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set (OS_SRCS
     linux/KeySend.cpp
-    linux/PWYubi.cpp
     linux/UUID.cpp
     linux/debug.cpp
     linux/dir.cpp
@@ -65,10 +64,15 @@ if (WIN32)
     linux/utf8conv.cpp
     linux/xsendstring.cpp
     )
+  set (OS_YUBI_SRC linux/PWYubi.cpp)
 else()
   message (FATAL_ERROR "Unsupported OS "
     ${CMAKE_SYSTEM_NAME}
     " - can't build OS library")
+endif()
+
+if(HAVE_YKPERS_H)
+    list(APPEND OS_SRC ${OS_YUBI_SRC})
 endif()
 
 add_library(os ${OS_SRCS})


### PR DESCRIPTION
When I try to build project on Linux with cmake
```sh
mkdir build && cd build
cmake -GNinja -DNO_YUBI=YES ..
```
, it failed to compile `src/os/linux/PWYubi.c`. `src/os/linux/Makefile` has logic to exclude this file from build with yubikey support disabled.
So this patch implement same logic for cmake build.