### PR TITLE
Fix saving current (V3 or V4) DB after previously exporting to V1 or …

### DIFF
--- a/src/ui/Windows/MainFile.cpp
+++ b/src/ui/Windows/MainFile.cpp
@@ -1491,7 +1491,7 @@ void DboxMain::OnExportVx(UINT nID)
   const PWSfileHeader saved_hdr = m_core.GetHeader();
 
   // Now export it in the requested version
-  rc = m_core.WriteFile(newfile, export_version);
+  rc = m_core.WriteFile(newfile, export_version, false);
 
   // Restore current database header
   m_core.SetHeader(saved_hdr);


### PR DESCRIPTION
…V2 format

Incorrectly calculating file signature causing issue creating intermediate backup