### PR TITLE
Fix cmake build on Linux with yubikey lib

### DIFF
--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -72,7 +72,7 @@ else()
 endif()
 
 if(HAVE_YKPERS_H)
-    list(APPEND OS_SRC ${OS_YUBI_SRC})
+    list(APPEND OS_SRCS ${OS_YUBI_SRC})
 endif()
 
 add_library(os ${OS_SRCS})


### PR DESCRIPTION
Commit e12b2f64717efa18589784f78894303ebaedf2a5 included a typo that resulted in a failing build of pwsafe with Yubikey support on Linux.