### PR TITLE
Prevent double click on CRichEditExtn doesn't include trailing white …

### DIFF
--- a/src/ui/Windows/ControlExtns.cpp
+++ b/src/ui/Windows/ControlExtns.cpp
@@ -451,6 +451,7 @@ BEGIN_MESSAGE_MAP(CRichEditExtn, CRichEditCtrl)
   ON_WM_CONTEXTMENU()
   ON_WM_LBUTTONDOWN()
   ON_WM_SETCURSOR()
+  ON_WM_LBUTTONDBLCLK()
   //}}AFX_MSG_MAP
 END_MESSAGE_MAP()
 
@@ -469,6 +470,24 @@ void CRichEditExtn::SetSel(long nStartChar, long nEndChar)
   m_nStartChar = nStartChar;
   m_nEndChar = nEndChar;
   CRichEditCtrl::SetSel(nStartChar, nEndChar);
+}
+
+void CRichEditExtn::OnLButtonDblClk(UINT nFlags, CPoint point)
+{
+  long nStartChar, nEndChar;
+
+  // Do what ever would normally happen
+  CRichEditCtrl::OnLButtonDblClk(nFlags, point);
+
+  // Get selection
+  CRichEditCtrl::GetSel(nStartChar, nEndChar);
+
+  // Check if this included a trailing whitespace and, if so, trim it
+  CString csTemp = GetSelText();
+  csTemp.TrimRight();
+
+  // Reselect without trailing whitespace
+  SetSel(nStartChar, nStartChar + csTemp.GetLength());
 }
 
 void CRichEditExtn::OnSetFocus(CWnd* pOldWnd)

--- a/src/ui/Windows/ControlExtns.h
+++ b/src/ui/Windows/ControlExtns.h
@@ -171,6 +171,7 @@ protected:
   afx_msg void OnContextMenu(CWnd *pWnd, CPoint point);
   afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
   afx_msg BOOL OnSetCursor(CWnd *pWnd, UINT nHitTest, UINT message);
+  afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
   //}}AFX_MSG
 
   DECLARE_MESSAGE_MAP()


### PR DESCRIPTION
…space

See SR 463 double click puts blank into the clipboard unintendedly