### PR TITLE
gtest-related makefile enhancements:

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -19,7 +19,7 @@ export RELEASENAME := $(RELEASENUM)$(RELEASE_SPECIAL)
 .PHONY:    all clean debug-clean release-clean debug release \
 	unicodedebug unicoderelease deb rpm rpmbuild tar signatures \
 	dist sha1sums upload upload-sf upload-src-sf upload-github git-tag I18N \
-	help test
+	help test debug-test release-test
 
 RELEASEDIR := ./Releases/
 
@@ -63,11 +63,13 @@ debug-clean:
 	$(MAKE) CONFIG=unicodedebug -C src/os/linux clean
 	$(MAKE) CONFIG=unicodedebug -C src/core clean
 	$(MAKE) CONFIG=unicodedebug -C src/ui/wxWidgets clean
+	$(MAKE) CONFIG=unicodedebug -C src/test clean
 
 release-clean:
 	$(MAKE) CONFIG=unicoderelease -C src/os/linux clean
 	$(MAKE) CONFIG=unicoderelease -C src/core clean
 	$(MAKE) CONFIG=unicoderelease -C src/ui/wxWidgets clean
+	$(MAKE) CONFIG=unicoderelease -C src/test clean
 
 # dist prepares stuff for upload - deprecated for Linux, until
 # we find an elegant way to tell deb and rpm distros apart.
@@ -131,8 +133,14 @@ I18N:
 help:
 	$(MAKE) -C help
 
-test:
-	$(MAKE) -C src/test test
+test: debug-test
+
+debug-test:
+	$(MAKE) CONFIG=unicodedebug -C src/test
+
+release-test:
+	$(MAKE) CONFIG=unicoderelease -C src/test
+
 
 # Local variables:
 # mode: makefile

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -1,7 +1,9 @@
 # Baby Makefile for Linux
 #
 
-BUILD			:= unicodedebug
+CONFIG ?=unicodedebug
+
+BUILD			:= $(CONFIG)
 
 TESTSRC         := coretest.cpp $(wildcard *Test.cpp)
 
@@ -12,8 +14,11 @@ INCPATH         = ..
 
 # libgtest: Packages do not include a compiled library.
 # Debian's package installs source in /usr/src/gtest
-# I built the package there using cmake in /usr/src/gtest/build
-LIBGTESTPATH = /usr/src/gtest/build
+GTEST_DIR     = /usr/src/gtest
+GTEST_HEADERS = /usr/include/gtest/*.h \
+				/usr/include/gtest/internal/*.h
+GTEST_SRCS_   = $(GTEST_DIR)/src/*.cc \
+				$(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
 
 #destination related macros
 TESTOBJ	 = $(addprefix $(OBJPATH)/,$(subst .cpp,.o,$(TESTSRC)))
@@ -21,7 +26,7 @@ TEST	 = $(BINPATH)/coretest
 OBJ	     = $(TESTOBJ) $(LIBOBJ)
 
 CXXFLAGS += -DUNICODE -Wall -I$(INCPATH) -std=c++11
-LDFLAGS   = -L$(LIBPATH) -L$(LIBGTESTPATH) -lcore -luuid -los -lcore -lxerces-c -lgtest -pthread
+LDFLAGS   = -L$(LIBPATH) -lcore -luuid -los -lcore -lxerces-c -pthread
 
 # rules
 .PHONY: all clean test run setup
@@ -32,16 +37,24 @@ $(OBJPATH)/%.o : %.c
 $(OBJPATH)/%.o : %.cpp
 	$(CXX) -g $(CXXFLAGS) -c $< -o $@
 
-all : setup test
+all : setup test gtest.a
+
+gtest-all.o: $(GTEST_SRCS_) $(GTEST_HEADERS)
+	$(CXX) -g $(CPPFLAGS) -I$(GTEST_DIR) $(CXXFLAGS) -c \
+		$(GTEST_DIR)/src/gtest-all.cc
+
+gtest.a: gtest-all.o
+	$(AR) $(ARFLAGS) $@ $^
+
 
 run test : $(TEST)
 	$(TEST)
 
-$(TEST): $(LIB) $(TESTOBJ)
-	$(CXX) -g $(CXXFLAGS) $(filter %.o,$^) $(LDFLAGS) -o $@
+$(TEST): $(LIB) $(TESTOBJ) gtest.a
+	$(CXX) -g $(CXXFLAGS) $(filter %.o,$^) $(LDFLAGS) gtest.a -o $@
 
 clean:
-	rm -f *~ $(OBJ) $(TEST) $(DEPENDFILE)
+	rm -f *~ $(OBJ) $(TEST) $(DEPENDFILE) gtest-all.o gtest.a
 
 setup:
 	@mkdir -p $(OBJPATH) $(LIBPATH) $(BINPATH)


### PR DESCRIPTION
* Automatically build gtest lib in-tree during build (instead of
    requiring it be manually built beforehand)
* Allow test build/run for release builds
* Add test dir to top-level clean targets