### PR TITLE
Fix autotype for level3+ keysyms: German Autotype Fix

### DIFF
--- a/CodeLite/PasswordSafe.workspace
+++ b/CodeLite/PasswordSafe.workspace
@@ -7,21 +7,25 @@
   <Project Name="Windows" Path="Windows.project" Active="No"/>
   <BuildMatrix>
     <WorkspaceConfiguration Name="Debug" Selected="no">
+      <Environment/>
       <Project Name="pwsafe" ConfigName="Debug"/>
       <Project Name="os" ConfigName="Debug"/>
       <Project Name="core" ConfigName="Debug"/>
     </WorkspaceConfiguration>
     <WorkspaceConfiguration Name="Release" Selected="no">
+      <Environment/>
       <Project Name="pwsafe" ConfigName="Release"/>
       <Project Name="os" ConfigName="Release"/>
       <Project Name="core" ConfigName="Release"/>
     </WorkspaceConfiguration>
     <WorkspaceConfiguration Name="DebugX" Selected="yes">
+      <Environment/>
       <Project Name="pwsafe" ConfigName="DebugX"/>
       <Project Name="os" ConfigName="DebugX"/>
       <Project Name="core" ConfigName="DebugX"/>
     </WorkspaceConfiguration>
     <WorkspaceConfiguration Name="ReleaseX" Selected="no">
+      <Environment/>
       <Project Name="pwsafe" ConfigName="ReleaseX"/>
       <Project Name="os" ConfigName="ReleaseX"/>
       <Project Name="core" ConfigName="ReleaseX"/>

--- a/CodeLite/core.project
+++ b/CodeLite/core.project
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <CodeLite_Project Name="core" InternalType="Library">
   <Plugins>
+    <Plugin Name="qmake">
+      <![CDATA[00060001N0005Debug0000000000000001N0006DebugE0000000000000001N0006DebugX0000000000000001N0007Release0000000000000001N0008ReleaseE0000000000000001N0008ReleaseX000000000000]]>
+    </Plugin>
     <Plugin Name="CMakePlugin">
       <![CDATA[[{
   "name": "DebugX",
@@ -21,9 +24,6 @@
   "arguments": [],
   "parentProject": ""
  }]]]>
-    </Plugin>
-    <Plugin Name="qmake">
-      <![CDATA[00060001N0005Debug0000000000000001N0006DebugE0000000000000001N0006DebugX0000000000000001N0007Release0000000000000001N0008ReleaseE0000000000000001N0008ReleaseX000000000000]]>
     </Plugin>
   </Plugins>
   <VirtualDirectory Name="XML">
@@ -130,6 +130,20 @@
     <File Name="../src/core/DBCompareData.h"/>
     <File Name="../src/core/PWSLog.cpp"/>
     <File Name="../src/core/PWSLog.h"/>
+    <File Name="../src/core/Item.cpp"/>
+    <File Name="../src/core/Item.h"/>
+    <File Name="../src/core/ItemAtt.cpp"/>
+    <File Name="../src/core/ItemAtt.h"/>
+    <File Name="../src/core/PWSfileV4.cpp"/>
+    <File Name="../src/core/PWSfileV4.h"/>
+    <File Name="../src/core/PWStime.cpp"/>
+    <File Name="../src/core/PWStime.h"/>
+    <File Name="../src/core/PWSfileHeader.cpp"/>
+    <File Name="../src/core/PWSfileHeader.h"/>
+    <File Name="../src/core/KeyWrap.cpp"/>
+    <File Name="../src/core/KeyWrap.h"/>
+    <File Name="../src/core/pbkdf2.cpp"/>
+    <File Name="../src/core/pbkdf2.h"/>
   </VirtualDirectory>
   <Dependencies Name="Release"/>
   <Dependencies Name="Debug"/>

--- a/CodeLite/os.project
+++ b/CodeLite/os.project
@@ -52,6 +52,7 @@
     <File Name="../src/os/linux/unicode2keysym.cpp"/>
     <File Name="../src/os/linux/unicode2keysym.h"/>
     <File Name="../src/os/linux/logit.cpp"/>
+    <File Name="../src/os/linux/media.cpp"/>
   </VirtualDirectory>
   <VirtualDirectory Name="os">
     <File Name="../src/os/env.h"/>

--- a/CodeLite/pwsafe.project
+++ b/CodeLite/pwsafe.project
@@ -209,7 +209,7 @@
 ../src/ui/wxWidgets/version.h: ../src/ui/wxWidgets/version.in
 	../Misc/mkversion.pl ../src/ui/wxWidgets/version.in ../src/ui/wxWidgets/version.h</CustomPreBuild>
       </AdditionalRules>
-      <Completion EnableCpp11="no">
+      <Completion EnableCpp11="no" EnableCpp14="no">
         <ClangCmpFlagsC/>
         <ClangCmpFlags/>
         <ClangPP/>
@@ -263,10 +263,9 @@ dir /usr/src/gtk+2.0-2.18.3/gdk
 #dummy line to keep CodeLite from stripping the TAB from the next line
 	
 ../src/ui/wxWidgets/version.h: ../src/ui/wxWidgets/version.in
-	../Misc/mkversion.pl ../src/ui/wxWidgets/version.in ../src/ui/wxWidgets/version.h
-</CustomPreBuild>
+	../Misc/mkversion.pl MAJOR=0 MINOR=98 SPECIAL=BETA ../src/ui/wxWidgets/version.in ../src/ui/wxWidgets/version.h</CustomPreBuild>
       </AdditionalRules>
-      <Completion EnableCpp11="no">
+      <Completion EnableCpp11="no" EnableCpp14="no">
         <ClangCmpFlagsC/>
         <ClangCmpFlags/>
         <ClangPP/>
@@ -317,7 +316,7 @@ dir /usr/src/gtk+2.0-2.18.3/gdk
 ../src/ui/wxWidgets/version.h: ../src/ui/wxWidgets/version.in
 	../Misc/mkversion.pl ../src/ui/wxWidgets/version.in ../src/ui/wxWidgets/version.h</CustomPreBuild>
       </AdditionalRules>
-      <Completion EnableCpp11="no">
+      <Completion EnableCpp11="no" EnableCpp14="no">
         <ClangCmpFlagsC/>
         <ClangCmpFlags/>
         <ClangPP/>
@@ -370,9 +369,10 @@ dir ../wx/src</StartupCommands>
 #dummy line to prevent CodeLite from stripping the TAB from the next line
 	
 ../src/ui/wxWidgets/version.h: ../src/ui/wxWidgets/version.in
-	../Misc/mkversion.pl ../src/ui/wxWidgets/version.in ../src/ui/wxWidgets/version.h</CustomPreBuild>
+	../Misc/mkversion.pl MAJOR=0 MINOR=98 SPECIAL=BETA ../src/ui/wxWidgets/version.in ../src/ui/wxWidgets/version.h
+</CustomPreBuild>
       </AdditionalRules>
-      <Completion EnableCpp11="no">
+      <Completion EnableCpp11="no" EnableCpp14="no">
         <ClangCmpFlagsC/>
         <ClangCmpFlags/>
         <ClangPP/>

--- a/src/core/PWSprefs.cpp
+++ b/src/core/PWSprefs.cpp
@@ -169,6 +169,8 @@ const PWSprefs::intPref PWSprefs::m_int_prefs[NumIntPrefs] = {
                             1, 60000},                              // application
   {_T("DlgOrientation"), AUTO, ptApplication, AUTO, WIDE},         // application
   {_T("TimedTaskChainDelay"), 100, ptApplication, -1, -1},         // application
+  {_T("AutotypeSelectAllKeyCode"), 0, ptApplication, 0, 255},         // application
+  {_T("AutotypeSelectAllModMask"), 0, ptApplication, 0, 255},         // application
 };
 
 const PWSprefs::stringPref PWSprefs::m_string_prefs[NumStringPrefs] = {

--- a/src/core/PWSprefs.h
+++ b/src/core/PWSprefs.h
@@ -133,6 +133,7 @@ public:
     PWLowercaseMinLength, PWSymbolMinLength, PWUppercaseMinLength,
     OptShortcutColumnWidth, ShiftDoubleClickAction, DefaultAutotypeDelay,
     DlgOrientation, TimedTaskChainDelay,
+    AutotypeSelectAllKeyCode, AutotypeSelectAllModMask, //X only
     NumIntPrefs};
 
   enum StringPrefs {CurrentBackup, CurrentFile, LastView, DefaultUsername,

--- a/src/os/linux/KeySend.cpp
+++ b/src/os/linux/KeySend.cpp
@@ -11,7 +11,26 @@
 #include "../../core/Util.h"
 #include "../../core/PWSprefs.h"
 
-static bool GetPref(PWSprefs::BoolPrefs pref) {
+template <typename EnumType>
+class PrefT;
+
+template <>
+struct PrefT<PWSprefs::BoolPrefs> {
+  typedef bool type;
+};
+
+template <>
+struct PrefT<PWSprefs::IntPrefs> {
+  typedef int type;
+};
+
+template <>
+struct PrefT<PWSprefs::StringPrefs> {
+  typedef StringX type;
+};
+
+template <typename PrefEnum, typename Ret = typename PrefT<PrefEnum>::type >
+static Ret GetPref(PrefEnum pref) {
   return PWSprefs::GetInstance()->GetPref(pref);
 }
 
@@ -75,7 +94,8 @@ void CKeySend::ResetKeyboardState() const
 
 void CKeySend::SelectAll() const
 {
-  m_impl->SelectAll(m_delayMS);
+  m_impl->SelectAll(m_delayMS, GetPref(PWSprefs::AutotypeSelectAllKeyCode),
+                    GetPref(PWSprefs::AutotypeSelectAllModMask));
 }
 
 void CKeySend::EmulateMods(bool emulate)

--- a/src/os/linux/xsendstring.cpp
+++ b/src/os/linux/xsendstring.cpp
@@ -7,7 +7,8 @@
 */
 
 /*
- * xsendstring - send a bunch of keystrokes to the app having current input focus
+ * xsendstring - send a bunch of keystrokes to the app having current input
+ *focus
  *
  * Calls X library functions defined in Xt and Xtst
  *
@@ -30,6 +31,9 @@
 #include <memory>
 #include <algorithm>
 #include <functional>
+#include <fstream>
+#include <sstream>
+#include <map>
 
 #include <X11/Intrinsic.h> // in libxt-dev
 #include <X11/keysym.h>
@@ -41,290 +45,282 @@
 #include "../../core/StringX.h"
 #include "./unicode2keysym.h"
 
-// We convert all chars in a string to a keycode and a set of modifier keys (like Shift)
-typedef struct _KeyPress {
-  KeyCode code;
-  unsigned int state;
-} KeyPressInfo;
-
 // X errors are reported via asynchronous callbacks, which we store here
-struct AutotypeGlobals
-{
-  Boolean      error_detected;
-  char      errorString[1024];
-} atGlobals  = { False, {0} };
+std::ostringstream g_xerrormsg;
 
-// We throw this exception when we detect something in atGlobals above
-class autotype_exception: public std::exception
-{
-  public:
-  virtual const char* what() const throw() {
-    return atGlobals.errorString;
-  }
+std::ostream &operator<<(std::ostream &os, unsigned char c) {
+  return os << std::showbase << std::hex << static_cast<int>(c);
+}
+// When something goes wrong, we write our error message to g_xerrormsg
+// above and throw this exception. We also throw this exception if we
+// notice that it has some data (that got there by XErrorHandler below)
+class autotype_exception : public std::exception {
+  std::string msg; // we get this from g_xerrormsg above
+public:
+  autotype_exception() : msg(g_xerrormsg.str()) {}
+  const char *what() const throw() override { return msg.c_str(); }
 };
 
 /*
  * ErrorHandler will be called when X detects an error. This function
- * just sets a global flag and saves the error message text
+ * just saves the error message text
  */
-int ErrorHandler(Display *my_dpy, XErrorEvent *event)
-{
-  char xmsg[512] = {0};
+int ErrorHandler(Display *my_dpy, XErrorEvent *event) {
+  char xmsg[512] = { 0 };
 
-  atGlobals.error_detected = TRUE;
   XGetErrorText(my_dpy, event->error_code, xmsg, NumberOf(xmsg) - 1);
-  snprintf(atGlobals.errorString, NumberOf(atGlobals.errorString)-1, "X error (%d): %s", event->request_code, xmsg);
+
+  g_xerrormsg << "X error (" << event->request_code << "): " << xmsg
+              << std::endl;
   return 0;
 }
 
+class XErrorHandlerInstaller {
 
+  typedef int(XErrorHandler)(Display *, XErrorEvent *);
+  XErrorHandler *m_pfnOldErrorHandler;
+
+public:
+  XErrorHandlerInstaller()
+      : m_pfnOldErrorHandler(XSetErrorHandler(ErrorHandler)) {}
+
+  ~XErrorHandlerInstaller() { XSetErrorHandler(m_pfnOldErrorHandler); }
+};
+
+enum class KeyEventType { PRESS, RELEASE };
 
 // A simple helper class
-class AutotypeEvent: public XKeyEvent {
+class AutotypeEvent : public XKeyEvent {
 public:
-  AutotypeEvent(Display *disp)
-  {
+  AutotypeEvent(Display *disp, KeyEventType ktype, int kcode, int kstate,
+                Time ktime = CurrentTime) {
     display = disp;
-    int    revert_to;
+    int revert_to;
     XGetInputFocus(display, &window, &revert_to);
     subwindow = None;
     x = y = x_root = y_root = 1;
     same_screen = True;
+    state = kstate;
+    keycode = kcode;
+    type = ktype == KeyEventType::PRESS? KeyPress: KeyRelease;
+    time = ktime;
+  }
+
+  bool IsPressed() const { return type == KeyPress; }
+};
+
+// helper method that throws if keysym is not mapped to any KeyCode
+KeyCode KeySymToKeyCode(Display *disp, KeySym sym);
+
+// These two classes help with RAII
+class XKeyboardMapping {
+  KeySym *symlist;
+  int keysyms_per_keycode;
+
+public:
+  XKeyboardMapping(Display *disp, KeyCode code)
+      : symlist(XGetKeyboardMapping(disp, code, 1, &keysyms_per_keycode)) {
+    if (!symlist) {
+      g_xerrormsg << "Could not get X keyboard mapping for keycode " << std::hex
+                  << std::showbase << code;
+      throw autotype_exception();
+    }
+  }
+  ~XKeyboardMapping() { XFree(symlist); }
+  size_t IndexOf(KeySym sym) const {
+    return std::find(symlist, symlist + keysyms_per_keycode, sym) - symlist;
+  }
+};
+
+////////////////////////////////////////////////
+// X ModMap has a fixed mapping between the index (0 - 8)
+// of a modifier in the modmap, and the mask associated
+// with that modifier. And we need to search the modmap
+// by both. This class encapsulates that mapping between
+// the index and mask of the modifier, the class invariant
+// being a valid mapping between the two
+class XModPos {
+public:
+  enum ModMapIndex : unsigned char {
+    MODMAP_INDEX_SHIFT = ShiftMapIndex,
+    MODMAP_INDEX_LOCK = LockMapIndex,
+    MODMAP_INDEX_CONTROL = ControlMapIndex,
+    MODMAP_INDEX_MOD1 = Mod1MapIndex,
+    MODMAP_INDEX_MOD2 = Mod2MapIndex,
+    MODMAP_INDEX_MOD3 = Mod3MapIndex,
+    MODMAP_INDEX_MOD4 = Mod4MapIndex,
+    MODMAP_INDEX_MOD5 = Mod5MapIndex,
+  };
+
+private:
+  unsigned char m_index;
+
+public:
+  explicit XModPos(ModMapIndex i) : m_index(i) {}
+
+  unsigned char index() const { return m_index; }
+  unsigned char mask() const { return 1 << m_index; }
+
+  bool last() const { return m_index == MODMAP_INDEX_MOD5; }
+
+  XModPos operator++() { return operator+=(1); }
+
+  XModPos &operator+=(unsigned char offset) {
+    if ((m_index + offset) <= MODMAP_INDEX_MOD5) {
+      m_index += offset;
+    } else {
+      g_xerrormsg << "attempt to offset modmap index at " << m_index << " by "
+                  << offset;
+      throw autotype_exception();
+    }
+    return *this;
+  }
+};
+
+class XModMap {
+  XModifierKeymap *modmap;
+
+public:
+  explicit XModMap(Display *disp) : modmap(XGetModifierMapping(disp)) {
+    if (!disp) {
+      g_xerrormsg << "Could not get X modifier map";
+      throw autotype_exception();
+    }
+  }
+  ~XModMap() { XFreeModifiermap(modmap); }
+
+  KeyCode ModifierKeyCode(XModPos pos) const {
+    const KeyCode *start =
+        modmap->modifiermap + pos.index() * modmap->max_keypermod;
+    const KeyCode *pkc = std::find_if_not(start, start + modmap->max_keypermod,
+                                          [](KeyCode c) { return c == 0; });
+    if (pkc == start + modmap->max_keypermod) {
+      // This is not an error. A KeyCode doesn't have to be mapped to each
+      // modifier index
+      return 0;
+    }
+    return *pkc;
+  }
+
+  XModPos IndexOf(KeyCode code) const {
+    const auto keys = modmap->modifiermap,
+               keys_end = modmap->modifiermap + 8 * modmap->max_keypermod;
+    const auto keyptr =
+        std::find_if(keys, keys_end, [code](KeyCode k) { return k == code; });
+    if (keyptr != keys_end) {
+      XModPos pos{ XModPos::MODMAP_INDEX_SHIFT };
+      pos += ((keyptr - keys) / modmap->max_keypermod - ShiftMapIndex);
+      return pos;
+    }
+    g_xerrormsg << "Could not find KeyCode " << code << " in modifier map";
+    throw autotype_exception();
   }
 };
 
 //////////////////////////////////////////////////////////////////////////////////////
-// AutotypeMethodBase
+// ModifierKey
 //
-// Base class for the various ways to emulate keystrokes that result in a keyboard
-// event interpreted by the receiving application as the intended character.
+// A keycode and the mask it generates, deduced from XModifierMap. You can
+// either create it from a fixed position in the XModifierMap, or from a
+// KeySym that is mapped to some KeyCode that's there in the XModifierMap
 //
-// This class takes care of wchar_t => KeySym => (KeyCode, Modifiers) combination, and
-// generates the key-up & key-down events in the required order to generate the
-// character being auto-typed.  The derived classes only need to implement the
-// virtual GenerateKeyEvent() member that emulates a single keystroke
+struct ModifierKey {
+  KeyCode code;
+  int mask;
+  using klist = std::vector<KeyEventType>;
+  klist set_events, unset_events;
 
-class AutotypeMethodBase
-{
-  // We use this array to look up modifier keycodes from modifier masks
-  struct ModInfo {
-    // These enums are uses as array index in SetModifiers() method below
-    // Don't change their values!!
-    enum ModType {Shift /*press and hold*/, Lock, Latch, Unknown};
-
-    int mask;
-    int ModMapIndex;
-    KeySym sym;
-    KeyCode key;
-    ModType type;
-
-  }  m_mods[8] =    {{ShiftMask,   ShiftMapIndex,   XK_Shift_L,   0, ModInfo::Shift},
-                     {LockMask,    LockMapIndex,    XK_Caps_Lock, 0, ModInfo::Lock},
-                     {ControlMask, ControlMapIndex, XK_Control_L, 0, ModInfo::Shift},
-                     {Mod1Mask,    Mod1MapIndex,    NoSymbol,     0, ModInfo::Unknown},
-                     {Mod2Mask,    Mod2MapIndex,    NoSymbol,     0, ModInfo::Unknown},
-                     {Mod3Mask,    Mod3MapIndex,    NoSymbol,     0, ModInfo::Unknown},
-                     {Mod4Mask,    Mod4MapIndex,    NoSymbol,     0, ModInfo::Unknown},
-                     {Mod5Mask,    Mod5MapIndex,    NoSymbol,     0, ModInfo::Unknown},
-                   };
-
-  void InitModInfo();
-
-protected:
-  Display *m_display;
-  bool     m_emulateMods = true;
+  ModifierKey(klist set_ev, klist unset_ev)
+      : code(0), mask(0), set_events(std::move(set_ev)),
+        unset_events(std::move(unset_ev)) {}
 
 public:
-  AutotypeMethodBase(Display *display, bool emulateMods):
-			m_display(display), m_emulateMods(emulateMods) {
-	XSetErrorHandler(ErrorHandler);
-	atGlobals.error_detected = false;
-  InitModInfo();
+  ModifierKey(Display *disp, XModPos pos, klist set_events = { KeyEventType::PRESS },
+              klist unset_events = { KeyEventType::RELEASE });
+  ModifierKey(Display *disp, KeySym ks, klist set_events = { KeyEventType::PRESS },
+              klist unset_events = { KeyEventType::RELEASE });
+  ModifierKey(Display *disp, KeyCode code, int mask,
+              klist set_events = { KeyEventType::PRESS },
+              klist unset_events = { KeyEventType::RELEASE });
+
+  bool IsValid() const {
+    return code != 0 && (mask != 0 && (mask == 1 || mask % 2 == 0));
   }
-
-  // virtual, because derived classes will have clean-ups of their own
-  virtual ~AutotypeMethodBase() {
-	  XSetErrorHandler(NULL);
-  }
-
-  // This function does the most heavy lifting, using the bare minimum api-specific
-  // support from derived classes implemented by overriding GenerateKeyEvent
-  void operator()(unsigned int keycode, unsigned int state, Time event_time = CurrentTime);
-  void operator()(XKeyEvent &ev);
-
-  bool EmulatesMods() const { return m_emulateMods; }
-  void EmulateMods(bool emulate) { m_emulateMods = emulate; }
-
-protected:
-  // This is not exposed as it will probably not do what you think.  Use SendKeyEvent above
-  virtual void GenerateKeyEvent(XKeyEvent *ev) = 0;
-
-  void PressModifiers(int masks) { SetModifiers(masks, true); }
-  void ReleaseModifiers(int masks) { SetModifiers(masks, false); }
-  void SetModifiers(int masks, bool set);
 };
 
-///////////////////////////////////////////////////////////////////////
-// For each modifier, finds the keycode that generates that modifier
-// and the type (shift, latch, etc) because that dictates what kind
-// of key events are required to use that modifier.
+ModifierKey::ModifierKey(Display *disp, XModPos pos, klist set_events,
+                         klist unset_events)
+    : ModifierKey(set_events, unset_events) {
+  XModMap modmap(disp);
+  // we can cheat safely now that index is known to be one of 1 - 8
+  mask = pos.mask();
+  code = modmap.ModifierKeyCode(pos);
+  if (code == 0) {
+    // if we are asked for a modifier at a specific index, it better be mapped
+    g_xerrormsg << "No KeyCode mapped to index " << pos.index();
+    throw autotype_exception();
+  }
+}
+
+ModifierKey::ModifierKey(Display *disp, KeySym ks, klist set_events,
+                         klist unset_events)
+    : ModifierKey(set_events, unset_events) {
+  XModMap modmap(disp);
+  code = KeySymToKeyCode(disp, ks);
+  const XModPos pos = modmap.IndexOf(code);
+  mask = pos.mask();
+}
+
+ModifierKey::ModifierKey(Display *disp, KeyCode kcode, int kmask,
+                         klist set_events, klist unset_events)
+    : ModifierKey(set_events, unset_events) {
+  code = kcode;
+  mask = kmask;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////
+// AutotypeMethodBase
 //
-// The KeySym is generated in the process and is needed for initialization,
-// but is not used afterwards
-void AutotypeMethodBase::InitModInfo()
-{
-  XModifierKeymap* modmap = XGetModifierMapping(m_display);
-  if (modmap) {
-    for(auto& m: m_mods) {
-      if (m.key == 0) {
-        if (m.sym != NoSymbol) {
-          // If we know the KeySym associated with the modifier, things are easy
-          m.key = XKeysymToKeycode(m_display, m.sym);
-        }
-        if (!m.key) {
-          // Either the KeySym is unknown, or XKeysymToKeycode failed above
-          // Look up the KeyCode in the XModifierKeymap
-          const auto keys = modmap->modifiermap + m.ModMapIndex*modmap->max_keypermod;
-          const auto keyptr = std::find_if(keys, keys + modmap->max_keypermod, [](KeyCode k){ return k != 0; });
-          m.key = (keyptr == keys + modmap->max_keypermod? 0: *keyptr);
-        }
-      }
+// Base class for the various ways to emulate keystrokes that result in a
+// keyboard event interpreted by the receiving application as the intended
+// character.
+//
+// This class takes care of wchar_t => KeySym => (KeyCode, Modifiers)
+// combination, and generates the key-up & key-down events in the required
+// order to generate the character being auto-typed.  The derived classes
+// only need to implement the virtual GenerateKeyEvent() member that
+// emulates a single keystroke
 
-      if (m.sym == NoSymbol && m.key != 0) {
-        // We know the KeyCode.  Now we need the KeySym to know what kind of key events
-        // to generate with that KeyCode
-        int keysyms_per_keycode = 0;
-        KeySym* symlist = XGetKeyboardMapping(m_display, m.key, 1, &keysyms_per_keycode);
-        if (symlist) {
-          // The keysym for a modifier must not require a modifier itself, so the first
-          // KeySym must not be empty
-          assert(symlist[0] != NoSymbol);
-          m.sym = symlist[0];
-          XFree(symlist);
-        }
-      }
-      if (m.type == ModInfo::Unknown && m.sym != NoSymbol) {
-        // The modifier "type" tells us the sequence of up or down key events
-        // to generate for that modifier
-        switch (m.sym) {
-          // These are known
-          case XK_Meta_L: case XK_Meta_R: case XK_Alt_L: case XK_Alt_R:
-          case XK_Super_L: case XK_Super_R: case XK_Hyper_L: case XK_Hyper_R:
-            m.type = ModInfo::Shift;
-            break;
-          default:
-          // Now we go by what it "sounds" like
-            const char *symstr = XKeysymToString(m.sym);
-            if (symstr) {
-              const size_t s_len = strlen(symstr);
-              auto ends_with = [symstr, s_len](const char* e, size_t e_len) {
-                return s_len >= e_len && strncmp(symstr + s_len - e_len, e, e_len) == 0;
-              };
-              m.type =  ends_with("Latch", 5)? ModInfo::Latch
-                       : ends_with("Lock", 4)? ModInfo::Lock
-                       : ends_with("Shift", 5) || ends_with("Switch", 6)? ModInfo::Shift
-                       : ModInfo::Unknown;
-            }
-            break;
-        }
-      }
-    }
-    XFreeModifiermap(modmap);
-  }
-  // Note that we may not have initialized every Modifier, but that may be ok
-  // because we may not actually use that modifier.  We can only tell while'
-  // autotyping
-}
+class AutotypeMethodBase {
+protected:
+  Display *m_display;
 
-void AutotypeMethodBase::operator()(unsigned int keycode, unsigned int state,
-							Time event_time /*= CurrentTime*/)
-{
-	XKeyEvent ev;
-	ev.display = m_display;
-	ev.keycode = keycode;
-	ev.state = state;
-	ev.time = event_time;
-	operator()(ev);
-}
+public:
+  explicit AutotypeMethodBase(Display *display) : m_display(display) {}
 
-void AutotypeMethodBase::operator()(XKeyEvent &ev)
-{
-  if (!ev.display)
-    ev.display = m_display;
-  else {
-    assert( ev.display == m_display);
-  }
+  // virtual, because derived classes will have clean-ups of their own
+  virtual ~AutotypeMethodBase() {}
 
-  if (m_emulateMods && ev.state) {
-    PressModifiers(ev.state);
-  }
-
-	ev.type = KeyPress;
-	GenerateKeyEvent(&ev);
-	ev.type = KeyRelease;
-	GenerateKeyEvent(&ev);
-
-  if (m_emulateMods && ev.state) {
-    ReleaseModifiers(ev.state);
-  }
-
-  XFlush(m_display);
-}
-
-///////////////////////////////////////////////////////////
-// Generate the modifier key events for all the modifier masks
-// (one event per mask).  For each mask, generate the keystrokes
-// (up, down, both, etc) for the keycodes corresponding to that
-// modifier based on the "type" of the modifier
-void AutotypeMethodBase::SetModifiers(int masks, bool set)
-{
-  // Shift modifiers require you to press the key for setting it, or release
-  // while unsetting
-  const int shift_events[] =  { (set? KeyPress: KeyRelease), 0};
-
-  // Lock modifiers (like CAPSLOCK) require you to press and release the key
-  // for both setting & unsetting
-  const int lock_events[] = {KeyPress, KeyRelease, 0};
-
-  // Latch modifiers require you to press and release the key for setting it
-  // it unsets itself as soon as any other key is pressed
-  const int latch_events[] = {KeyPress, KeyRelease, KeyPress, KeyRelease, 0};
-
-  // Note that these are indexed by the ModInfo::ModType enum values
-  const int* key_event_types[] = {shift_events, lock_events, latch_events, shift_events /*Unknown*/};
-
-  for (auto mod: m_mods) {
-    if (mod.mask & masks) {
-      const auto *events = key_event_types[mod.type];
-      for( const auto *e = events; *e; e++) {
-        XKeyEvent ev{};
-        ev.type = *e;
-        ev.display = m_display;
-        ev.keycode = mod.key;
-        ev.time = CurrentTime;
-        GenerateKeyEvent(&ev);
-      }
-    }
-  }
-}
+  virtual void GenerateKeyEvent(AutotypeEvent *ev) = 0;
+};
 
 //////////////////////////////////////////////////////////////////////////
 // AutotypeMethodXTEST
 //
 // Emulates keystrokes using the XTEST extension.
 //
-class AutotypeMethodXTEST: public AutotypeMethodBase
-{
+class AutotypeMethodXTEST : public AutotypeMethodBase {
 public:
-	AutotypeMethodXTEST(Display *display, bool emulateMods):
-	AutotypeMethodBase(display, emulateMods){ XTestGrabControl(display, true); }
-	~AutotypeMethodXTEST() { XTestGrabControl(m_display, false); }
+  explicit AutotypeMethodXTEST(Display *display) : AutotypeMethodBase(display) {
+    XTestGrabControl(display, true);
+  }
+  ~AutotypeMethodXTEST() override { XTestGrabControl(m_display, false); }
 
 protected:
-  virtual void GenerateKeyEvent(XKeyEvent *ev) {
-    XTestFakeKeyEvent(ev->display, ev->keycode, ev->type == KeyPress, CurrentTime);
+  void GenerateKeyEvent(AutotypeEvent *ev) override {
+    XTestFakeKeyEvent(ev->display, ev->keycode, ev->IsPressed()? True: False,
+                      CurrentTime);
   }
-
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -332,20 +328,47 @@ protected:
 //
 // Emulates keystrokes using the XSendEvent method
 //
-class AutotypeMethodSendKeys: public AutotypeMethodBase
-{
+class AutotypeMethodSendKeys : public AutotypeMethodBase {
 public:
-	AutotypeMethodSendKeys(Display *display, bool emulateMods):
-				AutotypeMethodBase(display, emulateMods){}
-	~AutotypeMethodSendKeys() { XSync(m_display, False); }
+  explicit AutotypeMethodSendKeys(Display *display) : AutotypeMethodBase(display) {}
+  ~AutotypeMethodSendKeys() override { XSync(m_display, False); }
+
 protected:
-  virtual void GenerateKeyEvent(XKeyEvent *ev) {
-	XSendEvent(ev->display, ev->window, TRUE,
-					ev->type == KeyPress? KeyPressMask: KeyReleaseMask, 
-					reinterpret_cast<XEvent *>(ev));
+  void GenerateKeyEvent(AutotypeEvent *ev) override {
+    XSendEvent(ev->display, ev->window, TRUE,
+               ev->IsPressed() ? KeyPressMask : KeyReleaseMask,
+               reinterpret_cast<XEvent *>(ev));
   }
 };
 
+//////////////////////////////////////////////////////////////////////////
+// AutotypeLogger
+//
+// This logs the keystrokes to the file provided
+//
+class AutotypeLogger : public AutotypeMethodBase {
+  std::ofstream atlog;
+  XComposeStatus cstat{};
+
+public:
+  explicit AutotypeLogger(Display *display, const char *filename)
+      : AutotypeMethodBase(display), atlog(filename) {}
+  ~AutotypeLogger() override {}
+
+protected:
+  void GenerateKeyEvent(AutotypeEvent *ev) override {
+    char buf[256]{};
+    KeySym ks{NoSymbol};
+    int nRet = XLookupString(ev, buf, NumberOf(buf)-1, &ks, &cstat);
+    if (nRet < 0 || static_cast<unsigned int>(nRet) >= NumberOf(buf)) nRet = 0;
+    buf[nRet] = 0;
+    const char *strks = XKeysymToString(ks);
+    if (!strks) strks = "NULL";
+    atlog << ev->keycode << (ev->IsPressed() ? " pressed" : " released")
+          << " with mask " << ev->state << " => char [" << buf << ']'
+          << ", keysym [" << ks << "], name [" << strks << ']' << std::endl;
+  }
+};
 
 //////////////////////////////////////////////////////////////////////////
 // Factory method for generating the correct type of autotype method, based
@@ -353,246 +376,392 @@ protected:
 //   1. User preference
 //   2. XTEST extension availability
 //
-AutotypeMethodBase* GetAutotypeMethod(Display* disp,
-									pws_os::AutotypeMethod method_preference)
-{
+AutotypeMethodBase *
+GetAutotypeMethod(Display *disp, pws_os::AutotypeMethod method_preference) {
+  // To enable logging for autotype, uncomment the following block of code
+  // Then run pwsafe in a terminal like this:
+  //
+  //    PASSWORDSAFE_AUTOTYPE_LOG=/tmp/pwsafe-autotype.log /path/to/pwsafe
+  //
+  // Then send the /tmp/pwsafe-autotype.log file to devs.
+  //
+  // IMPORTANT: remember NOT to use your actual passwords for this purpose.
+  // Your password can be deciphered from the log file. Delete the
+  // /tmp/pwsafe-autotype.log file after sending it to devs. Also, put the
+  // comments back on and rebuild once you are done testing
+  //
+
+  /*
+  const char *atlog = getenv("PASSWORDSAFE_AUTOTYPE_LOG");
+  if (atlog) {
+    return new AutotypeLogger(disp, atlog);
+  }
+  */
+
   int major_opcode, first_event, first_error;
   AutotypeMethodBase *method_ptr = nullptr;
   if (method_preference != pws_os::ATMETHOD_XSENDKEYS &&
-			XQueryExtension(disp, "XTEST", &major_opcode, &first_event, &first_error)) {
-    method_ptr = new AutotypeMethodXTEST(disp, true); // true => emulate modifiers independently
-  }
-  else {
-	method_ptr = new AutotypeMethodSendKeys(disp, false); // false => no emulation for modifier keys
+      XQueryExtension(disp, "XTEST", &major_opcode, &first_event,
+                      &first_error)) {
+    method_ptr = new AutotypeMethodXTEST(disp);
+  } else {
+    method_ptr = new AutotypeMethodSendKeys(disp);
   }
   return method_ptr;
 }
 
-// Helper method to check if an X extension is available
-bool XExtensionAvailable(Display *disp, const char* ext)
-{
-  int major_opcode, first_event, first_error;
-  return XQueryExtension(disp, ext, &major_opcode, &first_event, &first_error) == True;
-}
+///////////////////////////////////////////////////////
+// ModifierFactory
+//
+// Creates and caches Modifier keys from KeyCode/KeySym
 
-// Calculates the masks (actually, shifts) used by the modifier with the KeySym "sym"
-int FindModifierMask(Display* disp, KeySym sym)
-{
-  int modmask = 0;
-  XModifierKeymap* modmap = XGetModifierMapping(disp);
-  if (modmap) {
-    const int last = 8*modmap->max_keypermod;
-    //begin at 4th row, where Mod1 starts
-    for (int i = Mod1MapIndex*modmap->max_keypermod; i < last && !modmask; i++) {
-      //
-      const KeyCode kc = modmap->modifiermap[i];
-      if (!kc)
-        continue;
-      int keysyms_per_keycode = 0;
-      // For each keycode attached to this modifier, get a list of all keysyms
-      // attached with this keycode. If any of those keysyms is what we are looking
-      // for, then this is the modifier to use
-      KeySym* symlist = XGetKeyboardMapping(disp, kc, 1, &keysyms_per_keycode);
-      if ( symlist) {
-        for (int j = 0; j < keysyms_per_keycode; j++) {
-          if (sym == symlist[j]) {
-            modmask = (i / modmap->max_keypermod);
-            break;
-          }
-        }
-        XFree(symlist);
+class ModifierFactory {
+  Display *m_display;
+
+  // helper class for on-demand creation & caching of mods
+  template <typename Param> class ModifierCreator {
+    Display *m_display;
+    Param m_p;
+    ModifierKey *m_key = nullptr;
+
+  public:
+    ModifierCreator(Display *d, Param p) : m_display{ d }, m_p{ p } {}
+    operator ModifierKey &() {
+      if (!m_key) {
+        m_key = new ModifierKey(m_display, m_p);
       }
+      return *m_key;
     }
-    XFreeModifiermap(modmap);
+
+    ModifierCreator(const ModifierCreator &) = delete;
+    ModifierCreator(ModifierCreator &&) = delete;
+    ModifierCreator &operator=(const ModifierCreator &) = delete;
+    ModifierCreator &operator=(ModifierCreator &&) = delete;
+
+    ~ModifierCreator() { delete m_key; }
+  };
+
+  ModifierCreator<XModPos> m_shift, m_ctrl;
+  ModifierCreator<KeySym> m_mode_switch, m_level3_shift;
+
+public:
+  explicit ModifierFactory(Display *disp)
+      : m_display{ disp },
+        m_shift{ disp, XModPos{ XModPos::MODMAP_INDEX_SHIFT } },
+        m_ctrl{ disp, XModPos{ XModPos::MODMAP_INDEX_CONTROL } },
+        m_mode_switch{ disp, XK_Mode_switch },
+        m_level3_shift{ disp, XK_ISO_Level3_Shift } {}
+
+  std::vector<ModifierKey> GetModifiersForKeySym(KeyCode code, KeySym sym);
+
+  ModifierKey Control() { return m_ctrl; }
+};
+
+std::vector<ModifierKey> ModifierFactory::GetModifiersForKeySym(KeyCode code,
+                                                                KeySym sym) {
+  XKeyboardMapping symlist(m_display, code);
+  const size_t keysym_index = symlist.IndexOf(sym);
+
+  switch (keysym_index) {
+
+  case 0: // plain key
+    return {};
+
+  case 1:
+    return { m_shift };
+
+  case 2:
+    return { m_mode_switch };
+
+  case 3:
+    return { m_shift, m_mode_switch };
+
+  case 4:
+    return { m_level3_shift };
+
+  case 5:
+    return { m_shift, m_level3_shift };
+
+  case 6:
+    return { m_mode_switch, m_level3_shift };
+
+  case 7:
+    return { m_shift, m_mode_switch, m_level3_shift };
+
+  default:
+    g_xerrormsg << "Modifier keys for generating keysym " << sym
+                << " fall in unsupported " << keysym_index << " level";
+    throw autotype_exception();
   }
-  return modmask;
 }
 
-int CalcModifiersForKeysym(KeyCode code, KeySym sym, Display* disp)
-{
-  int modifiers = 0;
-  int keysyms_per_keycode = 0;
-  KeySym* symlist = XGetKeyboardMapping(disp, code, 1, &keysyms_per_keycode);
-  if (symlist != NULL && keysyms_per_keycode > 0) {
-    // Supported everywhere.  Note: order is important
-    std::vector<int> masks = {0, ShiftMask};
-    // These aren't necessarily supported in all systems.  Once again, order is important
-    for ( const auto s: {XK_Mode_switch, XK_ISO_Level3_Shift}) {
-      const int modshift = FindModifierMask(disp, s);
-      // May repeat.  Only consider it if we haven't added it already
-      if (modshift && std::find(masks.begin(), masks.end(), 1 << modshift) == masks.end()) {
-        std::vector<int> extra_masks;
-        // OR each element of mask with "1 << modshift" & insert the result in mask
-        std::transform(masks.begin(), masks.end(), std::back_inserter(extra_masks),
-                        std::bind(std::bit_or<int>(), std::placeholders::_1, 1 << modshift));
-        masks.insert(masks.end(), extra_masks.begin(), extra_masks.end());
-      }
-    }
-    // Get the index of the symbol we are searching for
-    const auto max_keysym_index = std::min(masks.size(), static_cast<size_t>(keysyms_per_keycode));
-    // return the modifiers at the same index
-    const size_t match_index = std::find(symlist, symlist + max_keysym_index, sym) - symlist;
-    if ( match_index != max_keysym_index)
-        modifiers = masks[match_index];
-    XFree(symlist);
-  }
-  return modifiers;
-}
-
-KeySym wchar2keysym(wchar_t wc)
-{
+KeySym _wchar2keysym(wchar_t wc) {
   if (wc < 0x100) {
-    if (wc >= 0x20)
-      return wc;
-    switch(wc) {
-      case L'\t': return XK_Tab;
-      case L'\r': return XK_Return;
-      case L'\n': return XK_Linefeed;
-      case '\010': return XK_BackSpace;
-      case '\177': return XK_Delete;
-      case '\033': return XK_Escape;
-      default:
-        return NoSymbol;
+    if (wc >= 0x20) return wc;
+    switch (wc) {
+    case L'\t':
+      return XK_Tab;
+    case L'\r':
+      return XK_Return;
+    case L'\n':
+      return XK_Linefeed;
+    case '\010':
+      return XK_BackSpace;
+    case '\177':
+      return XK_Delete;
+    case '\033':
+      return XK_Escape;
+    default:
+      return NoSymbol;
     }
   }
-  if (wc > 0x10ffff || (wc > 0x7e && wc < 0xa0))
-    return NoSymbol;
+  if (wc > 0x10ffff || (wc > 0x7e && wc < 0xa0)) return NoSymbol;
   KeySym sym = unicode2keysym(wc);
-  if (sym != NoSymbol)
-    return sym;
-  //For everything else, there's Mastercard :)
+  if (sym != NoSymbol) return sym;
+  // For everything else, there's Mastercard :)
   return wc | 0x01000000;
 }
 
-//converts a  single wchar_t to a byte string [i.e. char*]
-class wchar2bytes
-{
-private:
-  //MB_CUR_MAX is a function call, not a constant
-  char* bytes;
-public:
-  wchar2bytes(wchar_t wc):  bytes(new char[MB_CUR_MAX*2 + sizeof(wchar_t)*2 + 2 + 1]) {
-    mbstate_t ps;
-    memset(&ps, 0, sizeof(ps));//initialize mbstate
-    size_t n;
-    if ((n = wcrtomb(bytes, wc, &ps)) == size_t(-1))
-      snprintf(bytes, NumberOf(bytes), "U+%04X", int(wc));
-    else
-      bytes[n] = 0;
+KeySym _wchar2string2keysym(wchar_t wc) {
+  char ucstr[16] = { 0 };
+  snprintf(ucstr, 16, "U%04X", wc);
+  return XStringToKeysym(ucstr);
+}
+
+KeySym WcharToKeySym(Display *disp, wchar_t wc) {
+  using std::endl;
+  // Try a regular conversion first
+  KeySym sym = _wchar2keysym(wc);
+
+  // Failing which, get it algorithmically
+  if (sym == NoSymbol || !XKeysymToKeycode(disp, sym)) {
+    sym = _wchar2string2keysym(wc);
   }
-  ~wchar2bytes() { delete [] bytes; }
-  const char* str() const {return bytes;}
+
+  // its a no-go
+  if (sym == NoSymbol) {
+    g_xerrormsg
+        << std::hex << std::showbase
+        << "Could not convert wchar_t value to X KeySym. Aborting autotype."
+        << endl
+        << "If \'xmodmap -pk\' does not list this KeySym, you probably need "
+        << "to install an appropriate keyboard layout." << endl
+        << "wchar_t value: " << wc << endl;
+    throw autotype_exception();
+  }
+
+  return sym;
+}
+
+KeyCode KeySymToKeyCode(Display *disp, KeySym sym) {
+  const KeyCode code = XKeysymToKeycode(disp, sym);
+  if (!code) {
+    using std::endl;
+    const char *symStr = XKeysymToString(sym);
+    g_xerrormsg
+        << std::hex << std::showbase
+        << "Could not convert X KeySym to X keycode. Aborting autotype." << endl
+        << "If \'xmodmap -pk\' does not list this KeySym, you probably need "
+        << "to install an appropriate keyboard layout." << endl
+        << "KeySym value : " << sym << endl
+        << "KeySym string: " << (symStr ? symStr : "NULL") << endl;
+    throw autotype_exception();
+  }
+  return code;
+}
+
+template <class ContIter, class ModIter>
+void SequenceAutotypeEvents(ContIter ci, ModIter mbegin, ModIter mend,
+                            Display *disp, KeyCode code, bool emulateMods) {
+
+  using mem_evt_set = decltype(ModifierKey::set_events);
+  auto add_mods = [&](const mem_evt_set ModifierKey::* ms) {
+    std::for_each(mbegin, mend, [&](const ModifierKey &m) {
+      std::for_each((m.*ms).begin(), (m.*ms).end(), [&](KeyEventType kt) {
+          (*ci)++ = AutotypeEvent{ disp, kt, m.code, 0 };
+      });
+    });
+  };
+
+  std::for_each(mbegin, mend,
+                [](const ModifierKey &m) { assert(m.IsValid()); });
+
+  if (emulateMods) {
+    add_mods(&ModifierKey::set_events);
+  }
+
+  int mask = 0;
+  std::for_each(mbegin, mend,
+                [&mask](const ModifierKey &m) { mask |= m.mask; });
+
+  assert(std::distance(mbegin, mend) == 0 || mask != 0);
+
+  (*ci)++ = AutotypeEvent{ disp, KeyEventType::PRESS, code, mask };
+  (*ci)++ = AutotypeEvent{ disp, KeyEventType::RELEASE, code, mask };
+
+  if (emulateMods) {
+    add_mods(&ModifierKey::unset_events);
+  }
+}
+
+// This class helps me not include Xlib headers in xsendstring.h
+struct wchar2xevent_map_ptr {
+  using wchar2event_map =
+      std::map<StringX::value_type, std::vector<AutotypeEvent> >;
+  wchar2event_map m_map;
+  wchar2event_map *operator->() { return &m_map; }
 };
 
 /*
  * DoSendString - actually sends a string to the X Window having input focus
  *
- * The main task of this function is to convert the ascii char values
- * into X KeyCodes.  But they need to be converted to X KeySyms first
- * and then to the keycodes.  The KeyCodes can have any random values
- * and are not contiguous like the ascii values are.
+ * The main task of this function is to convert the wchar_t values
+ * into X Keyboard events. Keyboard events consist of keycodes and modifier
+ * flags like Shift, Alt, etc. The KeyCodes can have any random values
+ * and are not contiguous like the ascii/unicode values are, and their mapping
+ * to wchar_t values are system-dependent.
  *
- * Some escape sequences can be converted to the appropriate KeyCodes
- * by this function.  See the code below for details
+ * wchar_t => KeySym (eg. XK_A, or XK_Colon)
+ * KeySym  => keycode + index (of keysym into that keycode's keysym list.
+ *                             Each keycode can generate 1-8 keysyms in
+ *                             combination with modifier keys like Shift)
+ * index   => Modifier key + modifier mask
+ *
+ * Then we can generate X Keyboard events for each wchar_t. Sometimes, we
+ * also need to generate separate keyboard events for the modifier keys
+ * themselves.
+ *
+ * Modifier keys like Shift are press-and-hold, which means we need to generate
+ * a keydown event for the modifier key before the main key, and a keyup event
+ * afterwards. Some modifier keys (e.g. latch, lock, etc) behave differently,
+ * but we don't need those as we support only 8 keysyms per keycode. I'm not
+ * aware how those key events are actually generated by users on their
+ *keyboards.
  */
-void CKeySendImpl::DoSendString(const StringX& str, unsigned delayMS, bool emulateMods)
-{
-  atGlobals.error_detected = false;
-  atGlobals.errorString[0] = 0;
-
-  AutotypeEvent event(m_display);
+void CKeySendImpl::DoSendString(const StringX &str, unsigned delayMS,
+                                bool emulateMods) {
+  using std::vector;
+  g_xerrormsg.str(std::string());
 
   // convert all the chars into keycodes and required shift states first
   // Abort if any of the characters cannot be converted
-  typedef std::vector<KeyPressInfo> KeyPressInfoVector;
-  KeyPressInfoVector keypresses;
+  typedef vector<AutotypeEvent> AutotypeEventVector;
+  AutotypeEventVector keypresses;
 
-  for (StringX::const_iterator srcIter = str.begin(); srcIter != str.end(); ++srcIter) {
+  for (const auto &chr : str) {
 
-    //throw away 'vertical tab' chars which are only used on Windows to send a shift+tab
-    //as a workaround for some issues with IE
-    if (*srcIter == _T('\v'))
-      continue;
+    // throw away 'vertical tab' chars which are only used on Windows to send a
+    // shift+tab as a workaround for some issues with IE
+    if (chr == _T('\v')) continue;
 
-    //Try a regular conversion first
-    KeySym sym = wchar2keysym(*srcIter);
+    using maptype = wchar2xevent_map_ptr::wchar2event_map;
 
-    if (NoSymbol != sym) {
-      KeyPressInfo keypress = {0, 0};
-      if ((keypress.code = XKeysymToKeycode(event.display, sym)) != 0) {
-        //non-zero return value implies sym -> code was successful
-        keypress.state |= CalcModifiersForKeysym(keypress.code, sym, event.display);
-        keypresses.push_back(keypress);
-      }
-      else {
-        const char* symStr = XKeysymToString(sym);
-        snprintf(atGlobals.errorString, NumberOf(atGlobals.errorString),
-              "Could not get keycode for key char(%s) - sym(%#X) - str(%s). Aborting autotype.\n\nIf \'xmodmap -pk\' does not list this KeySym, you probably need to install an appropriate keyboard layout.",
-                          wchar2bytes(*srcIter).str(), static_cast<int>(sym), symStr ? symStr : "NULL");
-        atGlobals.error_detected = True;
-        return;
-      }
-    }
-    else {
-      snprintf(atGlobals.errorString, NumberOf(atGlobals.errorString),
-              "Cannot convert '%s' [U+%04X] to keysym. Aborting autotype", wchar2bytes(*srcIter).str(), int(*srcIter));
-      atGlobals.error_detected = True;
-      return;
+    wchar2xevent_map_ptr &charmap = *m_wcharmap;
+    maptype::const_iterator itr = charmap->lower_bound(chr);
+    if (itr != charmap->end() && charmap->key_comp()(itr->first, chr)) {
+      keypresses.insert(keypresses.end(), itr->second.begin(),
+                        itr->second.end());
+    } else {
+      const KeySym sym = WcharToKeySym(m_display, chr);
+      const KeyCode code = KeySymToKeyCode(m_display, sym);
+
+      const std::vector<ModifierKey> modkeys =
+          m_modFactory->GetModifiersForKeySym(code, sym);
+      std::for_each(modkeys.begin(), modkeys.end(),
+                    [](const ModifierKey &m) { assert(m.IsValid()); });
+
+      const AutotypeEventVector::size_type count = keypresses.size();
+
+      SequenceAutotypeEvents(std::back_inserter(keypresses), modkeys.begin(),
+                             modkeys.end(), m_display, code, emulateMods);
+
+      charmap->insert(itr,
+                      maptype::value_type{ chr, { keypresses.begin() + count,
+                                                  keypresses.end() } });
+
+      // hack to know after which keys to sleep
+      keypresses.push_back(AutotypeEvent{ m_display, KeyEventType::PRESS, 0, 0 });
     }
   }
 
-  m_method->EmulateMods(emulateMods);
-
-  for (KeyPressInfoVector::const_iterator itr = keypresses.begin(); itr != keypresses.end()
-                              && !atGlobals.error_detected; ++itr) {
-    event.keycode = itr->code;
-    event.state = itr->state;
-    event.time = CurrentTime;
-
-    (*m_method)(event);
-    pws_os::sleep_ms(delayMS);
+  for (auto k : keypresses) {
+    if (k.keycode) {
+      m_method->GenerateKeyEvent(&k);
+    } else {
+      XFlush(m_display);
+      pws_os::sleep_ms(delayMS);
+    }
   }
 }
 
-
-void CKeySendImpl::SendString(const StringX& str, unsigned delayMS)
-{
-  atGlobals.error_detected = false;
-  atGlobals.errorString[0] = 0;
-
+void CKeySendImpl::SendString(const StringX &str, unsigned delayMS) {
   DoSendString(str, delayMS, m_emulateModsSeparately);
-
-  if (atGlobals.error_detected)
-    throw autotype_exception();
 }
 
-void CKeySendImpl::SelectAll(unsigned delayMS)
-{
-  AutotypeEvent event(m_display);
-  event.keycode = XKeysymToKeycode(event.display, XK_a);
-  event.state = ControlMask;
-  event.time = CurrentTime;
-  (*m_method)(event);
+void CKeySendImpl::SelectAll(unsigned delayMS, int code /*= 0*/,
+                             int mask /*= 0*/) {
+  assert(mask >= 0 && mask <= 255);
+
+  std::vector<ModifierKey> modkeys;
+
+  XModMap modmap(m_display);
+
+  if (code) {
+    // user configured something, so use it even if mask is 0
+    // mask could have multiple bits, each bit would require its own modkey
+    for (XModPos pos{ XModPos::MODMAP_INDEX_SHIFT }; !pos.last(); ++pos) {
+      if (mask & pos.mask()) {
+        KeyCode kc = modmap.ModifierKeyCode(pos);
+        if (kc) {
+          // note that the press & hold behavior is hardcoded here
+          modkeys.push_back(ModifierKey{ m_display, kc, pos.mask() });
+        } else {
+          g_xerrormsg << "No KeyCode mapped to mask bit " << pos.index()
+                      << " for generating Select-All event";
+          throw autotype_exception();
+        }
+      }
+    }
+  } else {
+    // Ctrl-A it is!
+    code = KeySymToKeyCode(m_display, XK_A);
+    modkeys.push_back( m_modFactory->Control() );
+  }
+
+  std::for_each(modkeys.cbegin(), modkeys.cend(),
+                [](const ModifierKey &m) { assert(m.IsValid()); });
+
+  std::vector<AutotypeEvent> selectAllEvents;
+  SequenceAutotypeEvents(std::back_inserter(selectAllEvents), modkeys.cbegin(),
+                         modkeys.cend(), m_display, code,
+                         m_emulateModsSeparately);
+
+  for (auto k : selectAllEvents) {
+    m_method->GenerateKeyEvent(&k);
+  }
+  XFlush(m_display);
+  // sleep only after all keys for select-all are typed
   pws_os::sleep_ms(delayMS);
 }
 
-CKeySendImpl::CKeySendImpl(pws_os::AutotypeMethod method): m_display(XOpenDisplay(NULL))
-{
+CKeySendImpl::CKeySendImpl(pws_os::AutotypeMethod method)
+    : m_display(XOpenDisplay(nullptr)) {
   if (m_display) {
+    m_errHandlerInstaller = new XErrorHandlerInstaller;
     m_method = GetAutotypeMethod(m_display, method);
-  }
-  else {
-    if (!atGlobals.error_detected)
-      atGlobals.error_detected = true;
-    if (!atGlobals.errorString[0])
-      strncpy(atGlobals.errorString, "Could not open X display for autotyping", NumberOf(atGlobals.errorString));
+    m_modFactory = new ModifierFactory(m_display);
+    m_wcharmap = new wchar2xevent_map_ptr;
+  } else {
+    g_xerrormsg << "Could not open X display for autotyping";
 
     throw autotype_exception();
   }
 }
 
-CKeySendImpl::~CKeySendImpl()
-{
+CKeySendImpl::~CKeySendImpl() {
   delete m_method;
+  delete m_errHandlerInstaller;
+  delete m_modFactory;
+  delete m_wcharmap;
   XCloseDisplay(m_display);
 }

--- a/src/os/linux/xsendstring.h
+++ b/src/os/linux/xsendstring.h
@@ -28,20 +28,35 @@ namespace pws_os {
 // This is to keep Xlib headers in xsendstring.cpp only
 class AutotypeMethodBase;
 struct _XDisplay;
+class  XErrorHandlerInstaller;
+class ModifierFactory;
+struct wchar2xevent_map_ptr;
 
 class CKeySendImpl
 {
     // This takes effect the next time SendString is called
     bool m_emulateModsSeparately = true;
 
-    // The ctor throws if it can create this, because all X functions need it
+    // The ctor throws if it can't create this, because all X functions need it
     _XDisplay *m_display;
 
     // Can't change autotype method in the middle of an autotype session
     AutotypeMethodBase *m_method;
 
+    XErrorHandlerInstaller *m_errHandlerInstaller;
+
+    ModifierFactory *m_modFactory;
+
+    wchar2xevent_map_ptr  *m_wcharmap;
+
     // Does the actual autotype work with the help of m_method
     void DoSendString(const StringX& str, unsigned delayMS, bool emulateMods);
+
+    CKeySendImpl() = delete;
+    CKeySendImpl(const CKeySendImpl&) = delete;
+    CKeySendImpl(CKeySendImpl&&) = delete;
+    CKeySendImpl& operator=(const CKeySendImpl&) = delete;
+    CKeySendImpl& operator=(CKeySendImpl&&) = delete;
   public:
 
     CKeySendImpl(pws_os::AutotypeMethod method);
@@ -51,8 +66,8 @@ class CKeySendImpl
     void SendString(const StringX &data, unsigned delay);
     void EmulateMods(bool emulate) { m_emulateModsSeparately = emulate; }
     bool IsEmulatingMods() const { return m_emulateModsSeparately; }
-    // Autotypes a Ctrl-A
-    void SelectAll(unsigned delayMS);
+    // If code == 0, autotypes Ctrl-A
+    void SelectAll(unsigned delayMS, int code = 0, int mask = 0);
 };
 
 #endif


### PR DESCRIPTION
This fixes autotype for those keyboard layouts where additional symbols are generated by pressing the modifier key corresponding to ISO_Level3_Shift:

https://sourceforge.net/p/passwordsafe/bugs/1281/

Its a pretty big rewrite that simplifies the XWindows autotype logic greatly, making the code easily extensible and maintainable, at a slight (mostly theoretical & unnoticeable) cost to efficiency.  