### PR TITLE
Fix export of Named Password Policies to XML and implement FR to view associated entries

### DIFF
--- a/docs/ReleaseNotes.html
+++ b/docs/ReleaseNotes.html
@@ -69,6 +69,19 @@ Information about older versions may be found <a href="https://pwsafe.org/histor
 
 <h3><a name="V3.38.3"></a>Version V3.38.3</h3>
 <hr>
+<h4><a name="V3.38.3New"></a>New Features for V3.38.3</h4>
+<table>
+<tbody>
+<tr>
+<td align="center" width="100">[]</td>
+<td>It is now possible to list entries using a Named Password Policy from
+the Manage Password Policies dialog (right click on the name).</td>
+</tr>
+</tbody>
+</table>
+
+<br>
+<hr>
 <h4><a name="V3.38.3BugsFixed"></a>Bugs fixed in V3.38.3</h4>
 <table>
 <tbody>
@@ -80,6 +93,10 @@ Information about older versions may be found <a href="https://pwsafe.org/histor
 <td align="center" width="100"><a href="nojs.html" onclick="BR(1319);return false;">1319</a></td>
 <td>Re-implement fix for BR 1319 so that the added entry nolonger appears
 always selected until the display is refreshed.</td>
+</tr>
+<tr>
+<td align="center" width="100">[]</td>
+<td>Export of a complete database to XML now includes all Named Password Policies.</td>
 </tr>
 </tbody>
 </table>
@@ -94,18 +111,6 @@ always selected until the display is refreshed.</td>
 <td>Double click on a word in the Notes field, e.g. for copy &amp; paste,
 now no longer includes any trailing spaces.  This is different to the
 standard Microsoft processing in their products.</td>
-</tr>
-</tbody>
-</table>
-
-<br>
-<hr>
-<h4><a name="V3.38.2New"></a>New Features for V3.38.3</h4>
-<table>
-<tbody>
-<tr>
-<td align="center" width="100">-</td>
-<td>None</td>
 </tr>
 </tbody>
 </table>
@@ -199,6 +204,7 @@ is moved to it via editing.</td>
 <h4><a name="V3.38.1New"></a>New Features for V3.38.1</h4>
 <table>
 <tbody>
+<tr>
 <td align="center" width="100"><a href="nojs.html" onclick="FR(797);return false;">797</a></td>
 <td>Change the Add/Edit dialogs to allow a larger Notes field to be visible.  Protected entries now only have this information in the dialog caption. The Tooltip on how to unprotect an entry is now shown against the tutorial text at the top of the dialog.</td>
 </tr>
@@ -398,7 +404,6 @@ be changed.</td>
 <td>Non-ASCII symbols can now be specified in Password Policies.</td>
 </tr>
 <tr>
-<tr>
 <td align="center" width="100"><a href="nojs.html" onclick="BR(1245);return false;">1245</a></td>
 <td>Asterisk is now accepted as a symbol in Password Policies.</td>
 </tr>
@@ -416,7 +421,6 @@ consistent UI.</td>
 <td align="center" width="100"><a href="nojs.html" onclick="BR(1229);return false;">1229</a></td>
 <td>Hex digits checkbox can be selected in Generate Passwords.</td>
 </tr>
-<tr>
 <tr>
 <td align="center" width="100"><a href="nojs.html" onclick="BR(1228);return false;">1228</a></td>
 <td>Fixed incompatability with Password Policies generated with previous versions.</td>
@@ -483,7 +487,6 @@ last database is set as default for next invocation.</td>
 <td align="center" width="100"><a href="nojs.html" onclick="FR(728);return false;">728</a></td>
 <td>The default delay between characters on autotype is now configurable.</td>
 </tr>
-<tr>
 </tbody>
 </table>
 

--- a/docs/ReleaseNotes.txt
+++ b/docs/ReleaseNotes.txt
@@ -14,6 +14,8 @@ Bugs fixed in 3.38.3
 results in a normal entry.
 [1319] Re-implement fix for BR 1319 so that the added entry no longer 
 appears always selected until the display is refreshed.
+[] Export of a complete database to XML now includes all Named Password
+Policies.
 
 Changes to Existing Features in 3.38.3
 ======================================
@@ -23,7 +25,8 @@ standard Microsoft processing in their products.
 
 New Features for 3.38.3
 =======================
-None
+[] It is now possible to list entries using a Named Password Policy from
+the Manage Password Policies dialog (right click on the name).
 
 Bugs fixed in 3.38.2
 ====================

--- a/src/core/CoreImpExp.cpp
+++ b/src/core/CoreImpExp.cpp
@@ -561,6 +561,7 @@ int PWScore::WriteXMLFile(const StringX &filename,
 
     conv.ToUTF8(pwpolicies.c_str(), utf8, utf8Len);
     ofs.write(reinterpret_cast<const char *>(utf8), utf8Len);
+    ofs << endl;
   }
 
   if (!m_vEmptyGroups.empty()) {
@@ -667,8 +668,8 @@ int PWScore::WriteXMLFile(const StringX &filename,
   if (bStartComment) {
     bStartComment = false;
     ofs << " --> " << endl;
+    ofs << endl;
   }
-  ofs << endl;
 
   // Write what we have and reset the buffer
   fwrite(ofs.str().c_str(), 1, ofs.str().length(), xmlfile);
@@ -2312,21 +2313,21 @@ stringT PWScore::GetXMLPWPolicies(const OrderedItemList *pOIL)
 
   std::vector<StringX> vPWPolicies;
   const bool bSubset = pOIL->size() != GetNumEntries();
+  bool bNamedPasswordPolicies = !bSubset;
+  PSWDPolicyMapCIter iter;
+
   if (bSubset) {
     // If not exporting the whole database, only get referenced Password Policies
     PopulatePWPVector pwpv(&vPWPolicies);
     for_each(pOIL->begin(), pOIL->end(), pwpv);
-  }
 
-  bool bNamedPasswordPolicies(false);
-
-  PSWDPolicyMapCIter iter;
-  for (iter = m_MapPSWDPLC.begin(); iter != m_MapPSWDPLC.end(); iter++) {
-    // If OrderedList (i.e. not the whole database), only export a Password Policy
-    // if it is referenced by one of the entries being exported
-    if (bSubset && std::find(vPWPolicies.begin(), vPWPolicies.end(), iter->first) != vPWPolicies.end()) {
-      bNamedPasswordPolicies = true;
-      break;
+    for (iter = m_MapPSWDPLC.begin(); iter != m_MapPSWDPLC.end(); iter++) {
+      // If OrderedList (i.e. not the whole database), only export a Password Policy
+      // if it is referenced by one of the entries being exported
+      if (std::find(vPWPolicies.begin(), vPWPolicies.end(), iter->first) != vPWPolicies.end()) {
+        bNamedPasswordPolicies = true;
+        break;
+      }
     }
   }
 

--- a/src/core/PWScore.h
+++ b/src/core/PWScore.h
@@ -263,6 +263,9 @@ public:
                         StringX &sxPolicyName, const StringX &sxDateTime,
                         const UINT IDS_MESSAGE);
 
+  bool GetEntriesUsingNamedPasswordPolicy(const StringX sxPolicyName,
+                                          std::vector<st_GroupTitleUser> &ventries);
+
   // Populate setGTU & setUUID from m_pwlist. Returns false & empty set if
   // m_pwlist had one or more entries with same GTU/UUID respectively.
   bool InitialiseGTU(GTUSet &setGTU);

--- a/src/core/coredefs.h
+++ b/src/core/coredefs.h
@@ -39,7 +39,8 @@ struct st_SaveTypePW {
   }  
 };
 
-// Used to verify uniqueness of GTU using std::set
+// Used to verify uniqueness of GTU using std::set and
+// retrieving all entries using a given Named Password Policy
 struct st_GroupTitleUser {
   StringX group;
   StringX title;

--- a/src/ui/Windows/ManagePSWDPols.h
+++ b/src/ui/Windows/ManagePSWDPols.h
@@ -59,9 +59,11 @@ protected:
   afx_msg void OnUndo();
   afx_msg void OnRedo();
   afx_msg void OnPolicySelected(NMHDR *pNotifyStruct, LRESULT *pLResult);
+  afx_msg void OnPolicyRightClick(NMHDR *pNotifyStruct, LRESULT *pLResult);
   afx_msg void OnEntryDoubleClicked(NMHDR *pNotifyStruct, LRESULT *pLResult);
   afx_msg void OnColumnNameClick(NMHDR *pNotifyStruct, LRESULT *pLResult);
   afx_msg void OnColumnEntryClick(NMHDR *pNotifyStruct, LRESULT *pLResult);
+  afx_msg void OnListEntries();
 
   DECLARE_MESSAGE_MAP()
 
@@ -79,6 +81,7 @@ private:
   std::vector<st_PSWDPolicyChange> m_vchanges;
   int m_iundo_pos;
 
+  std::vector<st_GroupTitleUser> m_ventries;
   PSWDPolicyMap m_MapPSWDPLC;
   PWPolicy m_st_default_pp;
 

--- a/src/ui/Windows/PWPListEntries.cpp
+++ b/src/ui/Windows/PWPListEntries.cpp
@@ -1,0 +1,151 @@
+/*
+* Copyright (c) 2003-2016 Rony Shapiro <ronys@pwsafe.org>.
+* All rights reserved. Use of the code is allowed under the
+* Artistic License 2.0 terms, as specified in the LICENSE file
+* distributed with this code, or available from
+* http://www.opensource.org/licenses/artistic-license-2.0.php
+*/
+
+// PWPListEntries.cpp : implementation file
+//
+
+#include "stdafx.h"
+#include "PWPListEntries.h"
+#include "SecString.h"
+
+#include "resource.h"
+#include "resource3.h"
+
+// CPWPListEntries dialog
+
+IMPLEMENT_DYNAMIC(CPWPListEntries, CPWDialog)
+
+CPWPListEntries::CPWPListEntries(CWnd* pParent, StringX sxPolicyName, 
+  std::vector<st_GroupTitleUser> *pventries)
+	: CPWDialog(CPWPListEntries::IDD, pParent), m_sxPolicyName(sxPolicyName),
+  m_pventries(pventries), m_iSortedColumn(0),  m_bSortAscending(FALSE)
+{
+}
+
+CPWPListEntries::~CPWPListEntries()
+{
+}
+
+void CPWPListEntries::DoDataExchange(CDataExchange* pDX)
+{
+  CPWDialog::DoDataExchange(pDX);
+  DDX_Control(pDX, IDC_NPWP_LIST_ENTRIES, m_PolicyEntries);
+}
+
+BEGIN_MESSAGE_MAP(CPWPListEntries, CPWDialog)
+  ON_NOTIFY(HDN_ITEMCLICKW, 0, OnHeaderClicked)
+END_MESSAGE_MAP()
+
+BOOL CPWPListEntries::OnInitDialog()
+{
+  CPWDialog::OnInitDialog();
+
+  CString csTitle;
+  GetWindowText(csTitle);
+  csTitle += m_sxPolicyName.c_str();
+  SetWindowText(csTitle);
+
+  // Looks nicer with grid lines
+  DWORD dwExtendedStyle = m_PolicyEntries.GetExtendedStyle();
+  dwExtendedStyle |= LVS_EX_GRIDLINES;
+  m_PolicyEntries.SetExtendedStyle(dwExtendedStyle);
+
+  // Add columns
+  CString cs_text;
+  cs_text.LoadString(IDS_GROUP);
+  m_PolicyEntries.InsertColumn(0, cs_text);
+  cs_text.LoadString(IDS_TITLE);
+  m_PolicyEntries.InsertColumn(1, cs_text);
+  cs_text.LoadString(IDS_USERNAME);
+  m_PolicyEntries.InsertColumn(1, cs_text);
+
+  // Add entries
+  int nPos = 0;
+  for (size_t i = 0; i < m_pventries->size(); i++) {
+    st_GroupTitleUser st = m_pventries->at(i);
+    nPos = m_PolicyEntries.InsertItem(nPos, st.group.c_str());
+    m_PolicyEntries.SetItemText(nPos, 1, st.title.c_str());
+    m_PolicyEntries.SetItemText(nPos, 2, st.user.c_str());
+    m_PolicyEntries.SetItemData(nPos, i);
+    nPos++;
+  }
+
+  // Resize columns
+  m_PolicyEntries.SetColumnWidth(0, LVSCW_AUTOSIZE_USEHEADER);
+  m_PolicyEntries.SetColumnWidth(1, LVSCW_AUTOSIZE_USEHEADER);
+  m_PolicyEntries.SetColumnWidth(2, LVSCW_AUTOSIZE_USEHEADER);
+
+  return FALSE;
+}
+
+void CPWPListEntries::OnHeaderClicked(NMHDR *pNotifyStruct, LRESULT *pLResult)
+{
+  HD_NOTIFY *phdn = (HD_NOTIFY *)pNotifyStruct;
+
+  if (phdn->iButton == 0) {
+    // User clicked on header using left mouse button
+    if (phdn->iItem == m_iSortedColumn)
+      m_bSortAscending = !m_bSortAscending;
+    else
+      m_bSortAscending = TRUE;
+
+    m_iSortedColumn = phdn->iItem;
+    m_PolicyEntries.SortItems(CompareFunc, (LPARAM)this);
+
+    // Note: WINVER defines the minimum system level for which this is program compiled and
+    // NOT the level of system it is running on!
+    // In this case, these values are defined in Windows XP and later and supported
+    // by V6 of comctl32.dll (supplied with Windows XP) and later.
+    // They should be ignored by earlier levels of this dll or .....
+    //     we can check the dll version (code available on request)!
+
+#if (WINVER < 0x0501)  // These are already defined for WinXP and later
+#define HDF_SORTUP 0x0400
+#define HDF_SORTDOWN 0x0200
+#endif
+    HDITEM HeaderItem;
+    HeaderItem.mask = HDI_FORMAT;
+    m_PolicyEntries.GetHeaderCtrl()->GetItem(m_iSortedColumn, &HeaderItem);
+    // Turn off all arrows
+    HeaderItem.fmt &= ~(HDF_SORTUP | HDF_SORTDOWN);
+    // Turn on the correct arrow
+    HeaderItem.fmt |= ((m_bSortAscending == TRUE) ? HDF_SORTUP : HDF_SORTDOWN);
+    m_PolicyEntries.GetHeaderCtrl()->SetItem(m_iSortedColumn, &HeaderItem);
+  }
+
+  *pLResult = 0;
+}
+
+int CALLBACK CPWPListEntries::CompareFunc(LPARAM lParam1, LPARAM lParam2,
+                                          LPARAM closure)
+{
+  CPWPListEntries *self = (CPWPListEntries *)closure;
+  int nSortColumn = self->m_iSortedColumn;
+  const st_GroupTitleUser pLHS = self->m_pventries->at(lParam1);
+  const st_GroupTitleUser pRHS = self->m_pventries->at(lParam2);
+
+  int iResult(0);
+  switch (nSortColumn) {
+  case 0:
+    iResult = CompareNoCase(pLHS.group, pRHS.group);
+    break;
+  case 1:
+    iResult = CompareNoCase(pLHS.title, pRHS.title);
+    break;
+  case 2:
+    iResult = CompareNoCase(pLHS.user, pRHS.user);
+    break;
+  default:
+    ASSERT(FALSE);
+  }
+
+  if (!self->m_bSortAscending && iResult != 0)
+    iResult *= -1;
+
+  return iResult;
+}

--- a/src/ui/Windows/PWPListEntries.h
+++ b/src/ui/Windows/PWPListEntries.h
@@ -1,0 +1,49 @@
+/*
+* Copyright (c) 2003-2016 Rony Shapiro <ronys@pwsafe.org>.
+* All rights reserved. Use of the code is allowed under the
+* Artistic License 2.0 terms, as specified in the LICENSE file
+* distributed with this code, or available from
+* http://www.opensource.org/licenses/artistic-license-2.0.php
+*/
+
+#pragma once
+
+// CPWPListEntries dialog
+
+#include "resource.h"
+#include "PWDialog.h"
+
+#include "../../core/coredefs.h"
+
+#include <vector>
+
+class CPWPListEntries : public CPWDialog
+{
+	DECLARE_DYNAMIC(CPWPListEntries)
+
+public:
+	CPWPListEntries(CWnd* pParent = NULL, StringX sxPolicyName = L"",
+    std::vector<st_GroupTitleUser> *pventries = NULL);
+	virtual ~CPWPListEntries();
+
+// Dialog Data
+	enum { IDD = IDD_NPWP_LIST_ENTRIES };
+
+protected:
+	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+  virtual BOOL OnInitDialog();
+
+  afx_msg void OnHeaderClicked(NMHDR *pNotifyStruct, LRESULT *pLResult);
+
+	DECLARE_MESSAGE_MAP()
+
+  CListCtrl m_PolicyEntries;
+  int m_iSortedColumn;
+  BOOL m_bSortAscending;
+
+private:
+  std::vector<st_GroupTitleUser> *m_pventries;
+  StringX m_sxPolicyName;
+
+  static int CALLBACK CompareFunc(LPARAM lParam1, LPARAM lParam2, LPARAM lParamSort);
+};

--- a/src/ui/Windows/PasswordSafe.rc
+++ b/src/ui/Windows/PasswordSafe.rc
@@ -11,7 +11,8 @@
 #include "resource2.h"  // Menu, Toolbar & Accelerator resources
 #include "resource3.h"  // STRING resources
 #include "..\..\core\core.h"  // core STRING resources
-#include "VirtualKeyboard\VKresource.h"  // Virtual Keyboard resource
+#include "VirtualKeyboard\VKresource.h"  // Virtual Keyboard resource
+
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
 
@@ -1866,6 +1867,15 @@ BEGIN
     EDITTEXT        IDC_VERIFY2,108,185,180,14,ES_PASSWORD | ES_AUTOHSCROLL | NOT WS_VISIBLE | WS_DISABLED
 END
 
+IDD_NPWP_LIST_ENTRIES DIALOGEX 0, 0, 311, 151
+STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Entries using Named Password Policy: "
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    DEFPUSHBUTTON   "OK",IDOK,130,130,50,14
+    CONTROL         "",IDC_NPWP_LIST_ENTRIES,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_ALIGNLEFT | WS_BORDER | WS_TABSTOP,7,7,297,114
+END
+
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -2534,6 +2544,14 @@ BEGIN
     IDD_WZINPUTDB, DIALOG
     BEGIN
     END
+
+    IDD_NPWP_LIST_ENTRIES, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 304
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 144
+    END
 END
 #endif    // APSTUDIO_INVOKED
 
@@ -2573,7 +2591,8 @@ LANGUAGE 9, 1
 #include "..\..\core\core.rc2"    // non-MS VC++ edited core STRING resources
 #include "afxres.rc"         // Standard components
 #endif
-#endif
+#endif
+
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
 

--- a/src/ui/Windows/pwsafe-12.vcxproj
+++ b/src/ui/Windows/pwsafe-12.vcxproj
@@ -885,6 +885,7 @@
     <ClCompile Include="PWHdrCtrlNoChng.cpp" />
     <ClCompile Include="PWHistListCtrl.cpp" />
     <ClCompile Include="PWListCtrl.cpp" />
+    <ClCompile Include="PWPListEntries.cpp" />
     <ClCompile Include="PWPropertyPage.cpp" />
     <ClCompile Include="PWPropertySheet.cpp" />
     <ClCompile Include="PWResizeDialog.cpp" />
@@ -1014,6 +1015,7 @@
     <ClInclude Include="PWHdrCtrlNoChng.h" />
     <ClInclude Include="PWHistListCtrl.h" />
     <ClInclude Include="PWListCtrl.h" />
+    <ClCompile Include="PWPListEntries.h" />
     <ClInclude Include="PWPropertyPage.h" />
     <ClInclude Include="PWPropertySheet.h" />
     <ClInclude Include="PWResizeDialog.h" />

--- a/src/ui/Windows/pwsafe-12.vcxproj.filters
+++ b/src/ui/Windows/pwsafe-12.vcxproj.filters
@@ -408,6 +408,9 @@
     <ClCompile Include="filter\SetAttachmentFiltersDlg.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="PWPListEntries.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AboutDlg.h">
@@ -813,6 +816,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="filter\SetAttachmentFiltersDlg.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="PWPListEntries.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/ui/Windows/pwsafe-14.vcxproj
+++ b/src/ui/Windows/pwsafe-14.vcxproj
@@ -886,6 +886,7 @@
     <ClCompile Include="PWHdrCtrlNoChng.cpp" />
     <ClCompile Include="PWHistListCtrl.cpp" />
     <ClCompile Include="PWListCtrl.cpp" />
+    <ClCompile Include="PWPListEntries.cpp" />
     <ClCompile Include="PWPropertyPage.cpp" />
     <ClCompile Include="PWPropertySheet.cpp" />
     <ClCompile Include="PWResizeDialog.cpp" />
@@ -1015,6 +1016,7 @@
     <ClInclude Include="PWHdrCtrlNoChng.h" />
     <ClInclude Include="PWHistListCtrl.h" />
     <ClInclude Include="PWListCtrl.h" />
+    <ClInclude Include="PWPListEntries.h" />
     <ClInclude Include="PWPropertyPage.h" />
     <ClInclude Include="PWPropertySheet.h" />
     <ClInclude Include="PWResizeDialog.h" />
@@ -1375,6 +1377,21 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Image Include="graphics\toolbar\classic\exportDB.bmp" />
+    <Image Include="graphics\toolbar\classic\exportV1.bmp" />
+    <Image Include="graphics\toolbar\classic\exportV2.bmp" />
+    <Image Include="graphics\toolbar\classic\exportV3.bmp" />
+    <Image Include="graphics\toolbar\classic\exportV4.bmp" />
+    <Image Include="graphics\toolbar\new\exportDB.bmp" />
+    <Image Include="graphics\toolbar\new\exportDB_disabled.bmp" />
+    <Image Include="graphics\toolbar\new\exportV1.bmp" />
+    <Image Include="graphics\toolbar\new\exportV1_disabled.bmp" />
+    <Image Include="graphics\toolbar\new\exportV2.bmp" />
+    <Image Include="graphics\toolbar\new\exportV2_disabled.bmp" />
+    <Image Include="graphics\toolbar\new\exportV3.bmp" />
+    <Image Include="graphics\toolbar\new\exportV3_disabled.bmp" />
+    <Image Include="graphics\toolbar\new\exportV4.bmp" />
+    <Image Include="graphics\toolbar\new\exportV4_disabled.bmp" />
     <Image Include="graphics\Yubikey-button-disabled.bmp" />
     <Image Include="graphics\Yubikey-button.bmp" />
   </ItemGroup>

--- a/src/ui/Windows/pwsafe-14.vcxproj.filters
+++ b/src/ui/Windows/pwsafe-14.vcxproj.filters
@@ -408,6 +408,9 @@
     <ClCompile Include="filter\SetAttachmentFiltersDlg.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="PWPListEntries.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AboutDlg.h">
@@ -813,6 +816,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="filter\SetAttachmentFiltersDlg.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="PWPListEntries.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -1647,6 +1653,51 @@
       <Filter>Resource Files</Filter>
     </Image>
     <Image Include="graphics\Yubikey-button-disabled.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\classic\exportDB.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\new\exportDB.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\new\exportDB_disabled.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\classic\exportV1.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\new\exportV1.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\new\exportV1_disabled.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\classic\exportV2.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\new\exportV2.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\new\exportV2_disabled.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\classic\exportV3.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\new\exportV3.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\new\exportV3_disabled.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\classic\exportV4.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\new\exportV4.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="graphics\toolbar\new\exportV4_disabled.bmp">
       <Filter>Resource Files</Filter>
     </Image>
   </ItemGroup>

--- a/src/ui/Windows/res/PasswordSafe2.rc2
+++ b/src/ui/Windows/res/PasswordSafe2.rc2
@@ -439,6 +439,14 @@ BEGIN
     END
 END
 
+IDR_POPLISTENTRIES MENU
+BEGIN
+  POPUP ""
+    BEGIN
+      MENUITEM "List entries using this policy", ID_MENUITEM_LISTENTRIES
+    END
+END
+
 /////////////////////////////////////////////////////////////////////////////
 //
 // Toolbar is dynamic!

--- a/src/ui/Windows/res/PasswordSafe3.rc2
+++ b/src/ui/Windows/res/PasswordSafe3.rc2
@@ -960,6 +960,7 @@ BEGIN
   IDS_CLICKTOCOPYGENPSWD       "Click to copy generated password to clipboard"
   IDS_PR_MUSTHAVECHARACTERS    "Pronounceable passwords must contain either lowercase or uppercase characters or both"
   IDS_FORMAT_CMP_POLICY        "%s (%s)"
+  IDS_CLICKTOLISTENTRIES       "Right click a Named Password Policy to list the entries using it"
 END
 
 STRINGTABLE

--- a/src/ui/Windows/resource.h
+++ b/src/ui/Windows/resource.h
@@ -90,6 +90,7 @@
 #define IDI_UNLOCKEDICON                209
 #define IDR_POPLANGUAGES                210
 #define IDR_POPCOPYALLTOORIGINAL        211
+#define IDR_POPLISTENTRIES              212
 #define IDB_CLOGO                       220
 #define IDB_CLOGO_SMALL                 221
 #define IDB_PSLOGO                      223
@@ -383,6 +384,7 @@
 #define IDB_EXPORTV4_CLASSIC            543
 #define IDB_EXPORTV4_NEW                544
 #define IDB_EXPORTV4_NEW_D              545
+#define IDD_NPWP_LIST_ENTRIES           546
 #define IDC_APPVERSION                  1000
 #define IDC_VERSION                     1001
 #define IDC_APPVERSION2                 1002
@@ -822,14 +824,15 @@
 #define IDC_AFILTER_LGC_COMBOBOX        1523
 #define IDC_CMB_AVALIABLEMEDIATYPES     1524
 #define IDC_STATIC_TUTORIAL             1525
+#define IDC_NPWP_LIST_ENTRIES           1526
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        540
+#define _APS_NEXT_RESOURCE_VALUE        547
 #define _APS_NEXT_COMMAND_VALUE         30001
-#define _APS_NEXT_CONTROL_VALUE         1526
+#define _APS_NEXT_CONTROL_VALUE         1527
 #define _APS_NEXT_SYMED_VALUE           540
 #endif
 #endif

--- a/src/ui/Windows/resource2.h
+++ b/src/ui/Windows/resource2.h
@@ -280,10 +280,13 @@ Do NOT change the value of any resource used in a menu from V3.17 onwards.
 
 // Following for CEditExtn context menu
 // Really string constants, but "logically" they're menus...
-#define IDS_MENUSTRING_UNDO        34100
-#define IDS_MENUSTRING_CUT         34101
-#define IDS_MENUSTRING_COPY        34102
-#define IDS_MENUSTRING_PASTE       34103
-#define IDS_MENUSTRING_DELETE      34104
-#define IDS_MENUSTRING_SELECTALL   34105
-#define IDS_MENUSTRING_SHOWVKB     34106
+#define IDS_MENUSTRING_UNDO             34100
+#define IDS_MENUSTRING_CUT              34101
+#define IDS_MENUSTRING_COPY             34102
+#define IDS_MENUSTRING_PASTE            34103
+#define IDS_MENUSTRING_DELETE           34104
+#define IDS_MENUSTRING_SELECTALL        34105
+#define IDS_MENUSTRING_SHOWVKB          34106
+
+// Other
+#define ID_MENUITEM_LISTENTRIES         34200

--- a/src/ui/Windows/resource3.h
+++ b/src/ui/Windows/resource3.h
@@ -765,6 +765,7 @@
 #define IDS_SETATTACHMENTFILTER         5991
 #define IDS_AFILTERINFO                 5992
 #define IDS_NOMEDIATYPE                 5993
+#define IDS_CLICKTOLISTENTRIES          5994
 
 #define IDS_YUBI_CLICK_PROMPT           6000
 #define IDS_YUBI_INSERT_PROMPT          6001


### PR DESCRIPTION
Whilst implementing FR 806, found & fixed bug re: export of named password policies to XML. Then decided I needed a way to easily see what entries used a partiular named password policy and so implemented it as a FR.
Note: only tested under VS2015. VS2013 files edited manually as I have now standardised on VS2015 and uninstalled VS2013.