### PR TITLE
Logic mismatch between gmtime64_r/gmtime_r and gmtime64_s

### DIFF
--- a/src/os/linux/pws_time.cpp
+++ b/src/os/linux/pws_time.cpp
@@ -15,7 +15,7 @@
 
 int gmtime64_r(const __time64_t *timep, struct tm *result)
 {
-  return gmtime_r(reinterpret_cast<const time_t *>(timep), result) == 0;
+  return gmtime_r(reinterpret_cast<const time_t *>(timep), result) != 0;
 }
 
 int pws_os::asctime(TCHAR *s, size_t, tm const *t)


### PR DESCRIPTION
gmtime64_s is expecting gmtime64_r to return true on success, false on failure.
gmtime64_r is returning ( gmtime_r() ==  0), but gmtime_r returns pointer to struct on success or NULL on error.  So it appears that the check in gmtime64_r is backwards.

