### PR TITLE
Patch from Ubuntu to fix link failure when built with -Wl,--as-needed

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -27,7 +27,7 @@ TEST	   = $(BINPATH)/coretest
 OBJS     = $(TESTOBJ) $(GTEST_OBJ)
 
 CXXFLAGS += -DUNICODE -Wall -I$(INCPATH) -std=c++11
-LDFLAGS   = -L$(LIBPATH) -lcore -luuid -los -lcore -lxerces-c -pthread
+LDFLAGS   = -L$(LIBPATH) -lcore -los -luuid -lxerces-c -pthread
 
 # rules
 .PHONY: all clean test run setup


### PR DESCRIPTION
Reorder libs so uuid comes after other libs that require it