### PR TITLE
Included space in German translation.

### DIFF
--- a/src/ui/Windows/I18N/pos/pwsafe_de.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_de.po
@@ -1898,7 +1898,7 @@ msgstr "Browser Kommandozeileparameter"
 
 #. Resource IDs: (1001)
 msgid "Built on "
-msgstr "Erstellt am"
+msgstr "Erstellt am "
 
 #. Resource IDs: (520)
 msgid "Bulgarian"


### PR DESCRIPTION
Included a white space in the German translation.