### PR TITLE
Fix osx builds done using Xcode

### DIFF
--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -1477,7 +1477,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "../Misc/mkversion.pl ../src/ui/wxWidgets/version.in ../src/ui/wxWidgets/version.h\ntouch ../src/ui/wxWidgets/version.h";
+			shellScript = "../Misc/mkversion.pl MAJOR=0 MINOR=1 REV=0 SPECIAL=OSX ../src/ui/wxWidgets/version.in ../src/ui/wxWidgets/version.h\ntouch ../src/ui/wxWidgets/version.h";
 		};
 		E6CFEF1811EA41FB001402D8 /* Generate core_st */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Misc/mkversion.pl has changed and now expects some additional args.
Without those, it won't generate version.h. We pass some dummies
to keep it happy.