### PR TITLE
Fix rpm spec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,8 +318,8 @@ install (TARGETS pwsafe RUNTIME DESTINATION "bin")
 if (NOT WIN32)
    install (DIRECTORY xml DESTINATION "share/pwsafe/")
    install (FILES "docs/pwsafe.1" DESTINATION "share/man/man1") # gzip'ed in postinst
-   install (FILES "install/desktop/pwsafe.desktop" DESTINATION "share/pwsafe")
-   install (FILES "install/graphics/pwsafe.png" DESTINATION "share/pwsafe")
+   install (FILES "install/desktop/pwsafe.desktop" DESTINATION "share/applications")
+   install (FILES "install/graphics/pwsafe.png" DESTINATION "share/pixmaps")
    install (DIRECTORY "${CMAKE_BINARY_DIR}/src/ui/wxWidgets/I18N/mos/"
             DESTINATION "share/locale")
 
@@ -370,7 +370,7 @@ set (CPACK_RPM_PACKAGE_REQUIRES "wxBase3, wxGTK3, xerces-c, ykpers")
 set (CPACK_RPM_PACKAGE_URL "https://pwsafe.org/")
 set (CPACK_RPM_PACKAGE_LICENSE "Artistic2.0")
 set (CPACK_RPM_PACKAGE_GROUP "Applications/Utils")
-set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/share/man" "/usr/share/man/man1" "/usr/share/locale" "/usr/share/locale/da" "/usr/share/locale/da/LC_MESSAGES" "/usr/share/locale/de" "/usr/share/locale/de/LC_MESSAGES" "/usr/share/locale/es" "/usr/share/locale/es/LC_MESSAGES" "/usr/share/locale/fr" "/usr/share/locale/fr/LC_MESSAGES" "/usr/share/locale/it" "/usr/share/locale/it/LC_MESSAGES" "/usr/share/locale/ko" "/usr/share/locale/ko/LC_MESSAGES" "/usr/share/locale/nl" "/usr/share/locale/nl/LC_MESSAGES" "/usr/share/locale/pl" "/usr/share/locale/pl/LC_MESSAGES" "/usr/share/locale/ru" "/usr/share/locale/ru/LC_MESSAGES" "/usr/share/locale/sv" "/usr/share/locale/sv/LC_MESSAGES" "/usr/share/locale/zh" "/usr/share/locale/zh/LC_MESSAGES")
+set (CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/share/man" "/usr/share/man/man1" "/usr/share/locale" "/usr/share/locale/da" "/usr/share/locale/da/LC_MESSAGES" "/usr/share/locale/de" "/usr/share/locale/de/LC_MESSAGES" "/usr/share/locale/es" "/usr/share/locale/es/LC_MESSAGES" "/usr/share/locale/fr" "/usr/share/locale/fr/LC_MESSAGES" "/usr/share/locale/it" "/usr/share/locale/it/LC_MESSAGES" "/usr/share/locale/ko" "/usr/share/locale/ko/LC_MESSAGES" "/usr/share/locale/nl" "/usr/share/locale/nl/LC_MESSAGES" "/usr/share/locale/pl" "/usr/share/locale/pl/LC_MESSAGES" "/usr/share/locale/ru" "/usr/share/locale/ru/LC_MESSAGES" "/usr/share/locale/sv" "/usr/share/locale/sv/LC_MESSAGES" "/usr/share/locale/zh" "/usr/share/locale/zh/LC_MESSAGES" "/usr/share/applications" "/usr/share/pixmaps")
 include(CPack)
 ### End of packaging section
 ### End of CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,7 @@ set (CPACK_RPM_PACKAGE_REQUIRES "wxBase3, wxGTK3, xerces-c, ykpers")
 set (CPACK_RPM_PACKAGE_URL "https://pwsafe.org/")
 set (CPACK_RPM_PACKAGE_LICENSE "Artistic2.0")
 set (CPACK_RPM_PACKAGE_GROUP "Applications/Utils")
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/share/man" "/usr/share/man/man1" "/usr/share/locale" "/usr/share/locale/da" "/usr/share/locale/da/LC_MESSAGES" "/usr/share/locale/de" "/usr/share/locale/de/LC_MESSAGES" "/usr/share/locale/es" "/usr/share/locale/es/LC_MESSAGES" "/usr/share/locale/fr" "/usr/share/locale/fr/LC_MESSAGES" "/usr/share/locale/it" "/usr/share/locale/it/LC_MESSAGES" "/usr/share/locale/ko" "/usr/share/locale/ko/LC_MESSAGES" "/usr/share/locale/nl" "/usr/share/locale/nl/LC_MESSAGES" "/usr/share/locale/pl" "/usr/share/locale/pl/LC_MESSAGES" "/usr/share/locale/ru" "/usr/share/locale/ru/LC_MESSAGES" "/usr/share/locale/sv" "/usr/share/locale/sv/LC_MESSAGES" "/usr/share/locale/zh" "/usr/share/locale/zh/LC_MESSAGES")
 include(CPack)
 ### End of packaging section
 ### End of CMakeLists.txt


### PR DESCRIPTION
Hi,

Please, consider to merge my pull.

With this pull, I'm trying to fix these two issues (see #122):
1. The CPack problem that generates a bad RPM which conflicts with the `filesystem` package.
2. The location of `pwsafe.desktop` and `pwsafe.png`.

Regarding the last point, I'm not sure if my fix conflicts with other non-RPM-based environment.
Unfortunately, I didn't find an easy way to tell CPack to copy these files in the new locations only if the generator is RPM.
That is, a safer fix would be:

```
if(CPACK_GENERATOR MATCHES "RPM")
    install (FILES "install/desktop/pwsafe.desktop" DESTINATION "share/applications")
    install (FILES "install/graphics/pwsafe.png" DESTINATION "share/pixmaps")
else ()
    install (FILES "install/desktop/pwsafe.desktop" DESTINATION "share/pwsafe")
    install (FILES "install/graphics/pwsafe.png" DESTINATION "share/pwsafe")
endif(CPACK_GENERATOR MATCHES "RPM")
```

but putting this code in `CMakeLists.txt` doesn't work.

Best,

Marco