### PR TITLE
StringX's deallocate memset()'s can get optimized out by the compiler on gcc/clang

### DIFF
--- a/src/core/StringX.h
+++ b/src/core/StringX.h
@@ -28,6 +28,9 @@
 #include "../os/typedefs.h"
 #include "./PwsPlatform.h"
 
+// Using extern definition here instead of including "Util.h" because Util.h
+// references the StringX class and by including "Util.h" here, the StringX
+// class isn't fully defined yet.
 extern void trashMemory(void *buffer, size_t length);
 
 namespace S_Alloc

--- a/src/core/StringX.h
+++ b/src/core/StringX.h
@@ -28,6 +28,8 @@
 #include "../os/typedefs.h"
 #include "./PwsPlatform.h"
 
+extern void trashMemory(void *buffer, size_t length);
+
 namespace S_Alloc
 {
   template <typename T>
@@ -115,9 +117,7 @@ namespace S_Alloc
 
         if (n > 0) {
           const size_type N = n * sizeof(T);
-          std::memset(p, 0x55, N);
-          std::memset(p, 0xAA, N);
-          std::memset(p,    0, N);
+          trashMemory(p, N);
         }
         std::free(p);
       }

--- a/src/core/StringX.h
+++ b/src/core/StringX.h
@@ -117,7 +117,7 @@ namespace S_Alloc
 
         if (n > 0) {
           const size_type N = n * sizeof(T);
-          trashMemory(p, N);
+          trashMemory((void *)p, N);
         }
         std::free(p);
       }

--- a/src/core/Util.cpp
+++ b/src/core/Util.cpp
@@ -60,6 +60,12 @@ void trashMemory(void *buffer, size_t length)
     std::memset(buffer, 0x55, length);
     std::memset(buffer, 0xAA, length);
     std::memset(buffer,    0, length);
+#ifdef __GNUC__
+    // break compiler optimization of this function for gcc
+    // see trick used in google's boring ssl:
+    // https://boringssl.googlesource.com/boringssl/+/ad1907fe73334d6c696c8539646c21b11178f20f%5E!/#F0
+    __asm__ __volatile__("" : : "r"(buffer) : "memory");
+#endif
   }
 }
 #ifdef _WIN32


### PR DESCRIPTION
On Mac OS X 10.11 (clang), StringX's deallocation function uses a series of memset to securely scrub out sensitive memory after usage. Clang can optimize the memset()'s out completely leaving sensitive data in memory. I put together a test case:
```
#include <string>
#include "StringX.h"

extern StringX getXX();

void testGccStringXOptimization()
{
  StringX secureString = getXX();
  printf("%s\n", secureString.c_str());
  // <- check assembly to see if memset() is called
}
```
and on my machine (Apple LLVM version 7.3.0 (clang-703.0.31)):
```
__Z26testGccStringXOptimizationv:       ## @_Z26testGccStringXOptimizationv
Lfunc_begin0:
	.file	39 "/Users/sound/Desktop/pwsafe/src/os" "d.cpp"
	.loc	39 14 0                 ## /Users/sound/Desktop/pwsafe/src/os/d.cpp:14:0
	.cfi_startproc
## BB#0:
	pushq	%rbp
Ltmp0:
	.cfi_def_cfa_offset 16
Ltmp1:
	.cfi_offset %rbp, -16
	movq	%rsp, %rbp
Ltmp2:
	.cfi_def_cfa_register %rbp
	pushq	%rbx
	subq	$24, %rsp
Ltmp3:
	.cfi_offset %rbx, -24
	leaq	-32(%rbp), %rdi
Ltmp4:
	##DEBUG_VALUE: __is_long:this <- [%RDI+0]
	##DEBUG_VALUE: ~basic_string:this <- [%RDI+0]
	##DEBUG_VALUE: ~basic_string:this <- [%RDI+0]
	##DEBUG_VALUE: __get_short_pointer:this <- [%RDI+0]
	##DEBUG_VALUE: __get_long_pointer:this <- [%RDI+0]
	##DEBUG_VALUE: __is_long:this <- [%RDI+0]
	##DEBUG_VALUE: __get_pointer:this <- [%RDI+0]
	##DEBUG_VALUE: data:this <- [%RDI+0]
	##DEBUG_VALUE: c_str:this <- [%RDI+0]
	##DEBUG_VALUE: testGccStringXOptimization:secureString <- [%RDI+0]
	.loc	39 15 26 prologue_end   ## /Users/sound/Desktop/pwsafe/src/os/d.cpp:15:26
	callq	__Z5getXXv
	movb	$1, %bl
	.loc	2 1681 22               ## /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:1681:22
Ltmp5:
	testb	-32(%rbp), %bl
Ltmp6:
	.loc	2 1769 59               ## /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:1769:59
	leaq	-28(%rbp), %rdi
Ltmp7:
	##DEBUG_VALUE: addressof<const wchar_t>:__x <- %RDI
	##DEBUG_VALUE: pointer_to:__r <- %RDI
	.loc	2 1775 17               ## /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:1775:17
	cmovneq	-16(%rbp), %rdi
Ltmp8:
	##DEBUG_VALUE: __to_raw_pointer<const wchar_t>:__p <- %RDI
	.loc	39 16 3                 ## /Users/sound/Desktop/pwsafe/src/os/d.cpp:16:3
	callq	_puts
	.loc	2 1681 22               ## /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:1681:22
Ltmp9:
	testb	-32(%rbp), %bl
	je	LBB0_3
Ltmp10:
## BB#1:
	.loc	2 1760 34               ## /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:1760:34
	movq	-16(%rbp), %rdi
Ltmp11:
	##DEBUG_VALUE: deallocate:p <- %RDI
	##DEBUG_VALUE: deallocate:__p <- %RDI
	.loc	3 113 15                ## /Users/sound/Desktop/pwsafe/src/core/StringX.h:113:15
	testq	%rdi, %rdi
	je	LBB0_3
Ltmp12:
## BB#2:
	##DEBUG_VALUE: deallocate:__p <- %RDI
	##DEBUG_VALUE: deallocate:p <- %RDI
	.loc	3 122 9                 ## /Users/sound/Desktop/pwsafe/src/core/StringX.h:122:9
	callq	_free
Ltmp13:
LBB0_3:                                 ## %_ZNSt3__112basic_stringIwNS_11char_traitsIwEEN7S_Alloc11SecureAllocIwEEED1Ev.exit
	.loc	39 18 1                 ## /Users/sound/Desktop/pwsafe/src/os/d.cpp:18:1
	addq	$24, %rsp
	popq	%rbx
	popq	%rbp
	retq
```
Shows no traces of memset() during deallocation of StringX.

It does seem that replacing the memset()s with trashMemory() will cause the memory to be trashed properly. I've also imported a trick from boringssl to help gcc from optimizing trashMemory.

I'm no security expert but let me know what you think.
