### PR TITLE
Make the build reproducible

### DIFF
--- a/Misc/rc2cpp.pl
+++ b/Misc/rc2cpp.pl
@@ -18,7 +18,6 @@
 
 use strict;
 use warnings;
-use locale;
 use File::Basename;
 
 sub usage {

--- a/help/Makefile.linux
+++ b/help/Makefile.linux
@@ -6,10 +6,10 @@ ZIP = /usr/bin/zip
 all: default $(LANGS)
 
 default:
-	@cd default ; $(ZIP) -qr ../helpEN ./*
+	@cd default ; $(ZIP) -Xqr ../helpEN ./*
 
 $(LANGS):
-	@cd $(BASEDIRNAME)$@ ; $(ZIP) -qr ../help$@ ./*
+	@cd $(BASEDIRNAME)$@ ; $(ZIP) -Xqr ../help$@ ./*
 
 clean:
 	$(RM) *.zip


### PR DESCRIPTION
Debian has a reproducible build project (https://wiki.debian.org/ReproducibleBuilds) that strives to make package builds byte-for-byte reproducible in order to allow for easier verification.
The attached patch fixes some issues in pwsafe that cause builds to differ even when built under the identical environment/compiler conditions.
 - strip extra fields from zip file containing help files
 - don't honour locale in rc2cpp.pl, or else keys written
   into generated cpp source file will be sorted differently
   under different locales.