### PR TITLE
Added (restored) 'showdefault' flag for ResText tool

### DIFF
--- a/src/Tools/Windows/I18N/ResText/ResModule.cpp
+++ b/src/Tools/Windows/I18N/ResText/ResModule.cpp
@@ -68,6 +68,7 @@ CResModule::CResModule(void)
     , m_bQuiet(false)
     , m_bRTL(false)
     , m_bAdjustEOLs(false)
+    , m_bShowDefault(false)
 {
 }
 
@@ -438,8 +439,12 @@ BOOL CResModule::ReplaceString(LPCTSTR lpszType, WORD wLanguage)
             if (len)
                 wcsncpy((wchar_t *)&newTable[index], p, len);
             index += len;
-            if (len)
+            if (len) {
                 m_bDefaultStrings++;
+                if (m_bShowDefault && wcslen(msgid.c_str())) {
+                    _ftprintf(stderr, L"Default string: <%s>\n", msgid.c_str());
+                }
+            }
         }
         p += len;
         delete [] pBuf;
@@ -2180,8 +2185,12 @@ void CResModule::ReplaceStr(LPCWSTR src, WORD * dest, size_t * count, int * tran
         if (dest)
             wcscpy((wchar_t *)&dest[(*count)], src);
         (*count) += wcslen(src) + 1;
-        if (wcslen(src))
+        if (wcslen(src)) {
             (*def)++;
+            if (m_bShowDefault) {
+                _ftprintf(stderr, L"Default other: <%s>\n", src);
+            }
+        }
     }
     delete [] pBuf;
 }

--- a/src/Tools/Windows/I18N/ResText/ResModule.h
+++ b/src/Tools/Windows/I18N/ResText/ResModule.h
@@ -90,6 +90,7 @@ public:
     void    SetLanguage(WORD wLangID) {m_wTargetLang = wLangID;}
     void    SetRTL(bool bRTL = true) {m_bRTL = bRTL;}
     void    SetAdjustEOLs(bool bAdjustEOLs = true) {m_bAdjustEOLs = bAdjustEOLs;}
+    void    SetShowDefault(bool bShowDefault = true) { m_bShowDefault = bShowDefault; }
 
 private:
     static  BOOL CALLBACK EnumResNameCallback(HMODULE hModule, LPCTSTR lpszType, LPTSTR lpszName, LONG_PTR lParam);
@@ -147,6 +148,7 @@ private:
 
     bool            m_bRTL;
     bool            m_bAdjustEOLs;
+    bool            m_bShowDefault;
 
     int             m_bTranslatedStrings;
     int             m_bDefaultStrings;

--- a/src/Tools/Windows/I18N/ResText/ResText.cpp
+++ b/src/Tools/Windows/I18N/ResText/ResText.cpp
@@ -33,6 +33,7 @@ int _tmain(int argc, _TCHAR* argv[])
     bool bRTL = false;
     bool bUseHeader = false;
     bool bAdjustEOLs = false;
+    bool bShowDefault = false;
     //parse the command line
     std::vector<tstring> arguments;
     std::vector<tstring> switches;
@@ -66,6 +67,8 @@ int _tmain(int argc, _TCHAR* argv[])
             bUseHeader = true;
         if (wcscmp(I->c_str(), L"adjusteols")==0)
             bAdjustEOLs = true;
+        if (wcscmp(I->c_str(), L"showdefault") == 0)
+            bShowDefault = true;
     }
     std::vector<tstring>::iterator arg = arguments.begin();
 
@@ -125,6 +128,7 @@ int _tmain(int argc, _TCHAR* argv[])
             module.SetLanguage(wLang);
             module.SetRTL(bRTL);
             module.SetAdjustEOLs(bAdjustEOLs);
+            module.SetShowDefault(bShowDefault);
             if (!module.CreateTranslatedResources(sSrcDllFile.c_str(), sDstDllFile.c_str(), sPoFile.c_str()))
                 return -1;
             bShowHelp = false;
@@ -146,6 +150,7 @@ int _tmain(int argc, _TCHAR* argv[])
         _ftprintf(stdout, L"-quiet: don't print progress messages\n");
         _ftprintf(stdout, L"-rtl  : change the controls to RTL reading\n");
         _ftprintf(stdout, L"-adjusteols : if the msgid string has \\r\\n eols, enforce those for the translation too.\n");
+        _ftprintf(stdout, L"-showdefault  : print untranslated values to stderr\n");
         _ftprintf(stdout, L"\n");
         _ftprintf(stdout, L"Note: when extracting resources, C-resource header files can be specified\n");
         _ftprintf(stdout, L"like this: <resource.dll>*<resource.h>*<resource.h>*...\n");


### PR DESCRIPTION
This flag is useful when checking for untranslated entries (msgid will be printed to stderr).