### PR TITLE
Fix compile error on 32-bit FreeBSD

### DIFF
--- a/README.FREEBSD
+++ b/README.FREEBSD
@@ -10,14 +10,18 @@ from a wider audience.
 This has only been tested:
  * FreeBSD 10.2 amd64 with wx 3.0
  * FreeBSD 10.3 amd64 with wx 3.0
+ * FreeBSD 11.0 i386 with wx 3.0
+ * FreeBSD 11.0 amd64 with wx 3.0
 == Known not working ==
  * The help system
  * Debug builds
+ * -d / -e command line switches
 
 = Installation =
  1. Install:
     - archivers/zip
-    - devel/gmake-lite
+    - devel/gmake
+    - devel/cmake
     - devel/googletest
     - misc/e2fsprogs-libuuid
     - lang/clang38
@@ -25,7 +29,7 @@ This has only been tested:
     - x11-toolkits/wxgtk30
  2. mkdir build; cd build;
  3. cmake -D wxWidgets_CONFIG_EXECUTABLE=/usr/local/bin/wxgtk2u-3.0-config -D CMAKE_C_COMPILER=clang38 -DCMAKE_CXX_COMPILER=clang++38 ..
- 4. gmake-lite
+ 4. gmake
  5. Your `pwsafe` binary is in `build` (your current directory)
  6. At start you get a warning about the help system
 

--- a/src/core/ItemData.cpp
+++ b/src/core/ItemData.cpp
@@ -1731,7 +1731,7 @@ bool CItemData::Matches(int16 dca, int iFunction, const bool bShift) const
   return false;
 }
 
-bool CItemData::Matches(time_t time1, time_t time2, int iObject,
+bool CItemData::MatchesTime(time_t time1, time_t time2, int iObject,
                         int iFunction) const
 {
   //   Check time values are selected

--- a/src/core/ItemData.h
+++ b/src/core/ItemData.h
@@ -227,7 +227,7 @@ public:
                int iFunction) const;  // string values
   bool Matches(int num1, int num2, int iObject,
                int iFunction) const;  // integer values
-  bool Matches(time_t time1, time_t time2, int iObject,
+  bool MatchesTime(time_t time1, time_t time2, int iObject,
                int iFunction) const;  // time values
   bool Matches(int16 dca, int iFunction, const bool bShift = false) const;  // DCA values
   bool Matches(EntryType etype, int iFunction) const;  // Entrytype values

--- a/src/core/PWSFilters.cpp
+++ b/src/core/PWSFilters.cpp
@@ -1197,7 +1197,7 @@ bool PWSFilterManager::PassesFiltering(const CItemData &ci, const PWScore &core)
             if (ifunction == PWSMatch::MR_BETWEEN)
               t2 = now + (st_fldata.fnum2 * 86400);
           }
-          thistest_rc = pci->Matches(t1, t2,
+          thistest_rc = pci->MatchesTime(t1, t2,
                                      (int)ft, ifunction);
           tests++;
           break;


### PR DESCRIPTION
There are multiple functions named Matches() that differ only by
parameter type. In 32-bit BSD, the params for two of these are
both actually int. No callers are depending on the correct
overload to be bound based on type, so the easy fix is to rename one of
them, and change the call site to use the new name.

This fixes issue #196.

I built FreeBSD 32-bit and 64-bit and OS X and smoke-tested the app. I did not build Windows.