### PR TITLE
Save normal entry's PWH when becoming an alias

### DIFF
--- a/src/ui/Windows/AddEdit_Additional.cpp
+++ b/src/ui/Windows/AddEdit_Additional.cpp
@@ -261,7 +261,7 @@ BOOL CAddEdit_Additional::OnInitDialog()
     m_Help2.ShowWindow(SW_HIDE);
   }
 
-  UpdatePasswordHistory();
+  UpdatePasswordHistoryLC();
 
   if (M_uicaller() == IDS_VIEWENTRY || M_protected() != 0) {
     GetDlgItem(IDC_MAXPWHISTORY)->EnableWindow(FALSE);
@@ -981,7 +981,7 @@ void CAddEdit_Additional::OnHistListClick(NMHDR *pNMHDR, LRESULT *pResult)
   *pResult = 0;
 }
 
-void CAddEdit_Additional::UpdatePasswordHistory()
+void CAddEdit_Additional::UpdatePasswordHistoryLC()
 {
   // Set up PWH CListCtrl
   CString cs_text;

--- a/src/ui/Windows/AddEdit_Additional.h
+++ b/src/ui/Windows/AddEdit_Additional.h
@@ -41,7 +41,7 @@ public:
 
   void OnEntryHotKeyKillFocus();
   void OnEntryHotKeySetFocus();
-  void UpdatePasswordHistory();
+  void UpdatePasswordHistoryLC();
   bool HasBeenShown() const { return m_bInitdone; }
 
 protected:

--- a/src/ui/Windows/AddEdit_PropertySheet.cpp
+++ b/src/ui/Windows/AddEdit_PropertySheet.cpp
@@ -519,7 +519,7 @@ BOOL CAddEdit_PropertySheet::OnApply(const int &iCID)
   // password history is being saved and the Add_Additional property page
   // has already been shown
   if (bIsPSWDModified && m_AEMD.SavePWHistory == TRUE && m_pp_additional->HasBeenShown()) {
-    m_pp_additional->UpdatePasswordHistory();
+    m_pp_additional->UpdatePasswordHistoryLC();
   }
   return TRUE;
 }
@@ -647,9 +647,13 @@ void CAddEdit_PropertySheet::SetupInitialValues()
   // PWHistory fields
   // If user changes the password of its base entry from the
   // alias, we do record them in the base entry if the user wants them.
-  // For an alias, we will show its pre-alias password history
+  // For an alias, we will show its base entry's password history
   size_t num_err;
-  m_AEMD.PWHistory = m_AEMD.pci->GetPWHistory();
+  if (m_AEMD.pci->IsAlias())
+    m_AEMD.PWHistory = pciA->GetPWHistory();
+  else
+    m_AEMD.PWHistory = m_AEMD.pci->GetPWHistory();
+
   BOOL HasHistory = CreatePWHistoryList(m_AEMD.PWHistory,
                                         m_AEMD.MaxPWHistory,
                                         num_err,


### PR DESCRIPTION
When editing an alias, show base's PWH in AddEdit_Additional tab
Restore alias' PWH if user reverts it to a normal entry
Also rename AddEdit_Additional member function to be different to that of CItemData