### PR TITLE
Resolve various empty group/filter issues:

### DIFF
--- a/docs/ReleaseNotes.html
+++ b/docs/ReleaseNotes.html
@@ -107,6 +107,11 @@ a new entry (and not only when editing).</td>
 window's closed.</td>
 </tr>
 <tr>
+<td align="center" width="100">[]</td>
+<td>All empty groups are no longer shown when the user filters for only entries 
+with expired passwords.</td>
+</tr>
+<tr>
 <td align="center" width="100"><a href="nojs.html" onclick="BR(1378);return false;">1378</a></td>
 <td>Fix application crash if Add/Edit entry dialog is open when the database is locked
 e.g. via idle timer, workstation lock etc.</td>
@@ -192,6 +197,16 @@ send keyboard input to other applications e.g. browsers.</td>
 <tr>
 <td align="center" width="100">[]</td>
 <td>Add more Help to the Add/Edit Basic and Additional tabs.</td>
+</tr>
+<tr>
+<td align="center" width="100">[]</td>
+<td>Empty groups added but not yet saved are now included when the user filters
+on unsaved changes.</td>
+</tr>
+<tr>
+<td align="center" width="100">[]</td>
+<td>Empty groups, whose names satisfy a filter that include tests on group name
+values, are now included in the display when the filter is active.</td>
 </tr>
 <tr>
 <td align="center" width="100"><a href="nojs.html" onclick="FR(815);return false;">815</a></td>

--- a/docs/ReleaseNotes.txt
+++ b/docs/ReleaseNotes.txt
@@ -23,6 +23,8 @@ reduce character truncation.
 a new entry (and not only when editing).
 [] Update password history when Appy is clicked, not only when Edit
 window's closed.
+[] All empty groups are no longer shown when the user filters for only entries 
+with expired passwords.
 [1378] Fix application crash if Add/Edit entry dialog open when the database is locked
 e.g. via idle timer, workstation lock etc.
 [1373] An invalid or non-existent backup directory path can no longer be saved
@@ -56,6 +58,10 @@ New Features for 3.41.0pre
 [] New AutoType field '\#' toggles the use of the older mechanism to
 send keyboard input to other applications e.g. browsers.
 [] Add more Help to the Add/Edit Basic and Additional tabs.
+[] Empty groups added but not yet saved are now included when the user filters
+on unsaved changes.
+[] Empty groups, whose names satisfy a filter that include tests on group name
+values, are now included in the display when the filter is active.
 [815] The database backup location now supports environmental variables e.g. 
 %homedrive% and %homepath%.  If used, the resulting path at that time is
 also shown.

--- a/src/core/PWSFilters.cpp
+++ b/src/core/PWSFilters.cpp
@@ -1263,6 +1263,58 @@ bool PWSFilterManager::PassesFiltering(const CItemData &ci, const PWScore &core)
   return false;
 }
 
+bool PWSFilterManager::PassesEmptyGroupFiltering(const StringX &sxGroup)
+{
+  bool thistest_rc;
+
+  if (!m_currentfilter.IsActive())
+    return true;
+
+  for (auto groups_iter = m_vMflgroups.begin();
+       groups_iter != m_vMflgroups.end(); groups_iter++) {
+    const vfiltergroup &group = *groups_iter;
+
+    int tests(0);
+    bool thisgroup_rc = false;
+    for (auto iter = group.begin();
+         iter != group.end(); iter++) {
+      const int &num = *iter;
+      if (num == -1) // Padding to ensure group size is correct for FT_PWHIST & FT_POLICY
+        continue;
+
+      const st_FilterRow &st_fldata = m_currentfilter.vMfldata.at(num);
+      thistest_rc = false;
+
+      const FieldType ft = m_currentfilter.vMfldata[num].ftype;
+      const int ifunction = (int)st_fldata.rule;
+
+      // We are only testing the group value and, as an empty group, it must be present
+      if (ft != FT_GROUP || ifunction == PWSMatch::MR_PRESENT || ifunction == PWSMatch::MR_NOTPRESENT) {
+        continue;
+      }
+
+      thistest_rc = PWSMatch::Match(st_fldata.fstring, sxGroup,
+                                    st_fldata.fcase ? -ifunction : ifunction);
+      tests++;   
+
+      if (tests <= 1)
+        thisgroup_rc = thistest_rc;
+      else {
+        //Within groups, tests are always "AND" connected
+        thisgroup_rc = thistest_rc && thisgroup_rc;
+      }
+    }
+
+    // This group of tests completed -
+    //   if 'thisgroup_rc == true', leave now; else go on to next group
+    if (thisgroup_rc)
+      return true;
+  }
+
+  // We finished all the groups and haven't found one that is true - exclude entry.
+  return false;
+}
+
 bool PWSFilterManager::PassesPWHFiltering(const CItemData *pci) const
 {
   bool thistest_rc, bPresent;

--- a/src/core/PWSFilters.h
+++ b/src/core/PWSFilters.h
@@ -196,7 +196,6 @@ struct st_FilterRow {
     return *this;
   }
 
-
   bool operator==(const st_FilterRow &that) const
   {
     if (this != &that) {
@@ -393,6 +392,7 @@ class PWSFilterManager {
   PWSFilterManager();
   void CreateGroups();
   bool PassesFiltering(const CItemData &ci, const PWScore &core);
+  bool PassesEmptyGroupFiltering(const StringX &sxGroup);
 
   // predefined filters accessors, use by assigning to m_currentfilter
   const st_filters &GetExpireFilter() const {return m_expirefilter;}
@@ -401,14 +401,14 @@ class PWSFilterManager {
   st_filters m_currentfilter;
   
  private:
- bool PassesPWHFiltering(const CItemData *pci) const;
- bool PassesPWPFiltering(const CItemData *pci) const;
- bool PassesAttFiltering(const CItemData *pci, const PWScore &core) const;
+   bool PassesPWHFiltering(const CItemData *pci) const;
+   bool PassesPWPFiltering(const CItemData *pci) const;
+   bool PassesAttFiltering(const CItemData *pci, const PWScore &core) const;
 
- vfiltergroups m_vMflgroups, m_vHflgroups, m_vPflgroups, m_vAflgroups;
+   vfiltergroups m_vMflgroups, m_vHflgroups, m_vPflgroups, m_vAflgroups;
 
-  // predefined filters, set up at c'tor
- st_filters m_expirefilter, m_unsavedfilter;
+   // predefined filters, set up at c'tor
+   st_filters m_expirefilter, m_unsavedfilter;
 };
 
 #endif  /* __PWSFILTERS_H */

--- a/src/core/PWScore.h
+++ b/src/core/PWScore.h
@@ -428,6 +428,7 @@ public:
 
   // Empty Groups
   const std::vector<StringX> & GetEmptyGroups() const {return m_vEmptyGroups;}
+  const std::vector<StringX> & GetSavedEmptyGroups() const { return m_InitialvEmptyGroups; }
   bool IsEmptyGroup(const StringX &sxEmptyGroup) const;
   size_t GetNumberEmptyGroups() const {return m_vEmptyGroups.size();}
 

--- a/src/ui/Windows/DboxMain.cpp
+++ b/src/ui/Windows/DboxMain.cpp
@@ -3273,7 +3273,7 @@ int DboxMain::OnUpdateMenuToolbar(const UINT nID)
     case ID_MENUITEM_SHOWHIDE_UNSAVED:
       // Filter sub-menu mutually exclusive with use of internal filters for
       // display of unsaved or expired entries
-      if (!m_core.HasDBChanged() ||
+      if ((!m_core.HasDBChanged() && !m_core.HaveEmptyGroupsChanged()) ||
           (m_bFilterActive && !m_bUnsavedDisplayed))
         iEnable = FALSE;
       break;

--- a/src/ui/Windows/PWFindToolBar.h
+++ b/src/ui/Windows/PWFindToolBar.h
@@ -59,7 +59,8 @@ public:
                      CItemData::FieldBits &bsFields, CItemAtt::AttFieldBits &bsAttFields,
                      std::wstring &subgroup_name, 
                      bool &subgroup_bset, int &subgroup_object, int &subgroup_function)
-  {bAdvanced = m_bAdvanced;
+  {
+    bAdvanced = m_bAdvanced;
     bsFields = m_pst_SADV->bsFields; bsAttFields = m_pst_SADV->bsAttFields;
     subgroup_name = m_subgroup_name; subgroup_bset = m_subgroup_bset;
     subgroup_object = m_subgroup_object; subgroup_function = m_subgroup_function;}

--- a/src/ui/Windows/PWTreeCtrl.cpp
+++ b/src/ui/Windows/PWTreeCtrl.cpp
@@ -1107,6 +1107,7 @@ HTREEITEM CPWTreeCtrl::AddGroup(const CString &group, bool &bAlreadyExists)
         bAlreadyExists = false;
       } else
         ti = si;
+
       app.GetMainDlg()->m_mapGroupToTreeItem[sxPath2Root] = ti;
       app.GetMainDlg()->m_mapTreeItemToGroup[ti] = sxPath2Root;
     } while (!sxPath.empty());


### PR DESCRIPTION
1. All empty groups are no longer shown when the user filters for only entries with expired passwords.
2. Empty groups added but not yet saved are now included when the user filters on unsaved changes.
3. Empty groups, whose names satisfy a filter that include tests on group name values, are now included in the display when the filter is active.