### PR TITLE
Some more fixes

### DIFF
--- a/help/default/html/autotype.html
+++ b/help/default/html/autotype.html
@@ -187,15 +187,15 @@ style="margin-left:20px; border-spacing:10px">
 <p>For example:<br> "\{+Tab}" is equivalent to "Shift+Tab"<br> "\{+^Tab}" is
 equivalent to "Ctrl+Shift+Tab"<br> "\{^Home}" is equivalent to "Control+Home".</p> 
 
-<h4>Shortcuts and Aliases</h4>
+<h3>Shortcuts and Aliases</h3>
 
-<h5>Shortcuts</h5>
+<h4>Shortcuts</h4>
 
 <p>The AutoType string and all entry variables, e.g. \p for password, come for
 the shortcut's base entry. <i>No entry variables come from the shortcut entry
 itself.</i></p>
 
-<h5>Aliases</h>
+<h4>Aliases</h4>
 
 <p>The AutoType string and all entry variables <u>except</u> the current password 
 (\p) and previous password (\q) come from the alias entry.

--- a/src/core/Command.cpp
+++ b/src/core/Command.cpp
@@ -522,13 +522,14 @@ int AddEntryCommand::Execute()
 void AddEntryCommand::Undo()
 {
   if (!m_pcomInt->IsReadOnly() && m_CommandDBChange == DB) {
-    DeleteEntryCommand delete_entry_cmd(m_pcomInt, m_ci, this);
-    delete_entry_cmd.Execute();
-
+    // Do actions in reverse order to Execute
     if (m_ci.IsDependent()) {
       m_pcomInt->DoRemoveDependentEntry(m_ci.GetBaseUUID(), m_ci.GetUUID(),
         m_ci.GetEntryType());
     }
+
+    DeleteEntryCommand delete_entry_cmd(m_pcomInt, m_ci, this);
+    delete_entry_cmd.Execute();
   }
 }
 

--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -3148,6 +3148,82 @@ CItemData *PWScore::GetBaseEntry(const CItemData *pAliasOrSC)
   return NULL;
 }
 
+bool PWScore::GetValues(const CItemData *pci, StringX &sx_group, StringX &sx_title, StringX &sx_user,
+                        StringX &sx_pswd, StringX &sx_lastpswd,
+                        StringX &sx_notes, StringX &sx_url, StringX &sx_email, StringX &sx_autotype, StringX &sx_runcmd) const
+{
+  // The one place to get the values needed for AutoType & RunCmd based on entry type
+  const CItemData *pbci(NULL);
+
+  const CItemData::EntryType et = pci->GetEntryType();
+
+  if (et == CItemData::ET_ALIAS || et == CItemData::ET_SHORTCUT) {
+    pbci = GetBaseEntry(pci);
+    ASSERT(pbci != NULL);
+   if (pbci == NULL)
+     return false;
+  }
+
+  switch (et) {
+  case CItemData::ET_NORMAL:
+  case CItemData::ET_ALIASBASE:
+  case CItemData::ET_SHORTCUTBASE:
+    // Everything from entry
+    sx_group = pci->GetGroup();
+    sx_title = pci->GetTitle();
+    sx_user = pci->GetUser();
+
+    sx_pswd = pci->GetPassword();
+    sx_lastpswd = pci->GetPreviousPassword();
+
+    sx_notes = pci->GetNotes();
+    sx_url = pci->GetURL();
+    sx_email = pci->GetEmail();
+    sx_autotype = pci->GetAutoType();
+    sx_runcmd = pci->GetRunCommand();
+    break;
+  case CItemData::ET_ALIAS:
+    // Only current and last password are taken from its base entry
+    // Everything else is from the actual entry
+    sx_group = pci->GetGroup();
+    sx_title = pci->GetTitle();
+    sx_user = pci->GetUser();
+
+    sx_pswd = pbci->GetPassword();
+    sx_lastpswd = pbci->GetPreviousPassword();
+
+    sx_notes = pci->GetNotes();
+    sx_url = pci->GetURL();
+    sx_email = pci->GetEmail();
+    sx_autotype = pci->GetAutoType();
+    sx_runcmd = pci->GetRunCommand();
+    break;
+  case CItemData::ET_SHORTCUT:
+#ifdef BR1124
+    // For a shortcut username taken from entry, everything else is from its base
+    sx_user = pci->GetUser();
+#else
+    // For a shortcut everything is taken from its base entry
+    sx_user = pbci->GetUser();
+#endif
+    sx_group = pbci->GetGroup();
+    sx_title = pbci->GetTitle();
+    sx_pswd = pbci->GetPassword();
+    sx_lastpswd = pbci->GetPreviousPassword();
+
+    sx_notes = pbci->GetNotes();
+    sx_url = pbci->GetURL();
+    sx_email = pbci->GetEmail();
+    sx_autotype = pbci->GetAutoType();
+    sx_runcmd = pbci->GetRunCommand();
+    break;
+  default:
+    ASSERT(0);
+  }
+  
+  return true;
+}
+
 bool PWScore::SetUIInterFace(UIInterFace *pUIIF, size_t numsupported,
                              std::bitset<UIInterFace::NUM_SUPPORTED> bsSupportedFunctions)
 {

--- a/src/core/PWScore.h
+++ b/src/core/PWScore.h
@@ -336,6 +336,11 @@ public:
   const CItemData *GetBaseEntry(const CItemData *pAliasOrSC) const;
   CItemData *GetBaseEntry(const CItemData *pAliasOrSC);
 
+  // Used whenever entry values are needed for copy, autotype or run command
+  bool GetValues(const CItemData *pci, StringX &sx_group, StringX &sx_title, StringX &sx_user,
+                 StringX &sx_pswd, StringX &sx_lastpswd,
+                 StringX &sx_notes, StringX &sx_url, StringX &sx_email, StringX &sx_autotype, StringX &sx_runcmd) const;
+
   // alias/base and shortcut/base handling
   void SortDependents(UUIDVector &dlist, StringX &csDependents);
   size_t NumAliases(const pws_os::CUUID &base_uuid) const

--- a/src/ui/Windows/EditShortcutDlg.cpp
+++ b/src/ui/Windows/EditShortcutDlg.cpp
@@ -84,6 +84,15 @@ BOOL CEditShortcutDlg::OnInitDialog()
 {
   CPWDialog::OnInitDialog();
 
+  // Get Add/Edit font
+  CFont *pFont = Fonts::GetInstance()->GetAddEditFont();
+
+  // Change font size of the group, title & username fields and the base entry name
+  m_ex_group.SetFont(pFont);
+  m_ex_title.SetFont(pFont);
+  m_ex_username.SetFont(pFont);
+  GetDlgItem(IDC_MYBASE)->SetFont(pFont);
+
   CString cs_text;
   CSecString cs_target(L"\xab");
   // Leave \xab \xbb between group/title/user even if group or user is empty

--- a/src/ui/Windows/MainEdit.cpp
+++ b/src/ui/Windows/MainEdit.cpp
@@ -115,7 +115,6 @@ void DboxMain::OnAdd()
 
   if (rc == IDOK) {
     bool bWasEmpty = m_core.GetNumEntries() == 0;
-    bool bSetDefaultUser(false);
     CSecString &sxUsername = pAddEntryPSH->GetUsername();
 
     MultiCommands *pmulticmds = MultiCommands::Create(&m_core);
@@ -130,8 +129,6 @@ void DboxMain::OnAdd()
       INT_PTR rc2 = defDlg.DoModal();
 
       if (rc2 == IDOK) {
-        bSetDefaultUser = true;
-
         // Initialise a copy of the DB preferences
         prefs->SetupCopyPrefs();
 
@@ -141,11 +138,6 @@ void DboxMain::OnAdd()
 
         // Set new DB preferences String value (from Copy)
         StringX sxNewDBPrefsString(prefs->Store(true));
-
-        Command *pcmd_undo = UpdateGUICommand::Create(&m_core,
-                                                  UpdateGUICommand::WN_UNDO,
-                                                  UpdateGUICommand::GUI_REFRESH_BOTHVIEWS);
-        pmulticmds->Add(pcmd_undo);
 
         Command *pcmd = DBPrefsCommand::Create(&m_core, sxNewDBPrefsString);
         pmulticmds->Add(pcmd);
@@ -173,13 +165,6 @@ void DboxMain::OnAdd()
 
     pmulticmds->Add(AddEntryCommand::Create(&m_core, ci, baseUUID,
                                             pAddEntryPSH->GetAtt()));
-
-    if (bSetDefaultUser) {
-      Command *pcmd3 = UpdateGUICommand::Create(&m_core,
-                                                UpdateGUICommand::WN_EXECUTE_REDO,
-                                                UpdateGUICommand::GUI_REFRESH_BOTHVIEWS);
-      pmulticmds->Add(pcmd3);
-    }
 
     // Do it
     Execute(pmulticmds);
@@ -242,7 +227,9 @@ void DboxMain::OnCreateShortcut()
         (!dlg_createshortcut.m_username.IsEmpty())) {
       CQuerySetDef defDlg(this);
       defDlg.m_defaultusername.Format(IDS_SETUSERNAME, (const CString&)dlg_createshortcut.m_username);
+
       INT_PTR rc2 = defDlg.DoModal();
+
       if (rc2 == IDOK) {
         // Initialise a copy of the DB preferences
         prefs->SetupCopyPrefs();
@@ -292,11 +279,6 @@ void DboxMain::CreateShortcutEntry(CItemData *pci, const StringX &sx_group,
 
   MultiCommands *pmulticmds = MultiCommands::Create(&m_core);
   if (!sxNewDBPrefsString.empty()) {
-    Command *pcmd_undo = UpdateGUICommand::Create(&m_core,
-                                              UpdateGUICommand::WN_UNDO,
-                                              UpdateGUICommand::GUI_REFRESH_BOTHVIEWS);
-    pmulticmds->Add(pcmd_undo);
-
     Command *pcmd = DBPrefsCommand::Create(&m_core, sxNewDBPrefsString);
     pmulticmds->Add(pcmd);
   }
@@ -309,13 +291,6 @@ void DboxMain::CreateShortcutEntry(CItemData *pci, const StringX &sx_group,
 
   Command *pcmd = AddEntryCommand::Create(&m_core, ci_temp, pci->GetUUID());
   pmulticmds->Add(pcmd);
-
-  if (!sxNewDBPrefsString.empty()) {
-   Command *pcmd3 = UpdateGUICommand::Create(&m_core,
-                                              UpdateGUICommand::WN_EXECUTE_REDO,
-                                              UpdateGUICommand::GUI_REFRESH_BOTHVIEWS);
-    pmulticmds->Add(pcmd3);
-  }
 
   // Do it
   Execute(pmulticmds);

--- a/src/ui/Windows/MainEdit.cpp
+++ b/src/ui/Windows/MainEdit.cpp
@@ -1886,7 +1886,6 @@ void DboxMain::CopyDataToClipBoard(const CItemData::FieldType ft, const bool bSp
         size_t st_column;
         bool bURLSpecial;
 
-        CItemData *pbci = NULL;
         if (pci->IsAlias()) {
           pbci = GetBaseEntry(pci);
         }

--- a/src/ui/Windows/MainView.cpp
+++ b/src/ui/Windows/MainView.cpp
@@ -1701,9 +1701,6 @@ int DboxMain::InsertItemIntoGUITreeList(CItemData &ci, int iIndex,
   }
 
   int nImage = GetEntryImage(ci);
-  StringX group = ci.GetGroup();
-  StringX title = ci.GetTitle();
-  StringX username = ci.GetUser();
   StringX sx_fielddata(L"");
 
   if (iView & LISTONLY) {

--- a/src/ui/Windows/PWTreeCtrl.cpp
+++ b/src/ui/Windows/PWTreeCtrl.cpp
@@ -850,13 +850,15 @@ void CPWTreeCtrl::OnEndLabelEdit(NMHDR *pNotifyStruct, LRESULT *pLResult)
         pmulticmds->Add(DBEmptyGroupsCommand::Create(pcore, sxOldPath, sxNewPath,
                         DBEmptyGroupsCommand::EG_RENAME));
       } else {
-        // Rename any empty groups within this group
-        // Get current empty groups
-        pmulticmds->Add(DBEmptyGroupsCommand::Create(pcore, sxOldPath, sxNewPath,
-                        DBEmptyGroupsCommand::EG_RENAMEPATH));
+        if (!app.GetMainDlg()->IsInAddGroup()) {
+          // Rename any empty groups within this group
+          // Get current empty groups
+          pmulticmds->Add(DBEmptyGroupsCommand::Create(pcore, sxOldPath, sxNewPath,
+            DBEmptyGroupsCommand::EG_RENAMEPATH));
 
-        // Update map of groups
-        app.GetMainDlg()->UpdateGroupNamesInMap(sxOldPath, sxNewPath);
+          // Update map of groups
+          app.GetMainDlg()->UpdateGroupNamesInMap(sxOldPath, sxNewPath);
+        }
       }
 
     } // good group name (no GROUP_SEP)


### PR DESCRIPTION
I have made PWS consistent throughout wrt username and shortcuts. I have also backed out BR1124 but via an #ifdef/#else/#endif.  As it stands, BR1124 is undefined in the project.  Depending on your decision, you can either define it (not recommended), swap the code around and change #ifdef to #ifndef to re-instate BR1124 consistently or remove the #ifdef/#else#/endif and make the change you want permanent.  Search on BR1124 over the entire solution.