### PR TITLE
Set coretest target platform to match that of pwsafe.

### DIFF
--- a/src/test/coretest-14.vcxproj
+++ b/src/test/coretest-14.vcxproj
@@ -15,13 +15,14 @@
     <ProjectGuid>{0FF1232A-8377-4271-BC22-04E57A39FFB6}</ProjectGuid>
     <RootNamespace>coretest</RootNamespace>
     <Keyword>MFCProj</Keyword>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugM|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugM|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>


### PR DESCRIPTION
Without this set, VS2017 RC can't convert the project.
Also, as dropped XP support, remove it from coretest too.