### PR TITLE
Fix CString format errors when using StringX variables

### DIFF
--- a/src/ui/Windows/MainEdit.cpp
+++ b/src/ui/Windows/MainEdit.cpp
@@ -2304,13 +2304,13 @@ void DboxMain::AddDDEntries(CDDObList &in_oblist, const StringX &DropGroup,
           // This base is in fact an alias. ParseBaseEntryPWD already found 'proper base'
           // So dropped entry will point to the 'proper base' and tell the user.
           CString cs_msg;
-          cs_msg.Format(IDS_DDBASEISALIAS, sxgroup, sxtitle, sxuser);
+          cs_msg.Format(IDS_DDBASEISALIAS, sxgroup.c_str(), sxtitle.c_str(), sxuser.c_str());
           gmb.AfxMessageBox(cs_msg, NULL, MB_OK);
         } else
         if (pl.TargetType != CItemData::ET_NORMAL && pl.TargetType != CItemData::ET_ALIASBASE) {
           // Only normal or alias base allowed as target
           CString cs_msg;
-          cs_msg.Format(IDS_ABASEINVALID, sxgroup, sxtitle, sxuser);
+          cs_msg.Format(IDS_ABASEINVALID, sxgroup.c_str(), sxtitle.c_str(), sxuser.c_str());
           gmb.AfxMessageBox(cs_msg, NULL, MB_OK);
           continue;
         }
@@ -2328,7 +2328,7 @@ void DboxMain::AddDDEntries(CDDObList &in_oblist, const StringX &DropGroup,
         if (pl.TargetType != CItemData::ET_NORMAL && pl.TargetType != CItemData::ET_SHORTCUTBASE) {
           // Only normal or shortcut base allowed as target
           CString cs_msg;
-          cs_msg.Format(IDS_SBASEINVALID, sxgroup, sxtitle, sxuser);
+          cs_msg.Format(IDS_SBASEINVALID, sxgroup.c_str(), sxtitle.c_str(), sxuser.c_str());
           gmb.AfxMessageBox(cs_msg, NULL, MB_OK);
           continue;
         }

--- a/src/ui/Windows/MainManage.cpp
+++ b/src/ui/Windows/MainManage.cpp
@@ -123,7 +123,7 @@ int DboxMain::BackupSafe()
   rc = m_core.WriteFile(tempname, m_core.GetReadFileVersion(), false);
   if (rc == PWScore::CANT_OPEN_FILE) {
     CGeneralMsgBox gmb;
-    cs_temp.Format(IDS_CANTOPENWRITING, tempname);
+    cs_temp.Format(IDS_CANTOPENWRITING, tempname.c_str());
     cs_title.LoadString(IDS_FILEWRITEERROR);
     gmb.MessageBox(cs_temp, cs_title, MB_OK | MB_ICONWARNING);
     return PWScore::CANT_OPEN_FILE;
@@ -142,8 +142,8 @@ void DboxMain::OnRestoreSafe()
 int DboxMain::RestoreSafe()
 {
   int rc;
-  StringX backup, passkey, temp;
-  StringX currbackup =
+  StringX sx_backup, sx_passkey;
+  StringX sx_currbackup =
     PWSprefs::GetInstance()->GetPref(PWSprefs::CurrentBackup);
 
   if (m_bOpen) {
@@ -172,7 +172,7 @@ int DboxMain::RestoreSafe()
   while (1) {
     CPWFileDialog fd(TRUE,
                      L"bak",
-                     currbackup.c_str(),
+                     sx_currbackup.c_str(),
                      OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_LONGNAMES,
                      CString(MAKEINTRESOURCE(IDS_FDF_BUS)),
                      this);
@@ -192,20 +192,20 @@ int DboxMain::RestoreSafe()
       return PWScore::USER_CANCEL;
     }
     if (rc2 == IDOK) {
-      backup = fd.GetPathName();
+      sx_backup = fd.GetPathName();
       break;
     } else
       return PWScore::USER_CANCEL;
   }
 
-  rc = GetAndCheckPassword(backup, passkey, GCP_NORMAL);  // OK, CANCEL, HELP
+  rc = GetAndCheckPassword(sx_backup, sx_passkey, GCP_NORMAL);  // OK, CANCEL, HELP
 
   CGeneralMsgBox gmb;
   switch (rc) {
     case PWScore::SUCCESS:
       break; // Keep going...
     case PWScore::CANT_OPEN_FILE:
-      cs_temp.Format(IDS_CANTOPEN, backup);
+      cs_temp.Format(IDS_CANTOPEN, sx_backup.c_str());
       cs_title.LoadString(IDS_FILEOPENERROR);
       gmb.MessageBox(cs_temp, cs_title, MB_OK | MB_ICONWARNING);
     case TAR_OPEN:
@@ -233,9 +233,9 @@ int DboxMain::RestoreSafe()
 
   // Validate it unless user says NO
   CReport Rpt;
-  rc = m_core.ReadFile(backup, passkey, !m_bNoValidation, MAXTEXTCHARS, &Rpt);
+  rc = m_core.ReadFile(sx_backup, sx_passkey, !m_bNoValidation, MAXTEXTCHARS, &Rpt);
   if (rc == PWScore::CANT_OPEN_FILE) {
-    cs_temp.Format(IDS_CANTOPENREADING, backup);
+    cs_temp.Format(IDS_CANTOPENREADING, sx_backup.c_str());
     cs_title.LoadString(IDS_FILEREADERROR);
     gmb.MessageBox(cs_temp, cs_title, MB_OK | MB_ICONWARNING);
     return PWScore::CANT_OPEN_FILE;

--- a/src/ui/Windows/MainView.cpp
+++ b/src/ui/Windows/MainView.cpp
@@ -3761,7 +3761,7 @@ void DboxMain::OnToolBarFindReport()
       uistring = PWSMatch::GetRule(PWSMatch::MatchRule(abs(Fsubgroup_function)));
 
       cs_text.LoadString(uistring);
-      cs_temp.Format(IDS_ADVANCEDSUBSET, cs_Object, cs_text, Fsubgroup_name,
+      cs_temp.Format(IDS_ADVANCEDSUBSET, cs_Object, cs_text, Fsubgroup_name.c_str(),
                      cs_case);
     }
     buffer.Format(IDS_ADVANCEDOPTIONS, cs_temp);


### PR DESCRIPTION
Detected by new VS2017 RC whilst fixing 122 new warnings C4840 generated by new compiler
VS2017 C4840 recommended workaround not included yet