### PR TITLE
Add support for entry/group highlighting (if enabled) via commands

### DIFF
--- a/src/core/CommandInterface.h
+++ b/src/core/CommandInterface.h
@@ -33,6 +33,9 @@ class CommandInterface {
   virtual ItemListIter GetEntryEndIter() = 0;
   virtual ItemListConstIter GetEntryEndIter() const = 0;
 
+  virtual std::vector<StringX> &GetModifiedNodes() = 0;
+  virtual void SetModifiedNodes(std::vector<StringX> &) = 0;
+
   // Command-specific methods
   virtual void DoAddEntry(const CItemData &item, const CItemAtt *att) = 0;
   virtual void DoDeleteEntry(const CItemData &item) = 0;
@@ -81,6 +84,8 @@ class CommandInterface {
                                       const pws_os::CUUID &,
                                       CItemData::FieldType ft = CItemData::START,
                                       bool bUpdateGUI = true) = 0;
+  virtual void NotifyGUINeedsUpdating(UpdateGUICommand::GUI_Action ga,
+                                      const std::vector<StringX> &vGroups) = 0;
 
   virtual void AddExpiryEntry(const CItemData &ci) = 0;
   virtual void UpdateExpiryEntry(const CItemData &ci) = 0;

--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -3488,17 +3488,27 @@ int PWScore::DoRenameGroup(const StringX &sxOldPath, const StringX &sxNewPath)
   ItemListIter iter;
 
   for (iter = m_pwlist.begin(); iter != m_pwlist.end(); iter++) {
-    if (iter->second.GetGroup() == sxOldPath) {
+    StringX sxGroup = iter->second.GetGroup();
+    if (sxGroup == sxOldPath) {
       iter->second.SetGroup(sxNewPath);
+
+      // Add both to modified nodes even though old renamed to new
+      AddChangedNodes(sxOldPath);
+      AddChangedNodes(sxNewPath);
     }
-    else if ((iter->second.GetGroup().length() > len2) && (iter->second.GetGroup().substr(0, len2) == sxOldPath2) &&
-     (iter->second.GetGroup()[len2] != wcDot)) {
+    else if ((sxGroup.length() > len2) &&
+             (sxGroup.substr(0, len2) == sxOldPath2) &&
+             (sxGroup[len2] != wcDot)) {
       // Need to check that next symbol is not a dot
       // to ensure not affecting another group
       // (group name could contain trailing dots, for example abc..def.g)
       // subgroup name will have len > len2 (old_name + dot + subgroup_name)
-      StringX sxSubGroups = iter->second.GetGroup().substr(len2);
+      StringX sxSubGroups = sxGroup.substr(len2);
       iter->second.SetGroup(sxNewPath + sxDot + sxSubGroups);
+
+      // Add both to modified nodes even though old renamed to new
+      AddChangedNodes(sxOldPath);
+      AddChangedNodes(sxNewPath + sxDot + sxSubGroups);
     }
   }
   return 0;

--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -165,7 +165,7 @@ PWScore::~PWScore()
   }
 
   m_UHFL.clear();
-  m_vNodes_Modified.clear();
+  m_vModifiedNodes.clear();
 
   delete m_pFileSig;
 }
@@ -460,7 +460,7 @@ void PWScore::ClearDBData()
   m_DBCurrentState = CLEAN;
 
   // Clear changed nodes
-  m_vNodes_Modified.clear();
+  m_vModifiedNodes.clear();
 
   // Clear expired password entries
   m_ExpireCandidates.clear();
@@ -827,7 +827,7 @@ void PWScore::SetInitialValues()
   m_InitialRUEList = m_RUEList;                   // for detecting header changes
 
   // Clear changed nodes
-  m_vNodes_Modified.clear();
+  m_vModifiedNodes.clear();
 }
 
 int PWScore::Execute(Command *pcmd)
@@ -3159,6 +3159,16 @@ void PWScore::NotifyGUINeedsUpdating(UpdateGUICommand::GUI_Action ga,
     m_pUIIF->UpdateGUI(ga, entry_uuid, ft, bUpdateGUI);
 }
 
+void PWScore::NotifyGUINeedsUpdating(UpdateGUICommand::GUI_Action ga,
+                                     const std::vector<StringX> &vGroups)
+{
+  // This allows the core to provide feedback to the UI that the GUI needs
+  // updating due to a field having its value changed
+  if (m_pUIIF != NULL &&
+      m_bsSupportedFunctions.test(UIInterFace::UPDATEGUIGROUPS))
+    m_pUIIF->UpdateGUI(ga, vGroups);
+}
+
 void PWScore::GUISetupDisplayInfo(CItemData &ci)
 {
   // This allows the core to provide feedback to the UI that ???
@@ -3225,20 +3235,26 @@ void PWScore::UnlockFile2(const stringT &filename)
 bool PWScore::IsNodeModified(StringX &path) const
 {
   if (!IsEmptyGroup(path)) {
-    return std::find(m_vNodes_Modified.begin(),
-      m_vNodes_Modified.end(), path) != m_vNodes_Modified.end();
+    return std::find(m_vModifiedNodes.begin(),
+      m_vModifiedNodes.end(), path) != m_vModifiedNodes.end();
   } else {
     return find(m_InitialEmptyGroups.begin(), m_InitialEmptyGroups.end(), path) ==
       m_InitialEmptyGroups.end();
   }
 }
 
+void PWScore::SetModifiedNodes(std::vector<StringX> &saved_vNodes_Modified)
+{
+  m_vModifiedNodes = saved_vNodes_Modified;
+}
+
 void PWScore::AddChangedNodes(StringX path)
 {
   StringX nextpath(path);
   while (!nextpath.empty()) {
-    if (std::find(m_vNodes_Modified.begin(), m_vNodes_Modified.end(), nextpath) == m_vNodes_Modified.end())
-      m_vNodes_Modified.push_back(nextpath);
+    if (std::find(m_vModifiedNodes.begin(), m_vModifiedNodes.end(), nextpath) ==
+        m_vModifiedNodes.end())
+      m_vModifiedNodes.push_back(nextpath);
     size_t i = nextpath.find_last_of(_T("."));
     if (i == nextpath.npos)
       i = 0;

--- a/src/core/PWScore.h
+++ b/src/core/PWScore.h
@@ -586,9 +586,10 @@ private:
   void SetBase2ShortcutsMmap(ItemMMap &b2smm) {m_base2shortcuts_mmap = b2smm;}
   
   // Changed groups
-  std::vector<StringX> m_vNodes_Modified;
-  std::vector<StringX> m_saved_vNodes_Modified;
-
+  std::vector<StringX> m_vModifiedNodes;
+  std::vector<StringX> &GetModifiedNodes() { return m_vModifiedNodes; }
+  void SetModifiedNodes(std::vector<StringX> &saved_vNodes_Modified);
+ 
   // Following are private in PWScore, public in CommandInterface:
   void AddChangedNodes(StringX path);
 
@@ -609,6 +610,10 @@ private:
                               CItemData::FieldType ft = CItemData::START,
                               bool bUpdateGUI = true);
 
+  // Version for groups
+  void NotifyGUINeedsUpdating(UpdateGUICommand::GUI_Action ga,
+                              const std::vector<StringX> &vGroups);
+  
   // Create header for included(Text) and excluded(XML) exports
   StringX BuildHeader(const CItemData::FieldBits &bsFields, const bool bIncluded);
 

--- a/src/core/UIinterface.h
+++ b/src/core/UIinterface.h
@@ -32,11 +32,12 @@ public:
    * NOTE: New functions must be placed at the end of the list.
    * Sequential values must be used as they are used to access positions in
    * a std::bitset<NUM_SUPPORTED> variable.
+   *
+   * DO NOT change the order of the functions as UIs will fail
    */
   enum Functions {
     DATABASEMODIFIED = 0, UPDATEGUI, GUISETUPDISPLAYINFO, GUIREFRESHENTRY,
-    UPDATEWIZARD,
-    // Add new functions here!
+    UPDATEWIZARD, UPDATEGUIGROUPS,
     NUM_SUPPORTED};
 
   /*
@@ -53,6 +54,10 @@ public:
                          const pws_os::CUUID &entry_uuid,
                          CItemData::FieldType ft = CItemData::START,
                          bool bUpdateGUI = true) = 0;
+
+  // Version for groups
+  virtual void UpdateGUI(UpdateGUICommand::GUI_Action ga,
+                         const std::vector<StringX> &vGroups) = 0;
 
   // GUISetupDisplayInfo: let GUI populate DisplayInfo field in an entry
   virtual void GUISetupDisplayInfo(CItemData &ci) = 0;

--- a/src/ui/Windows/DboxMain.h
+++ b/src/ui/Windows/DboxMain.h
@@ -750,6 +750,10 @@ private:
   virtual void UpdateGUI(UpdateGUICommand::GUI_Action ga,
                          const pws_os::CUUID &entry_uuid,
                          CItemData::FieldType ft, bool bUpdateGUI);
+  // Version for groups
+  virtual void UpdateGUI(UpdateGUICommand::GUI_Action ga,
+                         const std::vector<StringX> &vGroups);
+  
   virtual void GUISetupDisplayInfo(CItemData &ci);
   virtual void GUIRefreshEntry(const CItemData &ci);
   virtual void UpdateWizard(const std::wstring &s);
@@ -844,7 +848,8 @@ private:
   void RefreshEntryFieldInGUI(CItemData &ci, CItemData::FieldType ft);
   void RefreshEntryPasswordInGUI(CItemData &ci);
   void RebuildGUI(const ViewType iView = BOTHVIEWS);
-  void UpdateEntryinGUI(CItemData &ci);
+  void UpdateEntryInGUI(CItemData &ci);
+  void UpdateGroupsInGUI(const std::vector<StringX> &vGroups);
   StringX GetListViewItemText(CItemData &ci, const int &icolumn);
   
   static const struct UICommandTableEntry {

--- a/src/ui/Windows/MainView.cpp
+++ b/src/ui/Windows/MainView.cpp
@@ -196,7 +196,11 @@ void DboxMain::UpdateGUI(UpdateGUICommand::GUI_Action ga,
       // Refresh one entry ListView row and in the tree if the Title/Username/Password
       // has changed and visible in the tree when entry has been edited
       ASSERT(pci != NULL);
-      UpdateEntryinGUI(*pci);
+      UpdateEntryInGUI(*pci);
+      break;
+    case UpdateGUICommand::GUI_REFRESH_GROUPS:
+      // Processed in UpdateGroupsInGUI
+      ASSERT(0);
       break;
     case UpdateGUICommand::GUI_DB_PREFERENCES_CHANGED:
       // Change any impact on the application due to a database preference change
@@ -212,6 +216,19 @@ void DboxMain::UpdateGUI(UpdateGUICommand::GUI_Action ga,
     default:
       break;
   }
+}
+
+void DboxMain::UpdateGUI(UpdateGUICommand::GUI_Action ga,
+                         const std::vector<StringX> &vGroups)
+{
+  if (ga != UpdateGUICommand::GUI_REFRESH_GROUPS) {
+    // Processed in UpdateGUI
+    ASSERT(0);
+    return;
+  }
+
+  // Update these groups in the Tree display - saves doing a complete refresh!
+  UpdateGroupsInGUI(vGroups);
 }
 
 void DboxMain::UpdateGUIDisplay()
@@ -715,20 +732,20 @@ void DboxMain::UpdateListItemField(const int lindex, const int type, const Strin
 
 void DboxMain::UpdateTreeItem(const HTREEITEM hItem, const CItemData &ci)
 {
-  CRect rect;
-
   CSecString csCurrentString = m_ctlItemTree.GetItemText(hItem);
   CSecString csNewString = m_ctlItemTree.MakeTreeDisplayString(ci);
 
   if (csCurrentString != csNewString) {
     m_ctlItemTree.SetItemText(hItem, csNewString);
-
-    m_ctlItemTree.GetItemRect(hItem, &rect, FALSE);
-    m_ctlItemTree.InvalidateRect(&rect);
   }
+
+  // Update view (e.g. nolonger highlighted if not changed)
+  CRect rect;
+  m_ctlItemTree.GetItemRect(hItem, &rect, FALSE);
+  m_ctlItemTree.InvalidateRect(&rect);
 }
 
-void DboxMain::UpdateEntryinGUI(CItemData &ci)
+void DboxMain::UpdateEntryInGUI(CItemData &ci)
 {
   DisplayInfo *pdi = (DisplayInfo *)ci.GetDisplayInfo();
   ASSERT(pdi != NULL);
@@ -818,6 +835,21 @@ void DboxMain::UpdateEntryinGUI(CItemData &ci)
         m_ctlItemList.EnsureVisible(iItem, false);
         break;
       }
+    }
+  }
+}
+
+void DboxMain::UpdateGroupsInGUI(const std::vector<StringX> &vGroups)
+{
+  // Update these group in the Tree display - saves doing a complete refresh!
+  std::map<StringX, HTREEITEM>::iterator it;
+
+  for (auto iter_group = vGroups.begin(); iter_group != vGroups.end(); iter_group++) {
+    it = m_mapGroupToTreeItem.find(*iter_group);
+    if (it != m_mapGroupToTreeItem.end()) {
+      CRect rect;
+      m_ctlItemTree.GetItemRect(it->second, &rect, FALSE);
+      m_ctlItemTree.InvalidateRect(&rect);
     }
   }
 }

--- a/src/ui/Windows/PWTreeCtrl.h
+++ b/src/ui/Windows/PWTreeCtrl.h
@@ -167,5 +167,5 @@ private:
   bool m_bEditLabelCompleted;
 
   bool m_bUseHighLighting;
-  std::vector<StringX> m_vNodes_Modified;
+  std::vector<StringX> m_vModifiedNodes;
 };

--- a/src/ui/Windows/ThisMfcApp.cpp
+++ b/src/ui/Windows/ThisMfcApp.cpp
@@ -1088,6 +1088,7 @@ BOOL ThisMfcApp::InitInstance()
   bsSupportedFunctions.set(UIInterFace::GUISETUPDISPLAYINFO);
   bsSupportedFunctions.set(UIInterFace::GUIREFRESHENTRY);
   bsSupportedFunctions.set(UIInterFace::UPDATEWIZARD);
+  bsSupportedFunctions.set(UIInterFace::UPDATEGUIGROUPS);
 
   m_core.SetUIInterFace(&dbox, UIInterFace::NUM_SUPPORTED, bsSupportedFunctions);
 

--- a/src/ui/Windows/res/PasswordSafe3.rc2
+++ b/src/ui/Windows/res/PasswordSafe3.rc2
@@ -1005,7 +1005,7 @@ BEGIN
   IDS_SB_TT_DBCLICK        "Doubleclick action for current entry"
   IDS_SB_TT_CBACTION       "Last clipboard action"
   IDS_SB_TT_CONFIG         "Configuration file status"
-  IDS_SB_TT_MODIFIED       "* means that the database has been modified since last save"
+  IDS_SB_TT_MODIFIED       "Change status since last save:\n* indicates the database has been changed\no indicates a database preference has been changed"
   IDS_SB_TT_MODE           "Database mode: read-only (R-O) or read/write (R/W)\n(Doubleclick to toggle mode)"
   IDS_SB_TT_NUMENTRIES     "Number of entries in database"
   IDS_SB_TT_FILTER         "A red and white indicator means that a filter is active\n(if showing, double click to clear filter)"


### PR DESCRIPTION
Add highlighting if a group is renamed
Update Status bar tooltip

Note: First change is quite extensive but is the basis for future use (currently only modified nodes)