### PR TITLE
Implement rename group via internal commands so that affected entries…

### DIFF
--- a/src/core/Command.h
+++ b/src/core/Command.h
@@ -32,6 +32,8 @@ class CommandInterface;
  * no Command object can be created on the stack.
  */
 
+class MultiCommands;
+
 // Base Command class
 
 class Command
@@ -455,6 +457,7 @@ public:
   static RenameGroupCommand *Create(CommandInterface *pcomInt,
                                     const StringX sxOldPath, const StringX sxNewPath)
   { return new RenameGroupCommand(pcomInt, sxOldPath, sxNewPath); }
+  ~RenameGroupCommand();
   int Execute();
   void Undo();
 
@@ -463,6 +466,7 @@ private:
                      StringX sxOldPath, StringX sxNewPath);
 
    StringX m_sxOldPath, m_sxNewPath;
+   MultiCommands *m_pmulticmds;
 };
 
 class ChangeDBHeaderCommand : public Command {
@@ -512,11 +516,14 @@ public:
   bool GetRC(Command *pcmd, int &rc);
   bool GetRC(const size_t ncmd, int &rc);
   std::size_t GetSize() const {return m_vpcmds.size();}
+  bool IsEmpty() const { return m_vpcmds.size() == 0; }
+  void SetNested() { SetInMultiCommand(); }
 
   std::vector<Command *> m_vpcmds;
 
  private:
   MultiCommands(CommandInterface *pcomInt);
+
   std::vector<int> m_vRCs;
 };
 

--- a/src/core/CommandInterface.h
+++ b/src/core/CommandInterface.h
@@ -62,8 +62,9 @@ class CommandInterface {
                                       SavePWHistoryMap &mapSavedHistory) = 0;
   virtual void UndoUpdatePasswordHistory(SavePWHistoryMap &mapSavedHistory) = 0;
 
-  virtual int DoRenameGroup(const StringX &sxOldPath, const StringX &sxNewPath) = 0;
-  virtual void UndoRenameGroup(const StringX &sxOldPath, const StringX &sxNewPath) = 0;
+  virtual int DoRenameGroup(const StringX &sxOldPath, const StringX &sxNewPath,
+                            MultiCommands * &pmulticmds) = 0;
+  virtual void UndoRenameGroup(MultiCommands *pmulticmds) = 0;
 
   virtual int DoChangeHeader(const StringX &sxNewValue, const PWSfile::HeaderType ht) = 0;
   virtual void UndoChangeHeader(const StringX &sxOldValue, const PWSfile::HeaderType ht) = 0;

--- a/src/core/PWScore.h
+++ b/src/core/PWScore.h
@@ -479,8 +479,9 @@ private:
                                       SavePWHistoryMap &mapSavedHistory);
   virtual void UndoUpdatePasswordHistory(SavePWHistoryMap &mapSavedHistory);
 
-  virtual int DoRenameGroup(const StringX &sxOldPath, const StringX &sxNewPath);
-  virtual void UndoRenameGroup(const StringX &sxOldPath, const StringX &sxNewPath);
+  virtual int DoRenameGroup(const StringX &sxOldPath, const StringX &sxNewPath,
+                            MultiCommands * &pmulticmds);
+  virtual void UndoRenameGroup(MultiCommands *pmulticmds);
 
   virtual int DoChangeHeader(const StringX &sxNewValue, const PWSfile::HeaderType ht);
   virtual void UndoChangeHeader(const StringX &sxOldValue, const PWSfile::HeaderType ht);

--- a/src/ui/Windows/MainEdit.cpp
+++ b/src/ui/Windows/MainEdit.cpp
@@ -558,18 +558,20 @@ void DboxMain::OnDuplicateGroup()
     // We either do only one set of multi-commands, none of them or both of them
     // as one multi-command (normals/bases first followed by dependents) and possibly
     // add empty groups
-    const int iDoExec = ((pmulti_cmd_base->GetSize() == 0) ? 0 : 1) +
-                        ((pmulti_cmd_deps->GetSize() == 0) ? 0 : 2);
-    if (iDoExec != 0 || pmulti_cmd_egrps->GetSize() != 0) {
+    const int iDoExec = (pmulti_cmd_base->IsEmpty() ? 0 : 1) +
+                        (pmulti_cmd_deps->IsEmpty() ? 0 : 2);
+    
+    if (iDoExec != 0 || !pmulti_cmd_egrps->IsEmpty()) {
       pcmd_undo = UpdateGUICommand::Create(&m_core, UpdateGUICommand::WN_UNDO,
                                             UpdateGUICommand::GUI_UNDO_IMPORT);
       pcmd_redo = UpdateGUICommand::Create(&m_core, UpdateGUICommand::WN_EXECUTE_REDO,
                                             UpdateGUICommand::GUI_REDO_IMPORT);
     }
+   
     switch (iDoExec) {
       case 0:
         // Do nothing unless there are empty groups
-        if (pmulti_cmd_egrps->GetSize() != 0) {
+        if (!pmulti_cmd_egrps->IsEmpty()) {
           pmulti_cmd_egrps->Insert(pcmd_undo);
           pmulti_cmd_egrps->Add(pcmd_redo);
           Execute(pmulti_cmd_egrps);
@@ -580,7 +582,7 @@ void DboxMain::OnDuplicateGroup()
       case 1:
         // Only normal/base entries
         pmulti_cmd_base->Insert(pcmd_undo);
-        if (pmulti_cmd_egrps->GetSize() != 0)
+        if (!pmulti_cmd_egrps->IsEmpty())
           pmulti_cmd_base->Add(pmulti_cmd_egrps);
         pmulti_cmd_base->Add(pcmd_redo);
         Execute(pmulti_cmd_base);
@@ -589,7 +591,7 @@ void DboxMain::OnDuplicateGroup()
       case 2:
         // Only dependents
         pmulti_cmd_deps->Insert(pcmd_undo);
-        if (pmulti_cmd_egrps->GetSize() != 0)
+        if (!pmulti_cmd_egrps->IsEmpty())
           pmulti_cmd_deps->Add(pmulti_cmd_egrps);
         pmulti_cmd_deps->Add(pcmd_redo);
         Execute(pmulti_cmd_deps);
@@ -600,10 +602,18 @@ void DboxMain::OnDuplicateGroup()
         // Both - normal entries/bases first then dependents
         MultiCommands *pmulti_cmds = MultiCommands::Create(&m_core);
         pmulti_cmds->Add(pcmd_undo);
+
+        pmulti_cmd_base->SetNested();
         pmulti_cmds->Add(pmulti_cmd_base);
+
+        pmulti_cmd_deps->SetNested();
         pmulti_cmds->Add(pmulti_cmd_deps);
-        if (pmulti_cmd_egrps->GetSize() != 0)
+
+        if (pmulti_cmd_egrps->GetSize() != 0) {
+          pmulti_cmd_egrps->SetNested();
           pmulti_cmds->Add(pmulti_cmd_egrps);
+        }
+
         pmulti_cmds->Add(pcmd_redo);
         Execute(pmulti_cmds);
         bChanged = true;
@@ -614,11 +624,11 @@ void DboxMain::OnDuplicateGroup()
     }
 
     // If we didn't populate the multi-commands, delete them
-    if (pmulti_cmd_base->GetSize() == 0)
+    if (pmulti_cmd_base->IsEmpty())
       delete pmulti_cmd_base;
-    if (pmulti_cmd_deps->GetSize() == 0)
+    if (pmulti_cmd_deps->IsEmpty())
       delete pmulti_cmd_deps;
-    if (pmulti_cmd_egrps->GetSize() == 0)
+    if (pmulti_cmd_egrps->IsEmpty())
       delete pmulti_cmd_egrps;
   } else { // !m_ctlItemTree.ItemHasChildren(ti)
     // User is duplicating an empty group - just add it
@@ -798,7 +808,7 @@ void DboxMain::ChangeSubtreeEntriesProtectStatus(const UINT nID)
     }
   }
 
-  if (pmulticmds->GetSize() != 0) {
+  if (!pmulticmds->IsEmpty()) {
     Execute(pmulticmds);
 
     ChangeOkUpdate();
@@ -954,7 +964,7 @@ void DboxMain::OnDelete()
     }
 
     // Now do it
-    if (pmcmd->GetSize() > 0) {
+    if (!pmcmd->IsEmpty()) {
       Execute(pmcmd);
     }
 

--- a/src/ui/Windows/MainFile.cpp
+++ b/src/ui/Windows/MainFile.cpp
@@ -2880,7 +2880,7 @@ void DboxMain::OnProperties()
       pmulticmds->Add(pcmd_desc);
     }
 
-    if (pmulticmds->GetSize() > 0) {
+    if (!pmulticmds->IsEmpty()) {
       // Do it
       Execute(pmulticmds);
       ChangeOkUpdate();
@@ -3802,7 +3802,7 @@ LRESULT DboxMain::CopyAllCompareResult(WPARAM wParam)
     pmulticmds->Add(pcmdCopy);
   }
 
-  if (pmulticmds->GetSize() == 0)
+  if (pmulticmds->IsEmpty())
     return FALSE;
 
   CWaitCursor waitCursor;
@@ -3894,7 +3894,7 @@ LRESULT DboxMain::SynchAllCompareResult(WPARAM wParam)
     }
   }
 
-  if (pmulticmds->GetSize() > 0) {
+  if (!pmulticmds->IsEmpty()) {
     CWaitCursor waitCursor;
     Execute(pmulticmds);
     waitCursor.Restore();

--- a/src/ui/Windows/MainManage.cpp
+++ b/src/ui/Windows/MainManage.cpp
@@ -551,7 +551,7 @@ void DboxMain::OnOptions()
     // If DB preferences changed and/or password history options
     if (pmulticmds != NULL) {
       int num_altered(0);
-      if (pmulticmds->GetSize() > 0) {
+      if (!pmulticmds->IsEmpty()) {
         // Do it
         Execute(pmulticmds);
 

--- a/src/ui/Windows/PWTreeCtrl.cpp
+++ b/src/ui/Windows/PWTreeCtrl.cpp
@@ -920,7 +920,7 @@ void CPWTreeCtrl::OnEndLabelEdit(NMHDR *pNotifyStruct, LRESULT *pLResult)
     }
   }
 
-  if (pmulticmds->GetSize() > 0)
+  if (!pmulticmds->IsEmpty())
     app.GetMainDlg()->Execute(pmulticmds);
   else
     delete pmulticmds;
@@ -1718,7 +1718,7 @@ void CPWTreeCtrl::OnBeginDrag(NMHDR *pNotifyStruct, LRESULT *pLResult)
     app.GetMainDlg()->Delete(pmcmd); // XXX assume we've a selected item here!
    
     // Now do it
-    if (pmcmd->GetSize() > 0) {
+    if (!pmcmd->IsEmpty()) {
       app.GetMainDlg()->Execute(pmcmd);
     }
   }

--- a/src/ui/wxWidgets/optionspropsheet.cpp
+++ b/src/ui/wxWidgets/optionspropsheet.cpp
@@ -548,6 +548,16 @@ void COptions::CreateControls()
 
   GetBookCtrl()->AddPage(itemPanel86, _("Security"));
 
+  wxPanel* itemPanel123 = new wxPanel(GetBookCtrl(), ID_PANEL7, wxDefaultPosition, wxDefaultSize, wxSUNKEN_BORDER | wxTAB_TRAVERSAL);
+  wxGrid* itemGrid124 = new wxGrid(itemPanel123, ID_GRID1, wxDefaultPosition, itemPanel123->ConvertDialogToPixels(wxSize(200, 150)), wxSUNKEN_BORDER | wxHSCROLL | wxVSCROLL);
+  itemGrid124->SetDefaultColSize(100);
+  itemGrid124->SetDefaultRowSize(25);
+  itemGrid124->SetColLabelSize(25);
+  itemGrid124->SetRowLabelSize(50);
+  itemGrid124->CreateGrid(50, 2, wxGrid::wxGridSelectCells);
+
+  GetBookCtrl()->AddPage(itemPanel123, _("Shortcuts"));
+
   wxPanel* itemPanel104 = new wxPanel( GetBookCtrl(), ID_PANEL6, wxDefaultPosition, wxDefaultSize, wxSUNKEN_BORDER|wxTAB_TRAVERSAL );
   wxBoxSizer* itemBoxSizer105 = new wxBoxSizer(wxVERTICAL);
   itemPanel104->SetSizer(itemBoxSizer105);
@@ -630,16 +640,6 @@ void COptions::CreateControls()
   itemBoxSizer105->Add(m_systrayclosediconcolourRB, 0, wxGROW|wxALL, 5);
 
   GetBookCtrl()->AddPage(itemPanel104, _("System"));
-
-  wxPanel* itemPanel123 = new wxPanel( GetBookCtrl(), ID_PANEL7, wxDefaultPosition, wxDefaultSize, wxSUNKEN_BORDER|wxTAB_TRAVERSAL );
-  wxGrid* itemGrid124 = new wxGrid( itemPanel123, ID_GRID1, wxDefaultPosition, itemPanel123->ConvertDialogToPixels(wxSize(200, 150)), wxSUNKEN_BORDER|wxHSCROLL|wxVSCROLL );
-  itemGrid124->SetDefaultColSize(100);
-  itemGrid124->SetDefaultRowSize(25);
-  itemGrid124->SetColLabelSize(25);
-  itemGrid124->SetRowLabelSize(50);
-  itemGrid124->CreateGrid(50, 2, wxGrid::wxGridSelectCells);
-
-  GetBookCtrl()->AddPage(itemPanel123, _("Shortcuts"));
 
   // Set validators
   itemCheckBox4->SetValidator( wxGenericValidator(& m_saveimmediate) );


### PR DESCRIPTION
… are shown as changed

Stop nested MultiCommands to duplicate savie/restore of DB information
(might not have caught all nested MultiCommands)