### PR TITLE
[wx] few fixes for alias/shortcut entries

### DIFF
--- a/src/ui/wxWidgets/PWSDragBar.cpp
+++ b/src/ui/wxWidgets/PWSDragBar.cpp
@@ -7,7 +7,7 @@
  */
 
 /** \file PWSDragBar.cpp
-* 
+*
 */
 // For compilers that support precompilation, includes "wx/wx.h".
 #include <wx/wxprec.h>
@@ -84,12 +84,12 @@ struct _DragbarElementInfo {
   const char** classic_bitmap;
   const char** classic_bitmap_disabled;
   CItemData::FieldType ft;
-} DragbarElements[] = { PWS_TOOLINFO(Group,     GROUP), 
-                        PWS_TOOLINFO(Title,     TITLE), 
-                        PWS_TOOLINFO(User,      USER), 
-                        PWS_TOOLINFO(Password,  PASSWORD), 
-                        PWS_TOOLINFO(Notes,     NOTES), 
-                        PWS_TOOLINFO(URL,       URL), 
+} DragbarElements[] = { PWS_TOOLINFO(Group,     GROUP),
+                        PWS_TOOLINFO(Title,     TITLE),
+                        PWS_TOOLINFO(User,      USER),
+                        PWS_TOOLINFO(Password,  PASSWORD),
+                        PWS_TOOLINFO(Notes,     NOTES),
+                        PWS_TOOLINFO(URL,       URL),
                         PWS_TOOLINFO(Email,     EMAIL)
                       };
 
@@ -128,18 +128,24 @@ PWSDragBar::~PWSDragBar()
 
 wxString PWSDragBar::GetText(int id) const
 {
-  CItemData* item = m_frame->GetSelectedEntry();
-  if (item) {
-    return towxstring(item->GetFieldValue(DragbarElements[id-DRAGBAR_TOOLID_BASE].ft));
-  }
-  return wxEmptyString;
+  const int idx = id - DRAGBAR_TOOLID_BASE;
+  wxASSERT( idx >= 0 && size_t(idx) < NumberOf(DragbarElements));
+
+  const CItemData *pci(nullptr), *pbci(nullptr);
+  pci = m_frame->GetSelectedEntry();
+  pbci = m_frame->GetBaseEntry(pci);
+
+  return pci ? towxstring(pci->GetEffectiveFieldValue(DragbarElements[idx].ft, pbci)) : wxEmptyString;
 }
 
 bool PWSDragBar::IsEnabled(int id) const
 {
   const int idx = id - DRAGBAR_TOOLID_BASE;
   wxASSERT( idx >= 0 && size_t(idx) < NumberOf(DragbarElements));
-  
-  CItemData* item = m_frame->GetSelectedEntry();
-  return item != 0 && item->GetFieldValue(DragbarElements[idx].ft).empty() == false;
+
+  const CItemData *pci(nullptr), *pbci(nullptr);
+  pci = m_frame->GetSelectedEntry();
+  pbci = m_frame->GetBaseEntry(pci);
+
+  return pci && !pci->IsFieldValueEmpty(DragbarElements[idx].ft, pbci);
 }

--- a/src/ui/wxWidgets/addeditpropsheet.cpp
+++ b/src/ui/wxWidgets/addeditpropsheet.cpp
@@ -813,7 +813,7 @@ static struct {short pv; wxString name;}
 void AddEditPropSheet::UpdateExpTimes()
 {
   // From m_item to display
-  
+
   m_item.GetXTime(m_tttXTime);
   m_item.GetXTimeInt(m_XTimeInt);
   m_XTime = m_CurXTime = m_item.GetXTimeL().c_str();
@@ -887,6 +887,21 @@ void AddEditPropSheet::ItemFieldsToPropSheet()
   m_url = m_item.GetURL().c_str();
   m_email = m_item.GetEmail().c_str();
   m_password = m_item.GetPassword();
+
+  if (m_item.IsAlias()) {
+    // Update password to alias form
+    // Show text stating that it is an alias
+
+    const CItemData *pbci = m_core.GetBaseEntry(&m_item);
+    ASSERT(pbci);
+    if (pbci) {
+      m_password = L"[" +
+                pbci->GetGroup() + L":" +
+                pbci->GetTitle() + L":" +
+                pbci->GetUser()  + L"]";
+    }
+  } // IsAlias
+
   PWSprefs *prefs = PWSprefs::GetInstance();
   if (prefs->GetPref(PWSprefs::ShowPWDefault)) {
     ShowPassword();
@@ -1235,7 +1250,26 @@ void AddEditPropSheet::OnOk(wxCommandEvent& /* evt */)
                      m_symbols    != m_item.GetSymbols().c_str()     ||
                      oldPWP       != pwp);
 
-      bIsPSWDModified = (password != m_item.GetPassword());
+
+        if (!m_item.IsAlias()) {
+          bIsPSWDModified = (password != m_item.GetPassword());
+        }
+        else {
+          // Update password to alias form
+          // Show text stating that it is an alias
+          const CItemData *pbci = m_core.GetBaseEntry(&m_item);
+          ASSERT(pbci);
+          if (pbci) {
+            StringX alias = L"[" +
+                pbci->GetGroup() + L":" +
+                pbci->GetTitle() + L":" +
+                pbci->GetUser()  + L"]";
+            bIsPSWDModified = (password != alias);
+          }
+          else {
+            bIsPSWDModified = true;
+          }
+        }
 
       if (bIsModified) {
         // Just modify all - even though only 1 may have actually been modified

--- a/src/ui/wxWidgets/dragbar.h
+++ b/src/ui/wxWidgets/dragbar.h
@@ -7,10 +7,10 @@
  */
 
 /** \file dragbar.h
- * 
+ *
  * Implements a generic toolbar-like class from which tool icons can be dragged and
- * dropped on targets accepting text drops.  
- * 
+ * dropped on targets accepting text drops.
+ *
  * This class exists solely because I couldn't find a way to handle
  * left mouse-down events in wxToolBar class.  Also, finding the tool
  * on which a click happens (if it were possible) is a pain
@@ -32,33 +32,34 @@ struct DragBarItem {
 
 WX_DECLARE_OBJARRAY(DragBarItem, DragBarItemsArray);
 
-class CDragBar : public wxControl 
+class CDragBar : public wxControl
 {
   wxSize              m_margins;
   DragBarItemsArray   m_items;
   wxOrientation       m_orientation;
   int                 m_bmpWidth;
   int                 m_bmpHeight;
-  
+
 public:
 
   struct IDragSourceTextProvider {
     virtual wxString GetText(int id) const = 0;
     virtual bool IsEnabled(int id) const = 0;
+    virtual ~IDragSourceTextProvider() {}
   };
 
   CDragBar(wxFrame* parent, IDragSourceTextProvider* provider, wxOrientation orient = wxHORIZONTAL);
   ~CDragBar();
 
-  void AddTool(int id, const wxBitmap& bmp, const wxString& tooltip = wxEmptyString, 
+  void AddTool(int id, const wxBitmap& bmp, const wxString& tooltip = wxEmptyString,
                                     const wxBitmap& bmpDisabled = wxNullBitmap);
   void ClearTools() { m_items.Empty(); }
   size_t GetToolsCount() const { return m_items.GetCount(); }
   void SetToolBitmaps(int id, const wxBitmap& bmp, const wxBitmap& bmpDisabled = wxNullBitmap);
-  
+
   //overridden from wxWindow
   virtual wxSize DoGetBestSize() const ;
-  
+
   void OnLeftDown(wxMouseEvent& evt);
   void OnPaint(wxPaintEvent& evt);
   void OnMouseMove(wxMouseEvent& evt);
@@ -67,17 +68,17 @@ public:
 
   DECLARE_CLASS(CDragBar)
   DECLARE_EVENT_TABLE()
-  
+
 private:
   IDragSourceTextProvider* m_provider;
-  
+
   int FindToolFromCoords(const wxPoint& pt);
   wxSize GetInvalidatedIconRange(const wxRect& rect);
-  
+
   int GetToolX(size_t idx) const {
     switch (m_orientation) {
-      case wxHORIZONTAL: 
-        return m_margins.GetWidth() + 
+      case wxHORIZONTAL:
+        return m_margins.GetWidth() +
                     static_cast<int>(idx * (m_margins.GetWidth() + m_bmpWidth));
       case wxVERTICAL:
         return m_margins.GetWidth();
@@ -86,7 +87,7 @@ private:
         wxASSERT(wxT("Invalid orientation")); return -1;
     }
   }
-  
+
   int GetToolY(size_t idx) const {
     switch(m_orientation) {
       case wxHORIZONTAL:

--- a/src/ui/wxWidgets/passwordsafeframe.h
+++ b/src/ui/wxWidgets/passwordsafeframe.h
@@ -387,7 +387,7 @@ public:
 
   void OnBackupSafe(wxCommandEvent& evt);
   void OnRestoreSafe(wxCommandEvent& evt);
-  
+
   void OnVisitWebsite(wxCommandEvent&);
 
   void OnPasswordSubset(wxCommandEvent& evt);
@@ -451,6 +451,7 @@ public:
   void ViewReport(CReport& rpt);
 
   CItemData *GetSelectedEntry() const;
+  CItemData* GetBaseEntry(const CItemData *item) const;
   CItemData *GetSelectedEntry(const wxCommandEvent& evt, CItemData &rueItem) const;
   wxString GetCurrentSafe() const { return towxstring(m_core.GetCurFile()); }
 
@@ -487,7 +488,6 @@ public:
   void CleanupAfterReloadFailure(bool tellUser);
   Command *Delete(CItemData *pci);
   Command *Delete(wxTreeItemId tid); // for group delete
-  CItemData* GetBaseOfSelectedEntry(); //traverses to the base item if the selected item is a shortcut
   void UpdateAccessTime(CItemData &ci);
   void CreateMainToolbar();
   void ReCreateMainToolbar();


### PR DESCRIPTION
Attempt to fix D'n'D from Dragbar for alias/shortcut items: tried to use the same checkers/getters as in MFC ver. (haven't found quick and clean way without adding PasswordSafeFrame::GetBaseEntry).
Also quick and dirty fix for Add/Edit dialog, to show "base reference" for Alias entries (without check for alias correctness and other alias/shortcuts improvements, that were recently added to MFC version).