### PR TITLE
Remove GUI info from core

### DIFF
--- a/src/core/Command.cpp
+++ b/src/core/Command.cpp
@@ -117,6 +117,20 @@ MultiCommands::~MultiCommands()
   }
 }
 
+Command * MultiCommands::SearchForCommand(const type_info &ti)
+{
+  // Initial implementation - search for first command of a specific class
+  // in a MultiCommand.  Could be enhanced to return a vector of commands
+  // if all commands of a specific class are required.
+
+  for (auto cmd_Iter = m_vpcmds.begin(); cmd_Iter != m_vpcmds.end(); cmd_Iter++) {
+    if (typeid(**cmd_Iter) == ti) {
+      return *cmd_Iter;
+    }
+  }
+  return nullptr;
+}
+
 int MultiCommands::Execute()
 {
   std::vector<Command *>::iterator cmd_Iter;

--- a/src/core/Command.h
+++ b/src/core/Command.h
@@ -23,6 +23,7 @@ class CommandInterface;
 
 #include <map>
 #include <vector>
+#include <typeinfo>
 
 /**
  * Command-derived classes are used to support undo/redo.
@@ -461,6 +462,9 @@ public:
   int Execute();
   void Undo();
 
+  void GetPaths(StringX &sxOldPath, StringX &sxNewPath)
+  { sxOldPath = m_sxOldPath; sxNewPath = m_sxNewPath; }
+
 private:
   RenameGroupCommand(CommandInterface *pcomInt,
                      StringX sxOldPath, StringX sxNewPath);
@@ -518,6 +522,8 @@ public:
   std::size_t GetSize() const {return m_vpcmds.size();}
   bool IsEmpty() const { return m_vpcmds.empty(); }
   void SetNested() { SetInMultiCommand(); }
+
+  Command * SearchForCommand(const type_info &ti);
 
  private:
   MultiCommands(CommandInterface *pcomInt);

--- a/src/core/CoreImpExp.cpp
+++ b/src/core/CoreImpExp.cpp
@@ -1364,9 +1364,6 @@ int PWScore::ImportPlaintextFile(const StringX &ImportedPrefix,
       ci_temp.SetStatus(CItemData::ES_ADDED);
     }
 
-    // Get GUI to populate its field
-    GUISetupDisplayInfo(ci_temp);
-
     // Need to check that entry keyboard shortcut not already in use!
     int32 iKBShortcut;
     ci_temp.GetKBShortcut(iKBShortcut);
@@ -1807,7 +1804,6 @@ int PWScore::ImportKeePassV1TXTFile(const StringX &filename,
 
     ci_temp.SetStatus(CItemData::ES_ADDED);
 
-    GUISetupDisplayInfo(ci_temp);
     Command *pcmd = AddEntryCommand::Create(this, ci_temp);
     pcmd->SetNoGUINotify();
     pmulticmds->Add(pcmd);
@@ -2288,9 +2284,6 @@ int PWScore::ImportKeePassV1CSVFile(const StringX &filename,
     }
 
     ci_temp.SetStatus(CItemData::ES_ADDED);
-
-    // Get GUI to populate its field
-    GUISetupDisplayInfo(ci_temp);
 
     // Add to commands to execute
     Command *pcmd = AddEntryCommand::Create(this, ci_temp);

--- a/src/core/CoreOtherDB.cpp
+++ b/src/core/CoreOtherDB.cpp
@@ -990,7 +990,6 @@ void PWScore::Synchronize(PWScore *pothercore,
         continue;
 
       CItemData updItem(curItem);
-      updItem.SetDisplayInfo(NULL);
 
       if (curItem.GetUUID() != otherItem.GetUUID()) {
         pws_os::Trace(_T("Synchronize: Mis-match UUIDs for [%ls:%ls:%ls]\n"),
@@ -1023,7 +1022,6 @@ void PWScore::Synchronize(PWScore *pothercore,
       if (!bUpdated)
         continue;
 
-      GUISetupDisplayInfo(updItem);
       updItem.SetStatus(CItemData::ES_MODIFIED);
 
       StringX sx_updated;

--- a/src/core/CoreOtherDB.cpp
+++ b/src/core/CoreOtherDB.cpp
@@ -872,6 +872,7 @@ int PWScore::MergeDependents(PWScore *pothercore, MultiCommands *pmulticmds,
                           sx_merged.c_str(), str_timestring.c_str());
       ci_temp.SetTitle(sx_newTitle);
     }
+
     // Check this is unique - if not - don't add this one! - its only an alias/shortcut!
     // We can't keep trying for uniqueness after adding a timestamp!
     foundPos = Find(ci_temp.GetGroup(), sx_newTitle, ci_temp.GetUser());
@@ -879,7 +880,8 @@ int PWScore::MergeDependents(PWScore *pothercore, MultiCommands *pmulticmds,
       continue;
 
     ci_temp.SetBaseUUID(new_base_uuid);
-    Command *pcmd1 = AddEntryCommand::Create(this, ci_temp);
+    ci_temp.SetStatus(CItemData::ES_ADDED);
+    Command *pcmd1 = AddEntryCommand::Create(this, ci_temp, new_base_uuid);
     pcmd1->SetNoGUINotify();
     pmulticmds->Add(pcmd1);
 

--- a/src/core/Item.cpp
+++ b/src/core/Item.cpp
@@ -25,16 +25,13 @@ CItem::CItem()
 
 CItem::CItem(const CItem &that) :
   m_fields(that.m_fields),
-  m_URFL(that.m_URFL),
-  m_display_info(that.m_display_info == NULL ?
-                 NULL : that.m_display_info->clone())
+  m_URFL(that.m_URFL)
 {
   memcpy(m_key, that.m_key, sizeof(m_key));
 }
 
 CItem::~CItem()
 {
-  delete m_display_info;
   delete m_blowfish;
   // Following protects against possible use-after-delete
   // bug, since new BF will be created, rather than
@@ -48,9 +45,6 @@ CItem& CItem::operator=(const CItem &that)
     m_fields = that.m_fields;
     m_URFL = that.m_URFL;
 
-    delete m_display_info;
-    m_display_info = that.m_display_info == NULL ?
-      NULL : that.m_display_info->clone();
     memcpy(m_key, that.m_key, sizeof(m_key));
     delete m_blowfish;
     m_blowfish = nullptr;

--- a/src/core/Item.h
+++ b/src/core/Item.h
@@ -43,14 +43,6 @@
 
 class BlowFish;
 
-struct DisplayInfoBase
-{
-  // Following used by display methods of the GUI
-  DisplayInfoBase() {}
-  virtual ~DisplayInfoBase() {}
-  virtual DisplayInfoBase *clone() const = 0; // virtual c'tor idiom
-};
-
 class CItem
 {
 public:
@@ -139,9 +131,6 @@ public:
   size_t NumberUnknownFields() const {return m_URFL.size();}
 
   CItem& operator=(const CItem& second);
-  // Following used by display methods - we just keep it handy
-  DisplayInfoBase *GetDisplayInfo() const {return m_display_info;}
-  void SetDisplayInfo(DisplayInfoBase *di) {delete m_display_info; m_display_info = di;}
   void Clear();
   void ClearField(int ft) {m_fields.erase(ft);}
 
@@ -195,9 +184,6 @@ private:
   // than the BlowFish object for copy c'tor and assignment
   unsigned char m_key[32];
   mutable BlowFish *m_blowfish = nullptr;
-
-  // Following used by display methods - we just keep it handy
-  DisplayInfoBase *m_display_info = nullptr;
 };
 
 #endif /* __ITEM_H */

--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -959,7 +959,6 @@ void PWScore::Redo()
     m_redo_iter++;
     m_redo_DBState_iter++;
   }
-
   
   // If user has set Save Immediately, then Redo changes the DB and it should be
   // saved (with or without an intermediate backup)
@@ -967,6 +966,18 @@ void PWScore::Redo()
 
   // Then tell the UI update the GUI
   NotifyGUINeedsUpdating(UpdateGUICommand::GUI_UPDATE_STATUSBAR, CUUID::NullUUID());
+}
+
+Command * PWScore::GetRedoCommand()
+{
+  ASSERT(m_redo_iter != m_vpcommands.end());
+  return *m_redo_iter;
+}
+
+Command * PWScore::GetUndoCommand()
+{
+  ASSERT(m_undo_iter != m_vpcommands.end());
+  return *m_undo_iter;
 }
 
 bool PWScore::AnyToUndo() const
@@ -3174,14 +3185,6 @@ void PWScore::NotifyGUINeedsUpdating(UpdateGUICommand::GUI_Action ga,
   if (m_pUIIF != NULL &&
       m_bsSupportedFunctions.test(UIInterFace::UPDATEGUIGROUPS))
     m_pUIIF->UpdateGUI(ga, vGroups);
-}
-
-void PWScore::GUISetupDisplayInfo(CItemData &ci)
-{
-  // This allows the core to provide feedback to the UI that ???
-  if (m_pUIIF != NULL &&
-      m_bsSupportedFunctions.test(UIInterFace::GUISETUPDISPLAYINFO))
-    m_pUIIF->GUISetupDisplayInfo(ci);
 }
 
 void PWScore::GUIRefreshEntry(const CItemData &ci)

--- a/src/core/PWScore.h
+++ b/src/core/PWScore.h
@@ -314,6 +314,8 @@ public:
   void ClearCommands();  // This should be private to prevent UI calling directly but called by coretest
   bool AnyToUndo() const;
   bool AnyToRedo() const;
+  Command * GetRedoCommand();
+  Command * GetUndoCommand();
 
   // Find in m_pwlist by group, title and user name, exact match
   ItemListIter Find(const StringX &a_group,
@@ -379,7 +381,6 @@ public:
   bool GetDBNotificationState()
   {return m_bNotifyDB;}
 
-  void GUISetupDisplayInfo(CItemData &ci);
   void GUIRefreshEntry(const CItemData &ci);
   void UpdateWizard(const stringT &s);
 

--- a/src/core/UIinterface.h
+++ b/src/core/UIinterface.h
@@ -36,7 +36,7 @@ public:
    * DO NOT change the order of the functions as UIs will fail
    */
   enum Functions {
-    DATABASEMODIFIED = 0, UPDATEGUI, GUISETUPDISPLAYINFO, GUIREFRESHENTRY,
+    DATABASEMODIFIED = 0, UPDATEGUI, GUIREFRESHENTRY,
     UPDATEWIZARD, UPDATEGUIGROUPS,
     NUM_SUPPORTED};
 
@@ -58,9 +58,6 @@ public:
   // Version for groups
   virtual void UpdateGUI(UpdateGUICommand::GUI_Action ga,
                          const std::vector<StringX> &vGroups) = 0;
-
-  // GUISetupDisplayInfo: let GUI populate DisplayInfo field in an entry
-  virtual void GUISetupDisplayInfo(CItemData &ci) = 0;
 
   // GUIRefreshEntry: called when the entry's graphic representation
   // may have changed - GUI should update and invalidate its display.

--- a/src/core/XML/XMLFileHandlers.cpp
+++ b/src/core/XML/XMLFileHandlers.cpp
@@ -964,7 +964,7 @@ void XMLFileHandlers::AddXMLEntries()
         m_numShortcutsRemoved++;
       }
     }
-    m_pXMLcore->GUISetupDisplayInfo(ci_temp);
+
     Command *pcmd = AddEntryCommand::Create(m_pXMLcore, ci_temp);
     pcmd->SetNoGUINotify();
     m_pmulticmds->Add(pcmd);

--- a/src/ui/Windows/DboxMain.h
+++ b/src/ui/Windows/DboxMain.h
@@ -70,6 +70,31 @@
 typedef BOOL (WINAPI *PSBR_CREATE) (HWND, LPCWSTR);
 typedef BOOL (WINAPI *PSBR_DESTROY) (HWND);
 
+// Entry to GUI mapping
+// Following used to keep track of display vs data
+// stored as opaque data in m_MapEntryToGUI
+// Exposed here because PWTreeCtrl needs to update it after drag&drop
+struct DisplayInfo {
+  int list_index;
+  HTREEITEM tree_item;
+
+  DisplayInfo() :list_index(-1), tree_item(0) {}
+  virtual ~DisplayInfo() {}
+
+  DisplayInfo(const DisplayInfo &that)
+    : list_index(that.list_index), tree_item(that.tree_item)
+  {}
+
+  DisplayInfo &operator=(const DisplayInfo &that)
+  {
+    if (this != &that) {
+      list_index = that.list_index;
+      tree_item = that.tree_item;
+    }
+    return *this;
+  }
+};
+
 enum SearchDirection {FIND_UP = -1, FIND_DOWN = 1};
 
 // List of all Popup menus in the Main Menu
@@ -366,6 +391,8 @@ public:
   bool IsInRename() const {return m_bInRename;}
   bool IsInAddGroup() const {return m_bInAddGroup;}
   void ResetInAddGroup() {m_bInAddGroup = false;}
+  void SetRenameGroups(const StringX sxNewPath)
+  { m_sxNewPath = sxNewPath; }
 
   //{{AFX_DATA(DboxMain)
   enum { IDD = IDD_PASSWORDSAFE_DIALOG };
@@ -391,6 +418,9 @@ public:
 
   // Used in Add & Edit & PasswordPolicyDlg
   PWPolicy m_pwp;
+
+  // Get link between entry and GUI
+  DisplayInfo * GetEntryGUIInfo(const CItemData &ci, const bool bASSERT = true);
 
   // Mapping Group to Tree Item to save searching all the time!
   // Be nice to have a bimap implementation
@@ -754,7 +784,6 @@ private:
   virtual void UpdateGUI(UpdateGUICommand::GUI_Action ga,
                          const std::vector<StringX> &vGroups);
   
-  virtual void GUISetupDisplayInfo(CItemData &ci);
   virtual void GUIRefreshEntry(const CItemData &ci);
   virtual void UpdateWizard(const std::wstring &s);
 
@@ -793,6 +822,15 @@ private:
   pws_os::CUUID m_LUUIDVisibleAtMinimize;  // to restore List entry position  upon un-minimize
   pws_os::CUUID m_TUUIDVisibleAtMinimize;  // to restore Tree entry position  upon un-minimize
   StringX m_sxVisibleGroup;                // to restore Tree group position  upon un-minimize
+ 
+  // Here lies the mapping between an entry and its place on the GUI (Tree/List views)
+  std::map<pws_os::CUUID, DisplayInfo, std::less<pws_os::CUUID> > m_MapEntryToGUI;
+  
+  // Set link between entry and GUI
+  void SetEntryGUIInfo(const CItemData &ci, DisplayInfo &di);
+
+  // Used in SaveGUIStatus to remember position during rename group - set by CPWTreeCtrl
+  StringX m_sxNewPath;
 
   StringX m_sxOriginalGroup;                 // Needed when doing recursive deletions of groups
 
@@ -851,6 +889,7 @@ private:
   void UpdateEntryInGUI(CItemData &ci);
   void UpdateGroupsInGUI(const std::vector<StringX> &vGroups);
   StringX GetListViewItemText(CItemData &ci, const int &icolumn);
+  void DoCommand(Command *pcmd = NULL, PWScore *pcore = NULL, const bool bUndo = true);
   
   static const struct UICommandTableEntry {
     UINT ID;
@@ -986,28 +1025,22 @@ private:
   std::stack<st_SaveGUIInfo> m_stkSaveGUIInfo;
 };
 
-// Following used to keep track of display vs data
-// stored as opaque data in CItemData.{Get,Set}DisplayInfo()
-// Exposed here because PWTreeCtrl needs to update it after drag&drop
-struct DisplayInfo : public DisplayInfoBase {
-  int list_index;
-  HTREEITEM tree_item;
+inline DisplayInfo * DboxMain::GetEntryGUIInfo(const CItemData &ci, const bool bASSERT)
+{
+  std::map<pws_os::CUUID, DisplayInfo, std::less<pws_os::CUUID> >::iterator E2G_iter;
 
- DisplayInfo() :list_index(-1), tree_item(0) {}
-  virtual ~DisplayInfo() {}
-  virtual DisplayInfo *clone() const // virtual c'tor idiom
-  { return new DisplayInfo(*this); }
- 
-  DisplayInfo(const DisplayInfo &that)
-  : list_index(that.list_index), tree_item(that.tree_item)
-  {}
-
-  DisplayInfo &operator=(const DisplayInfo &that)
-  {
-    if (this != &that) {
-      list_index = that.list_index;
-      tree_item = that.tree_item;
-    }
-    return *this;
+  E2G_iter = m_MapEntryToGUI.find(ci.GetUUID());
+  if (E2G_iter != m_MapEntryToGUI.end()) {
+    return &E2G_iter->second;
   }
-};
+
+  if (bASSERT) {
+    ASSERT(0);
+  }
+  return nullptr;  
+}
+
+inline void DboxMain::SetEntryGUIInfo(const CItemData &ci, DisplayInfo &di)
+{
+  m_MapEntryToGUI[ci.GetUUID()] = di;
+}

--- a/src/ui/Windows/DboxMain.h
+++ b/src/ui/Windows/DboxMain.h
@@ -420,7 +420,7 @@ public:
   PWPolicy m_pwp;
 
   // Get link between entry and GUI
-  DisplayInfo * GetEntryGUIInfo(const CItemData &ci, const bool bASSERT = true);
+  DisplayInfo * GetEntryGUIInfo(const CItemData &ci, const bool bAllowFail = false);
 
   // Mapping Group to Tree Item to save searching all the time!
   // Be nice to have a bimap implementation
@@ -1025,7 +1025,7 @@ private:
   std::stack<st_SaveGUIInfo> m_stkSaveGUIInfo;
 };
 
-inline DisplayInfo * DboxMain::GetEntryGUIInfo(const CItemData &ci, const bool bASSERT)
+inline DisplayInfo * DboxMain::GetEntryGUIInfo(const CItemData &ci, const bool bAllowFail)
 {
   std::map<pws_os::CUUID, DisplayInfo, std::less<pws_os::CUUID> >::iterator E2G_iter;
 
@@ -1034,7 +1034,7 @@ inline DisplayInfo * DboxMain::GetEntryGUIInfo(const CItemData &ci, const bool b
     return &E2G_iter->second;
   }
 
-  if (bASSERT) {
+  if (!bAllowFail) {
     ASSERT(0);
   }
   return nullptr;  

--- a/src/ui/Windows/DboxTray.cpp
+++ b/src/ui/Windows/DboxTray.cpp
@@ -306,7 +306,8 @@ void DboxMain::OnTraySelect(UINT nID)
   if (!GetRUEntry(m_RUEList, nID - ID_MENUITEM_TRAYSELECT1, ci))
       return;
 
-  DisplayInfo *pdi = (DisplayInfo *)ci.GetDisplayInfo();
+  DisplayInfo *pdi = GetEntryGUIInfo(ci, false);
+
   if (pdi != NULL) {
     // Could be null if RefreshViews not called,
     // In which case we've no display to select to.

--- a/src/ui/Windows/DboxTray.cpp
+++ b/src/ui/Windows/DboxTray.cpp
@@ -306,7 +306,7 @@ void DboxMain::OnTraySelect(UINT nID)
   if (!GetRUEntry(m_RUEList, nID - ID_MENUITEM_TRAYSELECT1, ci))
       return;
 
-  DisplayInfo *pdi = GetEntryGUIInfo(ci, false);
+  DisplayInfo *pdi = GetEntryGUIInfo(ci, true);
 
   if (pdi != NULL) {
     // Could be null if RefreshViews not called,

--- a/src/ui/Windows/MainFile.cpp
+++ b/src/ui/Windows/MainFile.cpp
@@ -3583,9 +3583,6 @@ LRESULT DboxMain::CopyCompareResult(PWScore *pfromcore, PWScore *ptocore,
   const CItemData *pfromEntry = &fromPos->second;
   CItemData ci_temp(*pfromEntry);  // Set up copy
 
-  DisplayInfo *pdi = new DisplayInfo;
-  ci_temp.SetDisplayInfo(pdi); // DisplayInfo values will be set later
-
   // If the UUID is not in use in the "to" core, copy it too, otherwise reuse current
   if (ptocore->Find(fromUUID) == ptocore->GetEntryEndIter()) {
     ci_temp.SetUUID(fromUUID);
@@ -3747,9 +3744,6 @@ LRESULT DboxMain::CopyAllCompareResult(WPARAM wParam)
     ASSERT(fromPos != pfromcore->GetEntryEndIter());
     const CItemData *pfromEntry = &fromPos->second;
     CItemData ci_temp(*pfromEntry);  // Set up copy
-
-    DisplayInfo *pdi = new DisplayInfo;
-    ci_temp.SetDisplayInfo(pdi); // DisplayInfo values will be set later
 
     // Special processing for password policies (default & named)
     StringX sxPolicyName = pfromEntry->GetPolicyName();

--- a/src/ui/Windows/MainFilters.cpp
+++ b/src/ui/Windows/MainFilters.cpp
@@ -191,7 +191,7 @@ void DboxMain::ApplyFilters()
   int iLastShown = m_FindToolBar.GetLastSelectedFoundItem(entry_uuid);
   if (iLastShown >= 0) {
     CItemData *pci = &m_core.Find(entry_uuid)->second;
-    DisplayInfo *pdi = (DisplayInfo *)pci->GetDisplayInfo();
+    DisplayInfo *pdi = GetEntryGUIInfo(*pci);
     m_LastFoundTreeItem = pdi->tree_item;
     m_LastFoundListItem = pdi->list_index;
   }

--- a/src/ui/Windows/MainMenu.cpp
+++ b/src/ui/Windows/MainMenu.cpp
@@ -1313,8 +1313,7 @@ void DboxMain::OnContextMenu(CWnd * /* pWnd */, CPoint screen)
       UpdateToolBarForSelectedItem(pci);
       if (pci != NULL) {
         // right-click was on an item (LEAF of some kind: normal, alias, shortcut)
-        DisplayInfo *pdi = (DisplayInfo *)pci->GetDisplayInfo();
-        ASSERT(pdi != NULL);
+        DisplayInfo *pdi = GetEntryGUIInfo(*pci);
         ASSERT(pdi->tree_item == ti);
         item = pdi->list_index;
         m_ctlItemTree.SelectItem(ti); // So that OnEdit gets the right one

--- a/src/ui/Windows/MainView.cpp
+++ b/src/ui/Windows/MainView.cpp
@@ -4544,8 +4544,9 @@ void DboxMain::RemoveFromGUI(CItemData &ci, const bool bUpdateGUI)
       m_LastFoundListItem = -1;
     }
 
-    pdi->list_index = -1;
-    pdi->tree_item = 0;
+    // Now remove from map
+    size_t num = m_MapEntryToGUI.erase(ci.GetUUID());
+    ASSERT(num == 1);
 
     FixListIndexes(); // sucks, as make M deletions an NxM operation
     if (bUpdateGUI) { // Make controls redraw

--- a/src/ui/Windows/MainView.cpp
+++ b/src/ui/Windows/MainView.cpp
@@ -1270,7 +1270,7 @@ void DboxMain::RefreshViews(const ViewType iView)
   for (auto listPos = m_core.GetEntryIter(); listPos != m_core.GetEntryEndIter();
        listPos++) {
     CItemData &ci = m_core.GetEntry(listPos);
-    DisplayInfo *pdi = GetEntryGUIInfo(ci, false);
+    DisplayInfo *pdi = GetEntryGUIInfo(ci, true);
     if (pdi != NULL) {
       pdi->list_index = -1;
       pdi->tree_item = 0;
@@ -1778,7 +1778,7 @@ void DboxMain::OnKeydownItemlist(NMHDR *pNotifyStruct, LRESULT *pLResult)
 int DboxMain::InsertItemIntoGUITreeList(CItemData &ci, int iIndex, 
                                 const bool bSort, const ViewType iView)
 {
-  DisplayInfo *pdi = GetEntryGUIInfo(ci, false);
+  DisplayInfo *pdi = GetEntryGUIInfo(ci, true);
   if (pdi != NULL && pdi->list_index != -1 && pdi->tree_item != 0) {
     // true iff item already displayed
     return iIndex;
@@ -4521,7 +4521,7 @@ void DboxMain::RemoveFromGUI(CItemData &ci, const bool bUpdateGUI)
   CItemData *pci2 = &iter->second;
   DisplayInfo *pdi2 = GetEntryGUIInfo(*pci2);
 
-  DisplayInfo *pdi = GetEntryGUIInfo(ci, false);
+  DisplayInfo *pdi = GetEntryGUIInfo(ci, true);
 
   if (pdi != NULL) {
     ASSERT(pdi2->list_index == pdi->list_index &&
@@ -4677,7 +4677,7 @@ void DboxMain::SaveGUIStatusEx(const ViewType iView)
       int i = m_ctlItemList.GetNextSelectedItem(pos);
       pci = (CItemData *)m_ctlItemList.GetItemData(i);
       ASSERT(pci != NULL);  // No groups in List View
-      DisplayInfo *pdi = GetEntryGUIInfo(*pci, false);
+      DisplayInfo *pdi = GetEntryGUIInfo(*pci, true);
       ASSERT(pdi != NULL && pdi->list_index == i);
       m_LUUIDSelectedAtMinimize = pci->GetUUID();
     } // p != 0
@@ -4687,7 +4687,7 @@ void DboxMain::SaveGUIStatusEx(const ViewType iView)
     if (i >= 0) {
       pci = (CItemData *)m_ctlItemList.GetItemData(i);
       ASSERT(pci != NULL);  // No groups in List View
-      DisplayInfo *pdi = GetEntryGUIInfo(*pci, false);
+      DisplayInfo *pdi = GetEntryGUIInfo(*pci, true);
       ASSERT(pdi != NULL && pdi->list_index == i);
       m_LUUIDVisibleAtMinimize = pci->GetUUID();
     } // i >= 0

--- a/src/ui/Windows/PWTreeCtrl.cpp
+++ b/src/ui/Windows/PWTreeCtrl.cpp
@@ -779,8 +779,7 @@ void CPWTreeCtrl::OnEndLabelEdit(NMHDR *pNotifyStruct, LRESULT *pLResult)
     ptvinfo->item.pszText[ptvinfo->item.cchTextMax - 1] = L'\0';
 
     // update corresponding List mode text - but  only those visible in Tree
-    DisplayInfo *pdi = (DisplayInfo *)pci->GetDisplayInfo();
-    ASSERT(pdi != NULL);
+    DisplayInfo *pdi = app.GetMainDlg()->GetEntryGUIInfo(*pci);
     int lindex = pdi->list_index;
 
     if (sxNewTitle != pci->GetTitle()) {
@@ -1148,8 +1147,7 @@ bool CPWTreeCtrl::MoveItem(MultiCommands *pmulticmds, HTREEITEM hitemDrag, HTREE
   if (itemData != 0) { // Non-NULL itemData implies Leaf
     CItemData *pci = (CItemData *)itemData;
 
-    DisplayInfo *pdi = (DisplayInfo *)pci->GetDisplayInfo();
-    ASSERT(pdi != NULL);
+    DisplayInfo *pdi = app.GetMainDlg()->GetEntryGUIInfo(*pci);
     ASSERT(pdi->list_index >= 0);
 
     // Update Group
@@ -1295,7 +1293,6 @@ bool CPWTreeCtrl::CopyItem(MultiCommands *pmulticmds, HTREEITEM hitemDrag, HTREE
     ci_temp.CreateUUID(); // Copy needs its own UUID
     ci_temp.SetGroup(sNewPath);
     ci_temp.SetTitle(ci_title);
-    ci_temp.SetDisplayInfo(new DisplayInfo);
 
     CItemData::EntryType temp_et = ci_temp.GetEntryType();
     switch (temp_et) {

--- a/src/ui/Windows/ThisMfcApp.cpp
+++ b/src/ui/Windows/ThisMfcApp.cpp
@@ -1085,7 +1085,6 @@ BOOL ThisMfcApp::InitInstance()
   std::bitset<UIInterFace::NUM_SUPPORTED> bsSupportedFunctions;
   bsSupportedFunctions.set(UIInterFace::DATABASEMODIFIED);
   bsSupportedFunctions.set(UIInterFace::UPDATEGUI);
-  bsSupportedFunctions.set(UIInterFace::GUISETUPDISPLAYINFO);
   bsSupportedFunctions.set(UIInterFace::GUIREFRESHENTRY);
   bsSupportedFunctions.set(UIInterFace::UPDATEWIZARD);
   bsSupportedFunctions.set(UIInterFace::UPDATEGUIGROUPS);

--- a/src/ui/wxWidgets/PwsSync.cpp
+++ b/src/ui/wxWidgets/PwsSync.cpp
@@ -691,7 +691,6 @@ void SyncStatusPage::Synchronize(PWScore* currentCore, const PWScore *otherCore)
       // found a match
       CItemData curItem = currentCore->GetEntry(foundPos);
       CItemData updItem(curItem);
-      updItem.SetDisplayInfo(NULL);
 
       uuid_array_t current_uuid, other_uuid;
       curItem.GetUUID(current_uuid);

--- a/src/ui/wxWidgets/mainEdit.cpp
+++ b/src/ui/wxWidgets/mainEdit.cpp
@@ -413,7 +413,6 @@ void PasswordSafeFrame::OnDuplicateEntry(wxCommandEvent& WXUNUSED(event))
 
     // Set up new entry
     CItemData ci2(*pci);
-    ci2.SetDisplayInfo(NULL);
     ci2.CreateUUID();
     ci2.SetGroup(ci2_group);
     ci2.SetTitle(ci2_title);


### PR DESCRIPTION
Also, as Execute, Redo, Undo were virtually identical - merge into one routine.