### PR TITLE
Fix build error on macOS 10.12.3 with Xcode 8.2.1

### DIFF
--- a/src/os/mac/file.cpp
+++ b/src/os/mac/file.cpp
@@ -354,7 +354,7 @@ std::FILE *pws_os::FOpen(const stringT &filename, const TCHAR *mode)
   return retval;
 }
 
-void pws_os::FClose(std::FILE *fd, const bool &bIsWrite)
+int pws_os::FClose(std::FILE *fd, const bool &bIsWrite)
 {
   if (fd != NULL) {
     if (bIsWrite) {


### PR DESCRIPTION
This is a minor change to fix a build error on Xcode 8.2.1.