### PR TITLE
gh270b - VS2015 compiler warnings for DebugM/ReleaseM x64 build

### DIFF
--- a/src/core/CoreImpExp.cpp
+++ b/src/core/CoreImpExp.cpp
@@ -1986,7 +1986,7 @@ int PWScore::ImportKeePassV1CSVFile(const StringX &filename,
   for (size_t i = 0; i < hdr_tokens.size(); i++) {
     vector<StringX>::iterator it(std::find(vs_Header.begin(), vs_Header.end(), hdr_tokens[i]));
     if (it != vs_Header.end()) {
-      i_Offset[it - vs_Header.begin()] = i;
+      i_Offset[it - vs_Header.begin()] = (int)i;
       num_found++;
     }
   }

--- a/src/core/ItemAtt.cpp
+++ b/src/core/ItemAtt.cpp
@@ -431,7 +431,7 @@ int CItemAtt::Read(PWSfile *in)
     trashMemory(AK, sizeof(AK));
     
     // calculate HMAC
-    hmac.Update(content, content_len);
+    hmac.Update(content, (unsigned long)content_len);
     hmac.Final(calculated_digest);
 
     if (memcmp(expected_digest, calculated_digest,

--- a/src/core/ItemData.cpp
+++ b/src/core/ItemData.cpp
@@ -1726,7 +1726,7 @@ bool CItemData::Matches(int num1, int num2, int iObject,
       GetSize(reinterpret_cast<size_t &>(iValue));
       break;
     case PASSWORDLEN:
-      iValue = GetPasswordLength();
+      iValue = (int)GetPasswordLength();
       break;
     case KBSHORTCUT:
       GetKBShortcut(iValue);

--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -1396,7 +1396,7 @@ static void ManageIncBackupFiles(const stringT &cs_filenamebase,
     unsigned int m = 1;
     for (x = 0; x < file_nums.size(); x++)
       if (file_nums[x] < next)
-        file_nums[x] = next <= 999 ? next++ : m++;
+        file_nums[x] = (unsigned long)(next <= 999 ? next++ : m++);
   }
 
   Format(cs_newname, L"%ls_%03d", cs_filenamebase.c_str(), nnn);

--- a/src/core/PWSfileV4.cpp
+++ b/src/core/PWSfileV4.cpp
@@ -251,7 +251,7 @@ size_t PWSfileV4::WriteCBC(unsigned char type, const unsigned char *data,
 
   m_hmac.Update(&type, 1);
   m_hmac.Update(buf, sizeof(buf));
-  m_hmac.Update(data, length);
+  m_hmac.Update(data, (unsigned long)length);
 
   return PWSfile::WriteCBC(type, data, length);
 }
@@ -310,7 +310,7 @@ size_t PWSfileV4::WriteContentFields(unsigned char *content, size_t len)
   _writecbc(m_fd, content, len, &fish, IV);
 
   // update content's HMAC
-  hmac.Update(content, len);
+  hmac.Update(content, (unsigned long)len);
 
   // write content's HMAC
   unsigned char digest[SHA256::HASHLEN];
@@ -344,7 +344,7 @@ size_t PWSfileV4::ReadCBC(unsigned char &type, unsigned char* &data,
 
     m_hmac.Update(&type, 1);
     m_hmac.Update(buf, sizeof(buf));
-    m_hmac.Update(data, length);
+    m_hmac.Update(data, (unsigned long)length);
   }
 
   return numRead;
@@ -411,7 +411,7 @@ void PWSfileV4::StretchKey(const unsigned char *salt, unsigned long saltLen,
 
   HMAC<SHA256, SHA256::HASHLEN, SHA256::BLOCKSIZE> hmac;
   ConvertString(passkey, pstr, passLen);
-  pbkdf2(pstr, passLen, salt, saltLen, N, &hmac, Ptag, &PtagLen);
+  pbkdf2(pstr, (unsigned long)passLen, salt, saltLen, N, &hmac, Ptag, &PtagLen);
 
 #ifdef UNICODE
   trashMemory(pstr, passLen);
@@ -836,10 +836,10 @@ bool PWSfileV4::VerifyKeyBlocks()
   unsigned char ReadEndKB[SHA256::HASHLEN];
   unsigned char CalcEndKB[SHA256::HASHLEN];
 
-  int nRead = fread(hnonce, sizeof(hnonce), 1, m_fd);
+  int nRead = (int)fread(hnonce, sizeof(hnonce), 1, m_fd);
   if (nRead != 1)
     return false;
-  nRead = fread(ReadEndKB, sizeof(ReadEndKB), 1, m_fd);
+  nRead = (int)fread(ReadEndKB, sizeof(ReadEndKB), 1, m_fd);
   if (nRead != 1)
     return false;
 
@@ -960,7 +960,7 @@ bool PWSfileV4::CKeyBlocks::RemoveKeyBlock(const StringX &passkey)
     return false;
 
   KeyBlockFinder find_kb(passkey);
-  const unsigned long old_size = m_kbs.size();
+  const unsigned long old_size = (unsigned long)m_kbs.size();
   m_kbs.erase(remove_if(m_kbs.begin(), m_kbs.end(), find_kb),
                m_kbs.end());
 

--- a/src/core/PWSfileV4.h
+++ b/src/core/PWSfileV4.h
@@ -96,7 +96,7 @@ public:
     KeyBlock &at(unsigned i) {return m_kbs.at(i);}
     const KeyBlock &at(unsigned i) const {return m_kbs.at(i);}
     bool empty() const {return m_kbs.empty();}
-    unsigned size() const {return m_kbs.size();}
+    unsigned size() const {return (unsigned)m_kbs.size();}
     const size_t KBLEN = PWSaltLength + sizeof(uint32) + KWLEN + KWLEN;
   };
 

--- a/src/core/VerifyFormat.cpp
+++ b/src/core/VerifyFormat.cpp
@@ -635,7 +635,7 @@ int VerifyXMLImportPWHistoryString(const StringX &PWHistory,
   if (rc != PWH_OK)
     nerror = ie;
 
-  n = out_entries.size();
+  n = (unsigned int)out_entries.size();
   Format(sxBuffer, L"%01d%02x%02x", s, m, n);
   newPWHistory = sxBuffer;
 

--- a/src/os/file.h
+++ b/src/os/file.h
@@ -39,6 +39,9 @@ namespace pws_os {
   extern bool SetFileTimes(const stringT &filename,
       time_t ctime, time_t mtime, time_t atime);
   extern const TCHAR PathSeparator; // slash for Unix, backslash for Windows
+
+  // Most stdio.h routines return -1 for an error (not INVALID_HANDLE_VALUE)
+  #define INVALID_FILE_DESCRIPTOR (int)-1
 }
 #endif /* __FILE_H */
 //-----------------------------------------------------------------------------

--- a/src/os/windows/file.cpp
+++ b/src/os/windows/file.cpp
@@ -416,7 +416,7 @@ int pws_os::FClose(std::FILE *fd, const bool &bIsWrite)
         // Windows FlushFileBuffers == Linux fsync
         int ifileno = _fileno(fd);
 
-        if ((HANDLE)ifileno != INVALID_HANDLE_VALUE) {
+        if (ifileno != INVALID_FILE_DESCRIPTOR) {
           intptr_t iosfhandle = _get_osfhandle(ifileno);
 
           if ((HANDLE)iosfhandle != INVALID_HANDLE_VALUE) {

--- a/src/os/windows/mem.cpp
+++ b/src/os/windows/mem.cpp
@@ -39,7 +39,7 @@ bool pws_os::mcryptProtect(void *p, size_t size)
   if (hCRYPT32) {
      LP_CryptProtectMemory protectPtr = (LP_CryptProtectMemory)GetProcAddress(hCRYPT32, "CryptProtectMemory");
      if (protectPtr)
-       res = (protectPtr(p, size, CRYPTPROTECTMEMORY_SAME_PROCESS) == TRUE);
+       res = (protectPtr(p, (DWORD)size, CRYPTPROTECTMEMORY_SAME_PROCESS) == TRUE);
      FreeLibrary(hCRYPT32);
   }
   return res;
@@ -56,7 +56,7 @@ bool pws_os::mcryptUnprotect(void *p, size_t size)
      LP_CryptProtectMemory unprotectPtr =
        LP_CryptProtectMemory(pws_os::GetFunction(hCRYPT32, "CryptUnprotectMemory"));
      if (unprotectPtr)
-       res = (unprotectPtr(p, size, CRYPTPROTECTMEMORY_SAME_PROCESS) == TRUE);
+       res = (unprotectPtr(p, (DWORD)size, CRYPTPROTECTMEMORY_SAME_PROCESS) == TRUE);
      pws_os::FreeLibrary(hCRYPT32);
   }
   return res;

--- a/src/ui/Windows/AddEdit_Additional.cpp
+++ b/src/ui/Windows/AddEdit_Additional.cpp
@@ -716,8 +716,8 @@ BOOL CAddEdit_Additional::OnApply()
     wchar_t buffer[6];
     swprintf_s(buffer, 6, L"%1x%02x%02x",
               (M_SavePWHistory() == FALSE) ? 0 : 1,
-              M_MaxPWHistory(),
-              M_pwhistlist().size());
+              (unsigned int)M_MaxPWHistory(),
+              (unsigned int)M_pwhistlist().size());
     if (M_PWHistory().GetLength() >= 5) {
       for (int i = 0; i < 5; i++) {
         M_PWHistory().SetAt(i, buffer[i]);
@@ -973,7 +973,7 @@ void CAddEdit_Additional::OnHistListClick(NMHDR *pNMHDR, LRESULT *pResult)
   LPNMITEMACTIVATE pNMItemActivate = reinterpret_cast<LPNMITEMACTIVATE>(pNMHDR);
   int selectedRow = pNMItemActivate->iItem;
   if (selectedRow >= 0) {
-    int indx = m_PWHistListCtrl.GetItemData(selectedRow);
+    int indx = (int)m_PWHistListCtrl.GetItemData(selectedRow);
     const StringX histpasswd = M_pwhistlist()[indx].password;
     GetMainDlg()->SetClipboardData(histpasswd);
 

--- a/src/ui/Windows/AddEdit_Attachment.cpp
+++ b/src/ui/Windows/AddEdit_Attachment.cpp
@@ -511,7 +511,7 @@ void CAddEdit_Attachment::ShowPreview()
     if (m_csMediaType.Left(5) == L"image") {
       // Should be an image file - but may not be supported by CImage - try..
       // Allocate attachment buffer
-      UINT imagesize = att.GetContentSize();
+      UINT imagesize = (UINT)att.GetContentSize();
       HGLOBAL gMemory = GlobalAlloc(GMEM_MOVEABLE, imagesize);
       ASSERT(gMemory);
 

--- a/src/ui/Windows/AddEdit_Basic.cpp
+++ b/src/ui/Windows/AddEdit_Basic.cpp
@@ -699,7 +699,7 @@ BOOL CAddEdit_Basic::OnApply()
       cs_errmsg.Format(M_original_entrytype() == CItemData::ET_ALIASBASE ?
                        IDS_CHANGINGBASEENTRY1 : IDS_CHANGINGBASEENTRY2,
                        static_cast<LPCWSTR>(cs_alias));
-      int rc = gmb.MessageBox(cs_errmsg, cs_title, MB_YESNO | MB_ICONEXCLAMATION | MB_DEFBUTTON2);
+      int rc = (int)gmb.MessageBox(cs_errmsg, cs_title, MB_YESNO | MB_ICONEXCLAMATION | MB_DEFBUTTON2);
 
       if (rc == IDNO) {
         UpdateData(FALSE);

--- a/src/ui/Windows/DboxMain.cpp
+++ b/src/ui/Windows/DboxMain.cpp
@@ -748,7 +748,7 @@ bool DboxMain::IsCharacterSupported(std::wstring &sProtect)
   ASSERT(sProtect.length() < 3);
 
   // Itemize - Uniscribe function
-  hr = ScriptItemize(sProtect.c_str(), sProtect.length(), cMaxItems, NULL, NULL, items, &cItems);
+  hr = ScriptItemize(sProtect.c_str(), (int)sProtect.length(), cMaxItems, NULL, NULL, items, &cItems);
 
   if (SUCCEEDED(hr) == FALSE)
     return bSupported;
@@ -1798,7 +1798,7 @@ void DboxMain::OnPasswordSafeWebsite()
 {
   HINSTANCE stat = ::ShellExecute(NULL, NULL, L"https://pwsafe.org/",
                               NULL, L".", SW_SHOWNORMAL);
-  if (int(stat) <= 32) {
+  if ((__int64)stat <= 32) {
 #ifdef _DEBUG
     CGeneralMsgBox gmb;
     gmb.AfxMessageBox(L"oops");
@@ -2055,14 +2055,14 @@ BOOL DboxMain::OnToolTipText(UINT, NMHDR *pNotifyStruct, LRESULT *pLResult)
   TOOLTIPTEXTW *pTTTW = (TOOLTIPTEXTW *)pNotifyStruct;
   wchar_t tc_FullText[4096];  // Maxsize of a string in a resource file
   CString cs_TipText;
-  UINT nID = (UINT)pNotifyStruct->idFrom;
+  UINT_PTR nID = pNotifyStruct->idFrom;
   if (pTTTW->uFlags & TTF_IDISHWND) {
     // idFrom is actually the HWND of the tool
     nID = ((UINT)(WORD)::GetDlgCtrlID((HWND)nID));
   }
 
   if (nID != 0) { // will be zero on a separator
-    if (AfxLoadString(nID, tc_FullText, 4095) == 0)
+    if (AfxLoadString((UINT)nID, tc_FullText, 4095) == 0)
       return FALSE;
 
     // this is the command id, not the button index
@@ -3283,7 +3283,7 @@ int DboxMain::OnUpdateMenuToolbar(const UINT nID)
     } else {
       POSITION pos = m_ctlItemList.GetFirstSelectedItemPosition();
       if (pos != NULL)
-        pci = (CItemData *)m_ctlItemList.GetItemData((int)pos - 1);
+        pci = (CItemData *)m_ctlItemList.GetItemData((int)(INT_PTR)pos - 1);
     }
   }
 

--- a/src/ui/Windows/MainEdit.cpp
+++ b/src/ui/Windows/MainEdit.cpp
@@ -690,7 +690,7 @@ void DboxMain::OnProtect(UINT nID)
   } else {
     POSITION pos = m_ctlItemList.GetFirstSelectedItemPosition();
     if (pos != NULL) {
-      pci = (CItemData *)m_ctlItemList.GetItemData((int)pos - 1);
+      pci = (CItemData *)m_ctlItemList.GetItemData((int)(INT_PTR)pos - 1);
     }
   }
   if (pci != NULL) {
@@ -874,7 +874,7 @@ void DboxMain::OnDelete()
         if (num_children == 0) {
           MultiCommands *pmcmd = MultiCommands::Create(&m_core);
           const StringX sxPath2 = m_sxOriginalGroup + L".";
-          const int len = sxPath2.length();
+          const int len = (int)sxPath2.length();
           std::vector<StringX> vEmptyGroups = m_core.GetEmptyGroups();
           for (size_t i = 0; i < vEmptyGroups.size(); i++) {
             if (vEmptyGroups[i] == m_sxOriginalGroup || vEmptyGroups[i].substr(0, len) == sxPath2) {
@@ -913,7 +913,7 @@ void DboxMain::OnDelete()
 
     POSITION pos = m_ctlItemList.GetFirstSelectedItemPosition();
     if (pos != NULL) {
-      pci = (CItemData *)m_ctlItemList.GetItemData((int)pos - 1);
+      pci = (CItemData *)m_ctlItemList.GetItemData((int)(INT_PTR)pos - 1);
     }
   }
 
@@ -944,7 +944,7 @@ void DboxMain::OnDelete()
     // resulting empty groups (after all sub-entries deleted) and the original group
     if (!m_sxOriginalGroup.empty()) {
       const StringX sxPath2 = m_sxOriginalGroup + L".";
-      const int len = sxPath2.length();
+      const int len = (int)sxPath2.length();
       std::vector<StringX> vEmptyGroups = m_core.GetEmptyGroups();
       for (size_t i = 0; i < vEmptyGroups.size(); i++) {
         if (vEmptyGroups[i] == m_sxOriginalGroup || vEmptyGroups[i].substr(0, len) == sxPath2) {

--- a/src/ui/Windows/MainFile.cpp
+++ b/src/ui/Windows/MainFile.cpp
@@ -1709,7 +1709,7 @@ int DboxMain::DoExportDB(const StringX &sx_Filename, const UINT nID,
     }
   }
 
-  numExported = OIL.size();
+  numExported = (int)OIL.size();
 
   export_core.SetCurFile(sx_Filename);
   export_core.SetReadOnly(false);
@@ -2068,7 +2068,7 @@ void DboxMain::OnExportAttachment()
   if (csMediaType.Left(5) == L"image") {
     // Should be an image file - but may not be supported by CImage - try..
     // Allocate attachment buffer
-    UINT imagesize = att.GetContentSize();
+    UINT imagesize = (UINT)att.GetContentSize();
     HGLOBAL gMemory = GlobalAlloc(GMEM_MOVEABLE, imagesize);
     ASSERT(gMemory);
 

--- a/src/ui/Windows/MainMenu.cpp
+++ b/src/ui/Windows/MainMenu.cpp
@@ -792,7 +792,7 @@ void DboxMain::CustomiseMenu(CMenu *pPopupMenu, const UINT uiMenuID,
         GGsubMenu.AppendMenu(MF_ENABLED | MF_STRING,
           ID_MENUITEM_EXPORTGRP2DB, GGstr);
         GGstr.LoadString(IDS_EXPORTGRPMENU);
-        pPopupMenu->AppendMenu(MF_POPUP, (UINT)GGsubMenu.Detach(), GGstr);
+        pPopupMenu->AppendMenu(MF_POPUP, (UINT_PTR)GGsubMenu.Detach(), GGstr);
       }
 
       pPopupMenu->InsertMenu((UINT)-1, MF_SEPARATOR);
@@ -992,7 +992,7 @@ void DboxMain::CustomiseMenu(CMenu *pPopupMenu, const UINT uiMenuID,
       EEsubMenu.AppendMenu(MF_ENABLED | MF_STRING,
                            ID_MENUITEM_EXPORTENT2DB, EEstr);
       EEstr.LoadString(IDS_EXPORTENTMENU);
-      pPopupMenu->AppendMenu(MF_POPUP, (UINT)EEsubMenu.Detach(), EEstr);
+      pPopupMenu->AppendMenu(MF_POPUP, (UINT_PTR)EEsubMenu.Detach(), EEstr);
 
       if (pci->IsShortcut() ? pbci->HasAttRef() : pci->HasAttRef()) {
         pPopupMenu->AppendMenu(MF_ENABLED | MF_STRING,

--- a/src/ui/Windows/MainView.cpp
+++ b/src/ui/Windows/MainView.cpp
@@ -4985,7 +4985,7 @@ void DboxMain::SaveGUIStatus()
   // HTREEITEM values may be different when we come to use it.
   POSITION pos = m_ctlItemList.GetFirstSelectedItemPosition();
   if (pos != NULL) {
-    pci_list = (CItemData *)m_ctlItemList.GetItemData((int)pos - 1);
+    pci_list = (CItemData *)m_ctlItemList.GetItemData((int)(INT_PTR)pos - 1);
     if (pci_list != NULL) {
       SaveGUIInfo.lSelected = pci_list->GetUUID();
       SaveGUIInfo.blSelectedValid = true;

--- a/src/ui/Windows/OptionsShortcuts.cpp
+++ b/src/ui/Windows/OptionsShortcuts.cpp
@@ -641,7 +641,7 @@ void COptionsShortcuts::OnKBShortcutDoulbleClick(NMHDR *pNotifyStruct, LRESULT *
   m_options_psh->EnableWindow(FALSE);
 
   DWORD_PTR lParam = m_EntryShortcutLC.GetItemData(iItem);
-  pws_os::CUUID &EntryUUID = GetKBShortcutUUID(lParam);
+  pws_os::CUUID &EntryUUID = GetKBShortcutUUID((int)(INT_PTR)lParam);
   iter = app.GetCore()->Find(EntryUUID);
   bool bEdited = GetMainDlg()->EditItem(&iter->second, NULL);
   if (!GetMainDlg()->IsDBReadOnly() && bEdited) {

--- a/src/ui/Windows/PWFindToolBar.cpp
+++ b/src/ui/Windows/PWFindToolBar.cpp
@@ -591,7 +591,7 @@ int CPWFindToolBar::GetLastSelectedFoundItem(pws_os::CUUID &entry_uuid)
 
   if (m_lastshown >= 0 && m_lastshown < (int)m_vFoundUUIDs.size()) {
     entry_uuid = m_vFoundUUIDs[m_lastshown];
-    return m_lastshown;
+    return (int)m_lastshown;
   }
 
   return -1;

--- a/src/ui/Windows/PWListCtrl.cpp
+++ b/src/ui/Windows/PWListCtrl.cpp
@@ -235,7 +235,7 @@ bool CPWListCtrl::FindNext(const CString &cs_find, const int iSubItem)
   if (pos == NULL)
     iItem = 0;
   else
-    iItem = (int)pos;
+    iItem = (int)(INT_PTR)pos;
 
   do {
     cs_text = GetItemText(iItem, iSubItem);
@@ -259,7 +259,7 @@ bool CPWListCtrl::FindNext(const CString &cs_find, const int iSubItem)
         break;
       }
       iItem++;
-    } while (iItem != (int)pos);
+    } while (iItem != (INT_PTR)pos);
   }
 
   if (bFound) {

--- a/src/ui/Windows/PWSFaultHandler.cpp
+++ b/src/ui/Windows/PWSFaultHandler.cpp
@@ -249,7 +249,7 @@ void PopulateMinidumpUserStreams(PWSprefs *prefs, bool bOpen, bool bRW, UserStre
   if (iStream == usAll || iStream == usPrefs || iStream == us1) {
     // Get all Boolean preferences
     sx_Buffer = prefs->PWSprefs::GetAllBoolPrefs();
-    len = std::min(sx_Buffer.length(), maxLen);
+    len = (int)std::min(sx_Buffer.length(), maxLen);
     SecureZeroMemory(szUserStream1, sizeof(szUserStream1));
     swprintf_s(szUserStream1, USERSTREAMSIZE,
                L"US01 %s", sx_Buffer.substr(0, len).c_str());
@@ -258,7 +258,7 @@ void PopulateMinidumpUserStreams(PWSprefs *prefs, bool bOpen, bool bRW, UserStre
   if (iStream == usAll || iStream == usPrefs || iStream == us2) {
     // Get all Integer preferences
     sx_Buffer = prefs->PWSprefs::GetAllIntPrefs();
-    len = std::min(sx_Buffer.length(), maxLen);
+    len = (int)std::min(sx_Buffer.length(), maxLen);
     SecureZeroMemory(szUserStream2, sizeof(szUserStream1));
     swprintf_s(szUserStream2, USERSTREAMSIZE,
                L"US02 %s", sx_Buffer.substr(0, len).c_str());
@@ -267,7 +267,7 @@ void PopulateMinidumpUserStreams(PWSprefs *prefs, bool bOpen, bool bRW, UserStre
   if (iStream == usAll || iStream == usPrefs || iStream == us3) {
     // Get SOME String preferences (do not include user data)
     sx_Buffer = prefs->PWSprefs::GetAllStringPrefs();
-    len = std::min(sx_Buffer.length(), maxLen);
+    len = (int)std::min(sx_Buffer.length(), maxLen);
     SecureZeroMemory(szUserStream3, sizeof(szUserStream1));
     swprintf_s(szUserStream3, USERSTREAMSIZE,
                L"US03 %s", sx_Buffer.substr(0, len).c_str());

--- a/src/ui/Windows/PWTreeCtrl.cpp
+++ b/src/ui/Windows/PWTreeCtrl.cpp
@@ -1943,7 +1943,7 @@ bool CPWTreeCtrl::CollectData(BYTE * &out_buffer, long &outLen)
     GetEntryData(out_oblist, pci);
   } else {
     const StringX DragPathParent = GetGroup(GetParentItem(m_hitemDrag));
-    m_nDragPathLen = DragPathParent.length();
+    m_nDragPathLen = (int)DragPathParent.length();
 
     StringX DragPath = GetGroup(m_hitemDrag);
     // Check if this is an empty group
@@ -2001,7 +2001,7 @@ bool CPWTreeCtrl::CollectData(BYTE * &out_buffer, long &outLen)
 
       if (conv.ToUTF8(vEmptyGroups[i].c_str(), utf8, utf8Len)) {
         outDDmemfile.Write((void *)&utf8Len, sizeof(utf8Len));
-        outDDmemfile.Write(reinterpret_cast<const char *>(utf8), utf8Len);
+        outDDmemfile.Write(reinterpret_cast<const char *>(utf8), (UINT)utf8Len);
       } else {
         ASSERT(0);
       }
@@ -2074,7 +2074,7 @@ bool CPWTreeCtrl::ProcessData(BYTE *in_buffer, const long &inLen,
 
       // Clear buffer
       memset(utf8, 0, buffer_size);
-      num_read = inDDmemfile.Read(utf8, utf8Len);
+      num_read = inDDmemfile.Read(utf8, (UINT)utf8Len);
       ASSERT(num_read == utf8Len);        
         
       conv.FromUTF8(utf8, utf8Len, sxEmptyGroup);

--- a/src/ui/Windows/PasskeyChangeDlg.cpp
+++ b/src/ui/Windows/PasskeyChangeDlg.cpp
@@ -158,7 +158,7 @@ void CPasskeyChangeDlg::OnOK()
 #ifndef PWS_FORCE_STRONG_PASSPHRASE
     cs_text.LoadString(IDS_USEITANYWAY);
     cs_msg += cs_text;
-    rc = gmb.AfxMessageBox(cs_msg, NULL, MB_YESNO | MB_ICONSTOP);
+    rc = (int)gmb.AfxMessageBox(cs_msg, NULL, MB_YESNO | MB_ICONSTOP);
     if (rc == IDYES)
       CPKBaseDlg::OnOK();
 #else

--- a/src/ui/Windows/SCWListCtrl.cpp
+++ b/src/ui/Windows/SCWListCtrl.cpp
@@ -77,17 +77,17 @@ void CSCWListCtrl::OnCustomDraw(NMHDR *pNotifyStruct, LRESULT *pLResult)
       // Sub-item PrePaint
       if (pLVCD->iSubItem == 0) {
         CRect rect;
-        GetSubItemRect(pLVCD->nmcd.dwItemSpec, pLVCD->iSubItem, LVIR_BOUNDS, rect);
+        GetSubItemRect((int)pLVCD->nmcd.dwItemSpec, pLVCD->iSubItem, LVIR_BOUNDS, rect);
         if (rect.top < 0) {
           *pLResult = CDRF_SKIPDEFAULT;
           break;
         }
         CRect rect1;
-        GetSubItemRect(pLVCD->nmcd.dwItemSpec, 1, LVIR_BOUNDS, rect1);
+        GetSubItemRect((int)pLVCD->nmcd.dwItemSpec, 1, LVIR_BOUNDS, rect1);
         rect.right = rect1.left;
         rect.DeflateRect(2, 2);
 
-        CString str = GetItemText(pLVCD->nmcd.dwItemSpec, pLVCD->iSubItem);
+        CString str = GetItemText((int)pLVCD->nmcd.dwItemSpec, pLVCD->iSubItem);
         pDC->SetTextColor(((pLVCD->nmcd.lItemlParam & REDTEXT) == REDTEXT) ?
                                 RGB(255, 0, 0) : crWindowText);
 

--- a/src/ui/Windows/ViewAttachmentDlg.cpp
+++ b/src/ui/Windows/ViewAttachmentDlg.cpp
@@ -243,7 +243,7 @@ BOOL CViewAttachmentDlg::OnInitDialog()
   int rc(0);
   HRESULT hr(S_OK);
 
-  UINT imagesize = m_pattachment->GetContentSize();
+  UINT imagesize = (UINT)m_pattachment->GetContentSize();
   HGLOBAL gMemory = GlobalAlloc(GMEM_MOVEABLE, imagesize);
   ASSERT(gMemory);
 

--- a/src/ui/Windows/filter/ManageFiltersDlg.cpp
+++ b/src/ui/Windows/filter/ManageFiltersDlg.cpp
@@ -193,7 +193,7 @@ BOOL CManageFiltersDlg::OnInitDialog()
     pflt_idata->flt_key.cs_filtername = L".";
     pflt_idata->flt_key.fpool = FPOOL_SESSION;
     pflt_idata->flt_flags = MFLT_REQUEST_COPY_TO_DB | MFLT_REQUEST_EXPORT | MFLT_INUSE;
-    m_FilterLC.SetItemData(iItem, (DWORD)pflt_idata);
+    m_FilterLC.SetItemData(iItem, (DWORD_PTR)pflt_idata);
   }
 
   // Set row height to take image by adding a dummy ImageList
@@ -879,7 +879,7 @@ void CManageFiltersDlg::UpdateFilterList()
     pflt_idata->flt_flags = (m_activefilter == iItem) ? MFLT_INUSE : 0;
     if (m_selectedfilter == iItem)
       pflt_idata->flt_flags |= MFLT_SELECTED;
-    m_FilterLC.SetItemData(iItem, (DWORD)pflt_idata);
+    m_FilterLC.SetItemData(iItem, (DWORD_PTR)pflt_idata);
     i++;
   }
 

--- a/src/ui/Windows/filter/PWFilterLC.cpp
+++ b/src/ui/Windows/filter/PWFilterLC.cpp
@@ -2497,7 +2497,7 @@ void CPWFilterLC::OnProcessKey(UINT nID)
         m_iItem = 0;
       pos = GetFirstSelectedItemPosition();
       if (pos > 0)
-        m_iItem = (int)pos - 1;
+        m_iItem = (int)(INT_PTR)pos - 1;
       EnsureVisible(m_iItem, FALSE);
       SetItemState(m_iItem, 0, LVIS_SELECTED);
       break;


### PR DESCRIPTION
This set of changes resolves all of the compiler warnings (known as of this instant in time) that were produced when building DebugM/ReleaseM x64 builds under VS2015. The changes were checked in both x86 and x64 builds.

A good number of the warnings came from the use of the size_t data type. In x86 size_t is a 32 bits, but in x64 it is 64 bits. Developers working in x64 builds need to be cognizant of this detail. It would be easy to create a situation where incompatibilities were introduced by using a size_t variable in a data structure and then writing the data structure to a file.

Developers working on VS2015 should probably build both x86 and x64 configurations to verify that they have not introduced any compiler warnings.