### PR TITLE
Fix two 64-bit build compiler warnings.

### DIFF
--- a/src/ui/Windows/AddEdit_Basic.cpp
+++ b/src/ui/Windows/AddEdit_Basic.cpp
@@ -967,7 +967,7 @@ LRESULT CAddEdit_Basic::OnZoomNotes(WPARAM, LPARAM lParam)
   if ((lParam < 0 && m_iPointSize <= 6) || (lParam > 0 && m_iPointSize >= 72))
     return 0L;
 
-  WPARAM wp_increment = (lParam > 0 ? 1 : -1) * 2;
+  UINT wp_increment = (lParam > 0 ? 1 : -1) * 2;
 
   CHARFORMAT2 cf;
   memset(&cf, 0, sizeof(cf));

--- a/src/ui/Windows/AddEdit_PropertySheet.cpp
+++ b/src/ui/Windows/AddEdit_PropertySheet.cpp
@@ -141,7 +141,7 @@ void CAddEdit_PropertySheet::OnSysCommand(UINT nID, LPARAM lParam)
     CGeneralMsgBox gmb;
     CString cs_message(MAKEINTRESOURCE(IDS_CANCEL_EXT_EDITOR)),
       cs_title(MAKEINTRESOURCE(IDS_EXT_EDITOR_ACTIVE));
-    int rc = gmb.MessageBox(cs_message, cs_title, MB_YESNO | MB_DEFBUTTON2 | MB_ICONEXCLAMATION);
+    INT_PTR rc = gmb.MessageBox(cs_message, cs_title, MB_YESNO | MB_DEFBUTTON2 | MB_ICONEXCLAMATION);
     if (rc == IDYES)
       m_pp_basic->CancelThreadWait();
     


### PR DESCRIPTION
This small change fixes two compiler warnings that occur in VS 2015 x64 builds.