### PR TITLE
Remove unnecessary code from CRichEditExtn used for Notes field in Ad…

### DIFF
--- a/src/ui/Windows/AddEdit_Basic.cpp
+++ b/src/ui/Windows/AddEdit_Basic.cpp
@@ -1176,6 +1176,16 @@ LRESULT CAddEdit_Basic::OnWordWrap(WPARAM, LPARAM)
 
   m_ex_notes.UpdateState(PWS_MSG_EDIT_WORDWRAP, m_bWordWrap);
 
+  // No idea why this is necessary but fixes the issue of no horizontaol
+  // scroll bar active after turning off Word Wrap if the preferences
+  // are Word Wrap and Hidden Notes. Without this "fix", user would have to
+  // ensure that the Notes field looses focus by clicking on another field.
+  m_ex_notes.EnableWindow(FALSE);
+  m_ex_notes.EnableWindow(TRUE);
+
+  if (m_isNotesHidden)
+    ShowNotes();
+
   return 0L;
 }
 

--- a/src/ui/Windows/AddEdit_Basic.cpp
+++ b/src/ui/Windows/AddEdit_Basic.cpp
@@ -127,7 +127,7 @@ CAddEdit_Basic::CAddEdit_Basic(CWnd *pParent, st_AE_master_data *pAEMD)
   m_ex_notes.SetContextMenu(vmenu_items);
 }
 
-void CAddEdit_Basic::DoDataExchange(CDataExchange* pDX)
+void CAddEdit_Basic::DoDataExchange(CDataExchange *pDX)
 {
   CAddEdit_PropertyPage::DoDataExchange(pDX);
 
@@ -413,8 +413,6 @@ BOOL CAddEdit_Basic::OnInitDialog()
     ShowNotes(true);
   } else {
     HideNotes(true);
-    m_ex_notes.EnableMenuItem(PWS_MSG_CALL_NOTESZOOMIN, false);
-    m_ex_notes.EnableMenuItem(PWS_MSG_CALL_NOTESZOOMOUT, false);
   }
 
   // Get current font size
@@ -445,14 +443,11 @@ BOOL CAddEdit_Basic::OnInitDialog()
       pBtn->SetBitmap(m_CopyPswdBitmap);
   }
 
-
-  // Update data data before setting initial Word Wrap
-  UpdateData(FALSE);
-
   // Set initial Word Wrap
   m_ex_notes.SetTargetDevice(NULL, m_bWordWrap ? 0 : 1);
   m_ex_notes.UpdateState(PWS_MSG_EDIT_WORDWRAP, m_bWordWrap);
 
+  UpdateData(FALSE);
   m_bInitdone = true;
   return TRUE;
 }
@@ -1016,10 +1011,6 @@ void CAddEdit_Basic::HideNotes(const bool bForceHide)
     m_ex_notes.EnableWindow(FALSE);
     m_ex_hidden_notes.ShowWindow(SW_SHOW);
     m_ex_hidden_notes.EnableWindow(TRUE);
-
-    // Disable zoom of hidden text
-    m_ex_notes.EnableMenuItem(PWS_MSG_CALL_NOTESZOOMIN, false);
-    m_ex_notes.EnableMenuItem(PWS_MSG_CALL_NOTESZOOMOUT, false);
   }
 }
 
@@ -1184,8 +1175,6 @@ LRESULT CAddEdit_Basic::OnWordWrap(WPARAM, LPARAM)
   m_ex_notes.SetTargetDevice(NULL, m_bWordWrap ? 0 : 1);
 
   m_ex_notes.UpdateState(PWS_MSG_EDIT_WORDWRAP, m_bWordWrap);
-
-  UpdateData(FALSE);
 
   return 0L;
 }

--- a/src/ui/Windows/AddEdit_Basic.h
+++ b/src/ui/Windows/AddEdit_Basic.h
@@ -79,11 +79,11 @@ public:
   // ClassWizard generate virtual function overrides
 
 protected:
-  BOOL PreTranslateMessage(MSG* pMsg);
+  BOOL PreTranslateMessage(MSG *pMsg);
 
   //{{AFX_VIRTUAL(CAddEdit_Basic)
   virtual BOOL OnInitDialog();
-  virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+  virtual void DoDataExchange(CDataExchange *pDX);    // DDX/DDV support
   virtual BOOL OnApply();
   virtual BOOL OnKillActive();
   //}}AFX_VIRTUAL

--- a/src/ui/Windows/ControlExtns.cpp
+++ b/src/ui/Windows/ControlExtns.cpp
@@ -12,11 +12,11 @@
 #include "ControlExtns.h"
 #include "InfoDisplay.h"      // for Listbox Tooltips
 
-#include "core/ItemField.h" // for CSecEditExtn
-#include "core/BlowFish.h"  // ditto
-#include "core/PWSrand.h"   // ditto
-#include "core/PWCharPool.h" // for CSymbolEdit
-#include "resource2.h"     // for CEditExtnX context menu
+#include "core/ItemField.h"   // for CSecEditExtn
+#include "core/BlowFish.h"    // ditto
+#include "core/PWSrand.h"     // ditto
+#include "core/PWCharPool.h"  // for CSymbolEdit
+#include "resource2.h"        // for CRichEditExtnX context menu
 
 #include "vsstyle.h"
 
@@ -427,8 +427,7 @@ void CEditExtnX::EnableMenuItem(const int message_number, const bool bEnable)
 // CRichEditExtnX
 
 CRichEditExtnX::CRichEditExtnX(COLORREF focusColor)
-  : m_bIsFocused(FALSE), m_nScrollHPos(-1), m_nScrollVPos(-1), m_crefInFocus(focusColor),
-  m_bContextMenu(false)
+  : m_bIsFocused(FALSE), m_crefInFocus(focusColor), m_bContextMenu(false)
 {
   m_vmenu_items.clear();
 }
@@ -454,7 +453,6 @@ BEGIN_MESSAGE_MAP(CRichEditExtnX, CRichEditCtrl)
   ON_WM_SETFOCUS()
   ON_WM_KILLFOCUS()
   ON_WM_CONTEXTMENU()
-  ON_WM_LBUTTONDOWN()
   ON_WM_SETCURSOR()
   ON_WM_LBUTTONDBLCLK()
   //}}AFX_MSG_MAP
@@ -462,20 +460,6 @@ END_MESSAGE_MAP()
 
 /////////////////////////////////////////////////////////////////////////////
 // CRichEditExtnX message handlers
-
-void CRichEditExtnX::GetSel(long &nStartChar, long &nEndChar)
-{
-  CRichEditCtrl::GetSel(nStartChar, nEndChar);
-  m_nStartChar = nStartChar;
-  m_nEndChar = nEndChar;
-}
-
-void CRichEditExtnX::SetSel(long nStartChar, long nEndChar)
-{
-  m_nStartChar = nStartChar;
-  m_nEndChar = nEndChar;
-  CRichEditCtrl::SetSel(nStartChar, nEndChar);
-}
 
 void CRichEditExtnX::OnLButtonDblClk(UINT nFlags, CPoint point)
 {
@@ -500,19 +484,6 @@ void CRichEditExtnX::OnSetFocus(CWnd *pOldWnd)
   m_bIsFocused = TRUE;
   CRichEditCtrl::OnSetFocus(pOldWnd);
 
-  // Reselect what the user had selected before losing focus
-  SetSel(m_nStartChar, m_nEndChar);
-
-  if (m_nScrollVPos >= 0) {
-    // Reset the scroll bar position.
-    SetScrollPos(SB_HORZ, m_nScrollHPos);
-    SetScrollPos(SB_VERT, m_nScrollVPos);
-
-    // Reset the display scroll position.
-    SendMessage(WM_HSCROLL, MAKEWPARAM(SB_THUMBTRACK, m_nScrollHPos), 0);
-    SendMessage(WM_VSCROLL, MAKEWPARAM(SB_THUMBTRACK, m_nScrollVPos), 0);
-  }
-
   SetBackgroundColor(FALSE, m_crefInFocus);
   Invalidate(TRUE);
 }
@@ -521,42 +492,10 @@ void CRichEditExtnX::OnKillFocus(CWnd *pNewWnd)
 {
   m_bIsFocused = FALSE;
 
-  // Get the scroll bar position.
-  m_nScrollHPos = GetScrollPos(SB_HORZ);
-  m_nScrollVPos = GetScrollPos(SB_VERT);
-
-  // Save user selection
-  GetSel(m_nStartChar, m_nEndChar);
-
   CRichEditCtrl::OnKillFocus(pNewWnd);
 
   SetBackgroundColor(FALSE, crefNoFocus);
   Invalidate(TRUE);
-}
-
-void CRichEditExtnX::OnLButtonDown(UINT nFlags, CPoint point)
-{
-  // Get the scroll bar position.
-  m_nScrollHPos = GetScrollPos(SB_HORZ);
-  m_nScrollVPos = GetScrollPos(SB_VERT);
-
-  int n = CharFromPos(point);
-  m_nStartChar = m_nEndChar = LOWORD(n);
-
-  CRichEditCtrl::OnLButtonDown(nFlags, point);
-
-  // Reselect what the user had selected before losing focus
-  SetSel(m_nStartChar, m_nEndChar);
-
-  if (m_nScrollVPos >= 0) {
-    // Reset the scroll bar position.
-    SetScrollPos(SB_HORZ, m_nScrollHPos);
-    SetScrollPos(SB_VERT, m_nScrollVPos);
-
-    // Reset the display scroll position.
-    SendMessage(WM_HSCROLL, MAKEWPARAM(SB_THUMBTRACK, m_nScrollHPos), 0);
-    SendMessage(WM_VSCROLL, MAKEWPARAM(SB_THUMBTRACK, m_nScrollVPos), 0);
-  }
 }
 
 BOOL CRichEditExtnX::OnSetCursor(CWnd *pWnd, UINT nHitTest, UINT message)

--- a/src/ui/Windows/ControlExtns.h
+++ b/src/ui/Windows/ControlExtns.h
@@ -167,8 +167,6 @@ public:
   void ChangeColour() {m_bIsFocused = TRUE;}
   void UpdateState(const int message_number, const bool new_state);
 
-  void GetSel(long &nStartChar, long &nEndChar);
-  void SetSel(long nStartChar, long nEndChar);
   void EnableMenuItem(const int message_number, const bool bEnable);
 
 protected:
@@ -176,7 +174,6 @@ protected:
   afx_msg void OnSetFocus(CWnd *pOldWnd);
   afx_msg void OnKillFocus(CWnd *pNewWnd);
   afx_msg void OnContextMenu(CWnd *pWnd, CPoint point);
-  afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
   afx_msg BOOL OnSetCursor(CWnd *pWnd, UINT nHitTest, UINT message);
   afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
   //}}AFX_MSG
@@ -188,8 +185,6 @@ private:
   BOOL m_bIsFocused;
   const COLORREF m_crefInFocus;
 
-  int m_nScrollHPos, m_nScrollVPos;
-  long m_nStartChar, m_nEndChar;
   std::vector<st_context_menu> m_vmenu_items;
   
   bool m_bContextMenu;

--- a/src/ui/Windows/RichEditCtrlExtn.cpp
+++ b/src/ui/Windows/RichEditCtrlExtn.cpp
@@ -8,8 +8,13 @@
 // RichEditCtrlExtns.cpp
 //
 
+// Used in AboutDlg and GeneralMsgBox ONLY where html links are required
+// NOT used in AddEdit_Basic for Notes - it uses CRichEditExtn defined in "ControlExtns.h"
+
 #include "stdafx.h"
+
 #include "RichEditCtrlExtn.h"
+
 #include <algorithm>
 #include <vector>
 #include <string>

--- a/src/ui/Windows/RichEditCtrlExtn.h
+++ b/src/ui/Windows/RichEditCtrlExtn.h
@@ -11,6 +11,9 @@
 // CRichEditControlExtn.h : header file
 // Extensions to standard CRichEditCtrl Control
 
+// Used in AboutDlg and GeneralMsgBox ONLY where html links are required
+// NOT used in AddEdit_Basic for Notes - it uses CRichEditExtn defined in "ControlExtns.h"
+
 #include <algorithm>
 #include <vector>
 #include <string>
@@ -21,6 +24,8 @@ class CRichEditCtrlExtn : public CRichEditCtrl
   // Construction
 public:
   CRichEditCtrlExtn();
+  virtual ~CRichEditCtrlExtn();
+
   void SetWindowText(LPCWSTR lpszString);
 
   // (Un)Register to be notified if the link clicked
@@ -34,6 +39,19 @@ public:
     int iEnd;
     wchar_t tcszURL[_MAX_PATH];
   };
+
+protected:
+  // Overrides
+  // ClassWizard generated virtual function overrides
+  //{{AFX_VIRTUAL(CRichEditCtrlExtn)
+  //}}AFX_VIRTUAL
+
+  // Generated message map functions
+  //{{AFX_MSG(CRichEditCtrlExtn)
+  afx_msg void OnLink(NMHDR *pNotifyStruct, LRESULT *pLResult);
+  //}}AFX_MSG
+
+  DECLARE_MESSAGE_MAP()
 
 private:
   // HTML formatting functions
@@ -67,26 +85,4 @@ private:
   // Callback returns "true" if it processed the link
   bool (*m_pfcnNotifyLinkClicked) (const CString &, const CString &, LPARAM);
   LPARAM m_NotifyInstance;
-
-  // Attributes
-private:
-
-  // Operations
-public:
-
-  // Overrides
-  // ClassWizard generated virtual function overrides
-  //{{AFX_VIRTUAL(CRichEditCtrlExtn)
-  //}}AFX_VIRTUAL
-
-  // Implementation
-public:
-  virtual ~CRichEditCtrlExtn();
-
-  // Generated message map functions
-protected:
-  //{{AFX_MSG(CRichEditCtrlExtn)
-  afx_msg void OnLink(NMHDR *pNotifyStruct, LRESULT *pLResult);
-  //}}AFX_MSG
-  DECLARE_MESSAGE_MAP()
 };


### PR DESCRIPTION
…dEdit_Basic

One issue remains - if preferences are: Notes are initially hidden with Word Wrap on,
after changing to word wrapping by context menu, the horizontal scroll bar doesn't appear
until the control is hidden and then re-shown i.e. clicking on URL or email field.
Doesn't occur in the other combinations of hidden notes & word wrap.