### PR TITLE
Avoid linking pwsafe-cli with X libraries

### DIFF
--- a/CodeLite/os.project
+++ b/CodeLite/os.project
@@ -53,6 +53,7 @@
     <File Name="../src/os/unix/unicode2keysym.h"/>
     <File Name="../src/os/unix/logit.cpp"/>
     <File Name="../src/os/unix/media.cpp"/>
+    <File Name="../src/os/unix/cleanup.cpp"/>
   </VirtualDirectory>
   <VirtualDirectory Name="os">
     <File Name="../src/os/env.h"/>

--- a/CodeLite/os.project
+++ b/CodeLite/os.project
@@ -54,6 +54,7 @@
     <File Name="../src/os/unix/logit.cpp"/>
     <File Name="../src/os/unix/media.cpp"/>
     <File Name="../src/os/unix/cleanup.cpp"/>
+    <File Name="../src/os/unix/keyname.cpp"/>
   </VirtualDirectory>
   <VirtualDirectory Name="os">
     <File Name="../src/os/env.h"/>

--- a/CodeLite/pwsafe.project
+++ b/CodeLite/pwsafe.project
@@ -129,6 +129,8 @@
     <File Name="../src/ui/wxWidgets/TimedTaskChain.cpp"/>
     <File Name="../src/ui/wxWidgets/TimedTaskChain.h"/>
     <File Name="../src/ui/wxWidgets/mainView.cpp"/>
+    <File Name="../src/ui/wxWidgets/passwordsubset.cpp"/>
+    <File Name="../src/ui/wxWidgets/passwordsubset.h"/>
   </VirtualDirectory>
   <Dependencies Name="Release">
     <Project Name="core"/>

--- a/src/os/unix/KeySend.cpp
+++ b/src/os/unix/KeySend.cpp
@@ -145,7 +145,3 @@ bool CKeySend::LookupVirtualKey(const StringX &kname, WORD &kval)
   }
 }
 
-stringT CKeySend::GetKeyName(WORD , bool)
-{
-  return stringT(_T(""));
-}

--- a/src/os/unix/Makefile
+++ b/src/os/unix/Makefile
@@ -40,7 +40,7 @@ LIBSRC          = cleanup.cpp debug.cpp dir.cpp env.cpp \
 									mem.cpp pws_str.cpp \
                   pws_time.cpp rand.cpp run.cpp\
                   utf8conv.cpp KeySend.cpp\
-                  sleep.cpp xsendstring.cpp\
+                  sleep.cpp xsendstring.cpp keyname.cpp \
                   registry.cpp UUID.cpp\
                   unicode2keysym.cpp $(YUBI_SRC)
 

--- a/src/os/unix/keyname.cpp
+++ b/src/os/unix/keyname.cpp
@@ -1,0 +1,14 @@
+/*
+* Copyright (c) 2003-2017 Rony Shapiro <ronys@pwsafe.org>.
+* All rights reserved. Use of the code is allowed under the
+* Artistic License 2.0 terms, as specified in the LICENSE file
+* distributed with this code, or available from
+* http://www.opensource.org/licenses/artistic-license-2.0.php
+*/
+
+#include "../KeySend.h"
+
+stringT CKeySend::GetKeyName(WORD , bool)
+{
+  return stringT(_T(""));
+}

--- a/src/ui/cli/Makefile
+++ b/src/ui/cli/Makefile
@@ -37,7 +37,7 @@ else
 	GTEST_HEADERS=/usr/include/gtest/*.h /usr/include/gtest/internal/*.h
 	GTEST_SRCS=$(GTEST_DIR)/src/*.cc $(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
 	GTEST_OBJ = $(OBJPATH)/gtest-all.o
-	EXTLIBS=-luuid -lxerces-c -lpthread -lXtst -lX11
+	EXTLIBS=-luuid -lxerces-c -lpthread
 endif
 
 CXXFLAGS += $(CPPFLAGS) -Wall -I$(COREPATH) -I../.. $(XERCESCPPFLAGS) -DUNICODE
@@ -61,7 +61,7 @@ $(LIBOS):
 	$(MAKE) -C $(OSPATH)/$(PLATFORM)
 
 $(EXE): $(LIBS) $(OBJ)
-	$(CXX) -g $(CXXFLAGS) $(filter %.o,$^)  -o $@ $(LD_FLAGS) \
+	$(CXX) -g $(filter %.o,$^)  -o $@ $(LD_FLAGS) \
 	-L$(LIBPATH) -lcore -los -lcore $(EXTLIBS)
 
 clean:


### PR DESCRIPTION
To let it build and run in headless environments. Otherwise, in some cases, it might require one to build X itself first.