### PR TITLE
Test Makefile Fixes

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -27,7 +27,7 @@ TEST	   = $(BINPATH)/coretest
 OBJS     = $(TESTOBJ) $(GTEST_OBJ)
 
 CXXFLAGS += -DUNICODE -Wall -I$(INCPATH) -std=c++11
-LDFLAGS   = -L$(LIBPATH) -lcore -los -luuid -lxerces-c -pthread
+LDFLAGS   = -L$(LIBPATH) -lcore -los -luuid -lxerces-c -pthread -lX11 -lXtst
 
 # rules
 .PHONY: all clean test run setup

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -27,7 +27,7 @@ TEST	   = $(BINPATH)/coretest
 OBJS     = $(TESTOBJ) $(GTEST_OBJ)
 
 CXXFLAGS += -DUNICODE -Wall -I$(INCPATH) -std=c++11
-LDFLAGS   = -L$(LIBPATH) -lcore -los -luuid -lxerces-c -pthread -lX11 -lXtst
+LDFLAGS  := $(LDFLAGS) -L$(LIBPATH) -lcore -los -luuid -lxerces-c -pthread -lX11 -lXtst
 
 # rules
 .PHONY: all clean test run setup


### PR DESCRIPTION
The autotools-based makefile for the test driver is missing LDFLAGS for the X11 and Xtst libs, causing linking to fail on Debian.  In addition, it does not honor LDFLAGS passed in from the build process.