### PR TITLE
Add a feature to display a password as QR code

### DIFF
--- a/CodeLite/pwsafe.project
+++ b/CodeLite/pwsafe.project
@@ -131,6 +131,8 @@
     <File Name="../src/ui/wxWidgets/mainView.cpp"/>
     <File Name="../src/ui/wxWidgets/passwordsubset.cpp"/>
     <File Name="../src/ui/wxWidgets/passwordsubset.h"/>
+    <File Name="../src/ui/wxWidgets/pwsqrcodedlg.cpp"/>
+    <File Name="../src/ui/wxWidgets/pwsqrcodedlg.h"/>
   </VirtualDirectory>
   <Dependencies Name="Release">
     <Project Name="core"/>
@@ -232,6 +234,7 @@
         <Library Value="Xtst"/>
         <Library Value="xerces-c"/>
         <Library Value="X11"/>
+        <Library Value="qrencode"/>
       </Linker>
       <ResourceCompiler Options="$(shell wx-config --rcflags)" Required="no"/>
       <General OutputFile="$(IntermediateDirectory)/$(ProjectName)" IntermediateDirectory="./DebugX" Command="./$(ProjectName)" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
@@ -340,6 +343,7 @@ dir /usr/src/gtk+2.0-2.18.3/gdk
         <Library Value="Xtst"/>
         <Library Value="xerces-c"/>
         <Library Value="X11"/>
+        <Library Value="qrencode"/>
       </Linker>
       <ResourceCompiler Options="$(shell wx-config --rcflags)" Required="no"/>
       <General OutputFile="$(IntermediateDirectory)/$(ProjectName)" IntermediateDirectory="./ReleaseX" Command="./$(ProjectName)" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>

--- a/README.LINUX.DEVELOPERS.txt
+++ b/README.LINUX.DEVELOPERS.txt
@@ -38,6 +38,7 @@ make
 pkg-config
 uuid-dev
 zip
+libqrencode-dev
 
 The script Misc/setup-deb-dev-env.sh can be run (sudo or as root) to
 install these and setup the gtest library.
@@ -55,6 +56,7 @@ make
 wxGTK3-devel
 xerces-c-devel
 ykpers-devel (see note 3 below)
+qrencode-devel
 
 To compile without Yubikey support, set the NO_YUBI flag
 for make, e.g.,

--- a/src/ui/wxWidgets/Makefile
+++ b/src/ui/wxWidgets/Makefile
@@ -103,7 +103,7 @@ BUILDPATHS=$(OBJECTPATH)
 PROGRAM=pwsafe
 LIBS=`$(WX_CONFIG) --debug=yes --unicode=yes --inplace --libs` -lcore -los -lcore -l$(YBPERS_LIBS)
 ifneq ($(findstring Darwin, $(shell uname -s)), Darwin)
-		LIBS += -luuid -lXtst -lX11 -lqrencode
+		LIBS += -luuid -lXtst -lX11
 		XERCESLIBFLAGS=-lxerces-c
 		XERCESCPPFLAGS=-DUSE_XML_LIBRARY=XERCES -DWCHAR_INCOMPATIBLE_XMLCH
 endif
@@ -134,7 +134,7 @@ BUILDPATHS=$(OBJECTPATH)
 PROGRAM=pwsafe
 LIBS=`$(WX_CONFIG) --debug=no --unicode=yes --inplace --libs` -lcore -los -lcore -l$(YBPERS_LIBS)
 ifneq ($(findstring Darwin, $(shell uname -s)), Darwin)
-		LIBS += -luuid -lXtst -lX11 -lqrencode
+		LIBS += -luuid -lXtst -lX11
 		XERCESLIBFLAGS=-lxerces-c
 		XERCESCPPFLAGS=-DUSE_XML_LIBRARY=XERCES -DWCHAR_INCOMPATIBLE_XMLCH
 endif
@@ -159,6 +159,10 @@ CPPINC += -I../..
 ifndef NO_YUBI
 YBPERS_LIBPATH?=$(LIBPATH)
 YBPERS_LIBPATH_FLAGS=-L$(YBPERS_LIBPATH)
+endif
+
+ifeq ($(findstring Linux, $(shell uname -s)), Linux)
+		LIBS += -lqrencode
 endif
 
 override LDFLAGS:=$(LIBS) -L$(LIBPATH) $(LINKERFLAGS) $(XERCESLIBFLAGS) $(YBPERS_LIBPATH_FLAGS) $(LDFLAGS)
@@ -188,7 +192,11 @@ SOURCES= passwordsafeframe.cpp \
 	fieldselectionpanel.cpp fieldselectiondlg.cpp pwsmenushortcuts.cpp \
 	$(YUBI_SRC) \
 	ManagePwdPolicies.cpp PasswordPolicy.cpp SelectionCriteria.cpp \
-	TimedTaskChain.cpp mainView.cpp passwordsubset.cpp pwsqrcodedlg.cpp
+	TimedTaskChain.cpp mainView.cpp passwordsubset.cpp
+
+ifeq ($(findstring Linux, $(shell uname -s)), Linux)
+		SOURCES += pwsqrcodedlg.cpp
+endif
 
 
 OBJECTS=$(SOURCES:%.cpp=$(OBJECTPATH)/%.o)

--- a/src/ui/wxWidgets/Makefile
+++ b/src/ui/wxWidgets/Makefile
@@ -103,7 +103,7 @@ BUILDPATHS=$(OBJECTPATH)
 PROGRAM=pwsafe
 LIBS=`$(WX_CONFIG) --debug=yes --unicode=yes --inplace --libs` -lcore -los -lcore -l$(YBPERS_LIBS)
 ifneq ($(findstring Darwin, $(shell uname -s)), Darwin)
-		LIBS += -luuid -lXtst -lX11
+		LIBS += -luuid -lXtst -lX11 -lqrencode
 		XERCESLIBFLAGS=-lxerces-c
 		XERCESCPPFLAGS=-DUSE_XML_LIBRARY=XERCES -DWCHAR_INCOMPATIBLE_XMLCH
 endif
@@ -134,7 +134,7 @@ BUILDPATHS=$(OBJECTPATH)
 PROGRAM=pwsafe
 LIBS=`$(WX_CONFIG) --debug=no --unicode=yes --inplace --libs` -lcore -los -lcore -l$(YBPERS_LIBS)
 ifneq ($(findstring Darwin, $(shell uname -s)), Darwin)
-		LIBS += -luuid -lXtst -lX11
+		LIBS += -luuid -lXtst -lX11 -lqrencode
 		XERCESLIBFLAGS=-lxerces-c
 		XERCESCPPFLAGS=-DUSE_XML_LIBRARY=XERCES -DWCHAR_INCOMPATIBLE_XMLCH
 endif
@@ -188,7 +188,7 @@ SOURCES= passwordsafeframe.cpp \
 	fieldselectionpanel.cpp fieldselectiondlg.cpp pwsmenushortcuts.cpp \
 	$(YUBI_SRC) \
 	ManagePwdPolicies.cpp PasswordPolicy.cpp SelectionCriteria.cpp \
-	TimedTaskChain.cpp mainView.cpp passwordsubset.cpp
+	TimedTaskChain.cpp mainView.cpp passwordsubset.cpp pwsqrcodedlg.cpp
 
 
 OBJECTS=$(SOURCES:%.cpp=$(OBJECTPATH)/%.o)

--- a/src/ui/wxWidgets/mainEdit.cpp
+++ b/src/ui/wxWidgets/mainEdit.cpp
@@ -867,15 +867,17 @@ void PasswordSafeFrame::OnPasswordSubset(wxCommandEvent &evt)
 
 void PasswordSafeFrame::OnPasswordQRCode(wxCommandEvent &evt)
 {
-  CItemData rueItem;
-  CItemData* item = GetSelectedEntry(evt, rueItem);
-  if (item != NULL) {
-	PWSQRCodeDlg dlg(this, item->GetPassword(),
-						towxstring(CItemData::FieldName(CItem::PASSWORD)) + _T(" of ") +
-						towxstring(item->GetGroup()) +
-						_T('[') + towxstring(item->GetTitle()) + _T(']') +
-						_T(':') + towxstring(item->GetUser()));
-    dlg.ShowModal();
+  if ( /* constexpr */ HasQRCode() ) {
+    CItemData rueItem;
+    CItemData* item = GetSelectedEntry(evt, rueItem);
+    if (item != NULL) {
+    PWSQRCodeDlg dlg(this, item->GetPassword(),
+              towxstring(CItemData::FieldName(CItem::PASSWORD)) + _T(" of ") +
+              towxstring(item->GetGroup()) +
+              _T('[') + towxstring(item->GetTitle()) + _T(']') +
+              _T(':') + towxstring(item->GetUser()));
+      dlg.ShowModal();
+    }
   }
 }
 

--- a/src/ui/wxWidgets/mainEdit.cpp
+++ b/src/ui/wxWidgets/mainEdit.cpp
@@ -37,6 +37,7 @@
 #include "wxutils.h"
 #include "guiinfo.h"
 #include "passwordsubset.h"
+#include "./pwsqrcodedlg.h"
 
 #include "../../core/PWSAuxParse.h"
 #include "../../core/Util.h"
@@ -862,6 +863,20 @@ void PasswordSafeFrame::OnPasswordSubset(wxCommandEvent &evt)
   CItemData* item = GetSelectedEntry(evt, rueItem);
   if (item != NULL)
     DoPasswordSubset(*item);
+}
+
+void PasswordSafeFrame::OnPasswordQRCode(wxCommandEvent &evt)
+{
+  CItemData rueItem;
+  CItemData* item = GetSelectedEntry(evt, rueItem);
+  if (item != NULL) {
+	PWSQRCodeDlg dlg(this, item->GetPassword(),
+						towxstring(CItemData::FieldName(CItem::PASSWORD)) + _T(" of ") +
+						towxstring(item->GetGroup()) +
+						_T('[') + towxstring(item->GetTitle()) + _T(']') +
+						_T(':') + towxstring(item->GetUser()));
+    dlg.ShowModal();
+  }
 }
 
 /*!

--- a/src/ui/wxWidgets/passwordsafeframe.cpp
+++ b/src/ui/wxWidgets/passwordsafeframe.cpp
@@ -63,6 +63,7 @@
 #include "../../core/core.h"
 #include "../../core/PWScore.h"
 #include "./SelectionCriteria.h"
+#include "./pwsqrcodedlg.h"
 
 // main toolbar images
 #include "./PwsToolbarButtons.h"
@@ -1756,7 +1757,9 @@ void PasswordSafeFrame::OnContextMenu(const CItemData* item)
     itemEditMenu.Append(ID_COPYUSERNAME,   _("Copy &Username to Clipboard"));
     itemEditMenu.Append(ID_COPYPASSWORD,   _("&Copy Password to Clipboard"));
     itemEditMenu.Append(ID_PASSWORDSUBSET, _("Display subset of Password"));
-    itemEditMenu.Append(ID_PASSWORDQRCODE, _("Display Password as &QR code"));
+	if (HasQRCode()) {
+		itemEditMenu.Append(ID_PASSWORDQRCODE, _("Display Password as &QR code"));
+	}
     itemEditMenu.Append(ID_COPYNOTESFLD,   _("Copy &Notes to Clipboard"));
     itemEditMenu.Append(ID_COPYURL,        _("Copy UR&L to Clipboard"));
     itemEditMenu.Append(ID_COPYEMAIL,      _("Copy email to Clipboard"));

--- a/src/ui/wxWidgets/passwordsafeframe.cpp
+++ b/src/ui/wxWidgets/passwordsafeframe.cpp
@@ -160,6 +160,8 @@ BEGIN_EVENT_TABLE( PasswordSafeFrame, wxFrame )
 
   EVT_MENU( ID_PASSWORDSUBSET, PasswordSafeFrame::OnPasswordSubset )
 
+  EVT_MENU( ID_PASSWORDQRCODE, PasswordSafeFrame::OnPasswordQRCode )
+
   EVT_MENU( ID_IMPORT_PLAINTEXT, PasswordSafeFrame::OnImportText )
 
   EVT_MENU( ID_IMPORT_KEEPASS, PasswordSafeFrame::OnImportKeePass )
@@ -1754,6 +1756,7 @@ void PasswordSafeFrame::OnContextMenu(const CItemData* item)
     itemEditMenu.Append(ID_COPYUSERNAME,   _("Copy &Username to Clipboard"));
     itemEditMenu.Append(ID_COPYPASSWORD,   _("&Copy Password to Clipboard"));
     itemEditMenu.Append(ID_PASSWORDSUBSET, _("Display subset of Password"));
+    itemEditMenu.Append(ID_PASSWORDQRCODE, _("Display Password as &QR code"));
     itemEditMenu.Append(ID_COPYNOTESFLD,   _("Copy &Notes to Clipboard"));
     itemEditMenu.Append(ID_COPYURL,        _("Copy UR&L to Clipboard"));
     itemEditMenu.Append(ID_COPYEMAIL,      _("Copy email to Clipboard"));
@@ -1920,6 +1923,7 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
     case ID_COPYPASSWORD:
     case ID_AUTOTYPE:
     case ID_PASSWORDSUBSET:
+    case ID_PASSWORDQRCODE:
       evt.Enable(!bGroupSelected && pci);
       break;
 

--- a/src/ui/wxWidgets/passwordsafeframe.h
+++ b/src/ui/wxWidgets/passwordsafeframe.h
@@ -120,6 +120,7 @@ enum {
   ID_EDITMENU_FIND_NEXT  = 10220,
   ID_EDITMENU_FIND_PREVIOUS,
   ID_PASSWORDSUBSET,
+  ID_PASSWORDQRCODE,
   ID_COPYEMAIL,
   ID_RUNCOMMAND,
   ID_COPYRUNCOMMAND,
@@ -393,6 +394,7 @@ public:
   void OnVisitWebsite(wxCommandEvent&);
 
   void OnPasswordSubset(wxCommandEvent& evt);
+  void OnPasswordQRCode(wxCommandEvent& evt);
 
 ////@begin PasswordSafeFrame member function declarations
 

--- a/src/ui/wxWidgets/pwsqrcodedlg.cpp
+++ b/src/ui/wxWidgets/pwsqrcodedlg.cpp
@@ -30,6 +30,8 @@ IMPLEMENT_CLASS( PWSQRCodeDlg, wxDialog )
 
 BEGIN_EVENT_TABLE(PWSQRCodeDlg, wxDialog)
 	EVT_BUTTON(wxID_CLOSE, PWSQRCodeDlg::OnClose)
+	EVT_INIT_DIALOG(PWSQRCodeDlg::OnInitDialog)
+	EVT_TIMER(wxID_ANY, PWSQRCodeDlg::OnTimer)
 END_EVENT_TABLE()
 
 
@@ -113,24 +115,27 @@ wxBitmap QRCodeBitmap( const StringX &data )
 
 PWSQRCodeDlg::PWSQRCodeDlg(wxWindow* parent,
 		                   const StringX &data,
-						   const wxString& description,
+						   const wxString& dlgTitle,
 					       const int seconds,
-					       const wxString &dlgTitle,
 					       const wxPoint &pos,
 					       const wxSize &size,
 					       long style,
-					       const wxString &name): wxDialog(parent, wxID_ANY, dlgTitle, pos, size, style, name)
+					       const wxString &name): wxDialog(parent, wxID_ANY, dlgTitle, pos, size, style, name), timer(this), secondsRemaining(seconds)
 {
-	CreateControls(data, description);
+	CreateControls(data);
 }
  
-void PWSQRCodeDlg::CreateControls(const StringX &data, const wxString &description)
+void PWSQRCodeDlg::CreateControls(const StringX &data)
 {
 	wxSizer *dlgSizer = new wxBoxSizer(wxVERTICAL);
 
 	dlgSizer->AddSpacer(TopMargin);
 
-	dlgSizer->Add( new wxStaticText(this, wxID_ANY, description) );
+	wxBoxSizer *promptSizer = new wxBoxSizer(wxHORIZONTAL);
+	promptSizer->Add( new wxStaticText(this, wxID_ANY, _T("Closing in ")) );
+	promptSizer->Add( secondsText = new wxStaticText(this, wxID_ANY, _T("")) );
+	dlgSizer->Add(promptSizer);
+
 	dlgSizer->AddSpacer(RowSeparation);
 	dlgSizer->Add( new wxStaticLine(this), wxSizerFlags().Expand() );
 	dlgSizer->AddSpacer(RowSeparation);
@@ -154,6 +159,29 @@ void PWSQRCodeDlg::OnClose(wxCommandEvent &evt)
 {
 	EndModal(wxID_CLOSE);
 }
+
+void PWSQRCodeDlg::OnTimer(wxTimerEvent &/*evt*/)
+{
+	if ( --secondsRemaining > 0 ) {
+		UpdateTimeRemaining();
+		timer.Start(1000);
+	} else {
+		EndModal(0);
+	}
+}
+
+void PWSQRCodeDlg::OnInitDialog(wxInitDialogEvent &/*evt*/)
+{
+	// true => oneshot. We don't want to be called every millisecond
+	timer.Start( 1000, true );
+	UpdateTimeRemaining();
+}
+
+void PWSQRCodeDlg::UpdateTimeRemaining()
+{
+	secondsText->SetLabel( wxString::Format(_T("%d seconds"), secondsRemaining) );
+}
+
 
 #ifdef __TEST_QR_CODE__
 ///////////////////////////////////////////////////////

--- a/src/ui/wxWidgets/pwsqrcodedlg.cpp
+++ b/src/ui/wxWidgets/pwsqrcodedlg.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2003-2017 Rony Shapiro <ronys@pwsafe.org>.
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+
+#ifndef WX_PRECOMP
+#include "wx/wx.h"
+#endif
+
+#include "./pwsqrcodedlg.h"
+#include "./wxutils.h"
+
+#ifdef __WXMSW__
+#include <wx/msw/msvcrt.h>
+#endif
+
+////////////////////////////////////////////////////////////////////////////
+// PasswordSafeSerach implementation
+IMPLEMENT_CLASS( PWSQRCodeDlg, wxDialog )
+
+BEGIN_EVENT_TABLE(PWSQRCodeDlg, wxDialog)
+	EVT_BUTTON(wxID_CLOSE, PWSQRCodeDlg::OnClose)
+END_EVENT_TABLE()
+
+PWSQRCodeDlg::PWSQRCodeDlg(wxWindow* parent,
+		                   const StringX &data,
+						   const wxString& description,
+					       const int seconds,
+					       const wxString &dlgTitle,
+					       const wxPoint &pos,
+					       const wxSize &size,
+					       long style,
+					       const wxString &name): wxDialog(parent, wxID_ANY, dlgTitle, pos, size, style, name)
+{
+	CreateControls(data, description);
+}
+ 
+void PWSQRCodeDlg::CreateControls(const StringX &data, const wxString &description)
+{
+	wxSizer *dlgSizer = new wxBoxSizer(wxVERTICAL);
+
+	dlgSizer->AddSpacer(TopMargin);
+
+	dlgSizer->Add( new wxStaticText(this, wxID_ANY, description) );
+
+	dlgSizer->AddSpacer(RowSeparation);
+
+	dlgSizer->Add( new wxButton(this, wxID_CLOSE) );
+
+	SetSizerAndFit(dlgSizer);
+}
+
+void PWSQRCodeDlg::OnClose(wxCommandEvent &evt)
+{
+	EndModal(wxID_CLOSE);
+}
+
+#ifdef __TEST_QR_CODE__
+///////////////////////////////////////////////////////
+// build it like this
+// g++ -D__TEST_QR_CODE__ -o qrtest
+//                  `/usr/bin/wx-config-3.0 --debug=yes --unicode=yes --inplace --cxxflags --libs`
+//                  -DUNICODE -I../.. pwsqrcodedlg.cpp  -lcore -los -lcore -L../../../lib/unicodedebug
+//
+#include <wx/cmdline.h>
+class QRTestApp: public wxApp {
+	public:
+
+		void OnInitCmdLine( wxCmdLineParser &parser) {
+			wxAppConsole::OnInitCmdLine(parser);
+			static const wxCmdLineEntryDesc cmdLineDesc[] =
+			{
+				{ wxCMD_LINE_PARAM, NULL, NULL, "secret", wxCMD_LINE_VAL_STRING, 0},
+				{ wxCMD_LINE_NONE }
+			};
+			parser.SetDesc(cmdLineDesc);
+		}
+
+		bool OnInit() override {
+			if ( !wxApp::OnInit() )
+				return false;
+
+			if ( this->argc != 2 ) {
+				std::cerr << "usage: " << basename(argv[0]) << " <text to generate qr code for>\n";
+				return false;
+			} else {
+				PWSQRCodeDlg dlg(nullptr, StringX(argv[1]), "Scan this QR Code and comapre with the program argument" );
+				dlg.ShowModal();
+				// Normall we return true here
+				return false;
+			}
+		}
+};
+
+wxIMPLEMENT_APP(QRTestApp);
+#endif
+

--- a/src/ui/wxWidgets/pwsqrcodedlg.cpp
+++ b/src/ui/wxWidgets/pwsqrcodedlg.cpp
@@ -55,7 +55,7 @@ wxBitmap QRCodeBitmap( const StringX &data )
 		return wxBitmap();
 
 	auto qc_data = reinterpret_cast<const char *>(utf8str);
-	QRcodePtr qc(QRcode_encodeString8bit(qc_data, 2, QR_ECLEVEL_H), &QRcode_free);
+	QRcodePtr qc(QRcode_encodeString8bit(qc_data, 0, QR_ECLEVEL_L), &QRcode_free);
 	if ( !qc || !qc->width )
 		return wxBitmap();
 

--- a/src/ui/wxWidgets/pwsqrcodedlg.cpp
+++ b/src/ui/wxWidgets/pwsqrcodedlg.cpp
@@ -91,10 +91,12 @@ wxBitmap QRCodeBitmap( const StringX &data )
 	};
 
 	vector<char> xbmp(pxTopMargin);
+	xbmp.reserve( imageWidth*imageWidth/8 );
 
 	// For each line of QR data, generate a line of pixels
 	for (auto line = 0; line < qc->width; ++line) {
 		vector<char> pxline(pxSideMargin);
+		pxline.reserve( imageWidth/8 );
 		const auto qrdata = qr2xbmp(line);
 		wxASSERT( qrdata.size() == (imageWidth - 2*margin)/8 );
 		pxline.insert(pxline.end(), qrdata.begin(), qrdata.end());

--- a/src/ui/wxWidgets/pwsqrcodedlg.cpp
+++ b/src/ui/wxWidgets/pwsqrcodedlg.cpp
@@ -141,8 +141,9 @@ void PWSQRCodeDlg::CreateControls(const StringX &data, const wxString &descripti
 	dlgSizer->AddSpacer(RowSeparation);
 	dlgSizer->Add( CreateSeparatedButtonSizer(wxCLOSE), wxSizerFlags().Expand() );
 	dlgSizer->AddSpacer(BottomMargin);
-
-	SetSizerAndFit(dlgSizer);
+	wxSizer *hSizer = new wxBoxSizer(wxHORIZONTAL);
+	hSizer->Add(dlgSizer, wxSizerFlags().Border(wxLEFT|wxRIGHT, SideMargin).Expand().Proportion(1));
+	SetSizerAndFit(hSizer);
 }
 
 void PWSQRCodeDlg::OnClose(wxCommandEvent &evt)

--- a/src/ui/wxWidgets/pwsqrcodedlg.cpp
+++ b/src/ui/wxWidgets/pwsqrcodedlg.cpp
@@ -10,6 +10,8 @@
 #include "wx/wx.h"
 #endif
 
+#include <algorithm>
+
 #include <wx/statline.h>
 
 #include <qrencode.h>
@@ -46,32 +48,100 @@ wxBitmap QRCodeBitmap( const StringX &data )
 		return wxBitmap();
 
 	auto qc_data = reinterpret_cast<const char *>(utf8str);
-	QRcodePtr qc(QRcode_encodeString8bit(qc_data, 0, QR_ECLEVEL_H), &QRcode_free);
+	QRcodePtr qc(QRcode_encodeString8bit(qc_data, 2, QR_ECLEVEL_H), &QRcode_free);
 
-	const size_t nbytes = (qc->width + 7)/8;
+	//constexpr auto intendedImageWidth = 300;
+	constexpr auto margin = 24;
+	constexpr int scale = 8;//(intendedImageWidth - 2*margin)/qc->width;
+	//scale = scale <= 0? 1: scale;
+	const int imageWidth = 2*margin + scale*qc->width;
+
+
+	const size_t nbytes = (imageWidth*imageWidth + 7)/8;
+	std::cout << "QR code width: " << qc->width << ", version " << qc->version << '\n'
+			<<	"image bytes: " << nbytes << '\n'
+			<<	"image width: " << imageWidth << '\n';
+
+	//wxASSERT_MSG(imageWidth*imageWidth == nbytes, _T("QRcode image width calculation is incorrect"));
+
 	std::vector<char> xbmp(nbytes);
 
-	const auto max_idx = std::min(nbytes, static_cast<size_t>(qc->width/8));
-	for (auto n = 0; n < max_idx; ++n) {
-		auto start = n*8;
-		xbmp[n] = 	((qc->data[start+0] & 1) << 0) |
-					((qc->data[start+1] & 1) << 1) |
-					((qc->data[start+2] & 1) << 2) |
-					((qc->data[start+3] & 1) << 3) |
-					((qc->data[start+4] & 1) << 4) |
-					((qc->data[start+5] & 1) << 5) |
-					((qc->data[start+6] & 1) << 6) |
-					((qc->data[start+7] & 1) << 7);
-	}
+	auto write_bits = [&xbmp](size_t start, size_t count, int bitval) {
+		constexpr char rbits[] = {0, 0b1, 0b11, 0b111, 0b1111, 0b11111, 0b111111, 0b1111111};
 
-	if (nbytes > max_idx) {
-		for (auto i = 0; i < qc->width%8; ++i) {
-			xbmp[nbytes-1] |= (qc->data[max_idx*8 + i] & 1);
+		if (start % 8) {
+			// num bits set in the last byte
+			const auto nset = start%8;
+			const auto last_byte = start/8;
+			// clear out the leftmost bits to be set now
+			const char b = (rbits[nset] & xbmp[last_byte]);
+			if (bitval) {
+				const auto mask = (rbits[8 - nset] << nset);
+				xbmp[last_byte] |= mask ;
+			}
 		}
-	}
+
+		const char byte = bitval? 0xff: 0;
+		for (size_t n = 0; n < count/8; n++)
+			xbmp[start/8 + n] = byte;
+
+		if ((start + count) % 8) {
+			xbmp[start/8 + count/8 + 1] = rbits[count%8];
+		}
+	};
+
+	using std::fill_n;
+	using std::copy_n;
+
+	// fill top margin
+	write_bits(0, imageWidth*margin, 0);
+	std::cout << "Top margin covers " << imageWidth*margin << '\n';
 
 	const int height = qc->width;
-	return wxBitmap( xbmp.data(), qc->width, height);
+	for (auto row = 0; row < height; ++row) {
+
+		const auto bmpRowStart = (8*row + margin)*imageWidth;
+		std::cout << "Image row " << row << ": " << bmpRowStart << '\n';
+
+		wxASSERT_MSG(bmpRowStart < nbytes*8 - imageWidth, _T("QRcode image width calculation is incorrect"));
+		
+		// left margin
+		write_bits(bmpRowStart, margin, 0);
+
+		auto bmpQRDataIndex = bmpRowStart + margin;
+		for (auto col = 0; col < qc->width; ++col) {
+			wxASSERT(bmpQRDataIndex < bmpRowStart + imageWidth);
+			const auto qcrow = row;
+			const auto qcidx = qcrow*qc->width + col;
+			const auto bit = qc->data[qcidx] & 1;
+
+			// This relies on the fact that scale is 8
+			//const auto byte = bit? 0xff: 0;
+			//xbmp[bmpQRDataIndex + col] = byte;
+			//bmpQRDataIndex++;
+			write_bits(bmpQRDataIndex + col, scale, bit);
+			bmpQRDataIndex += scale;
+		}
+
+		// right margin
+		//fill_n(xbmp.begin() + bmpQRDataIndex, (imageWidth - (bmpQRDataIndex - bmpRowStart))/8, 0);
+		write_bits(bmpQRDataIndex, imageWidth - (bmpQRDataIndex - bmpRowStart), 0);
+
+		// copy the row "scale -1" times over
+		for (auto s = 1; s < scale; ++s) {
+			auto src = bmpRowStart/8;
+			auto dst = bmpRowStart/8 + s*imageWidth/8;
+			const auto nbytes = imageWidth/8;
+			std::cout << "copying " << nbytes << " bytes in image row " << s << " : " << src << " => " << dst <<  '\n';
+			copy_n(xbmp.begin() + src, nbytes, xbmp.begin() + dst);
+		}
+
+	}
+
+	// fill bottom margin
+	write_bits(nbytes - imageWidth*margin, imageWidth*margin, 0);
+
+	return wxBitmap( xbmp.data(), imageWidth, imageWidth);
 }
 
 PWSQRCodeDlg::PWSQRCodeDlg(wxWindow* parent,
@@ -94,21 +164,25 @@ void PWSQRCodeDlg::CreateControls(const StringX &data, const wxString &descripti
 	dlgSizer->AddSpacer(TopMargin);
 
 	dlgSizer->Add( new wxStaticText(this, wxID_ANY, description) );
-
-	dlgSizer->Add( new wxStaticLine(this) );
-
+	dlgSizer->AddSpacer(RowSeparation);
+	dlgSizer->Add( new wxStaticLine(this), wxSizerFlags().Expand() );
 	dlgSizer->AddSpacer(RowSeparation);
 
 	wxBitmap bmp = QRCodeBitmap(data);
 	if (bmp.IsOk() ) {
-		dlgSizer->Add( new wxStaticBitmap(this, wxID_ANY, bmp), wxSizerFlags().Expand() );
+		dlgSizer->Add( new wxStaticBitmap(this, wxID_ANY, bmp), wxSizerFlags().Expand().Proportion(1) );
 	}
 	else
 		dlgSizer->Add( new wxStaticText(this, wxID_ANY, _T("Could not generate QR code")) );
 
 	dlgSizer->AddSpacer(RowSeparation);
-	dlgSizer->Add( new wxStaticLine(this) );
-	dlgSizer->Add( new wxButton(this, wxID_CLOSE), wxSizerFlags().Right().Bottom() );
+	dlgSizer->Add( new wxStaticLine(this), wxSizerFlags().Expand() );
+	dlgSizer->AddSpacer(RowSeparation);
+	wxStdDialogButtonSizer *btnSizer = new wxStdDialogButtonSizer;
+	btnSizer->AddButton( new wxButton(this, wxID_CLOSE) );
+	btnSizer->Realize();
+	dlgSizer->Add( btnSizer, wxSizerFlags().Expand() );
+	dlgSizer->AddSpacer(BottomMargin);
 
 	SetSizerAndFit(dlgSizer);
 }

--- a/src/ui/wxWidgets/pwsqrcodedlg.cpp
+++ b/src/ui/wxWidgets/pwsqrcodedlg.cpp
@@ -56,6 +56,8 @@ wxBitmap QRCodeBitmap( const StringX &data )
 
 	auto qc_data = reinterpret_cast<const char *>(utf8str);
 	QRcodePtr qc(QRcode_encodeString8bit(qc_data, 2, QR_ECLEVEL_H), &QRcode_free);
+	if ( !qc || !qc->width )
+		return wxBitmap();
 
 	constexpr auto margin = 24;
 	constexpr auto scale = 8;

--- a/src/ui/wxWidgets/pwsqrcodedlg.cpp
+++ b/src/ui/wxWidgets/pwsqrcodedlg.cpp
@@ -139,12 +139,7 @@ void PWSQRCodeDlg::CreateControls(const StringX &data, const wxString &descripti
 		dlgSizer->Add( new wxStaticText(this, wxID_ANY, _T("Could not generate QR code")) );
 
 	dlgSizer->AddSpacer(RowSeparation);
-	dlgSizer->Add( new wxStaticLine(this), wxSizerFlags().Expand() );
-	dlgSizer->AddSpacer(RowSeparation);
-	wxStdDialogButtonSizer *btnSizer = new wxStdDialogButtonSizer;
-	btnSizer->AddButton( new wxButton(this, wxID_CLOSE) );
-	btnSizer->Realize();
-	dlgSizer->Add( btnSizer, wxSizerFlags().Expand() );
+	dlgSizer->Add( CreateSeparatedButtonSizer(wxCLOSE), wxSizerFlags().Expand() );
 	dlgSizer->AddSpacer(BottomMargin);
 
 	SetSizerAndFit(dlgSizer);

--- a/src/ui/wxWidgets/pwsqrcodedlg.cpp
+++ b/src/ui/wxWidgets/pwsqrcodedlg.cpp
@@ -144,8 +144,9 @@ void PWSQRCodeDlg::CreateControls(const StringX &data)
 	if (bmp.IsOk() ) {
 		dlgSizer->Add( new wxStaticBitmap(this, wxID_ANY, bmp), wxSizerFlags().Expand().Proportion(1) );
 	}
-	else
+	else {
 		dlgSizer->Add( new wxStaticText(this, wxID_ANY, _T("Could not generate QR code")) );
+	}
 
 	dlgSizer->AddSpacer(RowSeparation);
 	dlgSizer->Add( CreateSeparatedButtonSizer(wxCLOSE), wxSizerFlags().Expand() );
@@ -155,7 +156,7 @@ void PWSQRCodeDlg::CreateControls(const StringX &data)
 	SetSizerAndFit(hSizer);
 }
 
-void PWSQRCodeDlg::OnClose(wxCommandEvent &evt)
+void PWSQRCodeDlg::OnClose(wxCommandEvent &/*evt*/)
 {
 	EndModal(wxID_CLOSE);
 }

--- a/src/ui/wxWidgets/pwsqrcodedlg.cpp
+++ b/src/ui/wxWidgets/pwsqrcodedlg.cpp
@@ -59,8 +59,8 @@ wxBitmap QRCodeBitmap( const StringX &data )
 	if ( !qc || !qc->width )
 		return wxBitmap();
 
-	constexpr auto margin = 24;
-	constexpr auto scale = 8;
+	constexpr unsigned margin = 24;
+	constexpr unsigned scale = 8;
 
 	// This is only for the ease of computation, to avoid filling and
 	// tracking bytes partially while generating the xbm data
@@ -68,7 +68,7 @@ wxBitmap QRCodeBitmap( const StringX &data )
 	static_assert( margin % scale == 0, "margin must be a multiple of scale");
 
 	// in pixels
-	const auto imageWidth = 2*margin + scale*qc->width;
+	const unsigned imageWidth = 2*margin + scale*qc->width;
 
 	const vector<char> pxTopMargin( (imageWidth*margin)/8, 0 );
 	const vector<char> pxSideMargin( margin/8, 0);
@@ -103,7 +103,7 @@ wxBitmap QRCodeBitmap( const StringX &data )
 		pxline.insert(pxline.end(), pxSideMargin.begin(), pxSideMargin.end());
 		wxASSERT( pxline.size() == imageWidth/8 );
 		// And repeat that line "scale" times
-		for (auto n = 0; n < scale; ++n)
+		for (unsigned n = 0; n < scale; ++n)
 			xbmp.insert(xbmp.end(), pxline.begin(), pxline.end());
 	}
 	xbmp.insert(xbmp.end(), pxTopMargin.begin(), pxTopMargin.end());

--- a/src/ui/wxWidgets/pwsqrcodedlg.h
+++ b/src/ui/wxWidgets/pwsqrcodedlg.h
@@ -26,7 +26,7 @@ class PWSQRCodeDlg : public wxDialog {
 public:
   PWSQRCodeDlg(wxWindow* parent,
 		  	   const StringX &data,
-			   const wxString& description,  //something like "search", or "merge" or "compare"
+			   const wxString& description,
 			   const int seconds = 15,
 			   const wxString &dlgTitle = wxT("Scan the QR code quickly"),
 			   const wxPoint &pos=wxDefaultPosition,

--- a/src/ui/wxWidgets/pwsqrcodedlg.h
+++ b/src/ui/wxWidgets/pwsqrcodedlg.h
@@ -51,3 +51,11 @@ public:
   void OnInitDialog(wxInitDialogEvent &evt);
 };
 
+constexpr bool HasQRCode() {
+#ifdef __linux
+	return true;
+#else
+	return false;
+#endif
+}
+

--- a/src/ui/wxWidgets/pwsqrcodedlg.h
+++ b/src/ui/wxWidgets/pwsqrcodedlg.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2003-2017 Rony Shapiro <ronys@pwsafe.org>.
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+
+/** \file pwsqrcodedlg.h
+ * 
+ */
+
+/*
+ * A dialog class to display a QR code. The dialog closes automatically for security reasons.
+ */
+
+#include <wx/dialog.h>
+
+#include "../../core/StringX.h"
+
+class PWSQRCodeDlg : public wxDialog {
+
+  DECLARE_CLASS(PWSQRCodeDlg)
+  DECLARE_EVENT_TABLE()
+
+public:
+  PWSQRCodeDlg(wxWindow* parent,
+		  	   const StringX &data,
+			   const wxString& description,  //something like "search", or "merge" or "compare"
+			   const int seconds = 15,
+			   const wxString &dlgTitle = wxT("Scan the QR code quickly"),
+			   const wxPoint &pos=wxDefaultPosition,
+			   const wxSize &size=wxDefaultSize,
+			   long style=wxDEFAULT_DIALOG_STYLE,
+			   const wxString &name=wxDialogNameStr);
+
+  ~PWSQRCodeDlg() = default;
+  
+  //void OnInitDialog(wxInitDialogEvent& evt)  override;
+  //void OnRelayoutDlg(wxCommandEvent& evt)  override;  
+  void CreateControls(const StringX &data, const wxString &description);
+  void OnClose(wxCommandEvent & evt);
+};
+

--- a/src/ui/wxWidgets/pwsqrcodedlg.h
+++ b/src/ui/wxWidgets/pwsqrcodedlg.h
@@ -15,6 +15,8 @@
  */
 
 #include <wx/dialog.h>
+#include <wx/timer.h>
+#include <wx/stattext.h>
 
 #include "../../core/StringX.h"
 
@@ -23,12 +25,17 @@ class PWSQRCodeDlg : public wxDialog {
   DECLARE_CLASS(PWSQRCodeDlg)
   DECLARE_EVENT_TABLE()
 
+  wxTimer timer;
+  int secondsRemaining;
+  wxStaticText *secondsText = nullptr;
+
+  void UpdateTimeRemaining();
+
 public:
   PWSQRCodeDlg(wxWindow* parent,
 		  	   const StringX &data,
-			   const wxString& description,
+			   const wxString& title,
 			   const int seconds = 15,
-			   const wxString &dlgTitle = wxT("Scan the QR code quickly"),
 			   const wxPoint &pos=wxDefaultPosition,
 			   const wxSize &size=wxDefaultSize,
 			   long style=wxDEFAULT_DIALOG_STYLE,
@@ -38,7 +45,9 @@ public:
   
   //void OnInitDialog(wxInitDialogEvent& evt)  override;
   //void OnRelayoutDlg(wxCommandEvent& evt)  override;  
-  void CreateControls(const StringX &data, const wxString &description);
+  void CreateControls(const StringX &data);
   void OnClose(wxCommandEvent & evt);
+  void OnTimer(wxTimerEvent &evt);
+  void OnInitDialog(wxInitDialogEvent &evt);
 };
 


### PR DESCRIPTION
Add an item to the popup menu brought up by right-clicking an item to show the entry's password as a QR code. For security reasons, the dialog closes automatically after 15 seconds.

![display-password-as-qrcode](https://user-images.githubusercontent.com/8086899/28870246-1106d7aa-776f-11e7-929a-a019462a8f31.png)

![qrcode-dlg](https://user-images.githubusercontent.com/8086899/28870253-193aa5c8-776f-11e7-95cf-eb9ce82268d6.png)

This is useful for quickly transferring a password to a mobile device securely using a [QR-code scanning app](https://play.google.com/store/apps/details?id=com.google.zxing.client.android&hl=en)




Cons: adds yet another build dependency: libqrencode

Currently its linux-only. Stil researching on osx.