### PR TITLE
Fix UpdatePasswordCommand test to use correct units

### DIFF
--- a/src/test/CommandsTest.cpp
+++ b/src/test/CommandsTest.cpp
@@ -267,7 +267,7 @@ TEST_F(CommandsTest, UpdatePassword)
   it.SetPassword(sxOldPassword);
   it.SetPWHistory(L"10300");  // On and save 3
   it.SetPMTime(tPMtime);       // Say password set yesterday
-  it.SetXTimeInt(i1day * 10);
+  it.SetXTimeInt(10);
   it.SetXTime(t - i1day * 2); // Say expired 2 days ago
 
   Command *pcmd = AddEntryCommand::Create(&core, it);


### PR DESCRIPTION
According to the V3 spec and the comments in CItemData::UpdatePassword,
the password expiration interval should be specified in days.  However
the test for UpdatePasswordCommand was setting it in seconds since epoch.
This lead to sign flipping on 32-bit systems which resulted in test failure.