### PR TITLE
Expand and shrink dragbar with the main frame

### DIFF
--- a/src/ui/wxWidgets/passwordsafeframe.cpp
+++ b/src/ui/wxWidgets/passwordsafeframe.cpp
@@ -302,7 +302,7 @@ void PasswordSafeFrame::CreateDragBar()
   wxASSERT(((wxBoxSizer*)origSizer)->GetOrientation() == wxVERTICAL);
 
   PWSDragBar* dragbar = new PWSDragBar(this);
-  origSizer->Insert(0, dragbar);
+  origSizer->Insert(0, dragbar, 1, wxEXPAND);
 
   const bool bShow = PWSprefs::GetInstance()->GetPref(PWSprefs::ShowDragbar);
   if (!bShow) {


### PR DESCRIPTION
This fixes a cosmetic problem with the dragbar.

Currently, just after unlocking a safe the dragbar appears as expected:
![shot nov 11 2017 11 06 03pm](https://user-images.githubusercontent.com/8379226/32695815-0d8c77f4-c735-11e7-9532-df7ae5efd358.jpeg)
Widening the passwordsafe window does not also widen the dragbar:
![shot nov 11 2017 11 06 10pm](https://user-images.githubusercontent.com/8379226/32695823-40595a9e-c735-11e7-83d7-47f6cf3b4f99.jpeg)