### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/src/ui/wxWidgets/wxutils.cpp
+++ b/src/ui/wxWidgets/wxutils.cpp
@@ -203,7 +203,7 @@ int pless(int* first, int* second) { return *first - *second; }
 // on Fedora or Ubuntu
 bool IsTaskBarIconAvailable()
 {
-#ifdef __WXGTK__
+#if defined(__WXGTK__) && defined(LINUX)
   const wxLinuxDistributionInfo ldi = wxGetLinuxDistributionInfo();
   if (ldi.Id.IsEmpty() || ldi.Id == wxT("Ubuntu") || ldi.Id == wxT("Fedora"))
     return false;


### PR DESCRIPTION
The function wxLinuxDistributionInfo is only available on Linux. Add check for LINUX symbol as per [documentation](http://docs.wxwidgets.org/3.0/group__group__funcmacro__networkuseros.html#ga06f6fb212c396bd20865ee4e2f69aa1f)
`This function is Linux-specific and is only available when the LINUX symbol is defined. `