### PR TITLE
Make wxDragbar not expandable in vertical direction.

### DIFF
--- a/src/ui/wxWidgets/passwordsafeframe.cpp
+++ b/src/ui/wxWidgets/passwordsafeframe.cpp
@@ -302,7 +302,7 @@ void PasswordSafeFrame::CreateDragBar()
   wxASSERT(((wxBoxSizer*)origSizer)->GetOrientation() == wxVERTICAL);
 
   PWSDragBar* dragbar = new PWSDragBar(this);
-  origSizer->Insert(0, dragbar, 1, wxEXPAND);
+  origSizer->Insert(0, dragbar, 0, wxEXPAND);
 
   const bool bShow = PWSprefs::GetInstance()->GetPref(PWSprefs::ShowDragbar);
   if (!bShow) {


### PR DESCRIPTION
The dragbar took with its single row of icons half of the space of the main frame.

![wxdragbar_wofix](https://user-images.githubusercontent.com/4042917/34116139-f09bc410-e417-11e7-873d-1969c626e5dc.png)

This change keeps the dragbar height at its necessary size.

![wxdragbar_fix](https://user-images.githubusercontent.com/4042917/34116313-83c904fa-e418-11e7-9fba-dd98dcbc0172.png)
