### PR TITLE
Make text entry fields of properties sheet expandable.

### DIFF
--- a/src/ui/wxWidgets/addeditpropsheet.cpp
+++ b/src/ui/wxWidgets/addeditpropsheet.cpp
@@ -263,7 +263,9 @@ void AddEditPropSheet::CreateControls()
   itemBoxSizer3->Add(itemStaticText4, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5);
 
   m_BasicFGSizer = new wxFlexGridSizer(0, 3, 0, 0);
-  itemBoxSizer3->Add(m_BasicFGSizer, 0, wxALIGN_LEFT|wxALL, 5);
+  m_BasicFGSizer->AddGrowableCol(1);
+  
+  itemBoxSizer3->Add(m_BasicFGSizer, 0, wxALIGN_LEFT|wxALL|wxEXPAND, 5);
   wxStaticText* itemStaticText6 = new wxStaticText( m_BasicPanel, wxID_STATIC, _("Group:"), wxDefaultPosition, wxDefaultSize, 0 );
   m_BasicFGSizer->Add(itemStaticText6, 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 

--- a/src/ui/wxWidgets/passwordsafeframe.cpp
+++ b/src/ui/wxWidgets/passwordsafeframe.cpp
@@ -302,7 +302,7 @@ void PasswordSafeFrame::CreateDragBar()
   wxASSERT(((wxBoxSizer*)origSizer)->GetOrientation() == wxVERTICAL);
 
   PWSDragBar* dragbar = new PWSDragBar(this);
-  origSizer->Insert(0, dragbar, 1, wxEXPAND);
+  origSizer->Insert(0, dragbar, 0, wxEXPAND);
 
   const bool bShow = PWSprefs::GetInstance()->GetPref(PWSprefs::ShowDragbar);
   if (!bShow) {


### PR DESCRIPTION
This change makes the text entry fields of the properties sheet expandable so that they get more available space. This makes more content of the text fields visible.

As it is now:
![addeditpropsheet_wofix](https://user-images.githubusercontent.com/4042917/34119231-b665a4c8-e421-11e7-86ac-781bb38b4703.png)

As it is due to applied changes:
![addeditpropsheet_wfix](https://user-images.githubusercontent.com/4042917/34119237-bcda1924-e421-11e7-86d5-1ce650bd4158.png)

