### PR TITLE
Make text entry fields of properties sheet expandable

### DIFF
--- a/src/ui/wxWidgets/addeditpropsheet.cpp
+++ b/src/ui/wxWidgets/addeditpropsheet.cpp
@@ -263,7 +263,9 @@ void AddEditPropSheet::CreateControls()
   itemBoxSizer3->Add(itemStaticText4, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5);
 
   m_BasicFGSizer = new wxFlexGridSizer(0, 3, 0, 0);
-  itemBoxSizer3->Add(m_BasicFGSizer, 0, wxALIGN_LEFT|wxALL, 5);
+  m_BasicFGSizer->AddGrowableCol(1);
+
+  itemBoxSizer3->Add(m_BasicFGSizer, 0, wxALIGN_LEFT|wxALL|wxEXPAND, 5);
   wxStaticText* itemStaticText6 = new wxStaticText( m_BasicPanel, wxID_STATIC, _("Group:"), wxDefaultPosition, wxDefaultSize, 0 );
   m_BasicFGSizer->Add(itemStaticText6, 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 


### PR DESCRIPTION
This change makes the text entry fields of the properties sheet expandable so that they get more available space. This makes more content of the text fields visible.

Layout without this change:
![addeditpropsheet_wofix](https://user-images.githubusercontent.com/4042917/34172258-be4a4f4c-e4f1-11e7-99c4-3c543e092a96.png)

Layout after applied change:
![addeditpropsheet_wfix](https://user-images.githubusercontent.com/4042917/34172356-0e271b76-e4f2-11e7-934b-fd435e9b2332.png)
