### PR TITLE
Updates for SlackBuild / CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,7 +405,8 @@ if (NOT WIN32)
 
    install (DIRECTORY ${PROJECT_BINARY_DIR}/help/
      DESTINATION "share/doc/passwordsafe/help"
-     FILES_MATCHING PATTERN "*.zip")
+     FILES_MATCHING PATTERN "*.zip"
+     PATTERN "CMakeFiles" EXCLUDE)
 
 else ()
    install (FILES "xml/pwsafe.xsd" DESTINATION "bin")

--- a/help/CMakeLists.txt
+++ b/help/CMakeLists.txt
@@ -34,12 +34,14 @@ else (WIN32)
     )
   # English help is a special case: default -> helpEN.zip
   add_custom_command(OUTPUT "helpEN.zip"
+    COMMAND "sed" "-i" "pwsafe*.hh?" "-e" "'s&html\\\\&html/&g'"
     COMMAND "zip" "-Xqr" "${CMAKE_CURRENT_BINARY_DIR}/helpEN" "./*"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/default"
     )
   # Other languages are amenable to a macro:
   macro(make_help LANG)
     add_custom_command(OUTPUT "help${LANG}.zip"
+      COMMAND "sed" "-i" "pwsafe*.hh?" "-e" "'s&html\\\\&html/&g'"
       COMMAND "zip" "-Xqr" "${CMAKE_CURRENT_BINARY_DIR}/help${LANG}" "./*"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/pwsafe${LANG}"
       )

--- a/install/slackware/.gitignore
+++ b/install/slackware/.gitignore
@@ -1,3 +1,4 @@
 logs/
 packages/
+build/
 

--- a/install/slackware/passwordsafe.SlackBuild
+++ b/install/slackware/passwordsafe.SlackBuild
@@ -2,7 +2,7 @@
 
 # Password Safe build script 
 #--
-# Last edited: 15.08.2017
+# Last edited: 19.11.2017
 #--
 
 if [ $UID = 0 ]; then
@@ -36,179 +36,153 @@ BUILD_ID=${BUILD_ID:-1}
 BUILDER_ID=${BUILDER_ID:-kan}
 OUTPUT=${OUTPUT:-$(pwd)/packages}
 LOGS=${LOGS:-$(pwd)/logs}
-YUBI_DISABLED=${NO_YUBI:-0}
-QR_DISABLED=${NO_QR:-0}
-
-if [ -n "${NO_YUBI-}" ] || [ "${NO_YUBI+x}" = x ]; then
-    YUBI_DISABLED=1
-else
-    YUBI_DISABLED=0
-fi
-
-if [ -n "${NO_QR-}" ] || [ "${NO_QR+x}" = x ]; then
-    QR_DISABLED=1
-else
-    QR_DISABLED=0
-fi
-
-if [ $YUBI_DISABLED -eq 1 ]; then
-    VERSION="noyubi-$VERSION"
-fi
-if [ $QR_DISABLED -eq 1 ]; then
-    VERSION="noqr-$VERSION"
-fi
+MAKE_OPTIONS="-j5"
 
 ##
-MAKEDIR=${GIT_ROOT}
-BINDIR=${GIT_ROOT}/src/ui/wxWidgets/GCCUnicodeRelease
 DOCSRCDIR=${GIT_ROOT}/docs
-XMLSRCDIR=${GIT_ROOT}/xml
-HELPSRCDIR=${GIT_ROOT}/help
-ISRCDIR=${GIT_ROOT}/src/ui/wxWidgets/I18N
+SRCDIR=${GIT_ROOT}/src
+MAKEDIR=${GIT_ROOT}/install/slackware/build
 ##
-PKGNAME=${PRGNAM}-${VERSION/-/.}-$ARCH-$BUILD_ID$BUILDER_ID
+PKGNAME=${PRGNAM}-${VERSION/-/.}-${ARCH}-${BUILD_ID}${BUILDER_ID}
 ##
 PREFIX="/usr"
-DOCDIR=$PREFIX/share/doc/$PRGNAM-$VERSION
-HELPDIR=$PREFIX/share/doc/passwordsafe/help
-XMLDIR=$PREFIX/share/$PRGNAM/xml
-MANDIR=$PREFIX/man
-PIXMAPDIR=$PREFIX/share/pixmaps
-APPDIR=$PREFIX/share/applications
-IDIR=$PREFIX/share/locale
+DOCDIR=${PREFIX}/share/doc/${PRGNAM}-${VERSION}
+HELPDIR=${PREFIX}/share/${PRGNAM}/help
+XMLDIR=${PREFIX}/share/${PRGNAM}/xml
+DEFDOCDIR="/usr/share/doc/passwordsafe"
+DEFHELPDIR="/usr/share/doc/passwordsafe/help"
+DEFXMLDIR="/usr/share/pwsafe/xml"
 ##
-OPTIMIZE="-O2"
 DATE=$(LC_ALL=C /bin/date +%d-%b-%Y)
 PKG=${PWD}/package-${PRGNAM}
 MYDIR=${PWD}
 
-MAKE_OPTIONS="-j4 release CONFIG=unicoderelease"
+FLAGS="-DCMAKE_INSTALL_PREFIX=${PREFIX} \
+-DCMAKE_BUILD_TYPE=Release"
+
+NO_YUBI=0
+NO_QR=0
+NO_GTEST=1
+
+# process parameters
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)
+            echo -e "Usage: $0 [--no-yubi] [--no-qr] [--gtest]\n\tno-yubi -- disable Yuibikey support\n\tno-qr -- disable QR-code support\n\tgtest -- enable gtest" >&2
+            exit 1
+            ;;
+        --no-yubi)
+            NO_YUBI=1
+            ;;
+        --no-qr)
+            NO_QR=1
+            ;;
+        --gtest)
+            NO_GTEST=0
+            ;;
+        *)
+            echo "Unknown flag $1" >&2
+            exit 1
+    esac
+    shift
+done
+
+if [ "${NO_YUBI}" == "1" ]; then
+    VERSION+="_noyubi"
+    FLAGS+="${FLAGS} -DNO_YUBI=ON"
+fi
+if [ "${NO_QR}" == "1" ]; then
+    VERSION+="_noqr"
+    FLAGS+="${FLAGS} -DNO_QR=ON"
+fi
+if [ "${NO_GTEST}" == "1" ]; then
+    FLAGS+="${FLAGS} -DNO_GTEST=ON"
+fi
 
 
-case "$ARCH" in
-  i[3456]86) SLKCFLAGS="$OPTIMIZE -march=$ARCH -mtune=$ARCH"
-             SLKLDFLAGS=""; LIBDIRSUFFIX=""
-             ;;
-  x86_64)    SLKCFLAGS="$OPTIMIZE -fPIC"
-             SLKLDFLAGS="-L/usr/lib64"; LIBDIRSUFFIX="64"
-             ;;
-esac
+PKGNAME=${PRGNAM}-${VERSION/-/.}-${ARCH}-${BUILD_ID}${BUILDER_ID}
 
 umask 022
 
-
 # Create working directories:
-mkdir -p $LOGS
-mkdir -p $OUTPUT
-mkdir -p $PKG
+mkdir -p ${LOGS}
+mkdir -p ${OUTPUT}
+mkdir -p ${PKG}
+mkdir -p ${MAKEDIR}
 # always erase old package's contents
-rm -rf $PKG/*
+rm -rf ${PKG}/* ${MAKEDIR}/*
 
 ## Package building
-echo Building ...
-export LDFLAGS="$SLKLDFLAGS"
-if [ $YUBI_DISABLED -ne 1 ]; then
-    SLKCFLAGS="$SLKCFLAGS -I/usr/include/ykpers-1"
-fi
-export CXXFLAGS="$SLKCFLAGS"
-export CFLAGS="$SLKCFLAGS"
-
-#make binaries
-cd $MAKEDIR
-echo "- cleanup"
-make release-clean
 echo "- patch"
-sed -i src/os/unix/dir.cpp -e "s&/usr/share/doc/passwordsafe/help/&${HELPDIR}/&g"
-sed -i src/os/unix/dir.cpp -e "s&/usr/share/pwsafe/xml/&${XMLDIR}/&g"
-echo "- binaries"
-make $MAKE_OPTIONS 2>&1 | tee $LOGS/make-${PRGNAM}.log || exit 1
-echo "- help"
-make help
-echo "- i18n"
-make I18N
+sed -i ${SRCDIR}/os/unix/dir.cpp -e "s&${DEFHELPDIR}&${HELPDIR}&g"
+sed -i ${SRCDIR}/os/unix/dir.cpp -e "s&${DEFXMLDIR}&${XMLDIR}&g"
 
-#collect files before packaging
-#copy binaries
-mkdir -p $PKG/$PREFIX/bin
-cp $BINDIR/pwsafe $PKG/$PREFIX/bin
-#copy docs
-mkdir -p $PKG/$DOCDIR/help
-cp $DOCSRCDIR/* $PKG/$DOCDIR
-cp $MAKEDIR/README* $MAKEDIR/LICENSE $PKG/$DOCDIR
-cp $MYDIR/../copyright $PKG/$DOCDIR
-mkdir -p $PKG/$HELPDIR
-cp $HELPSRCDIR/help*.zip $PKG/$HELPDIR
-#move man pages to mandir
-mkdir -p $PKG/$MANDIR/man1
-mv $PKG/$DOCDIR/*.1 $PKG/$MANDIR/man1
-#copy lang
-mkdir -p $PKG/$IDIR
-cp -R $ISRCDIR/mos/* $PKG/$IDIR
-#copy XML files
-mkdir -p $PKG/$XMLDIR
-cp $XMLSRCDIR/* $PKG/$XMLDIR
+echo Building ...
+cd ${MAKEDIR}
+cmake ${FLAGS} ${GIT_ROOT} 2>&1 | tee $LOGS/cmake-${PRGNAM}.log || exit 1
+
+echo "- make"
+make ${MAKE_OPTIONS} 2>&1 | tee $LOGS/make-${PRGNAM}.log || exit 1
+
+echo "- prepare package"
+DESTDIR=${PKG} make install 2>&1 | tee $LOGS/install-${PRGNAM}.log || exit 1
+
+# collect files before packaging
+# move help
+mkdir -p ${PKG}/${HELPDIR}
+mv ${PKG}/${DEFHELPDIR}/* ${PKG}/${HELPDIR}
+rmdir ${PKG}/${DEFHELPDIR}
+# copy docs
+mkdir -p ${PKG}/${DOCDIR}
+cp ${GIT_ROOT}/README* ${GIT_ROOT}/LICENSE ${GIT_ROOT}/install/copyright ${PKG}/${DOCDIR}
+mv ${PKG}${DEFDOCDIR}/* ${PKG}/${DOCDIR} || true
+rmdir ${PKG}/${DEFDOCDIR}
+
+# move XML files
+mkdir -p ${PKG}/${XMLDIR}
+mv ${PKG}/${DEFXMLDIR}/* ${PKG}/${XMLDIR}
+rmdir ${PKG}/${DEFXMLDIR}
+
 #copy buildscript
-mkdir -p $PKG/usr/src/slackbuild
-cp -a $MYDIR/$PRGNAM.SlackBuild $PKG/usr/src/slackbuild/
-mkdir -p $PKG/$PIXMAPDIR
-cp $MYDIR/../graphics/pwsafe.png $PKG/$PIXMAPDIR
-mkdir -p $PKG/$APPDIR
-cp $MYDIR/../desktop/pwsafe.desktop $PKG/$APPDIR
-#prepare package
-cd $PKG
+mkdir -p ${PKG}/usr/src/slackbuild
+cp -a ${MYDIR}/${PRGNAM}.SlackBuild ${PKG}/usr/src/slackbuild/
+
+cd ${PKG}
 # remove debugging symbols
 find . -print0 | xargs -0 file | grep "executable" | grep ELF | cut -f 1 -d : | xargs -0 strip --strip-unneeded 2> /dev/null || true
 find . -print0 | xargs -0 file | grep "shared object" | grep ELF | cut -f 1 -d : | xargs -0 strip --strip-unneeded 2> /dev/null || true
 
 # fix permissions
-find $PKG -type f -print0 | xargs -0 --no-run-if-empty chmod 644 
-chmod 755 $PKG/$PREFIX/bin/*
+find . -type f -print0 | xargs -0 --no-run-if-empty chmod 644
+chmod 755 ${PKG}/${PREFIX}/bin/*
 
-# compress doc files > 4 kB
-find $PKG/$DOCDIR -type f -size +4k ! -iname *.htm ! -iname *.html ! -iname *.sh ! -iname *.zip -print0 |
-	xargs -0 --no-run-if-empty /bin/gzip --verbose --best
-# Compress and link manpages, if any:
-if [ -d $PKG/$PREFIX/man ]; then
-  ( cd $PKG/$PREFIX/man
-    for mandir in $(find . -type d -name "man*") ; do
-      ( cd $mandir
-        for page in $( find . -type l -maxdepth 1) ; do
-          ln -s $( readlink $page ).gz $page.gz
-          rm $page
-        done
-        gzip -9 *.*
-      )
-    done
-  )
-fi
-
-mkdir -p $PKG/install
+mkdir  ${PKG}/install
 
 # make slack-desc package description file
-cp $MYDIR/slack-desc $PKG/install/slack-desc
-echo "$PRGNAM: build at $DATE" >> $PKG/install/slack-desc
+cp ${MYDIR}/slack-desc ${PKG}/install/slack-desc
+echo "${PRGNAM}: build at ${DATE}" >> ${PKG}/install/slack-desc
 
 set +o xtrace
 
-ROOTCOMMANDS="set -o errexit -o xtrace -o pipefail ; cd $PKG;
+ROOTCOMMANDS="set -o errexit -o xtrace -o pipefail ; cd ${PKG};
     chown -R root:root . ;"
-ROOTCOMMANDS="$ROOTCOMMANDS
+ROOTCOMMANDS="${ROOTCOMMANDS}
     if [ -x /usr/bin/requiredbuilder ]; then /usr/bin/requiredbuilder -v -b -p -y .; fi ;
-    /sbin/makepkg --linkadd y --chown n $OUTPUT/$PKGNAME.txz 2>&1 | tee $LOGS/makepkg-${PRGNAM}.log ;
-    cd $OUTPUT ;
-    md5sum $PKGNAME.txz > $PKGNAME.txz.md5 ;
-    rm -rf $PKG"
+    /sbin/makepkg --linkadd y --chown n ${OUTPUT}/${PKGNAME}.txz 2>&1 | tee ${LOGS}/makepkg-${PRGNAM}.log ;
+    cd ${OUTPUT};
+    md5sum ${PKGNAME}.txz > ${PKGNAME}.txz.md5;
+    rm -rf ${PKG}"
 
 if [ $UID = 0 ]; then
-    eval $ROOTCOMMANDS
+    eval ${ROOTCOMMANDS}
     set +o xtrace
 elif [ -x /usr/bin/fakeroot ]; then
     echo "[1mEntering fakeroot environment.[0m"
-    echo $ROOTCOMMANDS | /usr/bin/fakeroot
+    echo ${ROOTCOMMANDS} | /usr/bin/fakeroot
 else
     echo "[1mPlease enter your root password.[0m"
-    /bin/su -c "$ROOTCOMMANDS"
+    /bin/su -c "${ROOTCOMMANDS}"
 fi
 
-echo "Package is ready in $OUTPUT/$PKGNAME.txz"
+echo "Package is ready in ${OUTPUT}/${PKGNAME}.txz"
 #####


### PR DESCRIPTION
I've updated SlackBuild to use cmake, also there are few fixes for wx help archives built with CMake:
- temporary CMakeFiles directory was included into help archive;
- wx (at least in linux) wants to have `/` instead of `\` in path to files inside hhc/hhk/hhp, so I've added conversion step (but maybe it'll be better to use `/` in original hhc/hhk/hhp, hhw/hhc should support it too)