### PR TITLE
Fix #1426 "Linux, Tree View: Arrow key Behavior Not as Expected"

### DIFF
--- a/src/ui/wxWidgets/PWStree.cpp
+++ b/src/ui/wxWidgets/PWStree.cpp
@@ -99,6 +99,7 @@ BEGIN_EVENT_TABLE( PWSTreeCtrl, wxTreeCtrl )
   EVT_MENU( ID_RENAME, PWSTreeCtrl::OnRenameGroup )
   EVT_TREE_END_LABEL_EDIT( ID_TREECTRL, PWSTreeCtrl::OnEndLabelEdit )
   EVT_TREE_END_LABEL_EDIT( ID_TREECTRL_1, PWSTreeCtrl::OnEndLabelEdit )
+  EVT_TREE_KEY_DOWN( ID_TREECTRL, PWSTreeCtrl::OnKeyDown )
 ////@end PWSTreeCtrl event table entries
 END_EVENT_TABLE()
 
@@ -695,6 +696,21 @@ void PWSTreeCtrl::OnEndLabelEdit( wxTreeEvent& evt )
       wxFAIL_MSG(wxString::Format(wxT("End Label Edit handler received an unexpected identifier: %d"), evt.GetId()));
       break;
   }
+}
+
+void PWSTreeCtrl::OnKeyDown(wxTreeEvent& evt)
+{
+  if (evt.GetKeyCode() == WXK_LEFT) {
+    
+    wxTreeItemId item = GetSelection();
+    
+    if (item.IsOk() && ItemIsGroup(item) && IsExpanded(item)) {
+      Collapse(item);
+      return;
+    }
+  }
+
+  evt.Skip();
 }
 
 void PWSTreeCtrl::FinishAddingGroup(wxTreeEvent& evt, wxTreeItemId groupItem)

--- a/src/ui/wxWidgets/PWStree.h
+++ b/src/ui/wxWidgets/PWStree.h
@@ -17,6 +17,7 @@
  */
 
 ////@begin includes
+#include "wx/treebase.h"
 #include "wx/treectrl.h"
 ////@end includes
 #include "core/ItemData.h"
@@ -101,6 +102,9 @@ public:
   void OnRenameGroup(wxCommandEvent& evt);
 
   void OnEndLabelEdit( wxTreeEvent& evt );
+  
+  /// wxEVT_TREE_KEY_DOWN event handler for ID_TREECTRL
+  void OnKeyDown(wxTreeEvent& evt);
 
 ////@begin PWSTreeCtrl member function declarations
 


### PR DESCRIPTION
Fixes the reported issue #1426 on Sourceforge.
Now, left arrow key collapses a selected group or 
moves the selection up to the next item in the tree.