### PR TITLE
Implement save and restore of tree state

### DIFF
--- a/src/ui/wxWidgets/PWStree.cpp
+++ b/src/ui/wxWidgets/PWStree.cpp
@@ -869,7 +869,7 @@ std::vector<bool> PWSTreeCtrl::GetGroupDisplayState()
     GetRootItem(), 
     [&]
     (wxTreeItemId itemId) -> void { 
-      IsExpanded(itemId) ? groupstates.push_back(true) : groupstates.push_back(false);
+      groupstates.push_back(IsExpanded(itemId));
     }
   );
   

--- a/src/ui/wxWidgets/PWStree.h
+++ b/src/ui/wxWidgets/PWStree.h
@@ -125,6 +125,11 @@ public:
   void AddEmptyGroup(const StringX& group) { AddGroup(group); }
   void SetFilterState(bool state);
 
+  void SetGroupDisplayStateAllExpanded();
+  void SetGroupDisplayStateAllCollapsed();
+  void SaveGroupDisplayState();
+  void RestoreGroupDisplayState();
+
  private:
   //overridden from base for case-insensitive sort
   virtual int OnCompareItems(const wxTreeItemId& item1, const wxTreeItemId& item2);
@@ -136,6 +141,12 @@ public:
   void SetItemImage(const wxTreeItemId &node, const CItemData &item);
   void FinishAddingGroup(wxTreeEvent& evt, wxTreeItemId groupItem);
   void FinishRenamingGroup(wxTreeEvent& evt, wxTreeItemId groupItem, const wxString& oldPath);
+  
+  std::vector<bool> GetGroupDisplayState();
+  void SetGroupDisplayState(const std::vector<bool> &groupstates);
+  
+  template<typename GroupItemConsumer>
+  void TraverseTree(wxTreeItemId itemId, GroupItemConsumer&& consumer);
 ////@begin PWSTreeCtrl member variables
 ////@end PWSTreeCtrl member variables
   PWScore &m_core;

--- a/src/ui/wxWidgets/mainView.cpp
+++ b/src/ui/wxWidgets/mainView.cpp
@@ -59,7 +59,7 @@ void PasswordSafeFrame::OnListViewClick( wxCommandEvent& /* evt */ )
   PWSprefs::GetInstance()->SetPref(PWSprefs::LastView, _T("list"));
   ShowTree(false);
   ShowGrid(true);
-  m_currentView = GRID;
+  SetViewType(ViewType::GRID);
 }
 
 /*!
@@ -71,18 +71,18 @@ void PasswordSafeFrame::OnTreeViewClick( wxCommandEvent& /* evt */ )
   PWSprefs::GetInstance()->SetPref(PWSprefs::LastView, _T("tree"));
   ShowGrid(false);
   ShowTree(true);
-  m_currentView = TREE;
+  SetViewType(ViewType::TREE);
 }
 
 void PasswordSafeFrame::OnExpandAll(wxCommandEvent& /*evt*/)
 {
-  wxASSERT(m_currentView == TREE);
+  wxASSERT(IsTreeView());
   m_tree->ExpandAll();
 }
 
 void PasswordSafeFrame::OnCollapseAll(wxCommandEvent& /*evt*/)
 {
-  wxASSERT(m_currentView == TREE);
+  wxASSERT(IsTreeView());
 
   //we cannot just call wxTreeCtrl::CollapseAll(), since it tries to
   //collapse the invisible root item also, and thus ASSERTs

--- a/src/ui/wxWidgets/passwordsafeframe.cpp
+++ b/src/ui/wxWidgets/passwordsafeframe.cpp
@@ -264,7 +264,7 @@ PasswordSafeFrame::PasswordSafeFrame(wxWindow* parent, PWScore &core,
   : m_core(core), m_currentView(ViewType::GRID), m_search(0), m_sysTray(new SystemTray(this)),
     m_exitFromMenu(false), m_bRestoredDBUnsaved(false),
     m_RUEList(core), m_guiInfo(new GUIInfo), m_bTSUpdated(false), m_savedDBPrefs(wxEmptyString),
-    m_bShowExpiry(false), m_bFilterActive(false)
+    m_bShowExpiry(false), m_bFilterActive(false), m_InitialTreeDisplayStatusAtOpen(true)
 {
     Init();
     m_currentView = (PWSprefs::GetInstance()->GetPref(PWSprefs::LastView) == _T("list")) ? ViewType::GRID : ViewType::TREE;
@@ -848,8 +848,6 @@ void PasswordSafeFrame::ShowGrid(bool show)
 
 void PasswordSafeFrame::ShowTree(bool show)
 {
-  static bool initialShowTree = true;
-  
   if (show) {
     m_tree->Clear();
     wxFont font(towxstring(PWSprefs::GetInstance()->GetPref(PWSprefs::TreeFont)));
@@ -873,27 +871,31 @@ void PasswordSafeFrame::ShowTree(bool show)
     if (!m_tree->IsEmpty()) // avoid assertion!
       m_tree->SortChildrenRecursively(m_tree->GetRootItem());
 
-    m_guiInfo->RestoreTreeViewInfo(m_tree);
+    if (m_InitialTreeDisplayStatusAtOpen) {
+      m_InitialTreeDisplayStatusAtOpen = false;
+      
+      switch (PWSprefs::GetInstance()->GetPref(PWSprefs::TreeDisplayStatusAtOpen)) {
+        case PWSprefs::AllCollapsed:
+          m_tree->SetGroupDisplayStateAllCollapsed();
+          break;
+        case PWSprefs::AllExpanded:
+          m_tree->SetGroupDisplayStateAllExpanded();
+          break;
+        case PWSprefs::AsPerLastSave:
+          m_tree->RestoreGroupDisplayState();
+          break;
+        default:
+          m_tree->SetGroupDisplayStateAllCollapsed();
+      }
+      
+      m_guiInfo->SaveTreeViewInfo(m_tree);
+    }
+    else {
+      m_guiInfo->RestoreTreeViewInfo(m_tree);
+    }
   }
   else {
     m_guiInfo->SaveTreeViewInfo(m_tree);
-  }
-  
-  if (initialShowTree) {
-    switch (PWSprefs::GetInstance()->GetPref(PWSprefs::TreeDisplayStatusAtOpen)) {
-      case PWSprefs::AllCollapsed:
-        m_tree->SetGroupDisplayStateAllCollapsed();
-        break;
-      case PWSprefs::AllExpanded:
-        m_tree->SetGroupDisplayStateAllExpanded();
-        break;
-      case PWSprefs::AsPerLastSave:
-        m_tree->RestoreGroupDisplayState();
-        break;
-      default:
-        m_tree->SetGroupDisplayStateAllCollapsed();
-    }
-    initialShowTree = false;
   }
   
   m_tree->Show(show);
@@ -1211,6 +1213,7 @@ int PasswordSafeFrame::Open(const wxString &fname)
     StringX password = pwdprompt.GetPassword();
     int retval = Load(password);
     if (retval == PWScore::SUCCESS) {
+      m_InitialTreeDisplayStatusAtOpen = true;
       Show();
       wxGetApp().recentDatabases().AddFileToHistory(fname);
     }

--- a/src/ui/wxWidgets/passwordsafeframe.cpp
+++ b/src/ui/wxWidgets/passwordsafeframe.cpp
@@ -249,7 +249,7 @@ static void DisplayFileWriteError(int rc, const StringX &fname);
  */
 
 PasswordSafeFrame::PasswordSafeFrame(PWScore &core)
-: m_core(core), m_currentView(GRID), m_search(0), m_sysTray(new SystemTray(this)),
+: m_core(core), m_currentView(ViewType::GRID), m_search(0), m_sysTray(new SystemTray(this)),
   m_exitFromMenu(false), m_bRestoredDBUnsaved(false),
   m_RUEList(core), m_guiInfo(new GUIInfo), m_bTSUpdated(false), m_savedDBPrefs(wxEmptyString),
   m_bShowExpiry(false), m_bFilterActive(false)
@@ -261,13 +261,13 @@ PasswordSafeFrame::PasswordSafeFrame(wxWindow* parent, PWScore &core,
                                      wxWindowID id, const wxString& caption,
                                      const wxPoint& pos, const wxSize& size,
                                      long style)
-  : m_core(core), m_currentView(GRID), m_search(0), m_sysTray(new SystemTray(this)),
+  : m_core(core), m_currentView(ViewType::GRID), m_search(0), m_sysTray(new SystemTray(this)),
     m_exitFromMenu(false), m_bRestoredDBUnsaved(false),
     m_RUEList(core), m_guiInfo(new GUIInfo), m_bTSUpdated(false), m_savedDBPrefs(wxEmptyString),
     m_bShowExpiry(false), m_bFilterActive(false)
 {
     Init();
-    m_currentView = (PWSprefs::GetInstance()->GetPref(PWSprefs::LastView) == _T("list")) ? GRID : TREE;
+    m_currentView = (PWSprefs::GetInstance()->GetPref(PWSprefs::LastView) == _T("list")) ? ViewType::GRID : ViewType::TREE;
     if (PWSprefs::GetInstance()->GetPref(PWSprefs::AlwaysOnTop))
       style |= wxSTAY_ON_TOP;
     Create( parent, id, caption, pos, size, style );
@@ -537,7 +537,7 @@ void PasswordSafeFrame::CreateMenubar()
     menuBar->Refresh();
 
   // Update menu selections
-  GetMenuBar()->Check( (m_currentView == TREE) ? ID_TREE_VIEW : ID_LIST_VIEW, true);
+  GetMenuBar()->Check( (IsTreeView()) ? ID_TREE_VIEW : ID_LIST_VIEW, true);
   GetMenuBar()->Check( PWSprefs::GetInstance()->GetPref(PWSprefs::UseNewToolbar) ?
                        ID_TOOLBAR_NEW: ID_TOOLBAR_CLASSIC, true );
   m_statusBar->Setup();
@@ -800,8 +800,9 @@ int PasswordSafeFrame::Load(const StringX &passwd)
 
 bool PasswordSafeFrame::Show(bool show)
 {
-  ShowGrid(show && (m_currentView == GRID));
-  ShowTree(show && (m_currentView == TREE));
+  ShowGrid(show && IsGridView());
+  ShowTree(show && IsTreeView());
+  
   return wxFrame::Show(show);
 }
 
@@ -847,6 +848,8 @@ void PasswordSafeFrame::ShowGrid(bool show)
 
 void PasswordSafeFrame::ShowTree(bool show)
 {
+  static bool initialShowTree = true;
+  
   if (show) {
     m_tree->Clear();
     wxFont font(towxstring(PWSprefs::GetInstance()->GetPref(PWSprefs::TreeFont)));
@@ -875,7 +878,24 @@ void PasswordSafeFrame::ShowTree(bool show)
   else {
     m_guiInfo->SaveTreeViewInfo(m_tree);
   }
-
+  
+  if (initialShowTree) {
+    switch (PWSprefs::GetInstance()->GetPref(PWSprefs::TreeDisplayStatusAtOpen)) {
+      case PWSprefs::AllCollapsed:
+        m_tree->SetGroupDisplayStateAllCollapsed();
+        break;
+      case PWSprefs::AllExpanded:
+        m_tree->SetGroupDisplayStateAllExpanded();
+        break;
+      case PWSprefs::AsPerLastSave:
+        m_tree->RestoreGroupDisplayState();
+        break;
+      default:
+        m_tree->SetGroupDisplayStateAllCollapsed();
+    }
+    initialShowTree = false;
+  }
+  
   m_tree->Show(show);
   GetSizer()->Layout();
 }
@@ -911,6 +931,11 @@ int PasswordSafeFrame::Save(SaveType st /* = ST_INVALID*/)
   // Save Application related preferences
   prefs->SaveApplicationPreferences();
   prefs->SaveShortcuts();
+  
+  // Save Group Display State
+  if (IsTreeView() && prefs->GetPref(PWSprefs::TreeDisplayStatusAtOpen) == PWSprefs::AsPerLastSave) {
+    m_tree->SaveGroupDisplayState();
+  }
 
   if (m_core.GetCurFile().empty())
     return SaveAs();
@@ -1617,7 +1642,7 @@ void PasswordSafeFrame::OnEditBase(wxCommandEvent& /*evt*/)
 
 void PasswordSafeFrame::SelectItem(const CUUID& uuid)
 {
-    if (m_currentView == GRID) {
+    if (m_currentView == ViewType::GRID) {
       m_grid->SelectItem(uuid);
     }
     else {
@@ -1755,7 +1780,7 @@ void PasswordSafeFrame::OnContextMenu(const CItemData* item)
     groupEditMenu.Append(ID_ADDGROUP, _("Add &Group"));
     groupEditMenu.Append(ID_RENAME, _("&Rename Group"));
     groupEditMenu.Append(wxID_DELETE, _("&Delete Group"));
-    if (m_currentView == TREE)
+    if (IsTreeView())
       m_tree->PopupMenu(&groupEditMenu);
   } else {
     wxMenu itemEditMenu;
@@ -1836,7 +1861,7 @@ void PasswordSafeFrame::OnContextMenu(const CItemData* item)
       itemEditMenu.Delete(ID_RUNCOMMAND);
     }
 
-    if ( m_currentView == TREE )
+    if ( m_currentView == ViewType::TREE )
       m_tree->PopupMenu(&itemEditMenu);
     else
       m_grid->PopupMenu(&itemEditMenu);
@@ -1860,7 +1885,7 @@ CItemData* PasswordSafeFrame::GetBaseEntry(const CItemData *item) const
 //
 void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
 {
-  bool bGroupSelected(false), bFileIsReadOnly(false), bTreeView(m_currentView == TREE);
+  bool bGroupSelected(false), bFileIsReadOnly(false), bTreeView(IsTreeView());
   const CItemData *pci(nullptr), *pbci(nullptr);
 
   bFileIsReadOnly = m_core.IsReadOnly();
@@ -2017,7 +2042,7 @@ void PasswordSafeFrame::DatabaseModified(bool modified)
   }
   else if (m_core.HasDBChanged()) {  //"else if" => both DB and it's prefs can't change at the same time
     if (m_search) m_search->Invalidate();
-    if (m_currentView == TREE) {
+    if (IsTreeView()) {
       if (m_grid != NULL)
         m_grid->OnPasswordListModified();
     }
@@ -2160,7 +2185,7 @@ void PasswordSafeFrame::UpdateGUI(UpdateGUICommand::GUI_Action /*ga*/,
 }
 void PasswordSafeFrame::RefreshEntryFieldInGUI(const CItemData& item, CItemData::FieldType ft)
 {
-  if (m_currentView == GRID) {
+  if (m_currentView == ViewType::GRID) {
     m_grid->RefreshItemField(item.GetUUID(), ft);
   }
   else {
@@ -2172,7 +2197,7 @@ void PasswordSafeFrame::RefreshEntryFieldInGUI(const CItemData& item, CItemData:
 
 void PasswordSafeFrame::RefreshEntryPasswordInGUI(const CItemData& item)
 {
-  if (m_currentView == GRID) {
+  if (m_currentView == ViewType::GRID) {
     RefreshEntryFieldInGUI(item, CItemData::PASSWORD);
     //TODO: Update password history
   }
@@ -2188,10 +2213,10 @@ void PasswordSafeFrame::GUIRefreshEntry(const CItemData& item, bool bAllowFail)
   if (item.GetStatus() ==CItemData::ES_DELETED) {
     uuid_array_t uuid;
     item.GetUUID(uuid);
-    if (m_currentView == TREE) { m_tree->Remove(uuid); }
+    if (IsTreeView()) { m_tree->Remove(uuid); }
     else { m_grid->Remove(uuid); }
   } else {
-    if (m_currentView == TREE) { m_tree->UpdateItem(item); }
+    if (IsTreeView()) { m_tree->UpdateItem(item); }
     else { m_grid->UpdateItem(item); }
   }
 }
@@ -2978,7 +3003,7 @@ void PasswordSafeFrame::ViewReport(CReport& rpt)
   CViewReport vr(this, &rpt);
   vr.ShowModal();
 }
-
+ 
 void PasswordSafeFrame::OnExportVx(wxCommandEvent& evt)
 {
   int rc = PWScore::FAILURE;

--- a/src/ui/wxWidgets/passwordsafeframe.h
+++ b/src/ui/wxWidgets/passwordsafeframe.h
@@ -591,6 +591,8 @@ public:
   bool m_bShowExpiry, m_bShowUnsaved; // predefined filters
   bool m_bFilterActive;
   void ApplyFilters();
+  
+  bool m_InitialTreeDisplayStatusAtOpen;
 };
 
 BEGIN_DECLARE_EVENT_TYPES()

--- a/src/ui/wxWidgets/passwordsafeframe.h
+++ b/src/ui/wxWidgets/passwordsafeframe.h
@@ -166,6 +166,9 @@ class PasswordSafeFrame: public wxFrame, public UIInterFace
 {
     DECLARE_CLASS( PasswordSafeFrame )
     DECLARE_EVENT_TABLE()
+    
+private:
+    enum class ViewType { TREE, GRID } m_currentView;
 
 public:
     /// Constructors
@@ -424,7 +427,10 @@ public:
 
   void Execute(Command *pcmd, PWScore *pcore = NULL);
 
-  bool IsTreeView() const {return m_currentView == TREE;}
+  void SetViewType(const ViewType& view) { m_currentView = view; }
+  bool IsTreeView() const { return m_currentView == ViewType::TREE; }
+  bool IsGridView() const { return m_currentView == ViewType::GRID; }
+  
   void RefreshViews();
   void FlattenTree(OrderedItemList& olist);
 
@@ -550,7 +556,6 @@ public:
   /// File open, double-click, modify, r-o r/w, filter...
   void UpdateStatusBar();
   PWScore &m_core;
-  enum {TREE, GRID} m_currentView;
   PasswordSafeSearch* m_search;
   SystemTray* m_sysTray;
   bool m_exitFromMenu;


### PR DESCRIPTION
Resolves [issue 1407](https://sourceforge.net/p/passwordsafe/bugs/1407) 'PasswordSafe Linux 1.01B won't retain tree state' that was reported on Sourceforge.
Additionally, changed 'enum' to 'enum class' for more type safety regarding the property 'm_currentView'.