### PR TITLE
Prevent adding an additional slash to users preferences directory

### DIFF
--- a/src/os/unix/dir.cpp
+++ b/src/os/unix/dir.cpp
@@ -129,7 +129,7 @@ static stringT createuserprefsdir(void)
 {
   stringT cfgdir = pws_os::getenv("HOME", true);
   if (!cfgdir.empty()) {
-    cfgdir += _S("/.pwsafe");
+    cfgdir += _S(".pwsafe");
     struct stat statbuf;
     switch (::lstat(pws_os::tomb(cfgdir).c_str(), &statbuf)) {
     case 0:


### PR DESCRIPTION
pws_os::getenv already ensures that directory path ends with a slash.
Adding a slash in 'createuserprefsdir' leads to have two slashes
between the home and preferences directory.