### PR TITLE
[wx] Use IsTaskBarIconAvailable override only on wxWidgets before 3.0.4/3.1.1

### DIFF
--- a/src/ui/wxWidgets/wxutils.cpp
+++ b/src/ui/wxWidgets/wxutils.cpp
@@ -30,6 +30,7 @@
 #endif
 
 #include <wx/taskbar.h>
+#include <wx/versioninfo.h>
 
 /*
  * Reads a file into a PWScore object, and displays an appropriate msgbox
@@ -204,9 +205,15 @@ int pless(int* first, int* second) { return *first - *second; }
 bool IsTaskBarIconAvailable()
 {
 #if defined(__WXGTK__)
-  const wxLinuxDistributionInfo ldi = wxGetLinuxDistributionInfo();
-  if (ldi.Id.IsEmpty() || ldi.Id == wxT("Ubuntu") || ldi.Id == wxT("Fedora"))
-    return false;
+  const wxVersionInfo verInfo = wxGetLibraryVersionInfo();
+  int major = verInfo.GetMajor();
+  int minor = verInfo.GetMinor();
+  int micro = verInfo.GetMicro();
+  if (major < 3 || (minor == 0 && micro < 4) || (minor == 1 && micro < 1)) {
+    const wxLinuxDistributionInfo ldi = wxGetLinuxDistributionInfo();
+    if (ldi.Id.IsEmpty() || ldi.Id == wxT("Ubuntu") || ldi.Id == wxT("Fedora"))
+      return false;
+  }
 #endif
   return wxTaskBarIcon::IsAvailable();
 }


### PR DESCRIPTION
Current check for `ldi.Id.IsEmpty()` disable tray icon on any distro that have no `/etc/lsb_release` (for example, Slackware). 
wxWidgets 3.0.4/3.1.1 added check for non-X11 DM (https://github.com/wxWidgets/wxWidgets/commit/c0d77a721, https://github.com/wxWidgets/wxWidgets/commit/0d62f728), so it should be safe to use only wx's check when we use new (runtime) versions on any distro.
