### PR TITLE
Fix mixed release/debug autotools builds

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -47,8 +47,8 @@ export CPPFLAGS += -std=c++11
 all: I18N unicodedebug unicoderelease
 
 unicodedebug unicoderelease:
-	$(MAKE) -C src/os/unix $@
-	$(MAKE) -C src/core $@
+	$(MAKE) -C src/os/unix CONFIG=$@
+	$(MAKE) -C src/core CONFIG=$@
 	$(MAKE) -C src/ui/wxWidgets CONFIG=$@
 
 


### PR DESCRIPTION
When building with autotools, certain makefiles set compiler flags based
on the CONFIG value, which may be different from the build target. This
can lead to a "release" build being built with DEBUG defined.  This
can cause issues locating the help files, among other things.

This patch sets the CONFIG param for all sub-makefiles.

Tested on Debian 9.