### PR TITLE
Add menu items for lock/unlock of DB

### DIFF
--- a/src/ui/wxWidgets/passwordsafeframe.h
+++ b/src/ui/wxWidgets/passwordsafeframe.h
@@ -139,6 +139,8 @@ enum {
   ID_TOOLBAR_NEW,
   ID_TOOLBAR_CLASSIC,
   ID_SYNCHRONIZE,
+  ID_LOCK_SAFE,
+  ID_UNLOCK_SAFE,
 
   // languages
   ID_LANGUAGE_BEGIN,
@@ -366,6 +368,12 @@ public:
   /// wxEVT_ICONIZE event handler
   void OnIconize(wxIconizeEvent& evt);
 
+  /// wxEVT_COMMAND_MENU_SELECTED event handler for ID_LOCK_SAFE
+  void OnLockSafe(wxCommandEvent& evt);
+
+  /// wxEVT_COMMAND_MENU_SELECTED event handler for ID_UNLOCK_SAFE
+  void OnUnlockSafe(wxCommandEvent& evt);
+  
   /// wxEVT_COMMAND_MENU_SELECTED event handler for wxID_UNDO
   void OnUndo(wxCommandEvent& evt);
 
@@ -556,6 +564,7 @@ public:
   /// Update status bar - call when stuff changes:
   /// File open, double-click, modify, r-o r/w, filter...
   void UpdateStatusBar();
+  void UpdateMenuBar();
   PWScore &m_core;
   PasswordSafeSearch* m_search;
   SystemTray* m_sysTray;


### PR DESCRIPTION
- Added new menu items (Lock Safe/Unlock Safe) under menu item 'Edit'
  if taskbar icon is not available (see issue [#1443](https://sourceforge.net/p/passwordsafe/bugs/1443/) at SourceForge).

- Menu items 'Lock Safe', 'Unlock Safe' and 'Password Policies' are
  enabled and disabled depending on DB state.

- Related to reported issue [#446](https://github.com/pwsafe/pwsafe/issues/446) on GitHub.