### PR TITLE
Layoutimprovements of safecombinationsetup dialog

### DIFF
--- a/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
@@ -2145,10 +2145,9 @@ msgid ""
 "You can use any keyboard character. The combination is case-sensitive."
 msgstr ""
 "Eine neue Passwortdatenbank wird erstellt.\n"
-"Das Master-Passwort das sie eingeben, wird benutzt um die Passwortdatenbank zu "
-"verschlüsseln.\n"
-"Für das Master-Passwort kann jedes Zeichen der physischen oder der virtuellen "
-"Tastatur benutzt werden. Dabei wird die Groß-/Kleinschreibung beachtet."
+"Das Master-Passwort wird zur Verschlüsselung der Passwortdatenbank verwendet.\n"
+"Für das Master-Passwort darf jedes Zeichen der Tastatur verwendet werden.\n"
+"Dabei wird die Groß-/Kleinschreibung beachtet."
 
 #: ../../../ui/wxWidgets/safecombinationsetup.cpp:161
 msgid "Verify:"

--- a/src/ui/wxWidgets/safecombinationsetup.cpp
+++ b/src/ui/wxWidgets/safecombinationsetup.cpp
@@ -147,22 +147,22 @@ void CSafeCombinationSetup::CreateControls()
   itemDialog1->SetSizer(itemBoxSizer2);
 
   wxStaticText* itemStaticText3 = new wxStaticText( itemDialog1, wxID_STATIC, _("A new password database will be created.\nThe safe combination will be used to encrypt the password database file.\nYou can use any keyboard character. The combination is case-sensitive."), wxDefaultPosition, wxDefaultSize, 0 );
-  itemBoxSizer2->Add(itemStaticText3, 0, wxALIGN_LEFT|wxALL, 5);
+  itemBoxSizer2->Add(itemStaticText3, 0, wxALIGN_LEFT|wxALL, 15);
 
-  wxGridSizer* itemGridSizer4 = new wxGridSizer(2, 0, -50);
-  itemBoxSizer2->Add(itemGridSizer4, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5);
+  wxFlexGridSizer* itemGridSizer4 = new wxFlexGridSizer(2, 0, 10);
+  itemBoxSizer2->Add(itemGridSizer4, 0, wxALIGN_CENTER_HORIZONTAL|wxLEFT|wxRIGHT|wxEXPAND, 30);
 
   wxStaticText* itemStaticText5 = new wxStaticText( itemDialog1, wxID_STATIC, _("Safe Combination:"), wxDefaultPosition, wxDefaultSize, 0 );
   itemGridSizer4->Add(itemStaticText5, 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  wxTextCtrl* itemTextCtrl6 = new wxTextCtrl( itemDialog1, ID_PASSWORD, wxEmptyString, wxDefaultPosition, wxSize(itemDialog1->ConvertDialogToPixels(wxSize(120, -1)).x, -1), wxTE_PASSWORD );
-  itemGridSizer4->Add(itemTextCtrl6, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+  wxTextCtrl* itemTextCtrl6 = new wxTextCtrl( itemDialog1, ID_PASSWORD, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PASSWORD );
+  itemGridSizer4->Add(itemTextCtrl6, 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5);
 
   wxStaticText* itemStaticText7 = new wxStaticText( itemDialog1, wxID_STATIC, _("Verify:"), wxDefaultPosition, wxDefaultSize, 0 );
   itemGridSizer4->Add(itemStaticText7, 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  wxTextCtrl* itemTextCtrl8 = new wxTextCtrl( itemDialog1, ID_VERIFY, wxEmptyString, wxDefaultPosition, wxSize(itemDialog1->ConvertDialogToPixels(wxSize(120, -1)).x, -1), wxTE_PASSWORD );
-  itemGridSizer4->Add(itemTextCtrl8, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+  wxTextCtrl* itemTextCtrl8 = new wxTextCtrl( itemDialog1, ID_VERIFY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PASSWORD );
+  itemGridSizer4->Add(itemTextCtrl8, 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5);
 
 #ifndef NO_YUBI
   m_YubiBtn = new wxBitmapButton( itemDialog1, ID_YUBIBTN, itemDialog1->GetBitmapResource(wxT("graphics/Yubikey-button.xpm")), wxDefaultPosition, itemDialog1->ConvertDialogToPixels(wxSize(40, 15)), wxBU_AUTODRAW );
@@ -172,9 +172,11 @@ void CSafeCombinationSetup::CreateControls()
   itemGridSizer4->Add(m_yubiStatusCtrl, 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 #endif
 
+  itemGridSizer4->AddGrowableCol(1, 2);
+  
   wxStdDialogButtonSizer* itemStdDialogButtonSizer11 = new wxStdDialogButtonSizer;
 
-  itemBoxSizer2->Add(itemStdDialogButtonSizer11, 0, wxALIGN_LEFT|wxALL, 5);
+  itemBoxSizer2->Add(itemStdDialogButtonSizer11, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 10);
   wxButton* itemButton12 = new wxButton( itemDialog1, wxID_OK, _("&OK"), wxDefaultPosition, wxDefaultSize, 0 );
   itemStdDialogButtonSizer11->AddButton(itemButton12);
 


### PR DESCRIPTION
- Text fields of 'safecombinationsetup' dialog are now expandable to get available space
- The german text took too much space due to missing newline character so that dialog didn't look nice
- Centered buttons
- Added more gap between frame border and controls

**The original version with German text**
![pw_setup_dialog](https://user-images.githubusercontent.com/4042917/39971461-c2b0493e-56fb-11e8-8fa7-997be32c1474.png)
**The modified version with German text**
![pw_setup_dialog2](https://user-images.githubusercontent.com/4042917/39971462-ccad33f2-56fb-11e8-9f6a-102314c50c36.png)
**The modified version with English text**
![pw_setup_dialog3](https://user-images.githubusercontent.com/4042917/39971463-cf3d0296-56fb-11e8-9c19-a7b45b6c4bd7.png)
**The modified version with expandable text fields**
![pw_setup_dialog4](https://user-images.githubusercontent.com/4042917/39971464-d219c986-56fb-11e8-9d07-7eb61a90caee.png)
