### PR TITLE
Prevent lock/unlock if no safe is open

### DIFF
--- a/src/ui/wxWidgets/passwordsafeframe.cpp
+++ b/src/ui/wxWidgets/passwordsafeframe.cpp
@@ -2524,6 +2524,12 @@ void PasswordSafeFrame::SetFocus()
 }
 
 void PasswordSafeFrame::OnIconize(wxIconizeEvent& evt) {
+  
+  // If database was closed than there is nothing to do
+  if (m_core.GetCurFile().empty()) {
+    return;
+  }
+  
   const bool beingIconized =
 #if wxCHECK_VERSION(2,9,0)
     evt.IsIconized();


### PR DESCRIPTION
This prevents an assertion on maximize/restore if safe was closed previously.