### PR TITLE
Add check for virtual keyboard (xvkbd)

### DIFF
--- a/src/os/file.h
+++ b/src/os/file.h
@@ -37,6 +37,7 @@ namespace pws_os {
       time_t &ctime, time_t &mtime, time_t &atime);
   extern bool SetFileTimes(const stringT &filename,
       time_t ctime, time_t mtime, time_t atime);
+  extern bool ProgramExists(const stringT &filename);
   extern const TCHAR PathSeparator; // slash for Unix, backslash for Windows
 
   // Most stdio.h routines return -1 for an error (not INVALID_HANDLE_VALUE)

--- a/src/os/unix/file.cpp
+++ b/src/os/unix/file.cpp
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <cassert>
 #include <fstream>
+#include <sstream>
 
 #include <dirent.h>
 #include <fnmatch.h>
@@ -355,4 +356,37 @@ bool pws_os::SetFileTimes(const stringT &filename,
   UNREFERENCED_PARAMETER(atime);
 
   return true;
+}
+
+bool pws_os::ProgramExists(const stringT &filename)
+{
+  stringT pathEnvVar = pws_os::getenv("PATH", false);
+  
+  if (pathEnvVar.empty()) {
+    return false;
+  }
+
+  std::wistringstream wstringstream(pathEnvVar);
+  stringT path;
+
+  while(std::getline(wstringstream, path, _T(':')))
+  {
+    if (path.empty()) {
+      continue;
+    }
+    
+    if (path.back() != pws_os::PathSeparator) {
+      path.append(1, pws_os::PathSeparator);
+      path.append(filename);
+    }
+    else {
+      path.append(filename);
+    }
+    
+    if (pws_os::FileExists(path)) {
+      return true;
+    }
+  }
+  
+  return false;
 }

--- a/src/ui/wxWidgets/ExternalKeyboardButton.cpp
+++ b/src/ui/wxWidgets/ExternalKeyboardButton.cpp
@@ -10,14 +10,15 @@
 * 
 */
 // For compilers that support precompilation, includes "wx/wx.h".
-#include "wx/wxprec.h"
+#include <wx/wxprec.h>
 #include "../../core/PwsPlatform.h"
+#include "../../os/file.h"
 #ifdef __BORLANDC__
 #pragma hdrstop
 #endif
 
 #ifndef WX_PRECOMP
-#include "wx/wx.h"
+#include <wx/wx.h>
 #endif
 
 #include "./ExternalKeyboardButton.h"
@@ -66,7 +67,13 @@ void ExternalKeyboardButton::HandleCommandEvent(wxCommandEvent& evt)
   int xwinid = GDK_WINDOW_XWINDOW(window);
 #endif
   wxString command = wxString(wxT("xvkbd"));
-  
+
+  if (!pws_os::ProgramExists(command.wc_str())) {
+    wxMessageBox(_("Could not launch xvkbd.  Please make sure it's installed and in your PATH"), 
+                  _("Could not launch external onscreen keyboard"), wxOK | wxICON_ERROR);
+    return;
+  }
+
   switch(wxExecute(command, wxEXEC_ASYNC, nullptr)) //nullptr => we don't want a wxProcess as callback
   {
     case 0:
@@ -83,4 +90,5 @@ void ExternalKeyboardButton::HandleCommandEvent(wxCommandEvent& evt)
       break;
   }
 #endif
+
 }


### PR DESCRIPTION
If xvkbd (virtual keyboard) doesn't exist on users PC wxExecute still returns with a valid PID, which might be a [bug](http://wxwidgets.10942.n7.nabble.com/Asynchronous-wxExecute-failure-reporting-td78084.html) in the Wx framework. From the users perspective nothing points to the reason why the virtual keyboard doesn't appear, which looks like a problem of Password Safe. There are already two tickets on SourceForge referring to a not appearing virtual keyboard.

- [#930](https://sourceforge.net/p/passwordsafe/bugs/930/) Virtual keyboard doesn't work on Debian Linux
- [#944](https://sourceforge.net/p/passwordsafe/bugs/944/) Virtual keyboard not appearing