### PR TITLE
[MFC] Attempt to fix some issues win Clipboard

### DIFF
--- a/src/ui/Windows/PWSclipboard.cpp
+++ b/src/ui/Windows/PWSclipboard.cpp
@@ -61,7 +61,7 @@ private:
   static HGLOBAL s_hg;
   static size_t s_hgLen;
   static const UINT TIMER_ID = 576;
-  static void timerCallback(HWND, UINT, UINT_PTR, DWORD);
+  static void CALLBACK timerCallback(HWND, UINT, UINT_PTR, DWORD);
 };
 
 HGLOBAL PWSOleDataSource::s_hg;


### PR DESCRIPTION
- without `CALLBACK` compilation failed with VS 15.7.4;
- pwsafe crashed when clearing clipboard on lock if someone (for example, other pwsafe instance) put empty data to clipboard (we have invalid `dwlength`, because `GlobalSize` return unsigned value);
- sometimes global data at `s_hg` could be freed before timer callback (for example, when copying into VS).
