### PR TITLE
Cli fixes

### DIFF
--- a/src/ui/cli/diff.cpp
+++ b/src/ui/cli/diff.cpp
@@ -13,6 +13,7 @@
 
 #include "../../os/file.h"
 #include "../../core/core.h"
+#include "../../core/PWHistory.h"
 
 #include "../../core/StringXStream.h"
 #include <algorithm>
@@ -95,6 +96,21 @@ inline wostream& print_field_value(wostream &os, wchar_t tag,
       int16 dca = -1;
       if (item.GetDCA(dca) != -1) {
         LoadAString(fieldValue, dca2str(dca));
+      }
+      break;
+    }
+    case CItemData::PWHIST:
+    {
+      const StringX pwh_str = item.GetPWHistory();
+      if (!pwh_str.empty()) {
+        StringXStream value_stream;
+        size_t ignored;
+        PWHistList pwhl;
+        const bool save_pwhistory = CreatePWHistoryList(pwh_str, ignored, ignored, pwhl, PWSUtil::TMC_LOCALE);
+        value_stream << L"Save: " << (save_pwhistory? L"Yes" : L"No");
+        if ( !pwhl.empty() ) value_stream << endl;
+        for( const auto &pwh: pwhl) value_stream << pwh.changedate << L": " << pwh.password << endl;
+        fieldValue = value_stream.str();
       }
       break;
     }

--- a/src/ui/cli/diff.cpp
+++ b/src/ui/cli/diff.cpp
@@ -345,7 +345,7 @@ template <class left_line_t, class right_line_t>
 void sbs_print(const PWScore &core,
                const PWScore &otherCore,
                const CompareData &matches,
-               const CItemData::FieldBits comparedFields,
+               const CItemData::FieldBits &comparedFields,
                unsigned int cols, bool print_fields)
 {
   for_each( matches.cbegin(), matches.cend(), [&](const st_CompareData &cd) {
@@ -454,7 +454,6 @@ int Diff(PWScore &core, const UserArgs &ua)
 {
   CompareData current, comparison, conflicts, identical;
   PWScore otherCore;
-  constexpr bool treatWhitespacesAsEmpty = false;
   const StringX otherSafe{std2stringx(ua.opArg)};
 
   CItemData::FieldBits safeFields{ua.fields};
@@ -470,6 +469,7 @@ int Diff(PWScore &core, const UserArgs &ua)
 
   int status = OpenCore(otherCore, otherSafe);
   if ( status == PWScore::SUCCESS ) {
+    constexpr bool treatWhitespacesAsEmpty = false;
     core.Compare( &otherCore,
                   safeFields,
                          ua.subset.valid(),

--- a/src/ui/cli/diff.cpp
+++ b/src/ui/cli/diff.cpp
@@ -157,10 +157,10 @@ using unique_hdr_func_t = function<void(const st_CompareData &cd, wchar_t tag)>;
 void print_unique_items(wchar_t tag, const CompareData &cd, const PWScore &core,
                             unique_hdr_func_t hdr_fn)
 {
-  for_each(cd.cbegin(), cd.cend(), [tag, &core, &hdr_fn](const st_CompareData &d) {
+  for(const auto &d: cd) {
     hdr_fn(d, tag);
     const CItemData &item = core.Find(d.indatabase == CURRENT? d.uuid0: d.uuid1)->second;
-    for_each( begin(diff_fields), end(diff_fields), [&item, tag](CItemData::FieldType ft) {
+    for( auto ft : diff_fields ) {
       switch(ft) {
         case CItem::GROUP:
         case CItem::TITLE:
@@ -171,8 +171,8 @@ void print_unique_items(wchar_t tag, const CompareData &cd, const PWScore &core,
             print_field_value(wcout, tag, item, ft);
           }
       }
-    });
-  });
+    }
+  }
 }
 
 using item_diff_func_t = function<void(const CItemData &item,
@@ -183,8 +183,7 @@ using item_diff_func_t = function<void(const CItemData &item,
 void print_conflicting_item(const CItemData &item, const CItemData &otherItem,
                             const CItemData::FieldBits &fields, item_diff_func_t diff_fn)
 {
-  for_each( begin(diff_fields), end(diff_fields),
-              [&fields, &item, &otherItem, &diff_fn](CItemData::FieldType ft) {
+  for( auto ft: diff_fields ) {
     switch(ft) {
       case CItem::GROUP:
       case CItem::TITLE:
@@ -194,7 +193,7 @@ void print_conflicting_item(const CItemData &item, const CItemData &otherItem,
         diff_fn(item, otherItem, fields, ft);
         break;
     }
-  });
+  }
 }
 
 using conflict_hdr_func_t = function<void(const st_CompareData &cd,
@@ -205,13 +204,12 @@ void print_conflicts(const CompareData &conflicts, const PWScore &core,
                             const PWScore &otherCore, conflict_hdr_func_t hdr_fn,
                             item_diff_func_t diff_fn)
 {
-  for_each( conflicts.cbegin(), conflicts.cend(),
-                    [&core, &otherCore, &hdr_fn, &diff_fn](const st_CompareData &cd) {
+  for( const auto &cd: conflicts ) {
     const CItemData &item = core.Find(cd.uuid0)->second;
     const CItemData &otherItem = otherCore.Find(cd.uuid1)->second;
     hdr_fn(cd, item, otherItem);
     print_conflicting_item(item, otherItem, cd.bsDiffs, diff_fn);
-  });
+  }
 }
 
 //////////////////////////////////////////////////////////////////
@@ -334,9 +332,7 @@ StringType resize(StringType s, typename StringType::size_type len) {
 }
 
 lines_vec resize_lines(lines_vec lines, line_t::size_type cols ) {
-  std::for_each(lines.begin(), lines.end(), [cols](line_t &line) {
-    line = resize(line, cols);
-  });
+  for( auto &line: lines ) line = resize(line, cols);
   return lines;
 }
 
@@ -348,13 +344,13 @@ void sbs_print(const PWScore &core,
                const CItemData::FieldBits &comparedFields,
                unsigned int cols, bool print_fields)
 {
-  for_each( matches.cbegin(), matches.cend(), [&](const st_CompareData &cd) {
+  for( const auto &cd: matches ) {
     const CItemData::FieldBits &df = cd.bsDiffs.any()? cd.bsDiffs: comparedFields;
     left_line_t left_line{core, cd.uuid0, cols};
     right_line_t right_line{otherCore, cd.uuid1, cols};
     wcout << left_line() << L'|' << right_line() << endl;
     if ( print_fields ) {
-      for_each(begin(diff_fields), end(diff_fields), [&](CItemData::FieldType ft) {
+      for( auto ft: diff_fields ) {
         // print the fields if they were actually found to be different
         if (df.test(ft)) {
           StringXStream wssl, wssr;
@@ -370,11 +366,11 @@ void sbs_print(const PWScore &core,
           for (lines_vec::size_type idx = 0; idx < left_lines.size(); ++idx)
               wcout << left_lines[idx] << L'|' << right_lines[idx] << endl;
         }
-      });
+      }
     }
     wcout << resize(wstring(cols/5, left_line.sep_char), cols) << L'|'
           << resize(wstring(cols/5, right_line.sep_char), cols) << endl;
-  });
+  }
 };
 
 struct field_to_line
@@ -458,12 +454,11 @@ int Diff(PWScore &core, const UserArgs &ua)
 
   CItemData::FieldBits safeFields{ua.fields};
   safeFields.reset(CItem::POLICY);
-  for_each( begin(diff_fields), end(diff_fields),
-                [&ua, &safeFields](CItemData::FieldType ft) {
+  for( auto ft: diff_fields ) {
     if (ua.fields.test(ft) && CItemData::IsTextField(ft)) {
       safeFields.set(ft);
     }
-  });
+  }
   safeFields.reset(CItem::POLICY);
   safeFields.reset(CItem::RMTIME);
 

--- a/src/ui/cli/diff.cpp
+++ b/src/ui/cli/diff.cpp
@@ -304,20 +304,27 @@ static void context_diff(const PWScore &core, const PWScore &otherCore,
 // Side-by-side diff
 //////////
 
-using lines_vec = std::vector<std::wstring>;
-lines_vec stream2vec(StringXStream &wss, unsigned int offset, unsigned int columns) {
+using lines_t = std::wstring;
+using lines_vec = std::vector<lines_t>;
+
+lines_vec resize_lines(lines_vec lines, lines_t::size_type cols ) {
+  std::for_each(lines.begin(), lines.end(), [cols](lines_t &line) {
+    if (line.size() < cols) line.resize(cols, ' ');
+  });
+  return lines;
+}
+
+lines_vec stream2vec(StringXStream &wss, unsigned int offset) {
     lines_vec vlines;
     bool first_line = true;
     do {
         wstring line;
         std::getline(wss, line);
         if (first_line) {
-            line.resize(columns, L' ');
             vlines.push_back(line);
             first_line = false;
         } else {
             if ( !line.empty() ) {
-                line.resize(columns - offset, L' ');
                 vlines.push_back(wstring(offset, L' ') + line);
             }
         }
@@ -347,8 +354,8 @@ void sbs_print(const PWScore &core,
           wssl << left_line(ft) << flush;
           wssr << right_line(ft) << flush;
           const auto value_offset = CItemData::FieldName(ft).length() + 4;
-          lines_vec left_lines{stream2vec(wssl, value_offset, cols)},
-                  right_lines{stream2vec(wssr, value_offset, cols)};
+          lines_vec left_lines{resize_lines(stream2vec(wssl, value_offset), cols)},
+                  right_lines{resize_lines(stream2vec(wssr, value_offset), cols)};
           const int ndiff = left_lines.size() - right_lines.size();
           if (ndiff < 0)
               left_lines.insert(left_lines.end(), -ndiff, wstring(cols, L' '));

--- a/src/ui/cli/diff.cpp
+++ b/src/ui/cli/diff.cpp
@@ -12,6 +12,7 @@
 #include "./safeutils.h"
 
 #include "../../os/file.h"
+#include "../../core/core.h"
 
 #include "../../core/StringXStream.h"
 #include <algorithm>
@@ -65,10 +66,43 @@ inline StringX safe_file_hdr(const wchar_t *tag, const PWScore &core)
   return os.str();
 }
 
+uint32_t dca2str(uint16 dca) {
+  const std::map<int16_t, uint32_t> dca_id_str = {
+    {PWSprefs::DoubleClickAutoType,             IDSC_DCAAUTOTYPE},
+    {PWSprefs::DoubleClickBrowse,               IDSC_DCABROWSE},
+    {PWSprefs::DoubleClickBrowsePlus,           IDSC_DCABROWSEPLUS},
+    {PWSprefs::DoubleClickCopyNotes,            IDSC_DCACOPYNOTES},
+    {PWSprefs::DoubleClickCopyUsername,         IDSC_DCACOPYUSERNAME},
+    {PWSprefs::DoubleClickCopyPassword,         IDSC_DCACOPYPASSWORD},
+    {PWSprefs::DoubleClickCopyPasswordMinimize, IDSC_DCACOPYPASSWORDMIN},
+    {PWSprefs::DoubleClickRun,                  IDSC_DCARUN},
+    {PWSprefs::DoubleClickSendEmail,            IDSC_DCASENDEMAIL},
+    {PWSprefs::DoubleClickViewEdit,             IDSC_DCAVIEWEDIT}
+  };
+
+  const auto loc = dca_id_str.find(dca);
+  return loc != dca_id_str.end() ? loc->second: IDSC_INVALID;
+}
+
 inline wostream& print_field_value(wostream &os, wchar_t tag,
                                     const CItemData &item, CItemData::FieldType ft)
 {
-  return os << tag << L' ' << item.FieldName(ft) << L": " << item.GetFieldValue(ft);
+  StringX fieldValue;
+  switch (ft) {
+    case CItemData::DCA:
+    case CItemData::SHIFTDCA:
+    {
+      int16 dca = -1;
+      if (item.GetDCA(dca) != -1) {
+        LoadAString(fieldValue, dca2str(dca));
+      }
+      break;
+    }
+    default:
+      fieldValue = item.GetFieldValue(ft);
+      break;
+  }
+  return os << tag << L' ' << item.FieldName(ft) << L": " << fieldValue;
 }
 
 inline StringX rmtime(wchar_t tag, const CItemData &i)

--- a/src/ui/cli/diff.cpp
+++ b/src/ui/cli/diff.cpp
@@ -218,7 +218,8 @@ void print_conflicts(const CompareData &conflicts, const PWScore &core,
 void unified_print_unique_items(wchar_t tag, const CompareData &cd, const PWScore &core)
 {
   print_unique_items(tag, cd, core, [](const st_CompareData &cd, wchar_t tag) {
-    wcout << tag << st_GroupTitleUser{cd.group, cd.title, cd.user} << endl;
+    wcout << L"***************" << endl
+          << tag << st_GroupTitleUser{cd.group, cd.title, cd.user} << endl;
   });
 }
 
@@ -234,7 +235,8 @@ static void unified_diff(const PWScore &core, const PWScore &otherCore,
   auto hdr_fn = [](const st_CompareData &cd,
                    const CItemData &item,
                    const CItemData &otherItem) {
-    wcout << L"@@ " << st_GroupTitleUser{cd.group, cd.title, cd.user}
+    wcout << L"***************" << endl
+          << L"@@ " << st_GroupTitleUser{cd.group, cd.title, cd.user}
           << rmtime(L'-', item) << rmtime(L'+', otherItem) << L" @@" << endl;
   };
 

--- a/src/ui/cli/diff.cpp
+++ b/src/ui/cli/diff.cpp
@@ -174,7 +174,7 @@ void print_unique_items(wchar_t tag, const CompareData &cd, const PWScore &core,
         case CItem::USER:
           break;
         default:
-          if ( !item.GetFieldValue(ft).empty() ) {
+          if ( d.bsDiffs.test(ft) && !item.GetFieldValue(ft).empty() ) {
             print_field_value(wcout, tag, item, ft);
           }
       }

--- a/src/ui/cli/main.cpp
+++ b/src/ui/cli/main.cpp
@@ -83,7 +83,7 @@ static void usage(char *pname)
        << "       " << " = => exactly similar" << endl
        << "       " << " ^ => begins-with" << endl
        << "       " << " $ => ends with" << endl
-       << "       " << " ^ => contains" << endl
+       << "       " << " ~ => contains" << endl
        << "       " << " ! => negation" << endl
        << "       " << "a trailing /i => case insensitive, /I => case sensitive" << endl
        ;


### PR DESCRIPTION
1. Better indent multiline fields, like Notes & password history, especially in side-by-side diffs
2. Show human-readable values for password policy, history & double-click actions
3. While comparing, print only relevant fields, like those that were actually compared.