### PR TITLE
[wx] Introduce IsDbOpen() to the core

### DIFF
--- a/src/core/PWScore.h
+++ b/src/core/PWScore.h
@@ -125,6 +125,7 @@ public:
   void ReInit(bool bNewfile = false);
 
   // Following used to read/write databases and Get/Set file name
+  bool IsDbOpen() const { return !m_currfile.empty(); }
   StringX GetCurFile() const {return m_currfile;}
   void SetCurFile(const StringX &file) {m_currfile = file;}
 

--- a/src/ui/wxWidgets/mainManage.cpp
+++ b/src/ui/wxWidgets/mainManage.cpp
@@ -54,7 +54,7 @@ void PasswordSafeFrame::OnPreferencesClick( wxCommandEvent& /* evt */ )
     if (m_sysTray && prefs->GetPref(PWSprefs::UseSystemTray))
         m_sysTray->ShowIcon();
 
-    if (!m_core.GetCurFile().empty() && !m_core.IsReadOnly() &&
+    if (m_core.IsDbOpen() && !m_core.IsReadOnly() &&
         m_core.GetReadFileVersion() >= PWSfile::V30) { // older versions don't have prefs
       if (sxOldDBPrefsString != sxNewDBPrefsString ||
           m_core.GetHashIters() != window->GetHashItersValue()) {
@@ -85,7 +85,7 @@ void PasswordSafeFrame::OnBackupSafe(wxCommandEvent& /*evt*/)
   const wxString title(_("Please Choose a Name for this Backup:"));
 
   wxString dir;
-  if (m_core.GetCurFile().empty())
+  if (!m_core.IsDbOpen())
     dir = towxstring(PWSdirs::GetSafeDir());
   else {
     wxFileName::SplitPath(towxstring(m_core.GetCurFile()), &dir, nullptr, nullptr);
@@ -139,7 +139,7 @@ void PasswordSafeFrame::OnRestoreSafe(wxCommandEvent& /*evt*/)
   const wxFileName currbackup(towxstring(PWSprefs::GetInstance()->GetPref(PWSprefs::CurrentBackup)));
 
   wxString dir;
-  if (m_core.GetCurFile().empty())
+  if (!m_core.IsDbOpen())
     dir = towxstring(PWSdirs::GetSafeDir());
   else {
     wxFileName::SplitPath(towxstring(m_core.GetCurFile()), &dir, nullptr, nullptr);

--- a/src/ui/wxWidgets/pwsafeapp.cpp
+++ b/src/ui/wxWidgets/pwsafeapp.cpp
@@ -572,7 +572,7 @@ int PwsafeApp::OnExit()
   m_idleTimer->Stop();
   recentDatabases().Save();
   PWSprefs *prefs = PWSprefs::GetInstance();
-  if (!m_core.GetCurFile().empty())
+  if (m_core.IsDbOpen())
     prefs->SetPref(PWSprefs::CurrentFile, m_core.GetCurFile());
   // Save Application related preferences
   prefs->SaveApplicationPreferences();


### PR DESCRIPTION
This allows a more expressive check for an open database.

    Example: m_core.IsDbOpen()

Replaces in the wx implementation all checks for an empty
database file name string.

    Example: !m_core.GetCurFile().empty()