### PR TITLE
[wip] Mac build fixes

### DIFF
--- a/Xcode/generate-configs
+++ b/Xcode/generate-configs
@@ -34,8 +34,16 @@ foreach(split /\s+/, `$wxconfig --libs --unicode=yes --debug=$dbgflag`) {
 }
 print "OTHER_LDFLAGS = -L/usr/local/lib ", $libflags, "\n";
 
-my $cxxflags;
+my @HEADER_SEARCH_PATHS;
+my @GCC_PREPROCESSOR_DEFINITIONS;
 foreach(split /\s+/, `$wxconfig --cxxflags --unicode=yes --debug=$dbgflag`) {
-	$cxxflags .= $1." " if /\A-I(.+)/;
+    if (/\A-I(.+)/) {
+        push @HEADER_SEARCH_PATHS, $1;
+    }
+    if (/\A-D(.+)/) {
+        push @GCC_PREPROCESSOR_DEFINITIONS, $1;
+    }
 }
-print "HEADER_SEARCH_PATHS = ", $cxxflags, "\n";
+print "HEADER_SEARCH_PATHS = ".join(' ', @HEADER_SEARCH_PATHS)."\n";
+print "GCC_PREPROCESSOR_DEFINITIONS = ".join(' ', @GCC_PREPROCESSOR_DEFINITIONS)."\n";
+

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		6FF5D4A11DA14EE80032F5B6 /* passwordsubset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF5D49D1DA14AB20032F5B6 /* passwordsubset.cpp */; };
+		A29413002132D2F40054535C /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6B1448712B26D1500415AAE /* Cocoa.framework */; };
 		A2D181461C8FF86C0018AE03 /* media.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2D181451C8FF86C0018AE03 /* media.cpp */; };
 		A2FE25801C5ACEFD00210C36 /* AES.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE257E1C5ACEFD00210C36 /* AES.cpp */; };
 		A2FE258D1C5ACF7500210C36 /* Item.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25811C5ACF7500210C36 /* Item.cpp */; };
@@ -617,7 +618,7 @@
 		E6C94E911FA20593008F0072 /* pwsqrcodedlg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pwsqrcodedlg.cpp; sourceTree = "<group>"; };
 		E6C94E921FA20593008F0072 /* pwsqrcodedlg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pwsqrcodedlg.h; sourceTree = "<group>"; };
 		E6C94E941FA205E9008F0072 /* pwsqrencode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pwsqrencode.h; sourceTree = "<group>"; };
-		E6C94E951FA2075B008F0072 /* pwsqrencode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "pwsqrencode.mm"; sourceTree = "<group>"; };
+		E6C94E951FA2075B008F0072 /* pwsqrencode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = pwsqrencode.mm; sourceTree = "<group>"; };
 		E6C94E971FA3399F008F0072 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		E6C94E991FA33BA6008F0072 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E6CFEE4311EA0AFB001402D8 /* RecentDBList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RecentDBList.h; sourceTree = "<group>"; };
@@ -753,6 +754,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A29413002132D2F40054535C /* Cocoa.framework in Frameworks */,
 				E66D293E1D02B94C00C9BCBF /* Carbon.framework in Frameworks */,
 				E66D293C1D02B92F00C9BCBF /* libcore.a in Frameworks */,
 				E66D293D1D02B92F00C9BCBF /* libos.a in Frameworks */,
@@ -776,6 +778,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A29412FF2132D2F40054535C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		E6069D0319FE1CCA0055040F /* Configs */ = {
 			isa = PBXGroup;
 			children = (
@@ -1147,6 +1156,7 @@
 				E6B1448112B26CEE00415AAE /* OpenGL.framework */,
 				E6B1448712B26D1500415AAE /* Cocoa.framework */,
 				E6B1449312B26D7E00415AAE /* IOKit.framework */,
+				A29412FF2132D2F40054535C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1855,6 +1865,7 @@
 /* Begin XCBuildConfiguration section */
 		E66D29331D02B49B00C9BCBF /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E69541311A01150D00BC85E1 /* pwsafe-debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -1900,6 +1911,7 @@
 		};
 		E66D29341D02B49B00C9BCBF /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E69541321A01150D00BC85E1 /* pwsafe-release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -1995,17 +2007,22 @@
 		};
 		E6ADB80511956A93004E2BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E69541311A01150D00BC85E1 /* pwsafe-debug.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
 					UNICODE,
 					"_FILE_OFFSET_BITS=64",
 					_LARGE_FILES,
 					DEBUG,
 					_DEBUG,
 				);
-				HEADER_SEARCH_PATHS = ../src/;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					../src/,
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-Wall",
 					"-Wextra",
@@ -2016,15 +2033,20 @@
 		};
 		E6ADB80611956A93004E2BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E69541321A01150D00BC85E1 /* pwsafe-release.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
 					UNICODE,
 					"_FILE_OFFSET_BITS=64",
 					_LARGE_FILES,
 					NDEBUG,
 				);
-				HEADER_SEARCH_PATHS = ../src/;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					../src/,
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-Wall",
 					"-Wextra",

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		6FF5D4A11DA14EE80032F5B6 /* passwordsubset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF5D49D1DA14AB20032F5B6 /* passwordsubset.cpp */; };
+		A260BC952132D49900214C59 /* PolicyManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A260BC932132D49900214C59 /* PolicyManager.cpp */; };
 		A29413002132D2F40054535C /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6B1448712B26D1500415AAE /* Cocoa.framework */; };
 		A2D181461C8FF86C0018AE03 /* media.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2D181451C8FF86C0018AE03 /* media.cpp */; };
 		A2FE25801C5ACEFD00210C36 /* AES.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE257E1C5ACEFD00210C36 /* AES.cpp */; };
@@ -240,6 +241,8 @@
 /* Begin PBXFileReference section */
 		6FF5D49D1DA14AB20032F5B6 /* passwordsubset.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = passwordsubset.cpp; sourceTree = "<group>"; };
 		6FF5D49E1DA14AB20032F5B6 /* passwordsubset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = passwordsubset.h; sourceTree = "<group>"; };
+		A260BC932132D49900214C59 /* PolicyManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PolicyManager.cpp; sourceTree = "<group>"; };
+		A260BC942132D49900214C59 /* PolicyManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PolicyManager.h; sourceTree = "<group>"; };
 		A2D181451C8FF86C0018AE03 /* media.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = media.cpp; sourceTree = "<group>"; };
 		A2FE257E1C5ACEFD00210C36 /* AES.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AES.cpp; sourceTree = "<group>"; };
 		A2FE257F1C5ACEFD00210C36 /* AES.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AES.h; sourceTree = "<group>"; };
@@ -1350,6 +1353,8 @@
 		E6EE839111E87E9700B01518 /* core */ = {
 			isa = PBXGroup;
 			children = (
+				A260BC932132D49900214C59 /* PolicyManager.cpp */,
+				A260BC942132D49900214C59 /* PolicyManager.h */,
 				E6F8DC201D132657007DFBEC /* RUEList.cpp */,
 				E6F8DC211D132657007DFBEC /* RUEList.h */,
 				A2FE257E1C5ACEFD00210C36 /* AES.cpp */,
@@ -1734,6 +1739,7 @@
 				E6EE845111E87E9800B01518 /* XFilterXMLProcessor.cpp in Sources */,
 				A2FE25901C5ACF7500210C36 /* pbkdf2.cpp in Sources */,
 				E6EE845211E87E9800B01518 /* XSecMemMgr.cpp in Sources */,
+				A260BC952132D49900214C59 /* PolicyManager.cpp in Sources */,
 				E6EE845311E87E9800B01518 /* XMLFileHandlers.cpp in Sources */,
 				E6EE845411E87E9800B01518 /* XMLFileValidation.cpp in Sources */,
 				E6EE845511E87E9800B01518 /* XMLprefs.cpp in Sources */,


### PR DESCRIPTION
I was trying to build a fresh version for macOS (tagged as `1.06BETA`) and as always I followed instructions in [README.MAC.DEVELOPERS.txt](https://github.com/pwsafe/pwsafe/blob/1660b5433a5d6aaa2939bc5d66dfd28986dc997a/README.MAC.DEVELOPERS.txt)
Unfortunately it does not work. I can quickly fix all issues, and document them within this pull request in hope that it will be useful for future devs. Also I can work on this and polish this patchset to a mergeable state after communication about some changes.

Environment:
- macOS 10.13.6 High Sierra
- Xcode Version 9.4.1 (9F2000)

Preparations:
- wxWidgets 3.1.1 built with slightly modified configure script... mainly I deleted most old stuff, such as `--disable-compat24` flag that was removed from configure script.

Application:

After generation of pwsafe-debug.xcconfig and pwsafe-release.xcconfig, application was not built, because core target now uses wxWidgets: https://github.com/pwsafe/pwsafe/commit/4cc8cf272025070ccbe93fcc7493c7d75b22a6d8#r30291181

So (maybe this is not desirable actually) instead of fixing code, I simply try to link core with wx in the most straightforward way: I based `core` target configuration on already generated `pwsafe-*.xcconfig` files. Also it leads to `pwsafe-cli` target also being dependent on wx, which is bad, but I did the same.

It still was not able to build, because wx requires some preprocessor definitions, so I improved the script for generating xcconfig files to include `GCC_PREPROCESSOR_DEFINITIONS` settings, see https://github.com/vovkasm/pwsafe/commit/5523650e2ebeb886f71696c6c8717949d52dd514#diff-446adca1e1b66f072d52f6338af3a757. I think this improvement is useful on its own, because it allows to remove some custom definitions in xcode project file.

And still it was not able to build ))
Last change was to add missing files to `core` target, here: https://github.com/vovkasm/pwsafe/commit/c09c8969bd43740251412fe29c96e99723edb60d

After this pwsafe.app was built and runs without issues at first glance.

Please don't merge as is... because I'm almost sure that core should not depend on wxWidgets, even if it does, it should not depend on GUI part of wxWidgets.