### PR TITLE
Limit DB name and DB description on UI

### DIFF
--- a/src/ui/wxWidgets/properties.h
+++ b/src/ui/wxWidgets/properties.h
@@ -148,6 +148,9 @@ public:
   /// Should we show tooltips?
   static bool ShowToolTips();
 
+private:
+  wxString Truncate(const wxString& text);
+
 ////@begin CProperties member variables
 private:
   wxString m_database;

--- a/src/ui/wxWidgets/properties.h
+++ b/src/ui/wxWidgets/properties.h
@@ -148,9 +148,6 @@ public:
   /// Should we show tooltips?
   static bool ShowToolTips();
 
-private:
-  wxString Truncate(const wxString& text);
-
 ////@begin CProperties member variables
 private:
   wxString m_database;
@@ -170,6 +167,9 @@ private:
   StringX m_NewDbName;
   StringX m_NewDbDescription;
   const PWScore &m_core;
+
+  const size_t MAX_TEXT_CHARS = 30;
+  const size_t MAX_TEXT_LINES = 3;
 };
 
 #endif

--- a/src/ui/wxWidgets/wxutils.cpp
+++ b/src/ui/wxWidgets/wxutils.cpp
@@ -30,6 +30,7 @@
 #endif
 
 #include <wx/taskbar.h>
+#include <wx/tokenzr.h>
 #include <wx/versioninfo.h>
 
 /*
@@ -216,4 +217,47 @@ bool IsTaskBarIconAvailable()
   }
 #endif
   return wxTaskBarIcon::IsAvailable();
+}
+
+/**
+ * Limits a given string to the specified amount of characters and replaces the remaining
+ * characters with '...'. Intention of this function is to limit strings to the available
+ * space on the UI.
+ *
+ * A given string that contains newline characters will be tokenized at each such character
+ * and the truncation rule applied on each single token. The processing stops when the
+ * specified amount of tokens is reached.
+ *
+ * @param text the string that should be truncated.
+ * @param maxLength the number of characters to which each single string or token should be limited.
+ * @param maxTokens the number of tokens to which the tokenized text should be limited.
+ */
+wxString Truncate(const wxString& text, size_t maxLength, size_t maxTokens)
+{
+  size_t tokenCount = 0;
+  wxString truncatedString("");
+  wxStringTokenizer tokenizer(text, wxT("\r\n"));
+
+  if (!tokenizer.HasMoreTokens() && (text.Length() > maxLength)) { /* A single string without any newline characters */
+    truncatedString = text;
+    truncatedString = truncatedString.Truncate(maxLength) + wxT("...");
+  }
+  else {                                                            /* A string that contains newline characters */
+    while (tokenizer.HasMoreTokens() && (tokenCount < maxTokens)) {
+      tokenCount++;
+
+      auto token = tokenizer.GetNextToken();
+
+      if (token.Length() > maxLength) {
+        truncatedString += token.Truncate(maxLength) + wxT("...");
+      }
+      else {
+        truncatedString += token;
+      }
+
+      truncatedString += tokenizer.GetLastDelimiter();
+    }
+  }
+
+  return truncatedString;
 }

--- a/src/ui/wxWidgets/wxutils.h
+++ b/src/ui/wxWidgets/wxutils.h
@@ -328,4 +328,6 @@ typedef wxTextDataObject wxTextDataObjectEx;
 // on Fedora or Ubuntu
 bool IsTaskBarIconAvailable();
 
+wxString Truncate(const wxString& text, size_t maxLength, size_t maxTokens);
+
 #endif // __WXUTILS_H__


### PR DESCRIPTION
- Follow implementation of review proposal (see #488) for OnEditName and OnEditDescription
- Reserve three lines of static text for DB description
- Limit DB name and DB description to the available space on UI