### PR TITLE
[wx] Restrict policy validation and update to policy tab in Edit/View dialog

### DIFF
--- a/src/ui/wxWidgets/addeditpropsheet.cpp
+++ b/src/ui/wxWidgets/addeditpropsheet.cpp
@@ -753,7 +753,13 @@ void AddEditPropSheet::UpdatePWPolicyControls(const PWPolicy& pwp)
 
   if (!pwp.symbols.empty()) {
     m_symbols = pwp.symbols.c_str();
-    Validate(); TransferDataToWindow();
+
+    auto policyPanel = FindWindow(ID_PANEL_PPOLICY);
+
+    if (policyPanel) {
+      policyPanel->Validate();
+      policyPanel->TransferDataToWindow();
+    }
   }
 }
 


### PR DESCRIPTION
Fixes reported issue [1477](https://sourceforge.net/p/passwordsafe/bugs/1477) on SF.