### PR TITLE
[wx] Unification of password rules dialogs

### DIFF
--- a/src/ui/wxWidgets/PasswordPolicy.cpp
+++ b/src/ui/wxWidgets/PasswordPolicy.cpp
@@ -415,7 +415,7 @@ void CPasswordPolicy::CreateControls()
     itemStdDialogButtonSizer39->Show(false);
     itemStdDialogButtonSizer40->Show(true);
 
-     EnableSizerChildren(m_itemStaticBoxSizer6, !m_pwpUseNamedPolicyCtrl->IsChecked());
+    EnableSizerChildren(m_itemStaticBoxSizer6, !m_pwpUseNamedPolicyCtrl->IsChecked());
   }
   else {
     itemBoxSizer3->Show(true);
@@ -602,42 +602,32 @@ void CPasswordPolicy::OnHelpClick( wxCommandEvent& event )
 ////@end wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_HELP in CPasswordPolicy.
 }
 
-void CPasswordPolicy::SetPolicyData(const wxString &polname, const PWPolicy &pol)
+void CPasswordPolicy::SetPolicyData(const wxString &policyname, const PWPolicy &policy)
 {
-  m_polname = m_oldpolname = polname;
+  m_polname             = m_oldpolname             = policyname;
 
-  m_pwUseLowercase = m_oldpwUseLowercase =
-    (pol.flags & PWPolicy::UseLowercase) ==
-                       PWPolicy::UseLowercase;
-  m_pwUseUppercase = m_oldpwUseUppercase =
-    (pol.flags & PWPolicy::UseUppercase) ==
-                       PWPolicy::UseUppercase;
-  m_pwUseDigits = m_oldpwUseDigits =
-    (pol.flags & PWPolicy::UseDigits) ==
-                       PWPolicy::UseDigits;
-  m_pwUseSymbols = m_oldpwUseSymbols =
-    (pol.flags & PWPolicy::UseSymbols) ==
-                       PWPolicy::UseSymbols;
-  m_pwUseHex = m_oldpwUseHex =
-    (pol.flags & PWPolicy::UseHexDigits) ==
-                       PWPolicy::UseHexDigits;
-  m_pwUseEasyVision = m_oldpwUseEasyVision =
-    (pol.flags & PWPolicy::UseEasyVision) ==
-                       PWPolicy::UseEasyVision;
-  m_pwMakePronounceable = m_oldpwMakePronounceable =
-    (pol.flags & PWPolicy::MakePronounceable) ==
-                       PWPolicy::MakePronounceable;
-  m_pwdefaultlength = m_oldpwdefaultlength = pol.length;
-  m_pwDigitMinLength = m_oldpwDigitMinLength = pol.digitminlength;
-  m_pwLowerMinLength = m_oldpwLowerMinLength = pol.lowerminlength;
-  m_pwSymbolMinLength = m_oldpwSymbolMinLength = pol.symbolminlength;
-  m_pwUpperMinLength = m_oldpwUpperMinLength = pol.upperminlength;
+  m_pwUseLowercase      = m_oldpwUseLowercase      = (policy.flags & PWPolicy::UseLowercase)      == PWPolicy::UseLowercase;
+  m_pwUseUppercase      = m_oldpwUseUppercase      = (policy.flags & PWPolicy::UseUppercase)      == PWPolicy::UseUppercase;
+  m_pwUseDigits         = m_oldpwUseDigits         = (policy.flags & PWPolicy::UseDigits)         == PWPolicy::UseDigits;
+  m_pwUseSymbols        = m_oldpwUseSymbols        = (policy.flags & PWPolicy::UseSymbols)        == PWPolicy::UseSymbols;
+  m_pwUseHex            = m_oldpwUseHex            = (policy.flags & PWPolicy::UseHexDigits)      == PWPolicy::UseHexDigits;
+  m_pwUseEasyVision     = m_oldpwUseEasyVision     = (policy.flags & PWPolicy::UseEasyVision)     == PWPolicy::UseEasyVision;
+  m_pwMakePronounceable = m_oldpwMakePronounceable = (policy.flags & PWPolicy::MakePronounceable) == PWPolicy::MakePronounceable;
+  m_pwdefaultlength     = m_oldpwdefaultlength     = policy.length;
+  m_pwLowerMinLength    = m_oldpwLowerMinLength    = policy.lowerminlength;
+  m_pwUpperMinLength    = m_oldpwUpperMinLength    = policy.upperminlength;
+  m_pwDigitMinLength    = m_oldpwDigitMinLength    = policy.digitminlength;
+  m_pwSymbolMinLength   = m_oldpwSymbolMinLength   = policy.symbolminlength;
 
-  wxString symbols = pol.symbols.c_str();
-  if (symbols.empty())
+  wxString symbols = policy.symbols.c_str();
+
+  if (symbols.empty()) {
     SetDefaultSymbolDisplay(false);
-  else
+  }
+  else {
     m_Symbols = symbols;
+  }
+
   m_oldSymbols = m_Symbols;
 
   if (PolicyManager::IsDefaultPolicy(m_polname.wc_str())) {
@@ -646,7 +636,7 @@ void CPasswordPolicy::SetPolicyData(const wxString &polname, const PWPolicy &pol
     FindWindow(ID_POLICYNAME)->Enable(false);
 
     // Select default policy as initial policy in Generator mode (see Init())
-    auto index = m_pwpPoliciesSelectionCtrl->FindString(polname);
+    auto index = m_pwpPoliciesSelectionCtrl->FindString(policyname);
 
     if (index != wxNOT_FOUND) {
       m_pwpPoliciesSelectionCtrl->SetSelection(index);
@@ -657,12 +647,13 @@ void CPasswordPolicy::SetPolicyData(const wxString &polname, const PWPolicy &pol
   }
 }
 
-void CPasswordPolicy::CBox2Spin(wxCheckBox *cb, wxSpinCtrl *sp)
+void CPasswordPolicy::CBox2Spin(wxCheckBox *checkbox, wxSpinCtrl *spinner)
 {
   Validate();
   TransferDataFromWindow();
-  bool checked = cb->GetValue();
-  sp->Enable(checked);
+
+  spinner->Enable(checkbox->GetValue());
+
   Validate();
   TransferDataFromWindow();
 }
@@ -803,6 +794,13 @@ void CPasswordPolicy::OnUseNamedPolicy( wxCommandEvent& event )
 {
   EnableSizerChildren(m_itemStaticBoxSizer6, !event.IsChecked());
   m_pwpPoliciesSelectionCtrl->Enable(event.IsChecked());
+
+  if (!event.IsChecked()) {
+    m_pwpLCSpin->Enable(m_pwpUseLowerCtrl->GetValue());
+    m_pwpUCSpin->Enable(m_pwpUseUpperCtrl->GetValue());
+    m_pwpDigSpin->Enable(m_pwpUseDigitsCtrl->GetValue());
+    m_pwpSymSpin->Enable(m_pwpSymCtrl->GetValue());
+  }
 }
 
 /*!

--- a/src/ui/wxWidgets/PasswordPolicy.cpp
+++ b/src/ui/wxWidgets/PasswordPolicy.cpp
@@ -41,24 +41,24 @@
 BEGIN_EVENT_TABLE( CPasswordPolicy, wxDialog )
 
 ////@begin CPasswordPolicy event table entries
-  EVT_SPINCTRL( ID_SPINCTRL5        , CPasswordPolicy::OnAtLeastChars        )
-  EVT_SPINCTRL( ID_SPINCTRL6        , CPasswordPolicy::OnAtLeastChars        )
-  EVT_SPINCTRL( ID_SPINCTRL7        , CPasswordPolicy::OnAtLeastChars        )
-  EVT_SPINCTRL( ID_SPINCTRL8        , CPasswordPolicy::OnAtLeastChars        )
-  EVT_CHECKBOX( ID_CHECKBOX41       , CPasswordPolicy::OnUseNamedPolicy      )
-  EVT_COMBOBOX( ID_COMBOBOX41       , CPasswordPolicy::OnPolicynameSelection )
-  EVT_CHECKBOX( ID_CHECKBOX3        , CPasswordPolicy::OnPwPolUseLowerCase   )
-  EVT_CHECKBOX( ID_CHECKBOX4        , CPasswordPolicy::OnPwPolUseUpperCase   )
-  EVT_CHECKBOX( ID_CHECKBOX5        , CPasswordPolicy::OnPwPolUseDigits      )
-  EVT_CHECKBOX( ID_CHECKBOX6        , CPasswordPolicy::OnPwPolUseSymbols     )
-  EVT_BUTTON(   ID_RESET_SYMBOLS    , CPasswordPolicy::OnResetSymbolsClick   )
-  EVT_CHECKBOX( ID_CHECKBOX7        , CPasswordPolicy::OnEZreadCBClick       )
-  EVT_CHECKBOX( ID_CHECKBOX8        , CPasswordPolicy::OnPronouceableCBClick )
-  EVT_BUTTON(   ID_GENERATEPASSWORD2, CPasswordPolicy::OnGeneratePassword    )
-  EVT_BUTTON(   ID_COPYPASSWORD2    , CPasswordPolicy::OnCopyPassword        )
-  EVT_BUTTON(   wxID_OK             , CPasswordPolicy::OnOkClick             )
-  EVT_BUTTON(   wxID_CANCEL         , CPasswordPolicy::OnCancelClick         )
-  EVT_BUTTON(   wxID_HELP           , CPasswordPolicy::OnHelpClick           )
+  EVT_SPINCTRL( ID_SPINCTRL5        , CPasswordPolicy::OnAtLeastPasswordChars )
+  EVT_SPINCTRL( ID_SPINCTRL6        , CPasswordPolicy::OnAtLeastPasswordChars )
+  EVT_SPINCTRL( ID_SPINCTRL7        , CPasswordPolicy::OnAtLeastPasswordChars )
+  EVT_SPINCTRL( ID_SPINCTRL8        , CPasswordPolicy::OnAtLeastPasswordChars )
+  EVT_CHECKBOX( ID_CHECKBOX41       , CPasswordPolicy::OnUseNamedPolicy       )
+  EVT_COMBOBOX( ID_COMBOBOX41       , CPasswordPolicy::OnPolicynameSelection  )
+  EVT_CHECKBOX( ID_CHECKBOX3        , CPasswordPolicy::OnPwPolUseLowerCase    )
+  EVT_CHECKBOX( ID_CHECKBOX4        , CPasswordPolicy::OnPwPolUseUpperCase    )
+  EVT_CHECKBOX( ID_CHECKBOX5        , CPasswordPolicy::OnPwPolUseDigits       )
+  EVT_CHECKBOX( ID_CHECKBOX6        , CPasswordPolicy::OnPwPolUseSymbols      )
+  EVT_BUTTON(   ID_RESET_SYMBOLS    , CPasswordPolicy::OnResetSymbolsClick    )
+  EVT_CHECKBOX( ID_CHECKBOX7        , CPasswordPolicy::OnEZreadCBClick        )
+  EVT_CHECKBOX( ID_CHECKBOX8        , CPasswordPolicy::OnPronouceableCBClick  )
+  EVT_BUTTON(   ID_GENERATEPASSWORD2, CPasswordPolicy::OnGeneratePassword     )
+  EVT_BUTTON(   ID_COPYPASSWORD2    , CPasswordPolicy::OnCopyPassword         )
+  EVT_BUTTON(   wxID_OK             , CPasswordPolicy::OnOkClick              )
+  EVT_BUTTON(   wxID_CANCEL         , CPasswordPolicy::OnCancelClick          )
+  EVT_BUTTON(   wxID_HELP           , CPasswordPolicy::OnHelpClick            )
 ////@end CPasswordPolicy event table entries
 
 END_EVENT_TABLE()
@@ -854,26 +854,34 @@ void CPasswordPolicy::OnCopyPassword( wxCommandEvent& WXUNUSED(event) )
   }
 }
 
-/*
- * Just trying to give the user some visual indication that
- * the password length has to be bigger than the sum of all
- * "at least" lengths.  This is not comprehensive & foolproof
- * since there are far too many ways to make the password length
- * smaller than the sum of "at least" lengths, to even think of.
+/**
+ * wxEVT_SPINCTRL event handler for ID_SPINCTRL5, ID_SPINCTRL6, 
+ * ID_SPINCTRL7, ID_SPINCTRL8
+ * 
+ * Ensures that the sum of each character class' minimum counts 
+ * doesn't exceed the overall password length, increasing it as 
+ * necessary to give the user some visual indication.
+ * 
+ * This is not comprehensive & foolproof since there are far too 
+ * many ways to make the password length smaller than the sum of 
+ * "at least" lengths, to even think of.
  *
  * In OnOk(), we just ensure the password length is greater than
- * the sum of all enabled "at least" lengths.  We have to do this in the
- * UI, or else password generation crashes
+ * the sum of all enabled "at least" lengths.  We have to do this 
+ * in the UI, or else password generation crashes.
  */
-void CPasswordPolicy::OnAtLeastChars( wxSpinEvent& WXUNUSED(event) )
+void CPasswordPolicy::OnAtLeastPasswordChars( wxSpinEvent& WXUNUSED(event) )
 {
-  wxSpinCtrl* spinCtrls[] = {m_pwpUCSpin, m_pwpLCSpin, m_pwpDigSpin, m_pwpSymSpin};
+  wxSpinCtrl* spinControls[] = { m_pwpUCSpin, m_pwpLCSpin, m_pwpDigSpin, m_pwpSymSpin };
   int total = 0;
-  for (size_t idx = 0; idx < WXSIZEOF(spinCtrls); ++idx) {
-    if (spinCtrls[idx]->IsEnabled())
-      total += spinCtrls[idx]->GetValue();
+
+  // Calculate the sum of each character class' minimum count
+  for (const auto spinControl : spinControls) {
+    total += spinControl->IsEnabled() ? spinControl->GetValue() : 0;
   }
 
-  if (total > m_pwpLenCtrl->GetValue())
+  // Increase password length up to the allowed maximum
+  if ((m_pwpLenCtrl->GetMax() > total) && (total > m_pwpLenCtrl->GetValue())) {
     m_pwpLenCtrl->SetValue(total);
+  }
 }

--- a/src/ui/wxWidgets/PasswordPolicy.cpp
+++ b/src/ui/wxWidgets/PasswordPolicy.cpp
@@ -10,14 +10,14 @@
 *
 */
 // For compilers that support precompilation, includes "wx/wx.h".
-#include "wx/wxprec.h"
+#include <wx/wxprec.h>
 
 #ifdef __BORLANDC__
 #pragma hdrstop
 #endif
 
 #ifndef WX_PRECOMP
-#include "wx/wx.h"
+#include <wx/wx.h>
 #endif
 
 ////@begin includes
@@ -41,6 +41,10 @@
 BEGIN_EVENT_TABLE( CPasswordPolicy, wxDialog )
 
 ////@begin CPasswordPolicy event table entries
+  EVT_SPINCTRL( ID_SPINCTRL5        , CPasswordPolicy::OnAtLeastChars        )
+  EVT_SPINCTRL( ID_SPINCTRL6        , CPasswordPolicy::OnAtLeastChars        )
+  EVT_SPINCTRL( ID_SPINCTRL7        , CPasswordPolicy::OnAtLeastChars        )
+  EVT_SPINCTRL( ID_SPINCTRL8        , CPasswordPolicy::OnAtLeastChars        )
   EVT_CHECKBOX( ID_CHECKBOX41       , CPasswordPolicy::OnUseNamedPolicy      )
   EVT_COMBOBOX( ID_COMBOBOX41       , CPasswordPolicy::OnPolicynameSelection )
   EVT_CHECKBOX( ID_CHECKBOX3        , CPasswordPolicy::OnPwPolUseLowerCase   )
@@ -126,6 +130,7 @@ CPasswordPolicy::~CPasswordPolicy()
 void CPasswordPolicy::Init()
 {
 ////@begin CPasswordPolicy member initialisation
+  m_pwpLenCtrl = nullptr;
   m_pwMinsGSzr = nullptr;
   m_pwpUseLowerCtrl = nullptr;
   m_pwNumLCbox = nullptr;
@@ -211,8 +216,14 @@ void CPasswordPolicy::CreateControls()
   wxStaticText* itemStaticText8 = new wxStaticText( itemDialog1, wxID_STATIC, _("Password length: "), wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer7->Add(itemStaticText8, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  wxSpinCtrl* itemSpinCtrl9 = new wxSpinCtrl( itemDialog1, ID_PWLENSB, _T("12"), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 4, 1024, 12 );
-  itemBoxSizer7->Add(itemSpinCtrl9, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
+  m_pwpLenCtrl = new wxSpinCtrl(
+    itemDialog1, ID_PWLENSB, _T("12"), wxDefaultPosition, wxSize(80, -1), wxSP_ARROW_KEYS,
+    PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::PWDefaultLength),
+    PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::PWDefaultLength),
+    PWSprefs::GetInstance()->GetPrefDefVal(PWSprefs::PWDefaultLength)
+  );
+
+  itemBoxSizer7->Add(m_pwpLenCtrl, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
   m_pwMinsGSzr = new wxGridSizer(0, 2, 0, 0);
   m_itemStaticBoxSizer6->Add(m_pwMinsGSzr, 0, wxALIGN_LEFT|wxALL, 5);
@@ -227,7 +238,13 @@ void CPasswordPolicy::CreateControls()
   wxStaticText* itemStaticText13 = new wxStaticText( itemDialog1, wxID_STATIC, _("(At least "), wxDefaultPosition, wxDefaultSize, 0 );
   m_pwNumLCbox->Add(itemStaticText13, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_pwpLCSpin = new wxSpinCtrl( itemDialog1, ID_SPINCTRL5, wxT("0"), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 100, 0 );
+  m_pwpLCSpin = new wxSpinCtrl(
+    itemDialog1, ID_SPINCTRL5, wxT("0"), wxDefaultPosition, wxSize(80, -1), wxSP_ARROW_KEYS,
+    PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::PWLowercaseMinLength),
+    PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::PWLowercaseMinLength),
+    PWSprefs::GetInstance()->GetPrefDefVal(PWSprefs::PWLowercaseMinLength)
+  );
+
   m_pwNumLCbox->Add(m_pwpLCSpin, 0, wxALIGN_CENTER_VERTICAL|wxALL, 0);
 
   wxStaticText* itemStaticText15 = new wxStaticText( itemDialog1, wxID_STATIC, wxT(")"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -243,7 +260,13 @@ void CPasswordPolicy::CreateControls()
   wxStaticText* itemStaticText18 = new wxStaticText( itemDialog1, wxID_STATIC, _("(At least "), wxDefaultPosition, wxDefaultSize, 0 );
   m_pwNumUCbox->Add(itemStaticText18, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_pwpUCSpin = new wxSpinCtrl( itemDialog1, ID_SPINCTRL6, wxT("0"), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 100, 0 );
+  m_pwpUCSpin = new wxSpinCtrl(
+    itemDialog1, ID_SPINCTRL6, wxT("0"), wxDefaultPosition, wxSize(80, -1), wxSP_ARROW_KEYS,
+    PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::PWUppercaseMinLength),
+    PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::PWUppercaseMinLength),
+    PWSprefs::GetInstance()->GetPrefDefVal(PWSprefs::PWUppercaseMinLength)
+  );
+
   m_pwNumUCbox->Add(m_pwpUCSpin, 0, wxALIGN_CENTER_VERTICAL|wxALL, 0);
 
   wxStaticText* itemStaticText20 = new wxStaticText( itemDialog1, wxID_STATIC, wxT(")"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -259,7 +282,13 @@ void CPasswordPolicy::CreateControls()
   wxStaticText* itemStaticText23 = new wxStaticText( itemDialog1, wxID_STATIC, _("(At least "), wxDefaultPosition, wxDefaultSize, 0 );
   m_pwNumDigbox->Add(itemStaticText23, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_pwpDigSpin = new wxSpinCtrl( itemDialog1, ID_SPINCTRL7, wxT("0"), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 100, 0 );
+  m_pwpDigSpin = new wxSpinCtrl(
+    itemDialog1, ID_SPINCTRL7, wxT("0"), wxDefaultPosition, wxSize(80, -1), wxSP_ARROW_KEYS,
+    PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::PWDigitMinLength),
+    PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::PWDigitMinLength),
+    PWSprefs::GetInstance()->GetPrefDefVal(PWSprefs::PWDigitMinLength)
+  );
+
   m_pwNumDigbox->Add(m_pwpDigSpin, 0, wxALIGN_CENTER_VERTICAL|wxALL, 0);
 
   wxStaticText* itemStaticText25 = new wxStaticText( itemDialog1, wxID_STATIC, wxT(")"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -275,7 +304,13 @@ void CPasswordPolicy::CreateControls()
   wxStaticText* itemStaticText28 = new wxStaticText( itemDialog1, wxID_STATIC, _("(At least "), wxDefaultPosition, wxDefaultSize, 0 );
   m_pwNumSymbox->Add(itemStaticText28, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_pwpSymSpin = new wxSpinCtrl( itemDialog1, ID_SPINCTRL8, wxT("0"), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 100, 0 );
+  m_pwpSymSpin = new wxSpinCtrl(
+    itemDialog1, ID_SPINCTRL8, wxT("0"), wxDefaultPosition, wxSize(80, -1), wxSP_ARROW_KEYS,
+    PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::PWSymbolMinLength),
+    PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::PWSymbolMinLength),
+    PWSprefs::GetInstance()->GetPrefDefVal(PWSprefs::PWSymbolMinLength)
+  );
+
   m_pwNumSymbox->Add(m_pwpSymSpin, 0, wxALIGN_CENTER_VERTICAL|wxALL, 0);
 
   wxStaticText* itemStaticText30 = new wxStaticText( itemDialog1, wxID_STATIC, wxT(")"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -358,7 +393,7 @@ void CPasswordPolicy::CreateControls()
 
   // Set validators
   itemTextCtrl5->SetValidator( wxGenericValidator(& m_polname) );
-  itemSpinCtrl9->SetValidator( wxGenericValidator(& m_pwdefaultlength) );
+  m_pwpLenCtrl->SetValidator( wxGenericValidator(& m_pwdefaultlength) );
   m_pwpUseLowerCtrl->SetValidator( wxGenericValidator(& m_pwUseLowercase) );
   m_pwpLCSpin->SetValidator( wxGenericValidator(& m_pwLowerMinLength) );
   m_pwpUseUpperCtrl->SetValidator( wxGenericValidator(& m_pwUseUppercase) );
@@ -817,4 +852,28 @@ void CPasswordPolicy::OnCopyPassword( wxCommandEvent& WXUNUSED(event) )
   if (!(m_passwordCtrl->GetValue()).IsEmpty()) {
     PWSclipboard::GetInstance()->SetData(tostringx(m_passwordCtrl->GetValue()));
   }
+}
+
+/*
+ * Just trying to give the user some visual indication that
+ * the password length has to be bigger than the sum of all
+ * "at least" lengths.  This is not comprehensive & foolproof
+ * since there are far too many ways to make the password length
+ * smaller than the sum of "at least" lengths, to even think of.
+ *
+ * In OnOk(), we just ensure the password length is greater than
+ * the sum of all enabled "at least" lengths.  We have to do this in the
+ * UI, or else password generation crashes
+ */
+void CPasswordPolicy::OnAtLeastChars( wxSpinEvent& WXUNUSED(event) )
+{
+  wxSpinCtrl* spinCtrls[] = {m_pwpUCSpin, m_pwpLCSpin, m_pwpDigSpin, m_pwpSymSpin};
+  int total = 0;
+  for (size_t idx = 0; idx < WXSIZEOF(spinCtrls); ++idx) {
+    if (spinCtrls[idx]->IsEnabled())
+      total += spinCtrls[idx]->GetValue();
+  }
+
+  if (total > m_pwpLenCtrl->GetValue())
+    m_pwpLenCtrl->SetValue(total);
 }

--- a/src/ui/wxWidgets/PasswordPolicy.h
+++ b/src/ui/wxWidgets/PasswordPolicy.h
@@ -18,8 +18,8 @@
  */
 
 ////@begin includes
-#include "wx/valgen.h"
-#include "wx/spinctrl.h"
+#include <wx/valgen.h>
+#include <wx/spinctrl.h>
 ////@end includes
 #include "core/coredefs.h"
 #include "core/PWPolicy.h"
@@ -149,6 +149,9 @@ public:
   /// wxEVT_COMMAND_BUTTON_CLICKED event handler for ID_COPYPASSWORD2
   void OnCopyPassword( wxCommandEvent& event );
 
+  /// wxEVT_SPINCTRL event handler for ID_SPINCTRL5, ID_SPINCTRL6, ID_SPINCTRL7, ID_SPINCTRL8
+  void OnAtLeastChars(wxSpinEvent& evt);
+
 ////@end CPasswordPolicy event handler declarations
 
 ////@begin CPasswordPolicy member function declarations
@@ -213,6 +216,7 @@ private:
 
 ////@begin CPasswordPolicy member variables
   /* Controls for DialogType EDITOR */
+  wxSpinCtrl* m_pwpLenCtrl;
   wxGridSizer* m_pwMinsGSzr;
   wxCheckBox* m_pwpUseLowerCtrl;
   wxBoxSizer* m_pwNumLCbox;

--- a/src/ui/wxWidgets/PasswordPolicy.h
+++ b/src/ui/wxWidgets/PasswordPolicy.h
@@ -150,7 +150,7 @@ public:
   void OnCopyPassword( wxCommandEvent& event );
 
   /// wxEVT_SPINCTRL event handler for ID_SPINCTRL5, ID_SPINCTRL6, ID_SPINCTRL7, ID_SPINCTRL8
-  void OnAtLeastChars(wxSpinEvent& evt);
+  void OnAtLeastPasswordChars(wxSpinEvent& evt);
 
 ////@end CPasswordPolicy event handler declarations
 

--- a/src/ui/wxWidgets/addeditpropsheet.cpp
+++ b/src/ui/wxWidgets/addeditpropsheet.cpp
@@ -25,7 +25,6 @@
 ////@end includes
 #include <wx/datetime.h>
 
-#include <vector>
 #include "core/PWSprefs.h"
 #include "core/PWCharPool.h"
 #include "core/PWHistory.h"
@@ -37,6 +36,7 @@
 #include "./wxutils.h"
 
 #include <algorithm>
+#include <vector>
 
 #ifdef __WXMSW__
 #include <wx/msw/msvcrt.h>
@@ -426,7 +426,13 @@ void AddEditPropSheet::CreateControls()
   itemCheckBox51->SetValue(false);
   itemBoxSizer50->Add(itemCheckBox51, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_MaxPWHistCtrl = new wxSpinCtrl( m_AdditionalPanel, ID_SPINCTRL_MAX_PW_HIST, _T("0"), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 100, 0 );
+  m_MaxPWHistCtrl = new wxSpinCtrl(
+    m_AdditionalPanel, ID_SPINCTRL_MAX_PW_HIST, _T("0"), wxDefaultPosition, wxSize(60, -1), wxSP_ARROW_KEYS,
+    PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::NumPWHistoryDefault),
+    PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::NumPWHistoryDefault),
+    PWSprefs::GetInstance()->GetPrefDefVal(PWSprefs::NumPWHistoryDefault)
+  );
+
   itemBoxSizer50->Add(m_MaxPWHistCtrl, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
   wxStaticText* itemStaticText53 = new wxStaticText( m_AdditionalPanel, wxID_STATIC, _("last passwords"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -482,11 +488,14 @@ void AddEditPropSheet::CreateControls()
 
   auto *itemBoxSizer68 = new wxBoxSizer(wxHORIZONTAL);
   itemFlexGridSizer63->Add(itemBoxSizer68, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL, 0);
-  m_ExpTimeCtrl = new wxSpinCtrl( itemPanel59, ID_SPINCTRL_EXP_TIME, _T("90"),
-                                  wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS,
-                                  PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::DefaultExpiryDays),
-                                  PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::DefaultExpiryDays),
-                                  PWSprefs::GetInstance()->GetPref(PWSprefs::DefaultExpiryDays) );
+
+  m_ExpTimeCtrl = new wxSpinCtrl(
+    itemPanel59, ID_SPINCTRL_EXP_TIME, _T("90"), wxDefaultPosition, wxSize(80, -1), wxSP_ARROW_KEYS,
+    PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::DefaultExpiryDays),
+    PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::DefaultExpiryDays),
+    PWSprefs::GetInstance()->GetPrefDefVal(PWSprefs::DefaultExpiryDays)
+  );
+
   itemBoxSizer68->Add(m_ExpTimeCtrl, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
   wxStaticText* itemStaticText70 = new wxStaticText( itemPanel59, ID_STATICTEXT_DAYS, _("days"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -577,7 +586,13 @@ void AddEditPropSheet::CreateControls()
   wxStaticText* itemStaticText96 = new wxStaticText( m_PasswordPolicyPanel, wxID_STATIC, _("Password length: "), wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer95->Add(itemStaticText96, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxALL, 5);
 
-  m_pwpLenCtrl = new wxSpinCtrl( m_PasswordPolicyPanel, ID_SPINCTRL3, _T("12"), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 4, 1024, 12 );
+  m_pwpLenCtrl = new wxSpinCtrl(
+    m_PasswordPolicyPanel, ID_SPINCTRL3, _T("12"), wxDefaultPosition, wxSize(80, -1), wxSP_ARROW_KEYS,
+    PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::PWDefaultLength),
+    PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::PWDefaultLength),
+    PWSprefs::GetInstance()->GetPrefDefVal(PWSprefs::PWDefaultLength)
+  );
+
   itemBoxSizer95->Add(m_pwpLenCtrl, 0, wxALIGN_CENTER_VERTICAL|wxALL, 10);
 
   m_pwMinsGSzr = new wxGridSizer(0, 2, 0, 0);
@@ -591,7 +606,13 @@ void AddEditPropSheet::CreateControls()
   wxStaticText* itemStaticText101 = new wxStaticText( m_PasswordPolicyPanel, wxID_STATIC, _("(At least "), wxDefaultPosition, wxDefaultSize, 0 );
   m_pwNumLCbox->Add(itemStaticText101, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_pwpLCSpin = new wxSpinCtrl( m_PasswordPolicyPanel, ID_SPINCTRL5, _T("0"), wxDefaultPosition, wxSize(m_PasswordPolicyPanel->ConvertDialogToPixels(wxSize(40, -1)).x, -1), wxSP_ARROW_KEYS, 0, 100, 0 );
+  m_pwpLCSpin = new wxSpinCtrl(
+    m_PasswordPolicyPanel, ID_SPINCTRL5, _T("0"), wxDefaultPosition, wxSize(80, -1), wxSP_ARROW_KEYS,
+    PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::PWLowercaseMinLength),
+    PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::PWLowercaseMinLength),
+    PWSprefs::GetInstance()->GetPrefDefVal(PWSprefs::PWLowercaseMinLength)
+  );
+
   m_pwNumLCbox->Add(m_pwpLCSpin, 0, wxALIGN_CENTER_VERTICAL|wxALL, 0);
 
   wxStaticText* itemStaticText103 = new wxStaticText( m_PasswordPolicyPanel, wxID_STATIC, _(")"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -606,7 +627,13 @@ void AddEditPropSheet::CreateControls()
   wxStaticText* itemStaticText106 = new wxStaticText( m_PasswordPolicyPanel, wxID_STATIC, _("(At least "), wxDefaultPosition, wxDefaultSize, 0 );
   m_pwNumUCbox->Add(itemStaticText106, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_pwpUCSpin = new wxSpinCtrl( m_PasswordPolicyPanel, ID_SPINCTRL6, _T("0"), wxDefaultPosition, wxSize(m_PasswordPolicyPanel->ConvertDialogToPixels(wxSize(40, -1)).x, -1), wxSP_ARROW_KEYS, 0, 100, 0 );
+  m_pwpUCSpin = new wxSpinCtrl(
+    m_PasswordPolicyPanel, ID_SPINCTRL6, _T("0"), wxDefaultPosition, wxSize(80, -1), wxSP_ARROW_KEYS,
+    PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::PWUppercaseMinLength),
+    PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::PWUppercaseMinLength),
+    PWSprefs::GetInstance()->GetPrefDefVal(PWSprefs::PWUppercaseMinLength)
+  );
+
   m_pwNumUCbox->Add(m_pwpUCSpin, 0, wxALIGN_CENTER_VERTICAL|wxALL, 0);
 
   wxStaticText* itemStaticText108 = new wxStaticText( m_PasswordPolicyPanel, wxID_STATIC, _(")"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -621,7 +648,13 @@ void AddEditPropSheet::CreateControls()
   wxStaticText* itemStaticText111 = new wxStaticText( m_PasswordPolicyPanel, wxID_STATIC, _("(At least "), wxDefaultPosition, wxDefaultSize, 0 );
   m_pwNumDigbox->Add(itemStaticText111, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_pwpDigSpin = new wxSpinCtrl( m_PasswordPolicyPanel, ID_SPINCTRL7, _T("0"), wxDefaultPosition, wxSize(m_PasswordPolicyPanel->ConvertDialogToPixels(wxSize(40, -1)).x, -1), wxSP_ARROW_KEYS, 0, 100, 0 );
+  m_pwpDigSpin = new wxSpinCtrl(
+    m_PasswordPolicyPanel, ID_SPINCTRL7, _T("0"), wxDefaultPosition, wxSize(80, -1), wxSP_ARROW_KEYS,
+    PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::PWDigitMinLength),
+    PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::PWDigitMinLength),
+    PWSprefs::GetInstance()->GetPrefDefVal(PWSprefs::PWDigitMinLength)
+  );
+
   m_pwNumDigbox->Add(m_pwpDigSpin, 0, wxALIGN_CENTER_VERTICAL|wxALL, 0);
 
   wxStaticText* itemStaticText113 = new wxStaticText( m_PasswordPolicyPanel, wxID_STATIC, _(")"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -636,7 +669,13 @@ void AddEditPropSheet::CreateControls()
   wxStaticText* itemStaticText116 = new wxStaticText( m_PasswordPolicyPanel, wxID_STATIC, _("(At least "), wxDefaultPosition, wxDefaultSize, 0 );
   m_pwNumSymbox->Add(itemStaticText116, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_pwpSymSpin = new wxSpinCtrl( m_PasswordPolicyPanel, ID_SPINCTRL8, _T("0"), wxDefaultPosition, wxSize(m_PasswordPolicyPanel->ConvertDialogToPixels(wxSize(40, -1)).x, -1), wxSP_ARROW_KEYS, 0, 100, 0 );
+  m_pwpSymSpin = new wxSpinCtrl(
+    m_PasswordPolicyPanel, ID_SPINCTRL8, _T("0"), wxDefaultPosition, wxSize(80, -1), wxSP_ARROW_KEYS,
+    PWSprefs::GetInstance()->GetPrefMinVal(PWSprefs::PWSymbolMinLength),
+    PWSprefs::GetInstance()->GetPrefMaxVal(PWSprefs::PWSymbolMinLength),
+    PWSprefs::GetInstance()->GetPrefDefVal(PWSprefs::PWSymbolMinLength)
+  );
+
   m_pwNumSymbox->Add(m_pwpSymSpin, 0, wxALIGN_CENTER_VERTICAL|wxALL, 0);
 
   wxStaticText* itemStaticText118 = new wxStaticText( m_PasswordPolicyPanel, wxID_STATIC, _(")"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/src/ui/wxWidgets/addeditpropsheet.h
+++ b/src/ui/wxWidgets/addeditpropsheet.h
@@ -18,13 +18,13 @@
  */
 
 ////@begin includes
-#include "wx/propdlg.h"
-#include "wx/valgen.h"
-#include "wx/spinctrl.h"
-#include "wx/grid.h"
-#include "wx/datectrl.h"
-#include "wx/dateevt.h"
-#include "wx/statline.h"
+#include <wx/propdlg.h>
+#include <wx/valgen.h>
+#include <wx/spinctrl.h>
+#include <wx/grid.h>
+#include <wx/datectrl.h>
+#include <wx/dateevt.h>
+#include <wx/statline.h>
 ////@end includes
 #include "core/ItemData.h"
 #include "core/PWScore.h"
@@ -118,7 +118,7 @@ class UIInterFace;
  */
 
 class AddEditPropSheet: public wxPropertySheetDialog
-{    
+{
   DECLARE_CLASS( AddEditPropSheet )
   DECLARE_EVENT_TABLE()
 
@@ -217,6 +217,8 @@ public:
   void OnClearPWHist(wxCommandEvent& evt);
   void OnOk(wxCommandEvent& evt);
   void OnUpdateResetPWPolicyButton(wxUpdateUIEvent& evt);
+
+  /// wxEVT_SPINCTRL event handler for ID_SPINCTRL5, ID_SPINCTRL6, ID_SPINCTRL7, ID_SPINCTRL8
   void OnAtLeastChars(wxSpinEvent& evt);
 ////@begin AddEditPropSheet member function declarations
 

--- a/src/ui/wxWidgets/addeditpropsheet.h
+++ b/src/ui/wxWidgets/addeditpropsheet.h
@@ -219,7 +219,7 @@ public:
   void OnUpdateResetPWPolicyButton(wxUpdateUIEvent& evt);
 
   /// wxEVT_SPINCTRL event handler for ID_SPINCTRL5, ID_SPINCTRL6, ID_SPINCTRL7, ID_SPINCTRL8
-  void OnAtLeastChars(wxSpinEvent& evt);
+  void OnAtLeastPasswordChars(wxSpinEvent& evt);
 ////@begin AddEditPropSheet member function declarations
 
   wxString GetATime() const { return m_ATime ; }


### PR DESCRIPTION
- Width of all spinners is unified to 60 or 80 pixels depending on spinners max. value
- Value range of all spinners is set to values from preferences
- Takeover of AddEditPropSheet::OnAtLeastChars to CPasswordPolicy for an uniform behavior