### PR TITLE
Making dragbar tooltips translatable

### DIFF
--- a/src/ui/wxWidgets/PWSDragBar.cpp
+++ b/src/ui/wxWidgets/PWSDragBar.cpp
@@ -109,7 +109,7 @@ void PWSDragBar::RefreshButtons()
     for (int idx = 0; size_t(idx) < NumberOf(DragbarElements); ++idx) {
       AddTool(idx + DRAGBAR_TOOLID_BASE, BTN,
                 wxString(_("Drag this image onto another window to paste the '"))
-                        << DragbarElements[idx].name << _("' field."), BTN_DISABLED );
+                        << _(DragbarElements[idx].name) << _("' field."), BTN_DISABLED );
     }
   }
   else {


### PR DESCRIPTION
Dragbar tooltips are constructed from a fixed translated text and a non-translated field name text. Changing the latter also to translated.