### PR TITLE
[wx] Tweaks to layout of password dialogs

### DIFF
--- a/src/ui/wxWidgets/safecombinationchange.cpp
+++ b/src/ui/wxWidgets/safecombinationchange.cpp
@@ -54,15 +54,12 @@ BEGIN_EVENT_TABLE( CSafeCombinationChange, wxDialog )
 
 ////@begin CSafeCombinationChange event table entries
 #ifndef NO_YUBI
-  EVT_BUTTON( ID_YUBIBTN, CSafeCombinationChange::OnYubibtnClick )
-
-  EVT_BUTTON( ID_YUBIBTN2, CSafeCombinationChange::OnYubibtn2Click )
-  EVT_TIMER(CYubiMixin::POLLING_TIMER_ID, CSafeCombinationChange::OnPollingTimer)
+  EVT_BUTTON( ID_YUBIBTN,                   CSafeCombinationChange::OnYubibtnClick  )
+  EVT_BUTTON( ID_YUBIBTN2,                  CSafeCombinationChange::OnYubibtn2Click )
+  EVT_TIMER(  CYubiMixin::POLLING_TIMER_ID, CSafeCombinationChange::OnPollingTimer  )
 #endif
-
-  EVT_BUTTON( wxID_OK, CSafeCombinationChange::OnOkClick )
-
-  EVT_BUTTON( wxID_CANCEL, CSafeCombinationChange::OnCancelClick )
+  EVT_BUTTON( wxID_OK,                      CSafeCombinationChange::OnOkClick       )
+  EVT_BUTTON( wxID_CANCEL,                  CSafeCombinationChange::OnCancelClick   )
 
 ////@end CSafeCombinationChange event table entries
 END_EVENT_TABLE()
@@ -96,6 +93,8 @@ bool CSafeCombinationChange::Create( wxWindow* parent, wxWindowID id, const wxSt
   {
     GetSizer()->SetSizeHints(this);
   }
+  // Allow to resize the dialog in width, only.
+  SetMaxSize(wxSize(wxDefaultCoord, GetMinSize().y));
   Centre();
 ////@end CSafeCombinationChange creation
 #ifndef NO_YUBI
@@ -162,13 +161,14 @@ void CSafeCombinationChange::CreateControls()
 #endif
 
   wxFlexGridSizer* itemFlexGridSizer4 = new wxFlexGridSizer(DLGITEM_COLS, 0, 0);
-  itemBoxSizer2->Add(itemFlexGridSizer4, 0, wxALIGN_LEFT|wxALL, 5);
+  itemFlexGridSizer4->AddGrowableCol(1);
+  itemBoxSizer2->Add(itemFlexGridSizer4, 1, wxALIGN_LEFT|wxALL|wxEXPAND, 5);
 
   wxStaticText* itemStaticText5 = new wxStaticText( itemDialog1, wxID_STATIC, _("Old safe combination:"), wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT );
   itemFlexGridSizer4->Add(itemStaticText5, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_oldPasswdEntry = new CSafeCombinationCtrl( itemDialog1, ID_OLDPASSWD, &m_oldpasswd, wxDefaultPosition, wxSize(itemDialog1->ConvertDialogToPixels(wxSize(150, -1)).x, -1) );
-  itemFlexGridSizer4->Add(m_oldPasswdEntry, 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+  m_oldPasswdEntry = new CSafeCombinationCtrl( itemDialog1, ID_OLDPASSWD, &m_oldpasswd, wxDefaultPosition, wxDefaultSize );
+  itemFlexGridSizer4->Add(m_oldPasswdEntry, 1, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5);
 
 #ifndef NO_YUBI
   m_YubiBtn = new wxBitmapButton( itemDialog1, ID_YUBIBTN, itemDialog1->GetBitmapResource(wxT("graphics/Yubikey-button.xpm")), wxDefaultPosition, itemDialog1->ConvertDialogToPixels(wxSize(40, 15)), wxBU_AUTODRAW );
@@ -178,8 +178,8 @@ void CSafeCombinationChange::CreateControls()
   wxStaticText* itemStaticText8 = new wxStaticText( itemDialog1, wxID_STATIC, _("New safe combination:"), wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT );
   itemFlexGridSizer4->Add(itemStaticText8, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_newPasswdEntry = new CSafeCombinationCtrl( itemDialog1, ID_NEWPASSWD, &m_newpasswd, wxDefaultPosition, wxSize(itemDialog1->ConvertDialogToPixels(wxSize(150, -1)).x, -1) );
-  itemFlexGridSizer4->Add(m_newPasswdEntry, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+  m_newPasswdEntry = new CSafeCombinationCtrl( itemDialog1, ID_NEWPASSWD, &m_newpasswd, wxDefaultPosition, wxDefaultSize );
+  itemFlexGridSizer4->Add(m_newPasswdEntry, 1, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5);
 
 #ifndef NO_YUBI
   m_YubiBtn2 = new wxBitmapButton( itemDialog1, ID_YUBIBTN2, itemDialog1->GetBitmapResource(wxT("graphics/Yubikey-button.xpm")), wxDefaultPosition, itemDialog1->ConvertDialogToPixels(wxSize(40, 15)), wxBU_AUTODRAW );
@@ -189,8 +189,8 @@ void CSafeCombinationChange::CreateControls()
   wxStaticText* itemStaticText11 = new wxStaticText( itemDialog1, wxID_STATIC, _("Confirmation:"), wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT );
   itemFlexGridSizer4->Add(itemStaticText11, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_confirmEntry = new CSafeCombinationCtrl( itemDialog1, ID_CONFIRM, &m_confirm, wxDefaultPosition, wxSize(itemDialog1->ConvertDialogToPixels(wxSize(150, -1)).x, -1) );
-  itemFlexGridSizer4->Add(m_confirmEntry, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+  m_confirmEntry = new CSafeCombinationCtrl( itemDialog1, ID_CONFIRM, &m_confirm, wxDefaultPosition, wxDefaultSize );
+  itemFlexGridSizer4->Add(m_confirmEntry, 1, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5);
 
   itemFlexGridSizer4->Add(10, 10, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 

--- a/src/ui/wxWidgets/safecombinationentry.cpp
+++ b/src/ui/wxWidgets/safecombinationentry.cpp
@@ -66,18 +66,18 @@ IMPLEMENT_CLASS( CSafeCombinationEntry, wxDialog )
 BEGIN_EVENT_TABLE( CSafeCombinationEntry, wxDialog )
 
 ////@begin CSafeCombinationEntry event table entries
-  EVT_ACTIVATE( CSafeCombinationEntry::OnActivate )
-  EVT_BUTTON( ID_ELLIPSIS, CSafeCombinationEntry::OnEllipsisClick )
-  EVT_BUTTON( ID_NEWDB, CSafeCombinationEntry::OnNewDbClick )
+  EVT_ACTIVATE( CSafeCombinationEntry::OnActivate                              )
+  EVT_BUTTON(   ID_ELLIPSIS,       CSafeCombinationEntry::OnEllipsisClick      )
+  EVT_BUTTON(   ID_NEWDB,          CSafeCombinationEntry::OnNewDbClick         )
 #ifndef NO_YUBI
-  EVT_BUTTON( ID_YUBIBTN, CSafeCombinationEntry::OnYubibtnClick )
-  EVT_TIMER(POLLING_TIMER_ID, CSafeCombinationEntry::OnPollingTimer)
+  EVT_BUTTON(   ID_YUBIBTN,        CSafeCombinationEntry::OnYubibtnClick       )
+  EVT_TIMER(    POLLING_TIMER_ID,  CSafeCombinationEntry::OnPollingTimer       )
 #endif
-  EVT_BUTTON( wxID_OK, CSafeCombinationEntry::OnOk )
-  EVT_BUTTON( wxID_CANCEL, CSafeCombinationEntry::OnCancel )
-  EVT_COMBOBOX(ID_DBASECOMBOBOX, CSafeCombinationEntry::OnDBSelectionChange)
-  EVT_CHECKBOX(ID_READONLY, CSafeCombinationEntry::OnReadonlyClick)
-                ////@end CSafeCombinationEntry event table entries
+  EVT_BUTTON(   wxID_OK,           CSafeCombinationEntry::OnOk                 )
+  EVT_BUTTON(   wxID_CANCEL,       CSafeCombinationEntry::OnCancel             )
+  EVT_COMBOBOX( ID_DBASECOMBOBOX,  CSafeCombinationEntry::OnDBSelectionChange  )
+  EVT_CHECKBOX( ID_READONLY,       CSafeCombinationEntry::OnReadonlyClick      )
+////@end CSafeCombinationEntry event table entries
 END_EVENT_TABLE()
 
 /*!
@@ -116,6 +116,8 @@ bool CSafeCombinationEntry::Create( wxWindow* parent, wxWindowID id, const wxStr
   {
     GetSizer()->SetSizeHints(this);
   }
+  // Allow to resize the dialog in width, only.
+  SetMaxSize(wxSize(wxDefaultCoord, GetMinSize().y));
   Centre();
 ////@end CSafeCombinationEntry creation
 #ifndef NO_YUBI

--- a/src/ui/wxWidgets/safecombinationprompt.cpp
+++ b/src/ui/wxWidgets/safecombinationprompt.cpp
@@ -54,17 +54,14 @@ BEGIN_EVENT_TABLE( CSafeCombinationPrompt, wxDialog )
 
 #ifndef NO_YUBI
 ////@begin CSafeCombinationPrompt event table entries
-  EVT_BUTTON( ID_YUBIBTN, CSafeCombinationPrompt::OnYubibtnClick )
-
+  EVT_BUTTON( ID_YUBIBTN,  CSafeCombinationPrompt::OnYubibtnClick      )
+  EVT_TIMER(  POLLING_TIMER_ID, CSafeCombinationPrompt::OnPollingTimer )
 ////@end CSafeCombinationPrompt event table entries
-EVT_TIMER(POLLING_TIMER_ID, CSafeCombinationPrompt::OnPollingTimer)
 #endif
 
-  EVT_BUTTON( wxID_OK, CSafeCombinationPrompt::OnOkClick )
-
-  EVT_BUTTON( wxID_CANCEL, CSafeCombinationPrompt::OnCancelClick )
-
-  EVT_BUTTON( wxID_EXIT, CSafeCombinationPrompt::OnExitClick )
+  EVT_BUTTON( wxID_OK,     CSafeCombinationPrompt::OnOkClick           )
+  EVT_BUTTON( wxID_CANCEL, CSafeCombinationPrompt::OnCancelClick       )
+  EVT_BUTTON( wxID_EXIT,   CSafeCombinationPrompt::OnExitClick         )
 
 END_EVENT_TABLE()
 
@@ -98,6 +95,8 @@ bool CSafeCombinationPrompt::Create( wxWindow* parent, wxWindowID id, const wxSt
   {
     GetSizer()->SetSizeHints(this);
   }
+  // Allow to resize the dialog in width, only.
+  SetMaxSize(wxSize(wxDefaultCoord, GetMinSize().y));
   Centre();
 ////@end CSafeCombinationPrompt creation
 #ifndef NO_YUBI
@@ -150,28 +149,28 @@ void CSafeCombinationPrompt::CreateControls()
   itemDialog1->SetSizer(itemBoxSizer2);
 
   auto *itemBoxSizer3 = new wxBoxSizer(wxHORIZONTAL);
-  itemBoxSizer2->Add(itemBoxSizer3, 1, wxALIGN_CENTER_HORIZONTAL|wxALL, 5);
+  itemBoxSizer2->Add(itemBoxSizer3, 1, wxALIGN_CENTER_HORIZONTAL|wxALL|wxEXPAND, 5);
 
   wxStaticBitmap* itemStaticBitmap4 = new wxStaticBitmap( itemDialog1, wxID_STATIC, itemDialog1->GetBitmapResource(L"graphics/cpane.xpm"), wxDefaultPosition, itemDialog1->ConvertDialogToPixels(wxSize(49, 46)), 0 );
-  itemBoxSizer3->Add(itemStaticBitmap4, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
+  itemBoxSizer3->Add(itemStaticBitmap4, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxALL, 5);
 
   auto *itemBoxSizer5 = new wxBoxSizer(wxVERTICAL);
-  itemBoxSizer3->Add(itemBoxSizer5, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
+  itemBoxSizer3->Add(itemBoxSizer5, 1, wxALIGN_CENTER_VERTICAL|wxALL|wxGROW, 5);
 
   wxStaticText* itemStaticText6 = new wxStaticText( itemDialog1, wxID_STATIC, _("Please enter the safe combination for this password database."), wxDefaultPosition, wxDefaultSize, 0 );
-  itemBoxSizer5->Add(itemStaticText6, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5);
+  itemBoxSizer5->Add(itemStaticText6, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxALL, 5);
 
   wxStaticText* itemStaticText7 = new wxStaticText( itemDialog1, wxID_STATIC, _("filename"), wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer5->Add(itemStaticText7, 0, wxALIGN_LEFT|wxALL, 5);
 
   auto *itemBoxSizer8 = new wxBoxSizer(wxHORIZONTAL);
-  itemBoxSizer5->Add(itemBoxSizer8, 0, wxGROW|wxALL, 5);
+  itemBoxSizer5->Add(itemBoxSizer8, 0, wxGROW|wxALL|wxEXPAND, 5);
 
   wxStaticText* itemStaticText9 = new wxStaticText( itemDialog1, wxID_STATIC, _("Safe combination:"), wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer8->Add(itemStaticText9, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  m_scctrl = new CSafeCombinationCtrl( itemDialog1, ID_PASSWORD, &m_password, wxDefaultPosition, wxSize(itemDialog1->ConvertDialogToPixels(wxSize(150, -1)).x, -1) );
-  itemBoxSizer8->Add(m_scctrl, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
+  m_scctrl = new CSafeCombinationCtrl( itemDialog1, ID_PASSWORD, &m_password, wxDefaultPosition, wxDefaultSize );
+  itemBoxSizer8->Add(m_scctrl, 1, wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5);
 
   auto *itemBoxSizer11 = new wxBoxSizer(wxHORIZONTAL);
   itemBoxSizer5->Add(itemBoxSizer11, 0, wxGROW|wxALL, 5);


### PR DESCRIPTION
Dialogs for requesting password from user are restricted to grow in width.
Changing the width of such a dialog will only change the width of the text entry fields.
This should prevent something like the following example, which looks a bit strange.

![safecombinationentry](https://user-images.githubusercontent.com/4042917/53766430-1867fb00-3ed3-11e9-8919-bfcff8be3d7f.png)
