### PR TITLE
Fixes #541 compilation error

### DIFF
--- a/src/os/unix/pws_time.h
+++ b/src/os/unix/pws_time.h
@@ -13,8 +13,11 @@
 #ifdef __FreeBSD__
 #include <time.h>
 #endif
+
 typedef time_t __time32_t;
+#ifndef __time64_t 
 typedef uint64_t __time64_t;
+#endif
 
 extern int localtime64_r(const __time64_t *timep, struct tm *result);
 


### PR DESCRIPTION
Fixes #541 
Updates pws_time.h to check for existing definition of __time64_t before attempting to redefine it using a typedef.