### PR TITLE
Update runtime version of libcurl to match compile version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,12 +473,12 @@ set (CPACK_DEBIAN_PACKAGE_CONFLICTS "passwordsafe-common") # Debian package main
 if (${LSB_RELEASE_ID_SHORT} STREQUAL "Ubuntu")
 	## Ubuntu-specific
   string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.[0-9]+" "\\1.\\2" XercesC_VER ${XercesC_VERSION})
-	set (CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.11.1-0ubuntu7.2), libcurl3 (>= 7.47.0-1), libuuid1 (>= 2.17.2-0ubuntu1), libwxgtk3.0-0v5 (>= 3.0.0-2) | libwxgtk3.0-0 (>= 3.0.0-2), libxtst6 (>= 2:1.1.0-2), libxerces-c${XercesC_VER} (>= 3.1.0-1), libykpers-1-1 (>= 1.7.0-1), libqrencode3 (>= 3.4.4-1)")
+	set (CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.11.1-0ubuntu7.2), libcurl4 (>= 7.47.0-1), libuuid1 (>= 2.17.2-0ubuntu1), libwxgtk3.0-0v5 (>= 3.0.0-2) | libwxgtk3.0-0 (>= 3.0.0-2), libxtst6 (>= 2:1.1.0-2), libxerces-c${XercesC_VER} (>= 3.1.0-1), libykpers-1-1 (>= 1.7.0-1), libqrencode3 (>= 3.4.4-1)")
 endif (${LSB_RELEASE_ID_SHORT} STREQUAL "Ubuntu")
 
 if (${LSB_RELEASE_ID_SHORT} STREQUAL "Debian")
 	## Debian-specific:
-	set (CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.7-18lenny4), libcurl3 (>= 7.52.1-5), libuuid1 (>= 1.41.3-1), libwxgtk3.0-0 (>= 3.0.0-2) | libwxgtk3.0-0v5 (>= 3.0.0-2), libxtst6 (>= 2:1.0.3-1), libxerces-c3.1 (>= 3.1.1-1+b1), libykpers-1-1 (>= 1.7.0-1), libqrencode3 (>= 3.4.4-1+b2)")
+	set (CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.7-18lenny4), libcurl4 (>= 7.52.1-5), libuuid1 (>= 1.41.3-1), libwxgtk3.0-0 (>= 3.0.0-2) | libwxgtk3.0-0v5 (>= 3.0.0-2), libxtst6 (>= 2:1.0.3-1), libxerces-c3.1 (>= 3.1.1-1+b1), libykpers-1-1 (>= 1.7.0-1), libqrencode3 (>= 3.4.4-1+b2)")
   set (CPACK_DEBIAN_PACKAGE_RECOMMENDS "xvkbd (>= 3.3-1+b1)")
 endif (${LSB_RELEASE_ID_SHORT} STREQUAL "Debian")
 


### PR DESCRIPTION
This fixes a dependency conflict error when installing on Ubuntu. The
compile-time version is libcurl4*, so runtime one should match.

Related to https://github.com/pwsafe/pwsafe/issues/551