### PR TITLE
Option to disable online version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ endif (pwsafe_REVISION)
 # Configurable options:
 option (NO_YUBI "Set ON to disable YubiKey support" OFF)
 option (NO_GTEST "Set ON to disable gtest unit testing" OFF)
+option (NO_VERCHECK "Set ON to disable online version check" OFF)
 
 if (WIN32)
   option (WX_WINDOWS "Build wxWidget under Windows" OFF)
@@ -140,11 +141,13 @@ if (NOT WIN32 OR WX_WINDOWS)
                )
      endif (NOT PWSHINT_wxconfig)
   endif (NOT WIN32)
-  find_package(wxWidgets COMPONENTS adv base core html net REQUIRED)
+  find_package(wxWidgets COMPONENTS adv base core html REQUIRED)
   include(${wxWidgets_USE_FILE})
 
-  find_package(OpenSSL REQUIRED)
-  include_directories(${OPENSSL_INCLUDE_DIR})
+  if (NOT NO_VERCHECK)
+    find_package(OpenSSL REQUIRED)
+    include_directories(${OPENSSL_INCLUDE_DIR})
+  endif()
 endif (NOT WIN32 OR WX_WINDOWS)
 
 if (NOT WIN32)
@@ -222,6 +225,11 @@ if (res)
   set(pwsafe_VERSTRING "local")
 endif()
 
+if (NO_VERCHECK)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_VERCHECK")
+  message(STATUS "Online version check disabled")
+endif (NO_VERCHECK)
+
 # Assume that we're either MSVC or a Unix-like
 if (MSVC)
 # Debug build looks for dlls with _D postfix, this provides it:
@@ -238,7 +246,6 @@ set(CMAKE_CXX_FLAGS
 if (NO_YUBI)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_YUBI")
 endif (NO_YUBI)
-
 
 if (WX_WINDOWS)
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D __WX__")
@@ -368,9 +375,13 @@ if (XML_XERCESC)
   target_link_libraries(pwsafe ${XercesC_LIBRARY})
 endif (XML_XERCESC)
 
+if (NOT NO_VERCHECK)
+ set (CURL_LIBS "curl ${OPENSSL_SSL_LIBRARY}")
+endif ()
+
 if (APPLE)
     FIND_LIBRARY(QUARTZCORE_LIBS QuartzCore)
-    target_link_libraries(pwsafe ${wxWidgets_LIBRARIES} ${CMAKE_REQUIRED_LIBRARIES} ${QUARTZCORE_LIBS} curl ${OPENSSL_SSL_LIBRARY})
+    target_link_libraries(pwsafe ${wxWidgets_LIBRARIES} ${CMAKE_REQUIRED_LIBRARIES} ${QUARTZCORE_LIBS} ${CURL_LIBS})
 elseif (WIN32)
   if (NOT NO_YUBI)
    set (YUBILIB "YkLib22")
@@ -382,8 +393,7 @@ else ()
   if (NOT NO_QR)
     target_link_libraries(pwsafe qrencode  ${CMAKE_REQUIRED_LIBRARIES})
   endif (NOT NO_QR)
-  target_link_libraries(pwsafe ${wxWidgets_LIBRARIES} uuid Xtst X11 curl ${OPENSSL_SSL_LIBRARY}
-  ${CMAKE_REQUIRED_LIBRARIES})
+  target_link_libraries(pwsafe ${wxWidgets_LIBRARIES} uuid Xtst X11 ${CURL_LIBS} ${CMAKE_REQUIRED_LIBRARIES})
 endif()
 
 if (IPO_SUPPORTED)

--- a/CodeBlocks/PasswordSafe.workspace
+++ b/CodeBlocks/PasswordSafe.workspace
@@ -3,7 +3,7 @@
 	<Workspace title="PasswordSafe">
 		<Project filename="core/core.cbp" />
 		<Project filename="os/os.cbp" />
-		<Project filename="pwsafe/pwsafe.cbp" active="1">
+		<Project filename="pwsafe/pwsafe.cbp">
 			<Depends filename="core/core.cbp" />
 			<Depends filename="os/os.cbp" />
 		</Project>

--- a/CodeBlocks/core/core.cbp
+++ b/CodeBlocks/core/core.cbp
@@ -17,19 +17,6 @@
 				<Option run_host_application_in_terminal="1" />
 				<Option createDefFile="1" />
 				<Compiler>
-					<Add option="-Wnon-virtual-dtor" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wredundant-decls" />
-					<Add option="-Wcast-align" />
-					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wmissing-include-dirs" />
-					<Add option="-Wswitch-default" />
-					<Add option="-pedantic" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m64" />
@@ -37,11 +24,6 @@
 					<Add option="`../wx-config-filter --cxxflags --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="-fno-omit-frame-pointer" />
-					<Add option="-Wdouble-promotion" />
-					<Add option="-Wunused" />
-					<Add option="-Wuninitialized" />
-					<Add option="-Wlogical-op" />
-					<Add option="-Winvalid-pch" />
 					<Add option="-D_DEBUG" />
 					<Add option="-DDEBUG" />
 					<Add option="-DDEBUG_XMLPREFS" />
@@ -69,17 +51,6 @@
 				<Option compiler="gcc" />
 				<Option createDefFile="1" />
 				<Compiler>
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wredundant-decls" />
-					<Add option="-Wcast-align" />
-					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wmissing-include-dirs" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m32" />
@@ -87,11 +58,6 @@
 					<Add option="`../wx-config-filter32 --cxxflags --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="-fno-omit-frame-pointer" />
-					<Add option="-Wdouble-promotion" />
-					<Add option="-Wunused" />
-					<Add option="-Wuninitialized" />
-					<Add option="-Wlogical-op" />
-					<Add option="-Winvalid-pch" />
 					<Add option="-D_DEBUG" />
 					<Add option="-DDEBUG" />
 					<Add option="-DDEBUG_XMLPREFS" />
@@ -121,9 +87,6 @@
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-O2" />
-					<Add option="-Winit-self" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m64" />
@@ -153,9 +116,6 @@
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-O2" />
-					<Add option="-Winit-self" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m32" />
@@ -183,19 +143,6 @@
 				<Option compiler="gcc" />
 				<Option createDefFile="1" />
 				<Compiler>
-					<Add option="-Wnon-virtual-dtor" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wredundant-decls" />
-					<Add option="-Wcast-align" />
-					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wmissing-include-dirs" />
-					<Add option="-Wswitch-default" />
-					<Add option="-pedantic" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m64" />
@@ -203,11 +150,6 @@
 					<Add option="`../wx-config-filter --cxxflags --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="-fno-omit-frame-pointer" />
-					<Add option="-Wdouble-promotion" />
-					<Add option="-Wunused" />
-					<Add option="-Wuninitialized" />
-					<Add option="-Wlogical-op" />
-					<Add option="-Winvalid-pch" />
 					<Add option="-D_DEBUG" />
 					<Add option="-DDEBUG" />
 					<Add option="-DDEBUG_XMLPREFS" />
@@ -234,17 +176,6 @@
 				<Option compiler="gcc" />
 				<Option createDefFile="1" />
 				<Compiler>
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wredundant-decls" />
-					<Add option="-Wcast-align" />
-					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wmissing-declarations" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m32" />
@@ -252,11 +183,6 @@
 					<Add option="`../wx-config-filter32 --cxxflags --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="-fno-omit-frame-pointer" />
-					<Add option="-Wdouble-promotion" />
-					<Add option="-Wunused" />
-					<Add option="-Wuninitialized" />
-					<Add option="-Wlogical-op" />
-					<Add option="-Winvalid-pch" />
 					<Add option="-D_DEBUG" />
 					<Add option="-DDEBUG" />
 					<Add option="-DDEBUG_XMLPREFS" />
@@ -285,9 +211,6 @@
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-O2" />
-					<Add option="-Winit-self" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m64" />
@@ -316,9 +239,6 @@
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-O2" />
-					<Add option="-Winit-self" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m32" />
@@ -341,10 +261,27 @@
 			<Add alias="Debug64wx28" targets="Debug_L64;" />
 		</VirtualTargets>
 		<Compiler>
-			<Add option="-Wpedantic" />
+			<Add option="-Wnon-virtual-dtor" />
+			<Add option="-Wshadow" />
+			<Add option="-Winit-self" />
+			<Add option="-Wcast-align" />
+			<Add option="-Wundef" />
+			<Add option="-Wfloat-equal" />
+			<Add option="-Wunreachable-code" />
+			<Add option="-Wmissing-include-dirs" />
+			<Add option="-Wswitch-enum" />
+			<Add option="-Wswitch-default" />
+			<Add option="-Wzero-as-null-pointer-constant" />
+			<Add option="-Wextra" />
+			<Add option="-Wall" />
+			<Add option="-std=c++11" />
 			<Add option="-Wformat=2" />
-			<Add option="-Wcast-qual" />
-			<Add option="-Wold-style-cast" />
+			<Add option="-Wdouble-promotion" />
+			<Add option="-Wnull-dereference" />
+			<Add option="-Wduplicated-branches" />
+			<Add option="-Wduplicated-cond" />
+			<Add option="-Winvalid-pch" />
+			<Add option="-Wlogical-op" />
 			<Add option="-DUNICODE" />
 		</Compiler>
 		<Unit filename="../../src/core/BlowFish.cpp" />

--- a/CodeBlocks/os/os.cbp
+++ b/CodeBlocks/os/os.cbp
@@ -15,19 +15,6 @@
 				<Option compiler="gcc" />
 				<Option createDefFile="1" />
 				<Compiler>
-					<Add option="-Wnon-virtual-dtor" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wredundant-decls" />
-					<Add option="-Wcast-align" />
-					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wmissing-include-dirs" />
-					<Add option="-Wswitch-default" />
-					<Add option="-pedantic" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m64" />
@@ -35,10 +22,6 @@
 					<Add option="`../wx-config-filter --unicode=yes --debug=yes --inplace --cxxflags`" />
 					<Add option="-fsanitize=address" />
 					<Add option="-fno-omit-frame-pointer" />
-					<Add option="-Wunused" />
-					<Add option="-Wuninitialized" />
-					<Add option="-Wlogical-op" />
-					<Add option="-Winvalid-pch" />
 					<Add option="-D_DEBUG" />
 					<Add option="-DDEBUG" />
 					<Add option="-D__WXDEBUG__" />
@@ -60,17 +43,6 @@
 				<Option compiler="gcc" />
 				<Option createDefFile="1" />
 				<Compiler>
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wredundant-decls" />
-					<Add option="-Wcast-align" />
-					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wmissing-include-dirs" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m32" />
@@ -78,10 +50,6 @@
 					<Add option="`../wx-config-filter32 --cxxflags --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="-fno-omit-frame-pointer" />
-					<Add option="-Wunused" />
-					<Add option="-Wuninitialized" />
-					<Add option="-Wlogical-op" />
-					<Add option="-Winvalid-pch" />
 					<Add option="-D_DEBUG" />
 					<Add option="-DDEBUG" />
 					<Add option="-D__WXDEBUG__" />
@@ -106,11 +74,6 @@
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-O2" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m64" />
@@ -135,11 +98,6 @@
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-O2" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m32" />
@@ -163,31 +121,14 @@
 				<Option compiler="gcc" />
 				<Option createDefFile="1" />
 				<Compiler>
-					<Add option="-Wnon-virtual-dtor" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wredundant-decls" />
-					<Add option="-Wcast-align" />
-					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wmissing-include-dirs" />
-					<Add option="-Wswitch-default" />
-					<Add option="-pedantic" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m64" />
 					<Add option="-g" />
 					<Add option="`../wx-config-filter --unicode=yes --debug=yes --inplace --cxxflags`" />
+					<Add option="`pkg-config --cflags ykpers-1`" />
 					<Add option="-fsanitize=address" />
 					<Add option="-fno-omit-frame-pointer" />
-					<Add option="-Wunused" />
-					<Add option="-Wuninitialized" />
-					<Add option="-Wlogical-op" />
-					<Add option="-Winvalid-pch" />
-					<Add option="`pkg-config --cflags ykpers-1`" />
 					<Add option="-D_DEBUG" />
 					<Add option="-DDEBUG" />
 					<Add option="-D__WXDEBUG__" />
@@ -208,27 +149,14 @@
 				<Option compiler="gcc" />
 				<Option createDefFile="1" />
 				<Compiler>
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wredundant-decls" />
-					<Add option="-Wcast-align" />
-					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wmissing-include-dirs" />
-					<Add option="-Wswitch-default" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m32" />
 					<Add option="-g" />
 					<Add option="`../wx-config-filter32 --cxxflags --unicode=yes --debug=yes --inplace`" />
+					<Add option="`pkg-config --cflags ykpers-1`" />
 					<Add option="-fsanitize=address" />
 					<Add option="-fno-omit-frame-pointer" />
-					<Add option="-Wunused" />
-					<Add option="-Wuninitialized" />
-					<Add option="-Wlogical-op" />
-					<Add option="-Winvalid-pch" />
-					<Add option="`pkg-config --cflags ykpers-1`" />
 					<Add option="-D_DEBUG" />
 					<Add option="-DDEBUG" />
 					<Add option="-D__WXDEBUG__" />
@@ -252,11 +180,6 @@
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-O2" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m64" />
@@ -281,11 +204,6 @@
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-O2" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
-					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m32" />
@@ -302,10 +220,29 @@
 			</Target>
 		</Build>
 		<Compiler>
-			<Add option="-Wpedantic" />
+			<Add option="-Wnon-virtual-dtor" />
+			<Add option="-Wshadow" />
+			<Add option="-Winit-self" />
+			<Add option="-Wcast-align" />
+			<Add option="-Wundef" />
+			<Add option="-Wfloat-equal" />
+			<Add option="-Wunreachable-code" />
+			<Add option="-Wmissing-include-dirs" />
+			<Add option="-Wswitch-enum" />
+			<Add option="-Wswitch-default" />
+			<Add option="-Wzero-as-null-pointer-constant" />
+			<Add option="-Wextra" />
+			<Add option="-Wall" />
+			<Add option="-std=c++11" />
 			<Add option="-Wformat=2" />
 			<Add option="-Wcast-qual" />
 			<Add option="-Wno-unused-local-typedefs" />
+			<Add option="-Wdouble-promotion" />
+			<Add option="-Wnull-dereference" />
+			<Add option="-Wduplicated-branches" />
+			<Add option="-Wduplicated-cond" />
+			<Add option="-Winvalid-pch" />
+			<Add option="-Wlogical-op" />
 			<Add option="-DUNICODE" />
 		</Compiler>
 		<Unit filename="../../src/os/KeySend.h" />

--- a/CodeBlocks/pwsafe/pwsafe.cbp
+++ b/CodeBlocks/pwsafe/pwsafe.cbp
@@ -15,31 +15,14 @@
 				<Option parameters="-s" />
 				<Option projectLinkerOptionsRelation="2" />
 				<Compiler>
-					<Add option="-Wnon-virtual-dtor" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wredundant-decls" />
-					<Add option="-Wcast-align" />
-					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wmissing-include-dirs" />
-					<Add option="-Wswitch-default" />
-					<Add option="-pedantic" />
-					<Add option="-Wextra" />
 					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m64" />
 					<Add option="-g" />
-					<Add option="`../wx-config-filter --cxxflags --unicode=yes --debug=yes --inplace`" />
+					<Add option="`../wx-config-filter  --cxxflags --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="-fno-omit-frame-pointer" />
-					<Add option="-Wpedantic" />
-					<Add option="-Wunused" />
-					<Add option="-Wuninitialized" />
-					<Add option="-Wlogical-op" />
-					<Add option="-Winvalid-pch" />
 					<Add option="-D_DEBUG" />
 					<Add option="-DDEBUG" />
 					<Add option="-D__WXDEBUG__" />
@@ -51,7 +34,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m64" />
-					<Add option="`wx-config --libs --unicode=yes --debug=yes --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add library="core64d" />
 					<Add library="os64d" />
@@ -67,15 +50,6 @@
 				<Option compiler="gcc" />
 				<Option projectLinkerOptionsRelation="2" />
 				<Compiler>
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wcast-align" />
-					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wmissing-include-dirs" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
 					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
@@ -84,11 +58,6 @@
 					<Add option="`../wx-config-filter32 --cxxflags --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="-fno-omit-frame-pointer" />
-					<Add option="-Wpedantic" />
-					<Add option="-Wunused" />
-					<Add option="-Wuninitialized" />
-					<Add option="-Wlogical-op" />
-					<Add option="-Winvalid-pch" />
 					<Add option="-D_DEBUG" />
 					<Add option="-DDEBUG" />
 					<Add option="-D__WXDEBUG__" />
@@ -101,7 +70,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m32" />
-					<Add option="`wx-config --libs --unicode=yes --debug=yes --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add library="core32d" />
 					<Add library="os32d" />
@@ -119,15 +88,12 @@
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-O2" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
 					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m64" />
 					<Add option="`../wx-config-filter --cxxflags --unicode=yes --debug=no --inplace`" />
+					<Add option="-Wno-type-limits" />
 					<Add option="-DNDEBUG" />
 					<Add option="-DUSE_XML_LIBRARY=XERCES" />
 					<Add option="-DWCHAR_INCOMPATIBLE_XMLCH" />
@@ -137,7 +103,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m64" />
-					<Add option="`wx-config --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
 					<Add library="core64" />
 					<Add library="os64" />
 					<Add directory="../core" />
@@ -154,15 +120,12 @@
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-O2" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
 					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m32" />
 					<Add option="`../wx-config-filter32 --cxxflags --unicode=yes --debug=no --inplace`" />
+					<Add option="-Wno-type-limits" />
 					<Add option="-DNDEBUG" />
 					<Add option="-DUSE_XML_LIBRARY=XERCES" />
 					<Add option="-DWCHAR_INCOMPATIBLE_XMLCH" />
@@ -173,7 +136,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m32" />
-					<Add option="`wx-config --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
 					<Add library="core32" />
 					<Add library="os32" />
 					<Add directory="../core" />
@@ -194,10 +157,10 @@
 					<Add option="-Wredundant-decls" />
 					<Add option="-Wcast-align" />
 					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
 					<Add option="-Wunreachable-code" />
 					<Add option="-Wmissing-include-dirs" />
 					<Add option="-Wswitch-default" />
+					<Add option="-Wzero-as-null-pointer-constant" />
 					<Add option="-pedantic" />
 					<Add option="-Wextra" />
 					<Add option="-Wall" />
@@ -206,14 +169,9 @@
 					<Add option="-m64" />
 					<Add option="-g" />
 					<Add option="`../wx-config-filter --cxxflags --unicode=yes --debug=yes --inplace`" />
+					<Add option="`pkg-config --cflags ykpers-1`" />
 					<Add option="-fsanitize=address" />
 					<Add option="-fno-omit-frame-pointer" />
-					<Add option="-Wpedantic" />
-					<Add option="-Wunused" />
-					<Add option="-Wuninitialized" />
-					<Add option="-Wlogical-op" />
-					<Add option="-Winvalid-pch" />
-					<Add option="`pkg-config --cflags ykpers-1`" />
 					<Add option="-D_DEBUG" />
 					<Add option="-DDEBUG" />
 					<Add option="-D__WXDEBUG__" />
@@ -223,7 +181,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m64" />
-					<Add option="`wx-config --libs --unicode=yes --debug=yes --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
@@ -241,28 +199,15 @@
 				<Option compiler="gcc" />
 				<Option projectLinkerOptionsRelation="2" />
 				<Compiler>
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wcast-align" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wmissing-include-dirs" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
 					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m32" />
 					<Add option="-g" />
 					<Add option="`../wx-config-filter32 --cxxflags --unicode=yes --debug=yes --inplace`" />
+					<Add option="`pkg-config --cflags ykpers-1`" />
 					<Add option="-fsanitize=address" />
 					<Add option="-fno-omit-frame-pointer" />
-					<Add option="-Wpedantic" />
-					<Add option="-Wunused" />
-					<Add option="-Wuninitialized" />
-					<Add option="-Wlogical-op" />
-					<Add option="-Winvalid-pch" />
-					<Add option="`pkg-config --cflags ykpers-1`" />
 					<Add option="-D_DEBUG" />
 					<Add option="-DDEBUG" />
 					<Add option="-D__WXDEBUG__" />
@@ -273,7 +218,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m32" />
-					<Add option="`wx-config --libs --unicode=yes --debug=yes --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
@@ -293,19 +238,13 @@
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-O2" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
 					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m64" />
 					<Add option="`../wx-config-filter --cxxflags --unicode=yes --debug=no --inplace`" />
 					<Add option="`pkg-config --cflags ykpers-1`" />
+					<Add option="-Wno-type-limits" />
 					<Add option="-DNDEBUG" />
 					<Add option="-DUSE_XML_LIBRARY=XERCES" />
 					<Add option="-DWCHAR_INCOMPATIBLE_XMLCH" />
@@ -313,7 +252,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m64" />
-					<Add option="`wx-config --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
 					<Add library="core64y" />
@@ -332,20 +271,13 @@
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-O2" />
-					<Add option="-Wshadow" />
-					<Add option="-Winit-self" />
-					<Add option="-Wfloat-equal" />
-					<Add option="-Winline" />
-					<Add option="-Wunreachable-code" />
-					<Add option="-Wmissing-include-dirs" />
-					<Add option="-Wswitch-default" />
-					<Add option="-Wextra" />
 					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-fPIC" />
 					<Add option="-m32" />
 					<Add option="`../wx-config-filter32 --cxxflags --unicode=yes --debug=no --inplace`" />
 					<Add option="`pkg-config --cflags ykpers-1`" />
+					<Add option="-Wno-type-limits" />
 					<Add option="-DNDEBUG" />
 					<Add option="-DUSE_XML_LIBRARY=XERCES" />
 					<Add option="-DWCHAR_INCOMPATIBLE_XMLCH" />
@@ -354,7 +286,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m32" />
-					<Add option="`wx-config --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
 					<Add library="core32y" />
@@ -365,12 +297,33 @@
 			</Target>
 		</Build>
 		<Compiler>
+			<Add option="-Wnon-virtual-dtor" />
+			<Add option="-Wshadow" />
+			<Add option="-Winit-self" />
+			<Add option="-Wcast-align" />
+			<Add option="-Wundef" />
+			<Add option="-Wfloat-equal" />
+			<Add option="-Wunreachable-code" />
+			<Add option="-Wmissing-include-dirs" />
+			<Add option="-Wswitch-enum" />
+			<Add option="-Wswitch-default" />
+			<Add option="-Wzero-as-null-pointer-constant" />
+			<Add option="-Wextra" />
 			<Add option="-Wall" />
+			<Add option="-std=c++11" />
+			<Add option="-fPIC" />
 			<Add option="-Wformat=2" />
 			<Add option="-Wno-unused-local-typedefs" />
+			<Add option="-Wdouble-promotion" />
+			<Add option="-Wnull-dereference" />
+			<Add option="-Wduplicated-branches" />
+			<Add option="-Wduplicated-cond" />
+			<Add option="-Winvalid-pch" />
+			<Add option="-Wlogical-op" />
 			<Add option="-DUNICODE" />
 		</Compiler>
 		<Linker>
+			<Add option="`pkg-config --libs libcurl`" />
 			<Add library="uuid" />
 			<Add library="Xtst" />
 			<Add library="X11" />
@@ -385,6 +338,8 @@
 		<Unit filename="../../src/ui/wxWidgets/CompareDlg.h" />
 		<Unit filename="../../src/ui/wxWidgets/ComparisonGridTable.cpp" />
 		<Unit filename="../../src/ui/wxWidgets/ComparisonGridTable.h" />
+		<Unit filename="../../src/ui/wxWidgets/CryptKeyEntry.cpp" />
+		<Unit filename="../../src/ui/wxWidgets/CryptKeyEntry.h" />
 		<Unit filename="../../src/ui/wxWidgets/DbSelectionPanel.cpp" />
 		<Unit filename="../../src/ui/wxWidgets/DbSelectionPanel.h" />
 		<Unit filename="../../src/ui/wxWidgets/ExportTextWarningDlg.cpp" />

--- a/CodeBlocks/pwsafe/pwsafe.cbp
+++ b/CodeBlocks/pwsafe/pwsafe.cbp
@@ -30,11 +30,12 @@
 					<Add option="-DWCHAR_INCOMPATIBLE_XMLCH" />
 					<Add option="-DNO_YUBI" />
 					<Add option="-DNO_QR" />
+					<Add option="-DNO_VERCHECK" />
 					<Add directory="../../src" />
 				</Compiler>
 				<Linker>
 					<Add option="-m64" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=yes --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs core,base,adv,html --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add library="core64d" />
 					<Add library="os64d" />
@@ -66,11 +67,12 @@
 					<Add option="-DNO_YUBI" />
 					<Add option="-DwxSIZE_T_IS_UINT" />
 					<Add option="-DNO_QR" />
+					<Add option="-DNO_VERCHECK" />
 					<Add directory="../../src" />
 				</Compiler>
 				<Linker>
 					<Add option="-m32" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=yes --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs core,base,adv,html --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add library="core32d" />
 					<Add library="os32d" />
@@ -99,11 +101,12 @@
 					<Add option="-DWCHAR_INCOMPATIBLE_XMLCH" />
 					<Add option="-DNO_YUBI" />
 					<Add option="-DNO_QR" />
+					<Add option="-DNO_VERCHECK" />
 					<Add directory="../../src" />
 				</Compiler>
 				<Linker>
 					<Add option="-m64" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs core,base,adv,html --unicode=yes --debug=no --inplace`" />
 					<Add library="core64" />
 					<Add library="os64" />
 					<Add directory="../core" />
@@ -132,11 +135,12 @@
 					<Add option="-DNO_YUBI" />
 					<Add option="-DwxSIZE_T_IS_UINT" />
 					<Add option="-DNO_QR" />
+					<Add option="-DNO_VERCHECK" />
 					<Add directory="../../src" />
 				</Compiler>
 				<Linker>
 					<Add option="-m32" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs core,base,adv,html --unicode=yes --debug=no --inplace`" />
 					<Add library="core32" />
 					<Add library="os32" />
 					<Add directory="../core" />
@@ -181,10 +185,11 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m64" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=yes --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs core,base,adv,html --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
+					<Add option="`pkg-config --libs libcurl`" />
 					<Add library="core64yd" />
 					<Add library="os64yd" />
 					<Add directory="../core" />
@@ -218,10 +223,11 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m32" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=yes --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs core,base,adv,html --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
+					<Add option="`pkg-config --libs libcurl`" />
 					<Add library="core32yd" />
 					<Add library="os32yd" />
 					<Add directory="../core" />
@@ -252,9 +258,10 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m64" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs core,base,adv,html --unicode=yes --debug=no --inplace`" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
+					<Add option="`pkg-config --libs libcurl`" />
 					<Add library="core64y" />
 					<Add library="os64y" />
 					<Add directory="../core" />
@@ -286,9 +293,10 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m32" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs core,base,adv,html --unicode=yes --debug=no --inplace`" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
+					<Add option="`pkg-config --libs libcurl`" />
 					<Add library="core32y" />
 					<Add library="os32y" />
 					<Add directory="../core" />
@@ -323,7 +331,6 @@
 			<Add option="-DUNICODE" />
 		</Compiler>
 		<Linker>
-			<Add option="`pkg-config --libs libcurl`" />
 			<Add library="uuid" />
 			<Add library="Xtst" />
 			<Add library="X11" />

--- a/CodeBlocks/wx-config-filter
+++ b/CodeBlocks/wx-config-filter
@@ -1,3 +1,3 @@
 #!/bin/sh
 # have to use wrapper script, because C::B don't support stream redirection inside `expr`
-wx-config "$@" | sed 's/\(^\|\s\)-I/ -isystem /g'
+wx-config --version=3.0 "$@" | sed 's/\(^\|\s\)-I/ -isystem /g'

--- a/CodeBlocks/wx-config-filter32
+++ b/CodeBlocks/wx-config-filter32
@@ -4,4 +4,4 @@ exec=/usr/bin/32/wx-config
 if ! [ -x "$exec" ]; then
 exec=wx-config
 fi
-$exec "$@" | sed 's/\(^\|\s\)-I/ -isystem /g'
+$exec --version=3.0 "$@" | sed 's/\(^\|\s\)-I/ -isystem /g'

--- a/install/slackware/passwordsafe.SlackBuild
+++ b/install/slackware/passwordsafe.SlackBuild
@@ -65,12 +65,13 @@ FLAGS="-DCMAKE_INSTALL_PREFIX=${PREFIX} \
 NO_YUBI=0
 NO_QR=0
 NO_GTEST=1
+NO_VERCHECK=0
 
 # process parameters
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --help|-h)
-            echo -e "Usage: $0 [--no-yubi] [--no-qr] [--gtest]\n\tno-yubi -- disable Yuibikey support\n\tno-qr -- disable QR-code support\n\tgtest -- enable gtest" >&2
+            echo -e "Usage: $0 [--no-yubi] [--no-qr] [--no-vercheck] [--gtest]\n\tno-yubi -- disable Yuibikey support\n\tno-qr -- disable QR-code support\n\tno-vercheck -- disable online version check\n\tgtest -- enable gtest" >&2
             exit 1
             ;;
         --no-yubi)
@@ -78,6 +79,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         --no-qr)
             NO_QR=1
+            ;;
+        --no-vercheck)
+            NO_VERCHECK=1
             ;;
         --gtest)
             NO_GTEST=0
@@ -96,6 +100,10 @@ fi
 if [ "${NO_QR}" == "1" ]; then
     VERSION+="_noqr"
     FLAGS+="${FLAGS} -DNO_QR=ON"
+fi
+if [ "${NO_VERCHECK}" == "1" ]; then
+    VERSION+="_novercheck"
+    FLAGS+="${FLAGS} -DNO_VERCHECK=ON"
 fi
 if [ "${NO_GTEST}" == "1" ]; then
     FLAGS+="${FLAGS} -DNO_GTEST=ON"

--- a/src/ui/wxWidgets/about.cpp
+++ b/src/ui/wxWidgets/about.cpp
@@ -75,10 +75,11 @@ CAbout::CAbout( wxWindow* parent, wxWindowID id, const wxString& caption, const 
 {
   Init();
   Create(parent, id, caption, pos, size, style);
-
+#if defined(_DEBUG) || defined(DEBUG)
   // Print version information on standard output which might be useful for error reports.
   pws_os::Trace(GetLibWxVersion());
   pws_os::Trace(GetLibCurlVersion());
+#endif
 }
 
 /*!
@@ -373,6 +374,7 @@ void CAbout::Cleanup()
   }
 }
 
+#if defined(_DEBUG) || defined(DEBUG)
 /**
  * Provides version information about Curl library.
  */
@@ -409,6 +411,7 @@ wxString CAbout::GetLibWxVersion()
 {
   return wxString::Format("[wx] Wx Version:\n%s\n", wxGetLibraryVersionInfo().ToString());
 }
+#endif // debug
 
 /**
  * Checks whether database is closed.

--- a/src/ui/wxWidgets/about.cpp
+++ b/src/ui/wxWidgets/about.cpp
@@ -53,14 +53,19 @@ BEGIN_EVENT_TABLE( CAbout, wxDialog )
   EVT_HYPERLINK( ID_CHECKNEW     , CAbout::OnCheckNewClicked   )
   EVT_HYPERLINK( ID_SITEHYPERLINK, CAbout::OnVisitSiteClicked  )
   EVT_BUTTON(    wxID_CLOSE      , CAbout::OnCloseClick        )
+#ifndef NO_VERCHECK
   EVT_THREAD(    wxID_ANY        , CAbout::OnDownloadCompleted )
-
+#endif
 END_EVENT_TABLE()
 
+#ifndef NO_VERCHECK
 wxString CAbout::s_VersionData = wxEmptyString;
+const cstringT s_URL_VERSION   =  "https://pwsafe.org/latest.xml";
+#else
+const cstringT s_URL_VERSION   =  "https://pwsafe.org/news.shtml";
+#endif
 
 const wstringT s_URL_HOME      = L"https://pwsafe.org";
-const cstringT s_URL_VERSION   =  "https://pwsafe.org/latest.xml";
 
 /*!
  * CAbout constructors
@@ -78,7 +83,9 @@ CAbout::CAbout( wxWindow* parent, wxWindowID id, const wxString& caption, const 
 #if defined(_DEBUG) || defined(DEBUG)
   // Print version information on standard output which might be useful for error reports.
   pws_os::Trace(GetLibWxVersion());
+#ifndef NO_VERCHECK
   pws_os::Trace(GetLibCurlVersion());
+#endif // NO_VERCHECK
 #endif
 }
 
@@ -122,8 +129,10 @@ CAbout::~CAbout()
 
 void CAbout::Init()
 {
+#ifndef NO_VERCHECK
   m_VersionStatus = nullptr;
   m_CurlHandle = nullptr;
+#endif // NO_VERCHECK
 }
 
 /*!
@@ -179,9 +188,11 @@ void CAbout::CreateControls()
   wxStaticText* copyrightStaticText = new wxStaticText(aboutDialog, wxID_STATIC, _("Copyright (c) 2003-2019 Rony Shapiro"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
   rightSizer->Add(copyrightStaticText, 0, wxALIGN_LEFT|wxALL, 5);
 
+#ifndef NO_VERCHECK
   m_VersionStatus = new wxTextCtrl(aboutDialog, ID_TEXTCTRL, wxT("\n\n"), wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxTE_READONLY|wxNO_BORDER);
   rightSizer->Add(m_VersionStatus, 0, wxALIGN_LEFT|wxALL|wxEXPAND|wxRESERVE_SPACE_EVEN_IF_HIDDEN, 5);
   m_VersionStatus->Hide();
+#endif // NO_VERCHECK
 
   wxButton* closeButton = new wxButton(aboutDialog, wxID_CLOSE, _("&Close"), wxDefaultPosition, wxDefaultSize, 0);
   rightSizer->Add(closeButton, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5);
@@ -234,7 +245,9 @@ wxIcon CAbout::GetIconResource( const wxString& WXUNUSED(name) )
 
 void CAbout::OnCloseWindow( wxCloseEvent& WXUNUSED(event) )
 {
+#ifndef NO_VERCHECK
   Cleanup();
+#endif // NO_VERCHECK
   EndModal(wxID_CLOSE);
 }
 
@@ -244,10 +257,13 @@ void CAbout::OnCloseWindow( wxCloseEvent& WXUNUSED(event) )
 
 void CAbout::OnCloseClick( wxCommandEvent& WXUNUSED(event) )
 {
+#ifndef NO_VERCHECK
   Cleanup();
+#endif // NO_VERCHECK
   EndModal(wxID_CLOSE);
 }
 
+#ifndef NO_VERCHECK
 /**
  * Returns a <code>wxCriticalSection</code> object that is used to protect
  * the shared data <code>s_VersionData</code>, which is accessed by worker
@@ -402,14 +418,6 @@ wxString CAbout::GetLibCurlVersion()
   versionInfo << "[libcurl] Supported Protocols: " << protocols << "\n";
 
   return versionInfo;
-}
-
-/**
- * Provides version information about wxWidgets framework.
- */
-wxString CAbout::GetLibWxVersion()
-{
-  return wxString::Format("[wx] Wx Version:\n%s\n", wxGetLibraryVersionInfo().ToString());
 }
 #endif // debug
 
@@ -694,10 +702,32 @@ void CAbout::OnDownloadCompleted(wxThreadEvent& event)
     s_VersionData.Empty();
   }
 }
+#endif // NO_VERCHECK
+
+#if defined(_DEBUG) || defined(DEBUG)
+/**
+ * Provides version information about wxWidgets framework.
+ */
+wxString CAbout::GetLibWxVersion()
+{
+  return wxString::Format("[wx] Wx Version:\n%s\n", wxGetLibraryVersionInfo().ToString());
+}
+#endif // debug
 
 /**
  * wxEVT_HYPERLINK event handler for ID_SITEHYPERLINK
  */
 void CAbout::OnVisitSiteClicked(wxHyperlinkEvent& WXUNUSED(event)) {
   wxLaunchDefaultBrowser(s_URL_HOME);
+}
+
+/**
+ * wxEVT_HYPERLINK event handler for ID_CHECKNEW
+ */
+void CAbout::OnCheckNewClicked(wxHyperlinkEvent& WXUNUSED(event)) {
+#ifndef NO_VERCHECK
+  CheckNewVersion();
+#else
+  wxLaunchDefaultBrowser(s_URL_VERSION);
+#endif // NO_VERCHECK
 }

--- a/src/ui/wxWidgets/about.h
+++ b/src/ui/wxWidgets/about.h
@@ -63,8 +63,10 @@ class CAbout: public wxDialog, public wxThreadHelper
   bool CheckDatabaseStatus();
   bool SetupConnection();
   void Cleanup();
+#if defined(_DEBUG) || defined(DEBUG)
   wxString GetLibCurlVersion();
   wxString GetLibWxVersion();
+#endif
   static wxCriticalSection& CriticalSection();
   static size_t WriteCallback(char *receivedData, size_t size, size_t bytes, void *userData);
 

--- a/src/ui/wxWidgets/about.h
+++ b/src/ui/wxWidgets/about.h
@@ -19,12 +19,14 @@
 ////@begin includes
 #include <wx/hyperlink.h>
 #include <wx/event.h>
-#include <wx/thread.h>
 ////@end includes
 
 #include "os/typedefs.h"
 
+#ifndef NO_VERCHECK
+#include <wx/thread.h>
 #include <curl/curl.h>
+#endif // NO_VERCHECK
 
 /*!
  * Forward declarations
@@ -54,24 +56,32 @@
  * CAbout class declaration
  */
 
-class CAbout: public wxDialog, public wxThreadHelper
+class CAbout: public wxDialog
+#ifndef NO_VERCHECK
+, public wxThreadHelper
+#endif // NO_VERCHECK
 {
   DECLARE_CLASS( CAbout )
   DECLARE_EVENT_TABLE()
 
+#if defined(_DEBUG) || defined(DEBUG)
+  wxString GetLibWxVersion();
+#endif // debug
+
+#ifndef NO_VERCHECK
   void CompareVersionData();
   bool CheckDatabaseStatus();
   bool SetupConnection();
   void Cleanup();
 #if defined(_DEBUG) || defined(DEBUG)
   wxString GetLibCurlVersion();
-  wxString GetLibWxVersion();
-#endif
+#endif // debug
+
   static wxCriticalSection& CriticalSection();
   static size_t WriteCallback(char *receivedData, size_t size, size_t bytes, void *userData);
-
 protected:
   virtual wxThread::ExitCode Entry();
+#endif // NO_VERCHECK
 
 public:
   /// Constructors
@@ -84,18 +94,17 @@ public:
   /// Destructor
   ~CAbout();
 
-  /// Initialises member variables
+  /// Initializes member variables
   void Init();
 
   /// Creates the controls and sizers
   void CreateControls();
-
+#ifndef NO_VERCHECK
   void CheckNewVersion();
-
+#endif // NO_VERCHECK
 ////@begin CAbout event handler declarations
-
   /// event handler for ID_CHECKNEW
-  void OnCheckNewClicked(wxHyperlinkEvent& WXUNUSED(event)) { CheckNewVersion(); };
+  void OnCheckNewClicked(wxHyperlinkEvent& event);
 
   /// event handler for ID_SITEHYPERLINK
   void OnVisitSiteClicked(wxHyperlinkEvent& event);
@@ -106,8 +115,11 @@ public:
   /// wxEVT_CLOSE_WINDOW event handler
   void OnCloseWindow( wxCloseEvent& event );
 
+#ifndef NO_VERCHECK
   /// wxEVT_THREAD event handler for wxID_ANY
   void OnDownloadCompleted(wxThreadEvent& event);
+#endif // NO_VERCHECK
+
 ////@end CAbout event handler declarations
 
 ////@begin CAbout member function declarations
@@ -123,6 +135,7 @@ public:
   static bool ShowToolTips();
 
 private:
+#ifndef NO_VERCHECK
 ////@begin CAbout member variables
   wxTextCtrl* m_VersionStatus;
 ////@end CAbout member variables
@@ -132,9 +145,7 @@ private:
 
   /// Set to downloaded data by worker thread, resp. WriteCallback, and read by main thread for final version check
   static wxString s_VersionData;
-
-  static const wstringT s_HOME_URL;
-  static const cstringT s_VERSION_URL;
+#endif // NO_VERCHECK
 };
 
 #endif /* _ABOUT_H_ */


### PR DESCRIPTION
When active, it'll remove dependency on curl + ssl (if xerces build without curl too) and, link will be changed to open https://pwsafe.org/news.shtml in browser.
Also C::B project updated.