### PR TITLE
[wx] Store passphrase of newly created DB

### DIFF
--- a/src/ui/wxWidgets/safecombinationentry.cpp
+++ b/src/ui/wxWidgets/safecombinationentry.cpp
@@ -494,6 +494,8 @@ void CSafeCombinationEntry::OnNewDbClick( wxCommandEvent& /* evt */ )
 
   m_core.SetReadOnly(false); // new file can't be read-only...
   m_core.NewFile(tostringx(pksetup.GetPassword()));
+  m_password = tostringx(pksetup.GetPassword());
+
   if (m_core.WriteCurFile() == PWSfile::SUCCESS) {
     wxGetApp().recentDatabases().AddFileToHistory(newfile);
     EndModal(wxID_OK);


### PR DESCRIPTION
Storing the passphrase of newly created DB prevents that loading new DB provides  *PWSfile::WRONG_PASSWORD* (because an empty passphrase was used, instead of the one the user specified for new DB) and Core's internal state (m_bIsOpen) is wrongly set.