### PR TITLE
libmagic - update libs README.LINUX.DEVELOPERS.md and CMakeList RPM metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,7 +632,7 @@ set (CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
 endif (EXISTS "/etc/debian_version")
 
 ## RPM-specific
-set (CPACK_RPM_PACKAGE_REQUIRES "wxBase3, wxGTK3, xerces-c, ykpers, qrencode-libs file-libs")
+set (CPACK_RPM_PACKAGE_REQUIRES "wxBase3, wxGTK3, xerces-c, ykpers, qrencode-libs, file-libs")
 set (CPACK_RPM_PACKAGE_SUGGESTS "xvkbd")
 set (CPACK_RPM_PACKAGE_URL "https://pwsafe.org/")
 set (CPACK_RPM_PACKAGE_LICENSE "Artistic2.0")

--- a/README.LINUX.DEVELOPERS.md
+++ b/README.LINUX.DEVELOPERS.md
@@ -55,7 +55,6 @@ file-devel
 libXt-devel
 libXtst-devel
 libcurl-devel
-libqrencode-devel
 libuuid-devel
 libyubikey-devel
 make


### PR DESCRIPTION
Removed libqrencode-devel on README.LINUX.DEVELOPERS.md because correct one, already included, is qrencode-devel.
Update CMakeLists for a typo on RPM metadata -> file-libs inclusion.