### PR TITLE
Fix "Encrytion" typo in msgid strings

### DIFF
--- a/Misc/I18N/ru/omegat_wx/omegat/project_save.tmx
+++ b/Misc/I18N/ru/omegat_wx/omegat/project_save.tmx
@@ -4338,7 +4338,7 @@ Action:</seg>
     </tu>
     <tu>
       <tuv lang="EN-US">
-        <seg>Encrytion</seg>
+        <seg>Encryption</seg>
       </tuv>
       <tuv lang="RU-RU" changeid="pm_kan" changedate="20190503T175301Z" creationid="pm_kan" creationdate="20190503T175301Z">
         <seg>Шифрование</seg>

--- a/Misc/I18N/ru/omegat_wx/omegat_wx-level1.tmx
+++ b/Misc/I18N/ru/omegat_wx/omegat_wx-level1.tmx
@@ -3111,7 +3111,7 @@ Locked by</seg>
     </tu>
     <tu>
       <tuv lang="EN-US">
-        <seg>Encrytion</seg>
+        <seg>Encryption</seg>
       </tuv>
       <tuv lang="RU-RU" changeid="pm_kan" changedate="20190503T175301Z" creationid="pm_kan" creationdate="20190503T175301Z">
         <seg>Шифрование</seg>

--- a/Misc/I18N/ru/omegat_wx/omegat_wx-level2.tmx
+++ b/Misc/I18N/ru/omegat_wx/omegat_wx-level2.tmx
@@ -3111,7 +3111,7 @@ Locked by</seg>
     </tu>
     <tu>
       <tuv xml:lang="EN-US">
-        <seg>Encrytion</seg>
+        <seg>Encryption</seg>
       </tuv>
       <tuv xml:lang="RU-RU" changeid="pm_kan" changedate="20190503T175301Z" creationid="pm_kan" creationdate="20190503T175301Z">
         <seg>Шифрование</seg>

--- a/Misc/I18N/ru/omegat_wx/omegat_wx-omegat.tmx
+++ b/Misc/I18N/ru/omegat_wx/omegat_wx-omegat.tmx
@@ -3111,7 +3111,7 @@ Locked by</seg>
     </tu>
     <tu>
       <tuv lang="EN-US">
-        <seg>Encrytion</seg>
+        <seg>Encryption</seg>
       </tuv>
       <tuv lang="RU-RU" changeid="pm_kan" changedate="20190503T175301Z" creationid="pm_kan" creationdate="20190503T175301Z">
         <seg>Шифрование</seg>

--- a/src/ui/wxWidgets/CryptKeyEntry.cpp
+++ b/src/ui/wxWidgets/CryptKeyEntry.cpp
@@ -41,7 +41,7 @@ CryptKeyEntry::CryptKeyEntry(Mode mode)
     wxStdDialogButtonSizer* StdDialogButtonSizer1;
 
     if (mode == Mode::ENCRYPT) {
-      Create(nullptr, -1, _("Encrytion"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxTAB_TRAVERSAL, _T("id"));
+      Create(nullptr, -1, _("Encryption"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxTAB_TRAVERSAL, _T("id"));
       StaticTextDescription = new wxStaticText(this, wxID_ANY, _("Please enter an encryption key."), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
     }
     else {

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
@@ -2619,7 +2619,7 @@ msgstr "Synkronisering fejlede"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:44
 #, fuzzy
-msgid "Encrytion"
+msgid "Encryption"
 msgstr "Kryptering fejlede"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:45

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
@@ -2481,7 +2481,7 @@ msgid "Synchronization failed"
 msgstr "Synchronisation fehlgeschlagen"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:44
-msgid "Encrytion"
+msgid "Encryption"
 msgstr "Verschlüsselung"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:45

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
@@ -2665,7 +2665,7 @@ msgstr "Error de sincronización"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:44
 #, fuzzy
-msgid "Encrytion"
+msgid "Encryption"
 msgstr "Fallo de cifrado"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:45

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
@@ -2647,7 +2647,7 @@ msgstr "La synchronisation a échoué"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:44
 #, fuzzy
-msgid "Encrytion"
+msgid "Encryption"
 msgstr "L'encryptage a échoué"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:45

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
@@ -2508,7 +2508,7 @@ msgstr "Sikertelen szinkronizáció"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:44
 #, fuzzy
-msgid "Encrytion"
+msgid "Encryption"
 msgstr "Titkosítás sikertelen"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:45

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_it.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_it.po
@@ -2516,7 +2516,7 @@ msgid "Synchronization failed"
 msgstr "Sincronizzazione fallita"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:44
-msgid "Encrytion"
+msgid "Encryption"
 msgstr ""
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:45

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ko.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ko.po
@@ -2645,7 +2645,7 @@ msgstr "동기화 실패"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:44
 #, fuzzy
-msgid "Encrytion"
+msgid "Encryption"
 msgstr "암호화 실패"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:45

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
@@ -2676,7 +2676,7 @@ msgstr "Synchronisatie mislukt"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:44
 #, fuzzy
-msgid "Encrytion"
+msgid "Encryption"
 msgstr "Codering mislukt."
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:45

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
@@ -2607,7 +2607,7 @@ msgstr "Synchronizacja sie nie powiodła"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:44
 #, fuzzy
-msgid "Encrytion"
+msgid "Encryption"
 msgstr "Szyfrowanie nie powiodło się"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:45

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
@@ -2501,7 +2501,7 @@ msgid "Synchronization failed"
 msgstr "Сбой при синхронизации"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:44
-msgid "Encrytion"
+msgid "Encryption"
 msgstr "Шифрование"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:45

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
@@ -2655,7 +2655,7 @@ msgstr "Synkroniseringen misslyckades"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:44
 #, fuzzy
-msgid "Encrytion"
+msgid "Encryption"
 msgstr "Krypteringen misslyckades"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:45

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_zh.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_zh.po
@@ -2617,7 +2617,7 @@ msgstr "同步失败"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:44
 #, fuzzy
-msgid "Encrytion"
+msgid "Encryption"
 msgstr "加密失败"
 
 #: ../../../ui/wxWidgets/CryptKeyEntry.cpp:45


### PR DESCRIPTION
I noticed this typo while browsing through the code.  Since it's an internal string that isn't displayed anywhere, I don't suppose it matters all that much.  Regardless, here's a patch.