### PR TITLE
Use relative path for core headers in core/crypto

### DIFF
--- a/src/core/crypto/AES.cpp
+++ b/src/core/crypto/AES.cpp
@@ -12,7 +12,7 @@
 
 #include "AES.h"
 #include "bitops.h"
-#include "Util.h"
+#include "../Util.h"
 
 #define LTC_CLEAN_STACK
 

--- a/src/core/crypto/BlowFish.cpp
+++ b/src/core/crypto/BlowFish.cpp
@@ -10,9 +10,9 @@
 
 #include "BlowFish.h"
 #include "sha1.h"
-#include "PwsPlatform.h"
+#include "../PwsPlatform.h"
 #include "os/mem.h"
-#include "Util.h" // for trashMemory
+#include "../Util.h" // for trashMemory
 
 union aword
 {

--- a/src/core/crypto/TwoFish.cpp
+++ b/src/core/crypto/TwoFish.cpp
@@ -12,7 +12,7 @@
 
 #include "TwoFish.h"
 #include "bitops.h"
-#include "Util.h"
+#include "../Util.h"
 
 #define LTC_CLEAN_STACK
 #define TWOFISH_ALL_TABLES

--- a/src/core/crypto/hmac.h
+++ b/src/core/crypto/hmac.h
@@ -14,7 +14,7 @@
 
 // HMAC algorithm as per RFC2104
 
-#include "Util.h" // for ASSERT
+#include "../Util.h" // for ASSERT
 
 class HMAC_BASE
 {

--- a/src/core/crypto/sha1.cpp
+++ b/src/core/crypto/sha1.cpp
@@ -10,7 +10,7 @@
 
 /* based on SHA-1 in C By Steve Reid <steve@edmweb.com> */
 
-#include "PwsPlatform.h"
+#include "../PwsPlatform.h"
 //#define SHA1HANDSOFF Copies data before messing with it.
 
 #include <stdio.h>

--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -11,7 +11,7 @@
 //-----------------------------------------------------------------------------
 #include "sha256.h"
 #include "bitops.h"
-#include "Util.h"
+#include "../Util.h"
 
 #include <algorithm>
 

--- a/src/core/crypto/sha256.h
+++ b/src/core/crypto/sha256.h
@@ -13,7 +13,7 @@
 #define __SHA256_H
 
 #include "os/typedefs.h"
-#include "PwsPlatform.h"
+#include "../PwsPlatform.h"
 
 class SHA256
 {


### PR DESCRIPTION
These files are from one lib, so there is no need to resolve them using "additional include paths", also this simplifies include paths for os lib.