### PR TITLE
Fix Xcode build

### DIFF
--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -23,16 +23,22 @@
 /* Begin PBXBuildFile section */
 		6FF5D4A11DA14EE80032F5B6 /* PasswordSubsetDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF5D49D1DA14AB20032F5B6 /* PasswordSubsetDlg.cpp */; };
 		A2D181461C8FF86C0018AE03 /* media.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2D181451C8FF86C0018AE03 /* media.cpp */; };
-		A2FE25801C5ACEFD00210C36 /* AES.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE257E1C5ACEFD00210C36 /* AES.cpp */; };
 		A2FE258D1C5ACF7500210C36 /* Item.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25811C5ACF7500210C36 /* Item.cpp */; };
 		A2FE258E1C5ACF7500210C36 /* ItemAtt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25831C5ACF7500210C36 /* ItemAtt.cpp */; };
-		A2FE258F1C5ACF7500210C36 /* KeyWrap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25851C5ACF7500210C36 /* KeyWrap.cpp */; };
-		A2FE25901C5ACF7500210C36 /* pbkdf2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25871C5ACF7500210C36 /* pbkdf2.cpp */; };
 		A2FE25911C5ACF7500210C36 /* PWSfileHeader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25891C5ACF7500210C36 /* PWSfileHeader.cpp */; };
 		A2FE25921C5ACF7500210C36 /* PWSfileV4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE258B1C5ACF7500210C36 /* PWSfileV4.cpp */; };
 		A2FE25951C5ACFBD00210C36 /* PWStime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25931C5ACFBD00210C36 /* PWStime.cpp */; };
 		E0A70B9821C8FF8900A2FEA8 /* PolicyManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0A70B9621C8FF8900A2FEA8 /* PolicyManager.cpp */; };
 		E0A70B9B21C905A500A2FEA8 /* libcurl.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E0A70B9A21C905A500A2FEA8 /* libcurl.tbd */; };
+		E0C3C4422379B2C200715124 /* AES.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C42F2379B2C200715124 /* AES.cpp */; };
+		E0C3C4432379B2C200715124 /* BlowFish.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C4322379B2C200715124 /* BlowFish.cpp */; };
+		E0C3C4442379B2C200715124 /* KeyWrap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C4362379B2C200715124 /* KeyWrap.cpp */; };
+		E0C3C4452379B2C200715124 /* pbkdf2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C4382379B2C200715124 /* pbkdf2.cpp */; };
+		E0C3C4462379B2C200715124 /* sha1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C43A2379B2C200715124 /* sha1.cpp */; };
+		E0C3C4472379B2C200715124 /* sha256.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C43C2379B2C200715124 /* sha256.cpp */; };
+		E0C3C4492379B2C200715124 /* TwoFish.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C43F2379B2C200715124 /* TwoFish.cpp */; };
+		E0C3C44F2379CD7500715124 /* MenuFileHandlers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C44D2379CA7300715124 /* MenuFileHandlers.cpp */; };
+		E0C3C4502379CD8300715124 /* CryptKeyEntryDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C44A2379CA2A00715124 /* CryptKeyEntryDlg.cpp */; };
 		E60F25D812C4ACEB001E63C4 /* ExternalKeyboardButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E60F25D612C4ACEB001E63C4 /* ExternalKeyboardButton.cpp */; };
 		E6112A64131D720E00AA1454 /* ExpiredList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6112A61131D720E00AA1454 /* ExpiredList.cpp */; };
 		E61D6FA312617EFC0049FA2A /* MergeDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E61D6FA112617EFC0049FA2A /* MergeDlg.cpp */; };
@@ -127,7 +133,6 @@
 		E6EBC8141D16F9B600AF61CD /* argutils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EBC8121D16F9B600AF61CD /* argutils.cpp */; };
 		E6EBC8171D17165300AF61CD /* searchaction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EBC8151D17165300AF61CD /* searchaction.cpp */; };
 		E6EBC81A1D17184F00AF61CD /* strutils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EBC8181D17184F00AF61CD /* strutils.cpp */; };
-		E6EE841B11E87E9800B01518 /* BlowFish.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE839211E87E9700B01518 /* BlowFish.cpp */; };
 		E6EE841C11E87E9800B01518 /* CheckVersion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE839411E87E9700B01518 /* CheckVersion.cpp */; };
 		E6EE841D11E87E9800B01518 /* Command.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE839611E87E9700B01518 /* Command.cpp */; };
 		E6EE841E11E87E9800B01518 /* CoreImpExp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE839E11E87E9700B01518 /* CoreImpExp.cpp */; };
@@ -148,12 +153,8 @@
 		E6EE842F11E87E9800B01518 /* PWSprefs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE83C511E87E9700B01518 /* PWSprefs.cpp */; };
 		E6EE843011E87E9800B01518 /* PWSrand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE83C711E87E9700B01518 /* PWSrand.cpp */; };
 		E6EE843111E87E9800B01518 /* Report.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE83C911E87E9700B01518 /* Report.cpp */; };
-		E6EE843211E87E9800B01518 /* sha1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE83CB11E87E9700B01518 /* sha1.cpp */; };
-		E6EE843311E87E9800B01518 /* sha256.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE83CD11E87E9700B01518 /* sha256.cpp */; };
 		E6EE843411E87E9800B01518 /* StringX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE83CF11E87E9700B01518 /* StringX.cpp */; };
 		E6EE843511E87E9800B01518 /* SysInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE83D211E87E9700B01518 /* SysInfo.cpp */; };
-		E6EE843A11E87E9800B01518 /* TwoFish.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE83DC11E87E9700B01518 /* TwoFish.cpp */; };
-		E6EE843B11E87E9800B01518 /* twofish_tab.c in Sources */ = {isa = PBXBuildFile; fileRef = E6EE83DE11E87E9700B01518 /* twofish_tab.c */; };
 		E6EE843C11E87E9800B01518 /* UnknownField.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE83E011E87E9700B01518 /* UnknownField.cpp */; };
 		E6EE843D11E87E9800B01518 /* UTF8Conv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE83E211E87E9700B01518 /* UTF8Conv.cpp */; };
 		E6EE843E11E87E9800B01518 /* Util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EE83E411E87E9800B01518 /* Util.cpp */; };
@@ -242,16 +243,10 @@
 		6FF5D49D1DA14AB20032F5B6 /* PasswordSubsetDlg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PasswordSubsetDlg.cpp; sourceTree = "<group>"; };
 		6FF5D49E1DA14AB20032F5B6 /* PasswordSubsetDlg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PasswordSubsetDlg.h; sourceTree = "<group>"; };
 		A2D181451C8FF86C0018AE03 /* media.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = media.cpp; sourceTree = "<group>"; };
-		A2FE257E1C5ACEFD00210C36 /* AES.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AES.cpp; sourceTree = "<group>"; };
-		A2FE257F1C5ACEFD00210C36 /* AES.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AES.h; sourceTree = "<group>"; };
 		A2FE25811C5ACF7500210C36 /* Item.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Item.cpp; sourceTree = "<group>"; };
 		A2FE25821C5ACF7500210C36 /* Item.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Item.h; sourceTree = "<group>"; };
 		A2FE25831C5ACF7500210C36 /* ItemAtt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ItemAtt.cpp; sourceTree = "<group>"; };
 		A2FE25841C5ACF7500210C36 /* ItemAtt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ItemAtt.h; sourceTree = "<group>"; };
-		A2FE25851C5ACF7500210C36 /* KeyWrap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KeyWrap.cpp; sourceTree = "<group>"; };
-		A2FE25861C5ACF7500210C36 /* KeyWrap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyWrap.h; sourceTree = "<group>"; };
-		A2FE25871C5ACF7500210C36 /* pbkdf2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pbkdf2.cpp; sourceTree = "<group>"; };
-		A2FE25881C5ACF7500210C36 /* pbkdf2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pbkdf2.h; sourceTree = "<group>"; };
 		A2FE25891C5ACF7500210C36 /* PWSfileHeader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PWSfileHeader.cpp; sourceTree = "<group>"; };
 		A2FE258A1C5ACF7500210C36 /* PWSfileHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PWSfileHeader.h; sourceTree = "<group>"; };
 		A2FE258B1C5ACF7500210C36 /* PWSfileV4.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PWSfileV4.cpp; sourceTree = "<group>"; };
@@ -261,6 +256,26 @@
 		E0A70B9621C8FF8900A2FEA8 /* PolicyManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PolicyManager.cpp; sourceTree = "<group>"; };
 		E0A70B9721C8FF8900A2FEA8 /* PolicyManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PolicyManager.h; sourceTree = "<group>"; };
 		E0A70B9A21C905A500A2FEA8 /* libcurl.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcurl.tbd; path = usr/lib/libcurl.tbd; sourceTree = SDKROOT; };
+		E0C3C42F2379B2C200715124 /* AES.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AES.cpp; path = crypto/AES.cpp; sourceTree = "<group>"; };
+		E0C3C4302379B2C200715124 /* AES.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AES.h; path = crypto/AES.h; sourceTree = "<group>"; };
+		E0C3C4312379B2C200715124 /* bitops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bitops.h; path = crypto/bitops.h; sourceTree = "<group>"; };
+		E0C3C4322379B2C200715124 /* BlowFish.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BlowFish.cpp; path = crypto/BlowFish.cpp; sourceTree = "<group>"; };
+		E0C3C4332379B2C200715124 /* BlowFish.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlowFish.h; path = crypto/BlowFish.h; sourceTree = "<group>"; };
+		E0C3C4342379B2C200715124 /* Fish.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Fish.h; path = crypto/Fish.h; sourceTree = "<group>"; };
+		E0C3C4352379B2C200715124 /* hmac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hmac.h; path = crypto/hmac.h; sourceTree = "<group>"; };
+		E0C3C4362379B2C200715124 /* KeyWrap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = KeyWrap.cpp; path = crypto/KeyWrap.cpp; sourceTree = "<group>"; };
+		E0C3C4372379B2C200715124 /* KeyWrap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KeyWrap.h; path = crypto/KeyWrap.h; sourceTree = "<group>"; };
+		E0C3C4382379B2C200715124 /* pbkdf2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = pbkdf2.cpp; path = crypto/pbkdf2.cpp; sourceTree = "<group>"; };
+		E0C3C4392379B2C200715124 /* pbkdf2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pbkdf2.h; path = crypto/pbkdf2.h; sourceTree = "<group>"; };
+		E0C3C43A2379B2C200715124 /* sha1.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sha1.cpp; path = crypto/sha1.cpp; sourceTree = "<group>"; };
+		E0C3C43B2379B2C200715124 /* sha1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sha1.h; path = crypto/sha1.h; sourceTree = "<group>"; };
+		E0C3C43C2379B2C200715124 /* sha256.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sha256.cpp; path = crypto/sha256.cpp; sourceTree = "<group>"; };
+		E0C3C43D2379B2C200715124 /* sha256.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sha256.h; path = crypto/sha256.h; sourceTree = "<group>"; };
+		E0C3C43F2379B2C200715124 /* TwoFish.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TwoFish.cpp; path = crypto/TwoFish.cpp; sourceTree = "<group>"; };
+		E0C3C4402379B2C200715124 /* TwoFish.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TwoFish.h; path = crypto/TwoFish.h; sourceTree = "<group>"; };
+		E0C3C44A2379CA2A00715124 /* CryptKeyEntryDlg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CryptKeyEntryDlg.cpp; sourceTree = "<group>"; };
+		E0C3C44B2379CA2A00715124 /* CryptKeyEntryDlg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CryptKeyEntryDlg.h; sourceTree = "<group>"; };
+		E0C3C44D2379CA7300715124 /* MenuFileHandlers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MenuFileHandlers.cpp; sourceTree = "<group>"; };
 		E60F25D612C4ACEB001E63C4 /* ExternalKeyboardButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ExternalKeyboardButton.cpp; sourceTree = "<group>"; };
 		E60F25D712C4ACEB001E63C4 /* ExternalKeyboardButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExternalKeyboardButton.h; sourceTree = "<group>"; };
 		E6112A61131D720E00AA1454 /* ExpiredList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ExpiredList.cpp; sourceTree = "<group>"; };
@@ -659,8 +674,6 @@
 		E6EE838B11E87DAC00B01518 /* sleep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sleep.h; sourceTree = "<group>"; };
 		E6EE838C11E87DAC00B01518 /* typedefs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = typedefs.h; sourceTree = "<group>"; };
 		E6EE838D11E87DAC00B01518 /* utf8conv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utf8conv.h; sourceTree = "<group>"; };
-		E6EE839211E87E9700B01518 /* BlowFish.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BlowFish.cpp; sourceTree = "<group>"; };
-		E6EE839311E87E9700B01518 /* BlowFish.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlowFish.h; sourceTree = "<group>"; };
 		E6EE839411E87E9700B01518 /* CheckVersion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CheckVersion.cpp; sourceTree = "<group>"; };
 		E6EE839511E87E9700B01518 /* CheckVersion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CheckVersion.h; sourceTree = "<group>"; };
 		E6EE839611E87E9700B01518 /* Command.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Command.cpp; sourceTree = "<group>"; };
@@ -671,8 +684,6 @@
 		E6EE839F11E87E9700B01518 /* core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = core.h; sourceTree = "<group>"; };
 		E6EE83A211E87E9700B01518 /* core_st.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = core_st.cpp; sourceTree = "<group>"; };
 		E6EE83A311E87E9700B01518 /* core_st.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = core_st.h; sourceTree = "<group>"; };
-		E6EE83A411E87E9700B01518 /* Fish.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Fish.h; sourceTree = "<group>"; };
-		E6EE83A611E87E9700B01518 /* hmac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hmac.h; sourceTree = "<group>"; };
 		E6EE83A711E87E9700B01518 /* ItemData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ItemData.cpp; sourceTree = "<group>"; };
 		E6EE83A811E87E9700B01518 /* ItemData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ItemData.h; sourceTree = "<group>"; };
 		E6EE83A911E87E9700B01518 /* ItemField.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ItemField.cpp; sourceTree = "<group>"; };
@@ -707,19 +718,12 @@
 		E6EE83C811E87E9700B01518 /* PWSrand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PWSrand.h; sourceTree = "<group>"; };
 		E6EE83C911E87E9700B01518 /* Report.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Report.cpp; sourceTree = "<group>"; };
 		E6EE83CA11E87E9700B01518 /* Report.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Report.h; sourceTree = "<group>"; };
-		E6EE83CB11E87E9700B01518 /* sha1.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sha1.cpp; sourceTree = "<group>"; };
-		E6EE83CC11E87E9700B01518 /* sha1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sha1.h; sourceTree = "<group>"; };
-		E6EE83CD11E87E9700B01518 /* sha256.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sha256.cpp; sourceTree = "<group>"; };
-		E6EE83CE11E87E9700B01518 /* sha256.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sha256.h; sourceTree = "<group>"; };
 		E6EE83CF11E87E9700B01518 /* StringX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringX.cpp; sourceTree = "<group>"; };
 		E6EE83D011E87E9700B01518 /* StringX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringX.h; sourceTree = "<group>"; };
 		E6EE83D111E87E9700B01518 /* StringXStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringXStream.h; sourceTree = "<group>"; };
 		E6EE83D211E87E9700B01518 /* SysInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SysInfo.cpp; sourceTree = "<group>"; };
 		E6EE83D311E87E9700B01518 /* SysInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SysInfo.h; sourceTree = "<group>"; };
 		E6EE83DB11E87E9700B01518 /* trigram.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = trigram.h; sourceTree = "<group>"; };
-		E6EE83DC11E87E9700B01518 /* TwoFish.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TwoFish.cpp; sourceTree = "<group>"; };
-		E6EE83DD11E87E9700B01518 /* TwoFish.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TwoFish.h; sourceTree = "<group>"; };
-		E6EE83DE11E87E9700B01518 /* twofish_tab.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = twofish_tab.c; sourceTree = "<group>"; };
 		E6EE83DF11E87E9700B01518 /* UIinterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIinterface.h; sourceTree = "<group>"; };
 		E6EE83E011E87E9700B01518 /* UnknownField.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnknownField.cpp; sourceTree = "<group>"; };
 		E6EE83E111E87E9700B01518 /* UnknownField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UnknownField.h; sourceTree = "<group>"; };
@@ -788,6 +792,30 @@
 				E0A70B9A21C905A500A2FEA8 /* libcurl.tbd */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E0C3C42D2379B2A700715124 /* crypto */ = {
+			isa = PBXGroup;
+			children = (
+				E0C3C42F2379B2C200715124 /* AES.cpp */,
+				E0C3C4302379B2C200715124 /* AES.h */,
+				E0C3C4312379B2C200715124 /* bitops.h */,
+				E0C3C4322379B2C200715124 /* BlowFish.cpp */,
+				E0C3C4332379B2C200715124 /* BlowFish.h */,
+				E0C3C4342379B2C200715124 /* Fish.h */,
+				E0C3C4352379B2C200715124 /* hmac.h */,
+				E0C3C4362379B2C200715124 /* KeyWrap.cpp */,
+				E0C3C4372379B2C200715124 /* KeyWrap.h */,
+				E0C3C4382379B2C200715124 /* pbkdf2.cpp */,
+				E0C3C4392379B2C200715124 /* pbkdf2.h */,
+				E0C3C43A2379B2C200715124 /* sha1.cpp */,
+				E0C3C43B2379B2C200715124 /* sha1.h */,
+				E0C3C43C2379B2C200715124 /* sha256.cpp */,
+				E0C3C43D2379B2C200715124 /* sha256.h */,
+				E0C3C43F2379B2C200715124 /* TwoFish.cpp */,
+				E0C3C4402379B2C200715124 /* TwoFish.h */,
+			);
+			name = crypto;
 			sourceTree = "<group>";
 		};
 		E6069D0319FE1CCA0055040F /* Configs */ = {
@@ -1182,6 +1210,9 @@
 		E6ADB9A411957099004E2BE5 /* wxWidgets */ = {
 			isa = PBXGroup;
 			children = (
+				E0C3C44D2379CA7300715124 /* MenuFileHandlers.cpp */,
+				E0C3C44A2379CA2A00715124 /* CryptKeyEntryDlg.cpp */,
+				E0C3C44B2379CA2A00715124 /* CryptKeyEntryDlg.h */,
 				E6C94E941FA205E9008F0072 /* QREncode.h */,
 				E6C94E911FA20593008F0072 /* QRCodeDlg.cpp */,
 				E6C94E921FA20593008F0072 /* QRCodeDlg.h */,
@@ -1355,14 +1386,11 @@
 		E6EE839111E87E9700B01518 /* core */ = {
 			isa = PBXGroup;
 			children = (
+				E0C3C42D2379B2A700715124 /* crypto */,
 				E0A70B9621C8FF8900A2FEA8 /* PolicyManager.cpp */,
 				E0A70B9721C8FF8900A2FEA8 /* PolicyManager.h */,
 				E6F8DC201D132657007DFBEC /* RUEList.cpp */,
 				E6F8DC211D132657007DFBEC /* RUEList.h */,
-				A2FE257E1C5ACEFD00210C36 /* AES.cpp */,
-				A2FE257F1C5ACEFD00210C36 /* AES.h */,
-				E6EE839211E87E9700B01518 /* BlowFish.cpp */,
-				E6EE839311E87E9700B01518 /* BlowFish.h */,
 				E6EE839411E87E9700B01518 /* CheckVersion.cpp */,
 				E6EE839511E87E9700B01518 /* CheckVersion.h */,
 				E6EE839611E87E9700B01518 /* Command.cpp */,
@@ -1377,8 +1405,6 @@
 				E6DDC7001389120E00F0C0D1 /* DBCompareData.h */,
 				E6112A61131D720E00AA1454 /* ExpiredList.cpp */,
 				E6112A62131D720E00AA1454 /* ExpiredList.h */,
-				E6EE83A411E87E9700B01518 /* Fish.h */,
-				E6EE83A611E87E9700B01518 /* hmac.h */,
 				A2FE25811C5ACF7500210C36 /* Item.cpp */,
 				A2FE25821C5ACF7500210C36 /* Item.h */,
 				A2FE25831C5ACF7500210C36 /* ItemAtt.cpp */,
@@ -1387,12 +1413,8 @@
 				E6EE83A811E87E9700B01518 /* ItemData.h */,
 				E6EE83A911E87E9700B01518 /* ItemField.cpp */,
 				E6EE83AA11E87E9700B01518 /* ItemField.h */,
-				A2FE25851C5ACF7500210C36 /* KeyWrap.cpp */,
-				A2FE25861C5ACF7500210C36 /* KeyWrap.h */,
 				E6EE83AC11E87E9700B01518 /* Match.cpp */,
 				E6EE83AD11E87E9700B01518 /* Match.h */,
-				A2FE25871C5ACF7500210C36 /* pbkdf2.cpp */,
-				A2FE25881C5ACF7500210C36 /* pbkdf2.h */,
 				E6EE83AF11E87E9700B01518 /* Proxy.h */,
 				E683B216150481DF0013D588 /* pugixml */,
 				E6EE83B011E87E9700B01518 /* PWCharPool.cpp */,
@@ -1430,19 +1452,12 @@
 				A2FE25941C5ACFBD00210C36 /* PWStime.h */,
 				E6EE83C911E87E9700B01518 /* Report.cpp */,
 				E6EE83CA11E87E9700B01518 /* Report.h */,
-				E6EE83CB11E87E9700B01518 /* sha1.cpp */,
-				E6EE83CC11E87E9700B01518 /* sha1.h */,
-				E6EE83CD11E87E9700B01518 /* sha256.cpp */,
-				E6EE83CE11E87E9700B01518 /* sha256.h */,
 				E6EE83CF11E87E9700B01518 /* StringX.cpp */,
 				E6EE83D011E87E9700B01518 /* StringX.h */,
 				E6EE83D111E87E9700B01518 /* StringXStream.h */,
 				E6EE83D211E87E9700B01518 /* SysInfo.cpp */,
 				E6EE83D311E87E9700B01518 /* SysInfo.h */,
 				E6EE83DB11E87E9700B01518 /* trigram.h */,
-				E6EE83DE11E87E9700B01518 /* twofish_tab.c */,
-				E6EE83DC11E87E9700B01518 /* TwoFish.cpp */,
-				E6EE83DD11E87E9700B01518 /* TwoFish.h */,
 				E6EE83DF11E87E9700B01518 /* UIinterface.h */,
 				E6EE83E011E87E9700B01518 /* UnknownField.cpp */,
 				E6EE83E111E87E9700B01518 /* UnknownField.h */,
@@ -1695,7 +1710,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E6EE841B11E87E9800B01518 /* BlowFish.cpp in Sources */,
+				E0C3C4492379B2C200715124 /* TwoFish.cpp in Sources */,
 				E6EE841C11E87E9800B01518 /* CheckVersion.cpp in Sources */,
 				E6F8DC221D132657007DFBEC /* RUEList.cpp in Sources */,
 				E6EE841D11E87E9800B01518 /* Command.cpp in Sources */,
@@ -1706,11 +1721,11 @@
 				E6EE842211E87E9800B01518 /* ItemField.cpp in Sources */,
 				E6EE842411E87E9800B01518 /* Match.cpp in Sources */,
 				E6EE842511E87E9800B01518 /* PWCharPool.cpp in Sources */,
-				A2FE25801C5ACEFD00210C36 /* AES.cpp in Sources */,
 				E6EE842611E87E9800B01518 /* PWHistory.cpp in Sources */,
 				E6EE842711E87E9800B01518 /* PWPolicy.cpp in Sources */,
 				E6EE842811E87E9800B01518 /* PWSAuxParse.cpp in Sources */,
 				E6EE842911E87E9800B01518 /* PWScore.cpp in Sources */,
+				E0C3C4432379B2C200715124 /* BlowFish.cpp in Sources */,
 				A2FE258D1C5ACF7500210C36 /* Item.cpp in Sources */,
 				E6EE842A11E87E9800B01518 /* PWSdirs.cpp in Sources */,
 				E6EE842B11E87E9800B01518 /* PWSfile.cpp in Sources */,
@@ -1718,15 +1733,15 @@
 				E6EE842D11E87E9800B01518 /* PWSfileV3.cpp in Sources */,
 				E6EE842E11E87E9800B01518 /* PWSFilters.cpp in Sources */,
 				E6EE842F11E87E9800B01518 /* PWSprefs.cpp in Sources */,
+				E0C3C4422379B2C200715124 /* AES.cpp in Sources */,
 				A2D181461C8FF86C0018AE03 /* media.cpp in Sources */,
 				E6EE843011E87E9800B01518 /* PWSrand.cpp in Sources */,
+				E0C3C4442379B2C200715124 /* KeyWrap.cpp in Sources */,
+				E0C3C4462379B2C200715124 /* sha1.cpp in Sources */,
+				E0C3C4472379B2C200715124 /* sha256.cpp in Sources */,
 				E6EE843111E87E9800B01518 /* Report.cpp in Sources */,
-				E6EE843211E87E9800B01518 /* sha1.cpp in Sources */,
-				E6EE843311E87E9800B01518 /* sha256.cpp in Sources */,
 				E6EE843411E87E9800B01518 /* StringX.cpp in Sources */,
 				E6EE843511E87E9800B01518 /* SysInfo.cpp in Sources */,
-				E6EE843A11E87E9800B01518 /* TwoFish.cpp in Sources */,
-				E6EE843B11E87E9800B01518 /* twofish_tab.c in Sources */,
 				E6EE843C11E87E9800B01518 /* UnknownField.cpp in Sources */,
 				E6EE843D11E87E9800B01518 /* UTF8Conv.cpp in Sources */,
 				E6EE843E11E87E9800B01518 /* Util.cpp in Sources */,
@@ -1735,11 +1750,11 @@
 				E6EE844E11E87E9800B01518 /* XFileValidator.cpp in Sources */,
 				A2FE258E1C5ACF7500210C36 /* ItemAtt.cpp in Sources */,
 				E6EE844F11E87E9800B01518 /* XFileXMLProcessor.cpp in Sources */,
+				E0C3C4452379B2C200715124 /* pbkdf2.cpp in Sources */,
 				A2FE25921C5ACF7500210C36 /* PWSfileV4.cpp in Sources */,
 				A2FE25911C5ACF7500210C36 /* PWSfileHeader.cpp in Sources */,
 				E6EE845011E87E9800B01518 /* XFilterSAX2Handlers.cpp in Sources */,
 				E6EE845111E87E9800B01518 /* XFilterXMLProcessor.cpp in Sources */,
-				A2FE25901C5ACF7500210C36 /* pbkdf2.cpp in Sources */,
 				E6EE845211E87E9800B01518 /* XSecMemMgr.cpp in Sources */,
 				E0A70B9821C8FF8900A2FEA8 /* PolicyManager.cpp in Sources */,
 				E6EE845311E87E9800B01518 /* XMLFileHandlers.cpp in Sources */,
@@ -1749,7 +1764,6 @@
 				E6DDC7011389120E00F0C0D1 /* CoreOtherDB.cpp in Sources */,
 				E698275A14C01B7D0043C243 /* PWSLog.cpp in Sources */,
 				E683B21A150481DF0013D588 /* pugixml.cpp in Sources */,
-				A2FE258F1C5ACF7500210C36 /* KeyWrap.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1792,6 +1806,7 @@
 				E6ADBA401195709A004E2BE5 /* passwordsafeframe.cpp in Sources */,
 				E6ADBA411195709A004E2BE5 /* PasswordSafeSearch.cpp in Sources */,
 				E6ADBA431195709A004E2BE5 /* PropertiesDlg.cpp in Sources */,
+				E0C3C44F2379CD7500715124 /* MenuFileHandlers.cpp in Sources */,
 				E6ADBA921195709A004E2BE5 /* PWSafeApp.cpp in Sources */,
 				E6C94E931FA20593008F0072 /* QRCodeDlg.cpp in Sources */,
 				E6C94E961FA2075B008F0072 /* QREncode.mm in Sources */,
@@ -1822,6 +1837,7 @@
 				E6A7ECAF12CDEAA40021D898 /* SyncWizard.cpp in Sources */,
 				E6DDC6FC138911CB00F0C0D1 /* CompareDlg.cpp in Sources */,
 				E6DDC714138914B700F0C0D1 /* wxUtilities.cpp in Sources */,
+				E0C3C4502379CD8300715124 /* CryptKeyEntryDlg.cpp in Sources */,
 				E66EE0B313921B30005C10C5 /* ComparisonGridTable.cpp in Sources */,
 				E66FB84D13ACA5C3004DBB97 /* SizeRestrictedPanel.cpp in Sources */,
 				E691FB5A140D551F00925F96 /* FieldSelectionPanel.cpp in Sources */,
@@ -2080,6 +2096,7 @@
 					"-Wextra",
 				);
 				PRODUCT_NAME = os;
+				USER_HEADER_SEARCH_PATHS = ../src;
 			};
 			name = Debug;
 		};
@@ -2098,6 +2115,7 @@
 					"-Wextra",
 				);
 				PRODUCT_NAME = os;
+				USER_HEADER_SEARCH_PATHS = ../src;
 				ZERO_LINK = NO;
 			};
 			name = Release;

--- a/src/os/file.h
+++ b/src/os/file.h
@@ -40,7 +40,7 @@ namespace pws_os {
       time_t ctime, time_t mtime, time_t atime);
   extern bool ProgramExists(const stringT &filename);
   extern const TCHAR PathSeparator; // slash for Unix, backslash for Windows
-
+  extern bool RenameFile(const stringT &oldname, const stringT &newname);
   // Most stdio.h routines return -1 for an error (not INVALID_HANDLE_VALUE)
   #define INVALID_FILE_DESCRIPTOR (int)-1
 }

--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -33,6 +33,7 @@
 
 #include "core/PWSdirs.h"
 #include "os/sleep.h"
+#include "os/file.h"
 
 #include "CompareDlg.h"
 #include "ExportTextWarningDlg.h"


### PR DESCRIPTION
* Add new & moves files to appropriate groups/targets
* Fix Include path for 'os'
* Include headers required for symbols used in sources

Only built one scheme on Xcode 8.2.1