### PR TITLE
Enable "qrcode password display" feautre on OSX by default

### DIFF
--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -2137,7 +2137,6 @@
 					DEBUG,
 					_DEBUG,
 					NO_YUBI,
-					NO_QR,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = pwsafe.plist;
@@ -2163,7 +2162,6 @@
 					NDEBUG,
 					NO_YUBI,
 					"wxDEBUG_LEVEL=0",
-					NO_QR,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = pwsafe.plist;


### PR DESCRIPTION
It builds and works fine without any changes. No reason to exclude
it from build by default.