### PR TITLE
Adding missing wxwidget header

### DIFF
--- a/src/ui/wxWidgets/QRCodeDlg.cpp
+++ b/src/ui/wxWidgets/QRCodeDlg.cpp
@@ -13,6 +13,10 @@
 // For compilers that support precompilation, includes "wx/wx.h".
 #include <wx/wxprec.h>
 
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
 #ifdef __WXMSW__
 #include <wx/msw/msvcrt.h>
 #endif


### PR DESCRIPTION
Compilation with wxwidgets with no precomp headers is broken since commit 5b670035ed722b1351500610c1029ba8dd17179b as wx/wx.h is not included in this case.
Adding missing header.