### PR TITLE
Passing wxTRANSLATE as well to xgettext

### DIFF
--- a/src/ui/wxWidgets/I18N/Makefile
+++ b/src/ui/wxWidgets/I18N/Makefile
@@ -31,7 +31,7 @@ pos: $(POS)
 mos: $(MOS)
 
 $(POT) : $(SRCS)
-	@xgettext --default-domain=$(DOMAIN) --from-code=UTF-8 --language=C++ --keyword=_ --output=$@ $^
+	@xgettext --default-domain=$(DOMAIN) --from-code=UTF-8 --language=C++ --keyword=_ --keyword=wxTRANSLATE --output=$@ $^
 
 $(POS) : $(POT)
 	@msgmerge --update --backup=off $@ $^


### PR DESCRIPTION
wxTRANSLATE() is used for translation in case of static array initialization. However, it is not passed to xgettext (only _() ) so those strings will not appear in .pot/.po files. Adding it to xgettext.