### PR TITLE
Gitpod: Workaround for https://github.com/gitpod-io/gitpod/issues/1565

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -12,29 +12,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-sel
 USER root
 RUN true \
   && apt-get -q update \
-  && apt-get install -yq \
-    cmake-gui \
-    cmake \
-    fakeroot \
-    g++ \
-    gettext \
-    git \
-    libgtest-dev \
-    libcurl4-openssl-dev \
-    libqrencode-dev  \
-    libssl-dev \
-    libuuid1 \
-    ibwxgtk3.0-dev \
-    libxerces-c-dev \
-    libxt-dev \
-    libxtst-dev \
-    libykpers-1-dev \
-    libyubikey-dev \
-    make \
-    pkg-config \
-    uuid-dev \
-    zip \
-    libmagic-dev \
+  && sh ./Misc/setup-deb-dev-env.sh
   && apt-get autoremove -yq \
   && rm -rf /var/lib/apt/lists/*
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -9,6 +9,35 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-sel
 # RUN sudo apt-get -q update && #     sudo apt-get install -yq bastet && #     sudo rm -rf /var/lib/apt/lists/*
 #
 # More information: https://www.gitpod.io/docs/config-docker/
-RUN sudo apt-get -q update && sudo sh ./Misc/setup-deb-dev-env.sh && sudo apt install -yq cmake-gui && sudo rm -rf /var/lib/apt/lists/*
+USER root
+RUN true \
+  && apt-get -q update \
+  && apt-get install -yq \
+    cmake-gui \
+    cmake \
+    fakeroot \
+    g++ \
+    gettext \
+    git \
+    libgtest-dev \
+    libcurl4-openssl-dev \
+    libqrencode-dev  \
+    libssl-dev \
+    libuuid1 \
+    ibwxgtk3.0-dev \
+    libxerces-c-dev \
+    libxt-dev \
+    libxtst-dev \
+    libykpers-1-dev \
+    libyubikey-dev \
+    make \
+    pkg-config \
+    uuid-dev \
+    zip \
+    libmagic-dev \
+  && apt-get autoremove -yq \
+  && rm -rf /var/lib/apt/lists/*
+
 # Set debconf back to normal.
+USER gitpod
 RUN echo 'debconf debconf/frontend select Dialog' | sudo debconf-set-selections

--- a/Misc/setup-deb-dev-env.bash
+++ b/Misc/setup-deb-dev-env.bash
@@ -12,7 +12,8 @@
 LIBWXDEV="ibwxgtk3.0-dev"
 # Two internet points for writing the correct if statement to handle the above...
 
-apt-get install cmake fakeroot g++ gettext git libgtest-dev \
+apt-get install -qy \
+        cmake fakeroot g++ gettext git libgtest-dev \
         libcurl4-openssl-dev libqrencode-dev  libssl-dev libuuid1 \
         $LIBWXDEV libxerces-c-dev libxt-dev libxtst-dev \
         libykpers-1-dev libyubikey-dev make pkg-config uuid-dev zip \


### PR DESCRIPTION
Concluded that gitpod using `sudo apt-get` results in a permission issue (https://github.com/gitpod-io/gitpod/issues/1565). This is a workaround for this issue.

File setup-deb-dev-env
- This file has extension `.sh`, but is using a shebang `#!/bin/bash` for bash and in previous commit was calling `sh` to call this script which might break on some environments i.e environments without shebang support compiled in kernel and systems without dynamic linking (not necesary linked to gitpod, but good practice)
- Was using `apt-get` without `-y` which would cause an infinite loop in gitpod's docker environment that doesn't have set `DEBIAN_FRONTEND=noninteractive` to workaround https://github.com/gitpod-io/gitpod/issues/1171

Shellcheck (https://github.com/koalaman/shellcheck) has been recommended to ensure code quality of shell scripts

This also makes it to not use `setup-deb-dev-env.sh` let me know if you want to use this file in gitpod (seems to me as bad idea since it would be harder to cache), but i am willing to make changes to allow this file to be used.

Signed-off-by: Jacob Hrbek <kreyren@member.fsf.org>