### PR TITLE
Generate macOS builds using Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,63 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Force compatible Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_10.3.app/Contents/Developer
+    
+    - name: Print Xcode version in use
+      run: xcode-select -p
+      
+    # Runs a single command using the runners shell
+    - name: Run a one-line script
+      run: echo "$GITHUB_WORKSPACE"
+
+    # Runs a set of commands using the runners shell
+    - name: Install wxWidgets
+      run: brew install wxwidgets
+
+    - name: Generate xcconfigs
+      working-directory: ${{ github.workspace }}
+      run: Xcode/generate-configs -r /usr/local/bin/wx-config > Xcode/pwsafe-release.xcconfig
+    
+    - name: Build pwsafe
+      working-directory: ${{ github.workspace }}
+      run: xcodebuild -project Xcode/pwsafe-xcode6.xcodeproj -scheme pwsafe
+      
+    - name: Install dependencies for creating dmg
+      run: brew install create-dmg
+    
+    - name: Get Xcode build output location
+      run: echo "::set-env name=BUILD_OUTPUT_DIR::$(xcodebuild -showBuildSettings -project Xcode/pwsafe-xcode6.xcodeproj | fgrep CONFIGURATION_BUILD_DIR | cut -d= -f2 | sed 's/^ *\(.*\)/\1/')"
+
+    - name: Move app to another folder
+      run: mkdir "$BUILD_OUTPUT_DIR"/app && mv "$BUILD_OUTPUT_DIR"/pwsafe.app "$BUILD_OUTPUT_DIR"/app/
+      
+    - name: Create dmg
+      run: create-dmg --volname "Password Safe" --volicon "src/ui/wxWidgets/graphics/pwsafe.icns" --eula LICENSE ${{ github.workspace }}/PasswordSafe.dmg "$BUILD_OUTPUT_DIR/app"
+
+    - name: Upload artifacts
+      uses: 'actions/upload-artifact@v2'
+      with:
+        name: PasswordSafe.${{ github.sha }}.dmg
+        path: ${{ github.workspace }}/PasswordSafe.dmg

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -1683,10 +1683,12 @@
 			);
 			name = "Generate core_st";
 			outputPaths = (
+				"${PROJECT_DIR}/../src/core/core_st.cpp",
+				"${PROJECT_DIR}/../src/core/core_st.h",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"Generating coelib_st.cpp and core_st.h ...\"\n../Misc/rc2cpp.pl ../src/core/core.rc2";
+			shellScript = "echo \"Generating core_st.cpp and core_st.h ...\"\n\"${PROJECT_DIR}\"/../Misc/rc2cpp.pl \"${PROJECT_DIR}\"/../src/core/core.rc2\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -2137,7 +2137,6 @@
 					DEBUG,
 					_DEBUG,
 					NO_YUBI,
-					NO_QR,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = pwsafe.plist;
@@ -2163,7 +2162,6 @@
 					NDEBUG,
 					NO_YUBI,
 					"wxDEBUG_LEVEL=0",
-					NO_QR,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = pwsafe.plist;


### PR DESCRIPTION
This PR would probably generate a build using Github actions. There would be an Artifact link under the Checks tab, which would let you download a dmg. Users need to drag pwsafe.app from the dmg to their Applications folder.

Once merged, every subsequent PR would probably generate such a build.

However, this is a very minimal effort. The user would first need to install wxWidgets on his Mac by running "brew install wxWidgets".

This PR has another change that has been lying around in my fork: 883f38a: Enable QR code feature on Mac. It doesn't add any new dependencies. No reason to turn off the feature.