### PR TITLE
Bundle dependent libraries with pwsafe

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: mac-pwsafe
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -12,8 +12,8 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  build_mac_pwsafe:
+    name: Build pwsafe for macOS
     # The type of runner that the job will run on
     runs-on: macos-latest
 
@@ -43,16 +43,26 @@ jobs:
     - name: Build pwsafe
       working-directory: ${{ github.workspace }}
       run: xcodebuild -project Xcode/pwsafe-xcode6.xcodeproj -scheme pwsafe
-      
-    - name: Install dependencies for creating dmg
-      run: brew install create-dmg
-    
+
     - name: Get Xcode build output location
       run: echo "::set-env name=BUILD_OUTPUT_DIR::$(xcodebuild -showBuildSettings -project Xcode/pwsafe-xcode6.xcodeproj | fgrep CONFIGURATION_BUILD_DIR | cut -d= -f2 | sed 's/^ *\(.*\)/\1/')"
 
     - name: Move app to another folder
       run: mkdir "$BUILD_OUTPUT_DIR"/app && mv "$BUILD_OUTPUT_DIR"/pwsafe.app "$BUILD_OUTPUT_DIR"/app/
-      
+
+    - name: Fetch dylib bundler
+      run: git clone https://github.com/auriamg/macdylibbundler ~/work/macdylibbundler
+
+    - name: Build dylib bundler
+      run: /usr/bin/make
+      working-directory: /Users/runner/work/macdylibbundler/
+
+    - name: Copy dependencies
+      run: ~/work/macdylibbundler/dylibbundler -b -cd -x "$BUILD_OUTPUT_DIR"/app/pwsafe.app/Contents/MacOS/pwsafe -d "$BUILD_OUTPUT_DIR"/app/pwsafe.app/Contents/MacOS/libs -p '@executable_path/libs/'
+
+    - name: Install dependencies for creating dmg
+      run: brew install create-dmg
+
     - name: Create dmg
       run: create-dmg --volname "Password Safe" --volicon "src/ui/wxWidgets/graphics/pwsafe.icns" --eula LICENSE ${{ github.workspace }}/PasswordSafe.dmg "$BUILD_OUTPUT_DIR/app"
 

--- a/README.LINUX.DEVELOPERS.md
+++ b/README.LINUX.DEVELOPERS.md
@@ -67,6 +67,8 @@ install these.
 - libcurl-devel
 - libuuid-devel
 - libyubikey-devel
+- file-devel
+- libcurl-devel
 - make
 - openssl-devel
 - wxGTK3-devel


### PR DESCRIPTION
This PR will enable bundling the required wxWidgets dylibs (shared objects) with pwsafe, along with their dependencies. The resulting dmg is entirely self-contained: no need to run 'brew install wxwidgets' anymore.

Right now, the full list of bundled libraries consists of

libjpeg.9.dylib				libwx_baseu_net-3.0.0.5.0.dylib		libwx_osx_cocoau_html-3.0.0.5.0.dylib
libpng16.16.dylib			libwx_baseu_xml-3.0.0.5.0.dylib		libwx_osx_cocoau_qa-3.0.0.5.0.dylib
libtiff.5.dylib				libwx_osx_cocoau_adv-3.0.0.5.0.dylib	libwx_osx_cocoau_xrc-3.0.0.5.0.dylib
libwx_baseu-3.0.0.5.0.dylib		libwx_osx_cocoau_core-3.0.0.5.0.dylib

These are all copied alongside the pwsafe binary. They are not installed to any system directory like /usr/lib, or even /usr/local or /opt. They stay inside the pwsafe bundle directory.

All of these are basically copied (and their dependencies "fixed"), from the virtual machine where pwsafe is built, where these were installed by running 'brew install wxwidgets'.

The pwsafe build system downloads, builds and uses this tool: https://github.com/auriamg/macdylibbundler

You may want to check their licenses for compatibility:

https://github.com/auriamg/macdylibbundler/blob/master/LICENSE
https://github.com/Homebrew/homebrew-core/blob/master/LICENSE.txt
