### PR TITLE
Fix spelling error occured -> occurred

### DIFF
--- a/Misc/I18N/ru/omegat_wx/omegat/project_save.tmx
+++ b/Misc/I18N/ru/omegat_wx/omegat/project_save.tmx
@@ -11602,7 +11602,7 @@ and User fields match.</seg>
     </tu>
     <tu>
       <tuv lang="en-US">
-        <seg>Unexpected error occured during attachment export.</seg>
+        <seg>Unexpected error occurred during attachment export.</seg>
       </tuv>
       <tuv lang="ru-RU" changeid="pm_kan" changedate="20200823T124602Z" creationid="pm_kan" creationdate="20200823T124602Z">
         <seg>Ошибка при экспорте вложения.</seg>
@@ -11610,7 +11610,7 @@ and User fields match.</seg>
     </tu>
     <tu>
       <tuv lang="en-US">
-        <seg>Unexpected error occured during attachment import.</seg>
+        <seg>Unexpected error occurred during attachment import.</seg>
       </tuv>
       <tuv lang="ru-RU" changeid="pm_kan" changedate="20200823T124414Z" creationid="pm_kan" creationdate="20200823T124414Z">
         <seg>Ошибка при импорте вложения.</seg>

--- a/Misc/I18N/ru/omegat_wx/omegat_wx-level1.tmx
+++ b/Misc/I18N/ru/omegat_wx/omegat_wx-level1.tmx
@@ -8270,7 +8270,7 @@ and User fields match.</seg>
     </tu>
     <tu>
       <tuv lang="en-US">
-        <seg>Unexpected error occured during attachment export.</seg>
+        <seg>Unexpected error occurred during attachment export.</seg>
       </tuv>
       <tuv lang="ru-RU" changeid="pm_kan" changedate="20200823T124602Z" creationid="pm_kan" creationdate="20200823T124602Z">
         <seg>Ошибка при экспорте вложения.</seg>
@@ -8278,7 +8278,7 @@ and User fields match.</seg>
     </tu>
     <tu>
       <tuv lang="en-US">
-        <seg>Unexpected error occured during attachment import.</seg>
+        <seg>Unexpected error occurred during attachment import.</seg>
       </tuv>
       <tuv lang="ru-RU" changeid="pm_kan" changedate="20200823T124414Z" creationid="pm_kan" creationdate="20200823T124414Z">
         <seg>Ошибка при импорте вложения.</seg>

--- a/Misc/I18N/ru/omegat_wx/omegat_wx-level2.tmx
+++ b/Misc/I18N/ru/omegat_wx/omegat_wx-level2.tmx
@@ -8270,7 +8270,7 @@ and User fields match.</seg>
     </tu>
     <tu>
       <tuv xml:lang="en-US">
-        <seg>Unexpected error occured during attachment export.</seg>
+        <seg>Unexpected error occurred during attachment export.</seg>
       </tuv>
       <tuv xml:lang="ru-RU" changeid="pm_kan" changedate="20200823T124602Z" creationid="pm_kan" creationdate="20200823T124602Z">
         <seg>Ошибка при экспорте вложения.</seg>
@@ -8278,7 +8278,7 @@ and User fields match.</seg>
     </tu>
     <tu>
       <tuv xml:lang="en-US">
-        <seg>Unexpected error occured during attachment import.</seg>
+        <seg>Unexpected error occurred during attachment import.</seg>
       </tuv>
       <tuv xml:lang="ru-RU" changeid="pm_kan" changedate="20200823T124414Z" creationid="pm_kan" creationdate="20200823T124414Z">
         <seg>Ошибка при импорте вложения.</seg>

--- a/Misc/I18N/ru/omegat_wx/omegat_wx-omegat.tmx
+++ b/Misc/I18N/ru/omegat_wx/omegat_wx-omegat.tmx
@@ -8270,7 +8270,7 @@ and User fields match.</seg>
     </tu>
     <tu>
       <tuv lang="en-US">
-        <seg>Unexpected error occured during attachment export.</seg>
+        <seg>Unexpected error occurred during attachment export.</seg>
       </tuv>
       <tuv lang="ru-RU" changeid="pm_kan" changedate="20200823T124602Z" creationid="pm_kan" creationdate="20200823T124602Z">
         <seg>Ошибка при экспорте вложения.</seg>
@@ -8278,7 +8278,7 @@ and User fields match.</seg>
     </tu>
     <tu>
       <tuv lang="en-US">
-        <seg>Unexpected error occured during attachment import.</seg>
+        <seg>Unexpected error occurred during attachment import.</seg>
       </tuv>
       <tuv lang="ru-RU" changeid="pm_kan" changedate="20200823T124414Z" creationid="pm_kan" creationdate="20200823T124414Z">
         <seg>Ошибка при импорте вложения.</seg>

--- a/src/ui/Windows/I18N/pos/pwsafe_cz.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_cz.po
@@ -1318,7 +1318,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr ""
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Kritická chyba: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_de.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_de.po
@@ -1357,7 +1357,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr "Ein Punkt kan nicht als erstes Zeichen für eine Gruppe verwendet werden"
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Fataler Fehler aufgetreten: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_dk.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_dk.po
@@ -1318,7 +1318,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr ""
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "En fatal fejl opstod: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_es.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_es.po
@@ -1318,7 +1318,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr ""
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Ha ocurrido un error grave: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_fr.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_fr.po
@@ -1370,7 +1370,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr "Vous ne pouvez utiliser un point comme premier caractère d'un groupe."
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Une erreur fatale est arrivée: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_hu.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_hu.po
@@ -1318,7 +1318,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr ""
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Végzetes hiba történt: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_it.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_it.po
@@ -1331,7 +1331,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr "Un punto non può essere uwato come primo carattere del campo 'Gruppo'."
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Si è verificato un errore fatale: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_kr.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_kr.po
@@ -1318,7 +1318,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr ""
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "치명적인 오류가 발생했습니다: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_nl.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_nl.po
@@ -1431,7 +1431,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr "Een punt kan niet het eerste teken zijn in het Groepenveld."
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Een fatale fout heeft zich voorgedaan: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_pl.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_pl.po
@@ -1406,7 +1406,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr "Kropka nie może być użyta jako pierwszy znak pola Grupa."
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Wystąpił błąd krytyczny: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_pt_br.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_pt_br.po
@@ -1431,7 +1431,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr "Um ponto não pode ser usado como o primeiro caractere do campo Grupo."
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Ocorreu um erro fatal: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_ru.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_ru.po
@@ -1420,7 +1420,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr "Имя группы не может начинаться с точки"
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Произошла фатальная ошибка: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_sl.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_sl.po
@@ -1331,7 +1331,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr "Pike ni mogoče uporabiti kot prvi znak polja skupine."
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Prišlo je do usodne napake: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_sv.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_sv.po
@@ -1471,7 +1471,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr "En punkt kan inte användas som första tecken i gruppfältet."
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Ett allvarligt fel uppstod: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_tr.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_tr.po
@@ -1318,7 +1318,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr ""
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "Ölümcül bir hata oluştu:"
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/I18N/pos/pwsafe_zh.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_zh.po
@@ -1381,7 +1381,7 @@ msgid "A dot cannot be used as the first character of the Group field."
 msgstr "句点不能用作分组字段的首字符."
 
 #. Resource IDs: (5212)
-msgid "A fatal error occured: "
+msgid "A fatal error occurred: "
 msgstr "发生一个不可恢复的错误: "
 
 #. Resource IDs: (3363)

--- a/src/ui/Windows/PKBaseDlg.cpp
+++ b/src/ui/Windows/PKBaseDlg.cpp
@@ -201,7 +201,7 @@ void CPKBaseDlg::yubiProcessCompleted(YKLIB_RC yrc, unsigned short ts, const BYT
     YubiFailed(); // allow subclass to do something useful
     break;
 
-  default:                // A non-recoverable error has occured
+  default:                // A non-recoverable error has occurred
     m_yubi_timeout.ShowWindow(SW_HIDE);
     m_yubi_status.ShowWindow(SW_SHOW);
     // Generic error message

--- a/src/ui/Windows/WZSelectDB.cpp
+++ b/src/ui/Windows/WZSelectDB.cpp
@@ -986,7 +986,7 @@ void CWZSelectDB::yubiProcessCompleted(YKLIB_RC yrc, unsigned short ts, const BY
     m_yubi_status.ShowWindow(SW_SHOW);
     break;
 
-  default:                // A non-recoverable error has occured
+  default:                // A non-recoverable error has occurred
     m_state &= ~KEYPRESENT;
     m_pending = false;
     m_yubi_timeout.ShowWindow(SW_HIDE);

--- a/src/ui/Windows/res/PasswordSafe3.rc2
+++ b/src/ui/Windows/res/PasswordSafe3.rc2
@@ -121,7 +121,7 @@ STRINGTABLE
 BEGIN
   IDS_FILEERROR1          "Could not access file: %s"
   IDS_FILEERROR2          "%s is a directory"
-  IDS_ERRORMESSAGE        "A fatal error occured: "
+  IDS_ERRORMESSAGE        "A fatal error occurred: "
   IDS_FILEREADONLY        "Given path is a directory or file is read-only"
   IDS_FILEPATHNOTFOUND    "File or path not found."
   IDS_TERMINATE           "\nProgram will terminate."

--- a/src/ui/wxWidgets/AboutDlg.cpp
+++ b/src/ui/wxWidgets/AboutDlg.cpp
@@ -596,7 +596,7 @@ void AboutDlg::CompareVersionData()
  * This function gets executed in the secondary thread context and will use the
  * blocking function <code>curl_easy_perform</code> to perform the download,
  * which returns when download was successful, it failed or the configured timeout
- * occured. After <code>curl_easy_perform</code> completed the worker thread sends
+ * occurred. After <code>curl_easy_perform</code> completed the worker thread sends
  * a notification event to its parent thread to inform it about the result. The
  * parent thread will decide on the received exit code how to proceed.
  *
@@ -674,7 +674,7 @@ size_t AboutDlg::WriteCallback(char *receivedData, size_t size, size_t bytes, vo
  *
  * This event handler is called by worker thread when file download is accomplished.
  * CURLE_OK is the only acceptable exit code from worker thread to continue with version check.
- * All other exit codes indicate some sort of occured problem.
+ * All other exit codes indicate some sort of occurred problem.
  *
  * @see method <code>AboutDlg::Entry()</code> regarding worker thread and its exit codes.
  */

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -1236,7 +1236,7 @@ void AddEditPropSheetDlg::OnExport(wxCommandEvent& WXUNUSED(event))
   default:
     wxMessageDialog(
       this,
-      _("Unexpected error occured during attachment export."), _("Export Attachment"),
+      _("Unexpected error occurred during attachment export."), _("Export Attachment"),
       wxICON_ERROR
     ).ShowModal();
     break;

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
@@ -5751,7 +5751,7 @@ msgstr "Se Adgangskode Politik filtrene"
 #~ msgid "A dot is invalid as the first character of the Group field."
 #~ msgstr "Et punktum er ugyldig som den første karakter i Gruppe feltet."
 
-#~ msgid "A fatal error occured: "
+#~ msgid "A fatal error occurred: "
 #~ msgstr "En fatal fejl opstod: "
 
 #~ msgid "A required resource was unavailable."

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
@@ -5735,7 +5735,7 @@ msgstr "Passwortrichtlinien verwalten"
 #~ msgid "A dot is invalid as the first character of the Group field."
 #~ msgstr "Ein Punkt ist als erstes Zeichen einer Gruppe nicht zulässig."
 
-#~ msgid "A fatal error occured: "
+#~ msgid "A fatal error occurred: "
 #~ msgstr "Fataler Fehler aufgetreten: "
 
 #~ msgid "A future date is not valid for this field"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
@@ -6021,7 +6021,7 @@ msgstr "Ver filtros de políticas de contraseñas"
 #~ msgid "A dot is invalid as the first character of the Group field."
 #~ msgstr "No se permite un punto al comienzo del nombre de Grupo."
 
-#~ msgid "A fatal error occured: "
+#~ msgid "A fatal error occurred: "
 #~ msgstr "Ha ocurrido un error grave: "
 
 #~ msgid "A future date is not valid for this field"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
@@ -6049,7 +6049,7 @@ msgstr "Géger les stratégies de mot de passe"
 #~ msgstr ""
 #~ "Le point est invalide en tant que premier caractère du champ Groupe."
 
-#~ msgid "A fatal error occured: "
+#~ msgid "A fatal error occurred: "
 #~ msgstr "Une erreur fatale est arrivée: "
 
 #~ msgid "A future date is not valid for this field"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
@@ -5391,7 +5391,7 @@ msgstr "YubiKey Konfiguráció"
 #~ msgid ">>"
 #~ msgstr ">>"
 
-#~ msgid "A fatal error occured: "
+#~ msgid "A fatal error occurred: "
 #~ msgstr "Végzetes hiba történt: "
 
 #~ msgid "A future date is not valid for this field"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ko.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ko.po
@@ -5862,7 +5862,7 @@ msgstr "비밀번호 정책 필터 보기"
 #~ msgid "A dot is invalid as the first character of the Group field."
 #~ msgstr "점 기호는 그룹 필드의 첫번째 글자로 사용할 수 없습니다."
 
-#~ msgid "A fatal error occured: "
+#~ msgid "A fatal error occurred: "
 #~ msgstr "치명적인 오류가 발생했습니다: "
 
 #~ msgid "A future date is not valid for this field"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
@@ -6028,7 +6028,7 @@ msgstr "Zie wachtwoord beleids filters"
 #~ msgid "A dot is invalid as the first character of the Group field."
 #~ msgstr "Een stip is niet geldig als het eerste teken van een Groep veld."
 
-#~ msgid "A fatal error occured: "
+#~ msgid "A fatal error occurred: "
 #~ msgstr "Een fatale fout heeft zich voorgedaan:"
 
 #~ msgid "A future date is not valid for this field"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
@@ -6103,7 +6103,7 @@ msgstr "Dostępne polityki haseł:"
 #~ msgid "A dot is invalid as the first character of the Group field."
 #~ msgstr "Kropka nie może być pierwszym znakiem w nazwie Grupy."
 
-#~ msgid "A fatal error occured: "
+#~ msgid "A fatal error occurred: "
 #~ msgstr "Wystąpił błąd krytyczny: "
 
 #~ msgid "A future date is not valid for this field"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
@@ -867,7 +867,7 @@ msgid "An error occurred while reading the file."
 msgstr "Ошибка при чтении файла."
 
 #: src/ui/wxWidgets/AddEditPropSheetDlg.cpp:1150
-msgid "Unexpected error occured during attachment import."
+msgid "Unexpected error occurred during attachment import."
 msgstr "Ошибка при импорте вложения."
 
 #: src/ui/wxWidgets/AddEditPropSheetDlg.cpp:1163
@@ -907,7 +907,7 @@ msgid "An error occurred while writing the file."
 msgstr "Ошибка при записи файла."
 
 #: src/ui/wxWidgets/AddEditPropSheetDlg.cpp:1239
-msgid "Unexpected error occured during attachment export."
+msgid "Unexpected error occurred during attachment export."
 msgstr "Ошибка при экспорте вложения."
 
 #: src/ui/wxWidgets/AddEditPropSheetDlg.cpp:1420
@@ -6612,7 +6612,7 @@ msgstr "Да: не менее %d из %ls: %ls%ls"
 #~ msgid "A dot cannot be used as the first character of the Group field."
 #~ msgstr "Имя группы не может начинаться с точки"
 
-#~ msgid "A fatal error occured: "
+#~ msgid "A fatal error occurred: "
 #~ msgstr "Произошла фатальная ошибка: "
 
 #~ msgid "A future date is not valid for this field"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
@@ -5981,7 +5981,7 @@ msgstr "Se lösenords policyfilter"
 #~ msgid "A dot is invalid as the first character of the Group field."
 #~ msgstr "En punkt är inte giltig som första tecken i Grupp-fältet."
 
-#~ msgid "A fatal error occured: "
+#~ msgid "A fatal error occurred: "
 #~ msgstr "Ett fatalt fel uppstod:"
 
 #~ msgid "A future date is not valid for this field"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_zh.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_zh.po
@@ -5766,7 +5766,7 @@ msgstr "查看密码策略筛选"
 #~ msgid "A dot is invalid as the first character of the Group field."
 #~ msgstr "组字段首字符使用一个点无效！"
 
-#~ msgid "A fatal error occured: "
+#~ msgid "A fatal error occurred: "
 #~ msgstr "发生一个不可恢复的错误:"
 
 #~ msgid "A future date is not valid for this field"


### PR DESCRIPTION
Debian tooling (lintian) identified a spelling error in the passwordsafe
binary.  This patch updates all occurrences in the codebase to the
correct spelling, including instances in translation files (msg IDs) and comments.