### PR TITLE
Only run xdg-* functions in deb postint, prerm if the requried dirs exist

### DIFF
--- a/install/deb/postinst
+++ b/install/deb/postinst
@@ -1,7 +1,10 @@
-#!/bin/bash
-xdg-icon-resource install --novendor --size 48 --mode system \
-                  /usr/share/icons/hicolor/48x48/apps/pwsafe.png
-xdg-desktop-menu install --novendor --mode system \
-                  /usr/share/applications/passwordsafe.desktop
+#!/bin/bash -e
+
+if [[ -d "/usr/share/desktop-directories" || -d "/usr/local/share/desktop-directories" ]]; then
+    xdg-icon-resource install --novendor --size 48 --mode system \
+                    /usr/share/icons/hicolor/48x48/apps/pwsafe.png
+    xdg-desktop-menu install --novendor --mode system \
+                    /usr/share/applications/passwordsafe.desktop
+fi
 [ -f /usr/share/man/pwsafe.1 ] && gzip /usr/share/man/pwsafe.1
 exit 0

--- a/install/deb/prerm
+++ b/install/deb/prerm
@@ -1,5 +1,8 @@
 #!/bin/bash -e
-xdg-desktop-menu uninstall --mode system pwsafe.desktop
-xdg-icon-resource uninstall --size 48 --mode system \
-                  pwsafe.png
+
+if [[ -d "/usr/share/desktop-directories" || -d "/usr/local/share/desktop-directories" ]]; then
+    xdg-desktop-menu uninstall --mode system pwsafe.desktop
+    xdg-icon-resource uninstall --size 48 --mode system \
+                    pwsafe.png
+fi
 exit 0


### PR DESCRIPTION
Some distributions (debian, arch, maybe others) do not always create
the system-level /usr{,/local}/share/destop-directories paths which are
required for xdg-desktop-menu and similar programs to work correctly.

In addition, the prerm script uses the -e bash option (exit on non-zero
status).  However, the postinst script does not.

This can lead to the situation where the deb package can be installed,
but cannot be uninstalled. (upgrading still works)

This commit adds checks to the postinst and prerm scripts to only run the
xdg programs if at least one of the required directories exists.

This commit also adds the -e bash option to the postinst script, for
consistency.