### PR TITLE
Remove warning about implicit conversion and fix problem with filter view

### DIFF
--- a/src/core/PWSprefs.cpp
+++ b/src/core/PWSprefs.cpp
@@ -1583,10 +1583,10 @@ void PWSprefs::SaveApplicationPreferences()
         break;
       case CF_FILE_RW:
       case CF_FILE_RW_NEW:
-        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"top", m_rect.top) == 0);
-        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"bottom", m_rect.bottom) == 0);
-        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"left", m_rect.left) == 0);
-        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"right", m_rect.right) == 0);
+        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"top", static_cast<int>(m_rect.top)) == 0);
+        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"bottom", static_cast<int>(m_rect.bottom)) == 0);
+        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"left", static_cast<int>(m_rect.left)) == 0);
+        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"right", static_cast<int>(m_rect.right)) == 0);
         break;
       case CF_FILE_RO:
       case CF_NONE:
@@ -1610,10 +1610,10 @@ void PWSprefs::SaveApplicationPreferences()
         break;
       case CF_FILE_RW:
       case CF_FILE_RW_NEW:
-        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"PSS_top", m_PSSrect.top) == 0);
-        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"PSS_bottom", m_PSSrect.bottom) == 0);
-        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"PSS_left", m_PSSrect.left) == 0);
-        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"PSS_right", m_PSSrect.right) == 0);
+        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"PSS_top", static_cast<int>(m_PSSrect.top)) == 0);
+        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"PSS_bottom", static_cast<int>(m_PSSrect.bottom)) == 0);
+        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"PSS_left", static_cast<int>(m_PSSrect.left)) == 0);
+        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"PSS_right", static_cast<int>(m_PSSrect.right)) == 0);
         break;
       case CF_FILE_RO:
       case CF_NONE:

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -1994,6 +1994,8 @@ Command* AddEditPropSheetDlg::NewAddEntryCommand()
   // Create Command
   /////////////////////////////////////////////////////////////////////////////
 
+  m_Item.SetStatus(CItemData::ES_ADDED);
+  
   return AddEntryCommand::Create(
     &m_Core,
     m_Item, m_Item.GetBaseUUID(),
@@ -2179,6 +2181,7 @@ Command* AddEditPropSheetDlg::NewEditEntryCommand()
   }
   if (bIsModified || bIsPSWDModified) {
     m_Item.SetRMTime(t);
+    m_Item.SetStatus(CItemData::ES_MODIFIED);
   }
   if (m_tttExpirationTime != lastXtime) {
     m_Item.SetXTime(m_tttExpirationTime);

--- a/src/ui/wxWidgets/EditShortcutDlg.cpp
+++ b/src/ui/wxWidgets/EditShortcutDlg.cpp
@@ -393,6 +393,7 @@ void EditShortcutDlg::OnOk(wxCommandEvent& WXUNUSED(event))
       time(&t);
 
       modifiedShortcut.SetRMTime(t);
+      modifiedShortcut.SetStatus(CItemData::ES_MODIFIED);
 
       m_Core.Execute(
         EditEntryCommand::Create(&m_Core, *m_Shortcut, modifiedShortcut)


### PR DESCRIPTION
The last change on master had introduced implicit conversion of parameter, which lead to warnings. This is fixed with the change.
In addition the filter, e.g. not saved entries, had not been updated at the gui when undo or redo is done while the filter is active. This problem is fixed as well.