### PR TITLE
Add missing string resources and update text to long string

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -104,7 +104,7 @@
 #define IDSC_IMPORTLINESKIPPED          3259
 #define IDSC_IMPORTKNOWNHDRS            3260
 #define IDSC_IMPORTEMPTYLINESKIPPED     3261
-#define IDSC_PWHERRORLINE               3262
+/* #define IDSC_PWHERRORLINE               3262 */ // Not defined and not used
 #define IDSC_PWHISTORYSKIPPED           3263
 #define IDSC_IMPORTCONFLICTS1           3264
 #define IDSC_IMPORTCONFLICTS2           3265
@@ -332,14 +332,6 @@
 #define IDSC_DEFAULT_POLICY             4114
 #define IDSC_ATLEASTIGNORED             4115
 #define IDSC_INVALIDLOCKER              4116
-#define IDSC_EXPORTDB                   4117
-#define IDSC_IMPORTKEEPASS1CSV          4118
-#define IDSC_IMPORTKEEPASS1TXT          4119
-#define IDSC_IMPORTXML                  4120
-#define IDSC_IMPORTTEXT                 4121
-#define IDSC_MERGE                      4122
-#define IDSC_COMPARE                    4123
-#define IDSC_SNCHRONIZE                 4124
 
 #define IDSC_COMPARESTATISTICS          5356
 #define IDSC_COMPARESTATS               5359

--- a/src/core/core.rc2
+++ b/src/core/core.rc2
@@ -228,8 +228,10 @@ BEGIN
   IDSC_START_REPORT        "Start Report"
   IDSC_END_REPORT1         "End Report"
   IDSC_END_REPORT2         "--------------------------------------------------------------------------------"
-  IDSC_COMPARESTATISTICS   "Compare complete of current database:\n\t %s\n and:\n\t %s"
-  IDSC_COMPARESTATS        "\tGroup:'%s'; Title:'%s'; User:'%s'"
+  IDSC_COMPARESTATISTICS   "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+  IDSC_COMPARESTATS        "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+  IDSC_SEARCHRESULTS1      "\tNo entries were found containing search string '%ls' %ls"
+  IDSC_SEARCHRESULTS2      "\tThe following entries contain search string '%ls' %ls"
 END
 
 STRINGTABLE
@@ -294,6 +296,7 @@ BEGIN
   IDSC_WILLEXPIRE          "will expire"
   IDSC_AND                 "And"
   IDSC_OR                  "Or"
+  IDSC_RELATIVE            "Relative"
 END
 
 STRINGTABLE
@@ -455,4 +458,5 @@ END
 STRINGTABLE
 BEGIN
   IDSC_DRAGNUMBER          " Drag # %d"
+  IDSC_DRAGPOLICY          "%ls - Drag & Drop %ls"
 END

--- a/src/ui/Windows/I18N/pos/pwsafe_cz.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_cz.po
@@ -2154,8 +2154,8 @@ msgstr "Porovnej výsledky databáze"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "Porovnej celou databázi:\n\t %s\n and:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "Porovnej celou databázi:\n\t %ls\n and:\n\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7794,8 +7794,8 @@ msgstr "\tZáznam - Skupina:\"%s\"; Název:\"%s\"; Uživatel:\"%s\"\n\t\tse liš
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tSkupina:'%s'; Název:'%s'; Uživatel:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tSkupina:'%ls'; Název:'%ls'; Uživatel:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_de.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_de.po
@@ -2193,8 +2193,8 @@ msgstr "Vergleiche der Datenbank Ergebnisse"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "Vollständiger Vergleich zwischen aktueller Datenbank:\n\t %s\n und:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "Vollständiger Vergleich zwischen aktueller Datenbank:\n\t %ls\n und:\n\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7833,8 +7833,8 @@ msgstr "\tEintrag - Gruppe:\"%s\"; Titel:\"%s\"; Benutzer:\"%s\"\n\t\that Unters
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tGruppe:'%s'; Titel:'%s'; Benutzer:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGruppe:'%ls'; Titel:'%ls'; Benutzer:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_dk.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_dk.po
@@ -2154,8 +2154,8 @@ msgstr "Sammenlign Database Resultater"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "fuldstændigt den nuværende database:\n\t %s\nog:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "fuldstændigt den nuværende database:\n\t %ls\nog:\n\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7794,8 +7794,8 @@ msgstr "\tPost - Gruppe:\"%s\"; Titel:\"%s\"; Bruger:\"%s\"\n\t\thar forskelle i
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tGruppe:'%s'; Titel:'%s'; Bruger:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGruppe:'%ls'; Titel:'%ls'; Bruger:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_es.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_es.po
@@ -2154,8 +2154,8 @@ msgstr "Comparar resultados de las Bases de Datos"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "Comparación completa de la base de datos actual:\n\t %s\n y:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "Comparación completa de la base de datos actual:\n\t %ls\n y:\n\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7794,8 +7794,8 @@ msgstr "\tEntrada - Grupo:\"%s\"; Título:\"%s\"; Usuario:\"%s\"\n\t\t tienen di
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tGrupo:'%s'; Título:'%s'; Usuario:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGrupo:'%ls'; Título:'%ls'; Usuario:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_fr.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_fr.po
@@ -2206,8 +2206,8 @@ msgstr "Comparer les résultats de la base"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "Comparaison complète de la base courante:\n\t %s\n et:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "Comparaison complète de la base courante:\n\t %ls\n et:\n\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7846,8 +7846,8 @@ msgstr "\tEntrée - Groupe : \"%s\"; Titre : \"%s\"; Utilisateur : \"%s\"\n\t\tc
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tGroupe:'%s'; Titre:'%s'; Usager:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGroupe:'%ls'; Titre:'%ls'; Usager:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_hu.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_hu.po
@@ -2154,8 +2154,8 @@ msgstr "Adatbázisösszehasonlítás eredménye"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "Összehasonlítás elkészült az aktuális adatbázisra: \n\t %s\n és:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "Összehasonlítás elkészült az aktuális adatbázisra: \n\t %ls\n és:\n\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7794,8 +7794,8 @@ msgstr "\tBejegyzés - Csoport:\"%s\"; Megnevezés:\"%s\"; Felhasználó:\"%s\"\
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tCsoport:'%s'; Megnevezés:'%s'; Felhasználó:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tCsoport:'%ls'; Megnevezés:'%ls'; Felhasználó:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_it.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_it.po
@@ -2167,8 +2167,8 @@ msgstr "Risultati confronto database"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "Confronto completato dei seguenti database:\n\t %s\n e:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "Confronto completato dei seguenti database:\n\t %ls\n e:\n\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7807,8 +7807,8 @@ msgstr "\tElemento - Gruppo:\"%s\"; Titolo:\"%s\"; Utente:\"%s\"\n\t\tpresenta d
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tGruppo:'%s'; Titolo:'%s'; Utente:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGruppo:'%ls'; Titolo:'%ls'; Utente:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_kr.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_kr.po
@@ -2154,8 +2154,8 @@ msgstr "데이터베이스 비교 결과"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "현재 데이터베이스의 비교 완료\n\t %s\n 그리고:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "현재 데이터베이스의 비교 완료\n\t %ls\n 그리고:\n\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7794,8 +7794,8 @@ msgstr "\t그룹:\"%s\"; 제목:\"%s\"; 사용자 이름:\"%s\"를 포함한 항
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\t그룹:'%s'; 제목:'%s'; 사용자 이름:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\t그룹:'%ls'; 제목:'%ls'; 사용자 이름:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_nl.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_nl.po
@@ -2193,8 +2193,8 @@ msgstr "Vergelijk Database Resultaten"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "Vergelijk volledig van huidige database:\n\t %s\n en:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "Vergelijk volledig van huidige database:\n\t %ls\n en:\n\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7834,8 +7834,8 @@ msgstr "\tinvoer - Groep:\"%s\"; Titel:\"%s\"; Gebruiker:\"%s\"\n\t\thas differe
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tGroep:'%s'; Titel:'%s'; Gebruiker:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGroep:'%ls'; Titel:'%ls'; Gebruiker:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_pl.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_pl.po
@@ -2167,8 +2167,8 @@ msgstr "Wyniki Porównania Bazy Danych"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "Zakończono porównanie bieżącej bazy danych:\n\t %s\n i:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "Zakończono porównanie bieżącej bazy danych:\n\t %ls\n i:\n\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7807,8 +7807,8 @@ msgstr "\tWpis - grupa:\"%s\"; tytuł:\"%s\"; użytkownik:\"%s\"\n\t\tróżni si
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tGrupa:'%s'; Nazwa:'%s'; Użytkownik:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGrupa:'%ls'; Nazwa:'%ls'; Użytkownik:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_pt_br.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_pt_br.po
@@ -2167,8 +2167,8 @@ msgstr "Comparar Resultados do Banco de Dados"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "Comparar completa do banco de dados atual:\n\t %s\n e:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "Comparar completa do banco de dados atual:\n\t %ls\n e:\n\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7807,8 +7807,8 @@ msgstr "\tEntrada - Grupo:\"%s\"; Tiítulo:\"%s\"; Usuário:\"%s\"\n\t\ttem dife
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tGrupo:'%s'; Título:'%s'; Usuário:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGrupo:'%ls'; Título:'%ls'; Usuário:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_ru.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_ru.po
@@ -2310,8 +2310,8 @@ msgstr "Результаты сравнения"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "Завершено сравнение текущего контейнера:\n\t %s\n и:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "Завершено сравнение текущего контейнера:\n\t %ls\n и:\n\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -8229,8 +8229,8 @@ msgstr "\tЭлемент — Группа: «%s»; Заголовок: «%s»; �
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tГруппа: «%s»; Заголовок: «%s»; Имя пользователя: «%s»"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tГруппа: «%ls»; Заголовок: «%ls»; Имя пользователя: «%ls»"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_sl.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_sl.po
@@ -2167,8 +2167,8 @@ msgstr "Primerjaj rezultate zbirke podatkov"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "Primerjaj popolno trenutno zbirko podatkov:\n\t %s\n in:\n\t %s"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\m"
+msgstr "Primerjaj popolno trenutno zbirko podatkov:\n\t %ls\n in:\n\t %ls\m"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7807,8 +7807,8 @@ msgstr "\tVnos - Skupina:\"%s\"; Naslov:\"%s\"; Uporabnik:\"%s\"\n\t\tima razlik
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tSkupina:'%s'; Naslov:'%s'; Uporabnik:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tSkupina:'%ls'; Naslov:'%ls'; Uporabnik:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_sv.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_sv.po
@@ -2342,14 +2342,14 @@ msgstr "Jämför databasresultat"
 #, c-format
 msgid ""
 "Compare complete of current database:\n"
-"\t %s\n"
+"\t %ls\n"
 " and:\n"
-"\t %s"
+"\t %ls\n"
 msgstr ""
 "Jämförelsen klar med aktuell databas:\n"
-"\t %s\n"
+"\t %ls\n"
 " och:\n"
-"\t %s"
+"\t %ls\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -8887,8 +8887,8 @@ msgstr ""
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tGrupp:'%s'; Titel:'%s'; Användare:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGrupp:'%ls'; Titel:'%ls'; Användare:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_tr.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_tr.po
@@ -2154,8 +2154,8 @@ msgstr "Veritabanı Sonuçlarını Karşılaştır"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "Geçerli veritabanı:\n\t %s\n ve:\n\t %s\nkarşılaştırması tamamlandı."
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "Geçerli veritabanı:\n\t %ls\n ve:\n\t %ls\nkarşılaştırması tamamlandı.\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7794,8 +7794,8 @@ msgstr "\tGirdi - Gup:\"%s\"; Başlık:\"%s\"; Kullanıcı:\"%s\"\n\t\taşağıd
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\tGrup:'%s'; Başlık:'%s'; Kullanıcı:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGrup:'%ls'; Başlık:'%ls'; Kullanıcı:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/Windows/I18N/pos/pwsafe_zh.po
+++ b/src/ui/Windows/I18N/pos/pwsafe_zh.po
@@ -2167,8 +2167,8 @@ msgstr "比较数据库结果"
 
 #. Resource IDs: (5356)
 #, c-format
-msgid "Compare complete of current database:\n\t %s\n and:\n\t %s"
-msgstr "当前数据库:\n\t %s\n 和:\n\t %s\n数据库比较完成"
+msgid "Compare complete of current database:\n\t %ls\n and:\n\t %ls\n"
+msgstr "当前数据库:\n\t %ls\n 和:\n\t %ls\n数据库比较完成\n"
 
 #. Resource IDs: (32091 - Menu, 32091 - MenuEx)
 msgid "Compare entries..."
@@ -7807,8 +7807,8 @@ msgstr "\t条目 - 分组:\"%s\"; 标题:\"%s\"; 用户:\"%s\"\n\t\t在下列字
 
 #. Resource IDs: (5359)
 #, c-format
-msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-msgstr "\t分组:'%s'; 标题:'%s'; 用户:'%s'"
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\t分组:'%ls'; 标题:'%ls'; 用户:'%ls'"
 
 #. Resource IDs: (3391)
 #, c-format

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-28 12:52+0100\n"
+"POT-Creation-Date: 2021-03-19 21:58+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -231,7 +231,7 @@ msgstr "Datoer og Tider"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:348
 #: ../../../ui/wxWidgets/HelpMap.h:41 ../../../ui/wxWidgets/HelpMap.h:49
-#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:141
+#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:143
 msgid "Password Policy"
 msgstr "Adgangskode Politik"
 
@@ -245,7 +245,7 @@ msgid "Set Date/Time"
 msgstr "Sæt Dato/Tid"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:370
-#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:137
+#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:139
 msgid "Password"
 msgstr "Adgangskode"
 
@@ -529,14 +529,14 @@ msgstr "Brug STORE bogstaver"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:747
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:281
-#: ../../../core/core_st.cpp:260
+#: ../../../core/core_st.cpp:262
 #, fuzzy
 msgid "Use digits"
 msgstr "Brug Tal"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:771
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:305
-#: ../../../core/core_st.cpp:262
+#: ../../../core/core_st.cpp:264
 #, fuzzy
 msgid "Use symbols"
 msgstr "Standart Brugernavn"
@@ -572,7 +572,7 @@ msgstr "Generer Udtalbare adgangskoder"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:815
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:350
-#: ../../../core/core_st.cpp:253
+#: ../../../core/core_st.cpp:255
 msgid "Or"
 msgstr "Eller"
 
@@ -620,7 +620,7 @@ msgstr "Egenskaber"
 #: ../../../ui/wxWidgets/CreateShortcutDlg.cpp:219
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:269
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:274
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
 msgid "Text"
 msgstr "Tekst"
 
@@ -676,7 +676,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:160
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:173
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:192
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:301
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:317
 msgid "Unknown"
 msgstr "Ukendt"
 
@@ -791,7 +791,7 @@ msgstr "[Notater er skjult - klik her for at vise dem]"
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:1653
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2145
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2820
-#: ../../../core/core_st.cpp:74
+#: ../../../core/core_st.cpp:76
 msgid "Default Policy"
 msgstr ""
 
@@ -812,7 +812,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:144
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:151
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:159
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:200
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:201
 #: ../../../ui/wxWidgets/PWSafeApp.cpp:367
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:737
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:756
@@ -836,7 +836,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:249
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:277
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:316
-#: ../../../core/core_st.cpp:274
+#: ../../../core/core_st.cpp:288
 msgid "Error"
 msgstr "Fejl"
 
@@ -1009,7 +1009,7 @@ msgid "Synchronize this item..."
 msgstr "Synkroniser..."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:482
-#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:357
+#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:286
 msgid "Synchronize"
 msgstr "Synkroniser"
 
@@ -1091,8 +1091,8 @@ msgid "Current safe was opened read-only"
 msgstr "Åben som læs-kun"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:793
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:996
-#: ../../../ui/wxWidgets/SyncWizard.cpp:618
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
+#: ../../../ui/wxWidgets/SyncWizard.cpp:619
 #, fuzzy, c-format
 msgid ""
 "The database:\n"
@@ -1110,7 +1110,7 @@ msgstr ""
 "det venligst ved at teste databasen."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:794
-#: ../../../ui/wxWidgets/SyncWizard.cpp:617
+#: ../../../ui/wxWidgets/SyncWizard.cpp:618
 msgid "Synchronization failed"
 msgstr "Synkronisering fejlede"
 
@@ -1465,7 +1465,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/GridCtrl.cpp:164
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:292
-#: ../../../core/core_st.cpp:147
+#: ../../../core/core_st.cpp:149
 msgid "Title"
 msgstr "Titel"
 
@@ -1689,7 +1689,7 @@ msgid "Value"
 msgstr "Værdi:"
 
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:291
-#: ../../../core/core_st.cpp:133
+#: ../../../core/core_st.cpp:135
 msgid "Group"
 msgstr "Gruppe"
 
@@ -1773,24 +1773,24 @@ msgstr ""
 msgid "Error parsing Run Command"
 msgstr "Fejl ved analyse af Kør Kommando"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:56
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:57
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:355
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:362
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:166
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:623
 msgid "Write Error"
 msgstr "Skrive Fejl"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:61
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:62
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:165
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:622
 #, fuzzy
 msgid "Could not open file for writing!"
 msgstr "Kunne ikke åbne filen for at skrive til den!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:64
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:65
 msgid ""
 "Write operation failed!\n"
 "File may have been corrupted.\n"
@@ -1800,59 +1800,59 @@ msgstr ""
 "Filen kan være bleve korrupt.\n"
 "Prøv at gemme et andet sted"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:69
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:70
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 #, fuzzy
 msgid "Unknown error"
 msgstr "Ukendt fejl"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:90
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:91
 #, fuzzy
 msgid "Do you want to save changes to the password database: "
 msgstr "Vil du gemme ændringer til adgangskode databasen: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:145
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:146
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:557
 msgid "Please choose a name for the new database"
 msgstr "Vælg Venligst et navn til den nye database"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:155
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:156
 #, fuzzy
 msgid "psafe3 files (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 msgstr "Password Safe Databaser (*.psafe3)|*.psafe3|Alle filer (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Lock is done by yourself"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Remove Lock?"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:194
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:195
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:602
 #, fuzzy
 msgid "Could not lock file.\n"
 msgstr "Kunne ikke åbne filen for at læse den!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:196
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:197
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:452
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:604
 msgid "Locked by "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:236
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:237
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:515
 msgid "Please Choose a Database to Open:"
 msgstr "Vælg Venligst en Database at Åbne:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:353
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Save database elsewhere or with "
@@ -1863,7 +1863,7 @@ msgstr ""
 "%s. Prøv enten at gemme databasen med et andet navn eller afslut uden at "
 "gemme."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:360
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Do you wish to save changes to your "
@@ -1872,12 +1872,12 @@ msgstr ""
 "%s. Prøv enten at gemme databasen med et andet navn eller afslut uden at "
 "gemme."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 msgid "Unable to create intermediate backup."
 msgstr "Ude af stand til at oprette mellemliggende sikkerhedskopi."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:386
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:387
 #, c-format
 msgid ""
 "The original database, \"%ls\", is in pre-3.0 format. It will be unchanged.\n"
@@ -1886,12 +1886,12 @@ msgid ""
 "the \"File->Export To-> Old (1.x or 2) format\" command."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:388
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:389
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:447
 msgid "File version warning"
 msgstr "Fil versions advarsel"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:445
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
 #, c-format
 msgid ""
 "The original database, '%ls', is in pre-3.0 format. The data will now be "
@@ -1900,15 +1900,15 @@ msgid ""
 "Old (1.x or 2) format' command."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:458
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
 msgid "Please choose a name for the current (Untitled) database:"
 msgstr "Vælg Venligst et navn til den nuværende (Ubetitlede) database:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:460
 msgid "Please choose a new name for the current database:"
 msgstr "Vælg Venligst et nyt navn til den nuværende database:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:467
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:468
 #, fuzzy
 msgid ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|"
@@ -1917,7 +1917,7 @@ msgstr ""
 "Password Safe Databaser (*.psafe3; *.dat)|*.psafe3; *.dat|Alle filer (*.*)|*."
 "*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:479
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -1928,253 +1928,253 @@ msgstr ""
 "\n"
 "Filen er for øjeblikket låst af %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:481
 msgid "File lock error"
 msgstr "Fil låse fejl"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:547
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
 #, fuzzy
 msgid "Do you wish to save this restored database as new database?"
 msgstr "Vil du gemme ændringer til adgangskode databasen: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:549
 #, fuzzy
 msgid "Unsaved restored database"
 msgstr "i databasen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:580
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:581
 #, fuzzy
 msgid "Do you want to save changes to the password database"
 msgstr "Vil du gemme ændringer til adgangskode databasen: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:617
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:618
 msgid "Export Text"
 msgstr "Eksporter Tekst"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:621
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:622
 #, fuzzy
 msgid "Export Text failed"
 msgstr "Importer Tekst fejlede"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:623
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
 msgid "Please name the plaintext file"
 msgstr "Navngiv venligst den alm. tekst fil"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1143
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:625
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1144
 #, fuzzy
 msgid ""
 "Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
 msgstr ""
 "Tekst filer (*.txt)|*.txt|CSV filer (*.csv)|*.csv|Alle filer (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:634
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:635
 msgid "Advanced Text Export Options"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:654
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:697
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:655
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:698
 #, fuzzy
 msgid "export"
 msgstr "eksporteret"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:660
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:661
 msgid "Export XML"
 msgstr "Eksporter XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:664
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:665
 #, fuzzy
 msgid "Export XML failed"
 msgstr "Importer XML fejlede"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:666
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
 msgid "Please name the XML file"
 msgstr "Navngiv venligst XML filen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:668
 #, fuzzy
 msgid "XML files (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 msgstr "XML filer (*.xml)|*.xml|Alle filer (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:678
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:679
 msgid "Advanced XML Export Options"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:712
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:716
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:713
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:717
 #, fuzzy
 msgid "Password Safe Databases (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 msgstr ""
 "Password Safe Databaser (*.psafe3; *.dat)|*.psafe3; *.dat|Alle filer (*.*)|*."
 "*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:720
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:721
 #, fuzzy
 msgid "Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 msgstr ""
 "Password Safe Databaser (*.psafe3; *.dat)|*.psafe3; *.dat|Alle filer (*.*)|*."
 "*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:731
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:732
 msgid "Please name the exported database"
 msgstr "Navngiv venligst den exporterede database"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:748
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:749
 msgid "Could not figure out why PasswordSafeFrame::OnExportVx was invoked"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:782
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:783
 msgid "You must save this database before it can be exported."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 #, fuzzy
 msgid "Exporting database: "
 msgstr "Fletter databasen: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid " to "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:841
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:842
 #, fuzzy
 msgid "Export complete.  Do you wish to see a detailed report?"
 msgstr "Vil du erstatte den?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:852
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:853
 msgid "No entries satisfied your selection criteria and so none were exported!"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:865
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:866
 msgid "Passkey incorrect"
 msgstr "Hovednøgle ukorrekt"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:873
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
 msgid ""
 "The current database was opened in read-only mode.  You cannot import into "
 "it."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:875
 #, fuzzy
 msgid "Import text"
 msgstr "Importer Tekst"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:882
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
 #, fuzzy
 msgid "The database:"
 msgstr "i databasen:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
 #, fuzzy
 msgid "has duplicate entries with the same group/title/user combination."
 msgstr "har duplikerede poster med den samme gruppe/titel/Bruger kombination."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
 msgid "  Please fix by validating database."
 msgstr " Orden det venligst ved at teste databasen."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:931
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:886
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:932
 #, fuzzy
 msgid "Import Text failed"
 msgstr "Importer Tekst fejlede"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 #, fuzzy, c-format
 msgid "%ls file being imported: %ls"
 msgstr "%ls filen der importeres: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:921
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:926
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:223
-#: ../../../ui/wxWidgets/SyncWizard.cpp:572
+#: ../../../ui/wxWidgets/SyncWizard.cpp:573
 #: ../../../ui/wxWidgets/wxUtilities.cpp:59
 #: ../../../ui/wxWidgets/wxUtilities.cpp:64
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "File Read Error"
 msgstr "Fil Læse Fejl"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:923
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:222
 #: ../../../ui/wxWidgets/wxUtilities.cpp:58
 #, fuzzy
 msgid "Could not open file for reading!"
 msgstr "Kunne ikke åbne filen for at læse den!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:928
 #, fuzzy
 msgid "Invalid format"
 msgstr "Ugyldigt format"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Updated "
 msgstr "Opdateret %d %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Imported "
 msgstr "Importeret"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entry"
 msgstr "post"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entries"
 msgstr "poster"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
 #, fuzzy
 msgid "Skipped "
 msgstr "Sprunget over "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:957
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:958
 #, fuzzy
 msgid "with Password History errors "
 msgstr "med Adgangskode Historik fejl "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid "Renamed "
 msgstr "Omdøb "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed successfully"
 msgstr "Fuldført succesfuldt"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed but ...."
 msgstr "Fuldført men ...."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:981
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1127
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1197
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1218
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1279
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:982
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1128
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1219
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
 #, fuzzy
 msgid "Do you wish to see a detailed report?"
 msgstr "Vil du erstatte den?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1045
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:998
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1046
 msgid "Import XML failed"
 msgstr "Importer XML fejlede"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1007
-#: ../../../core/core_st.cpp:238
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../core/core_st.cpp:240
 #, fuzzy, c-format
 msgid ""
 "Can't find XML Schema Definition file (%ls) in your PasswordSafe Application "
@@ -2186,20 +2186,20 @@ msgstr ""
 "Kopier det venligst fra din installations fil, eller geninstallerl "
 "PasswordSafe."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 #, fuzzy
 msgid "Missing XSD File - "
 msgstr "Manglende XSD File"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid " Build"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 msgid "XML"
 msgstr "XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1051
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1052
 #, fuzzy, c-format
 msgid ""
 "File: %ls failed validation against XML Schema:\n"
@@ -2210,7 +2210,7 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1057
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1058
 #, fuzzy, c-format
 msgid ""
 "File: %ls passed Validation but had the following errors during import:\n"
@@ -2221,25 +2221,25 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1078
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1079
 msgid "The following records were skipped:"
 msgstr "De følgende poster blev sprunget over:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1080
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1081
 #, c-format
 msgid " / skipped %d"
 msgstr "/ sprunget over %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1085
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1086
 msgid "The following records had errors in their Password History:"
 msgstr "De følgende poster havde fejl i deres Adgangskode Historik:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1087
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1088
 #, c-format
 msgid " / with Password History errors %d"
 msgstr "/ med Adgangskode Historik fejl %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1092
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1093
 msgid ""
 "The following records were renamed as an entry already exists in your "
 "database or in the Import file:"
@@ -2247,12 +2247,12 @@ msgstr ""
 "De følgende poster blev omdøbt fordi en adgang allerede eksisterer i din "
 "database eller i den Importerede fil:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1094
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1095
 #, c-format
 msgid " / renamed %d"
 msgstr "/ omdøbt %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1099
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1100
 #, fuzzy, c-format
 msgid ""
 "File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See "
@@ -2261,25 +2261,25 @@ msgstr ""
 "Filen: %ls blev importeret (poster testet %d / importeret %d%ls%ls%ls). Se "
 "rapport for detaljer."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:95
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:97
 msgid "entry"
 msgstr "post"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:93
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:95
 msgid "entries"
 msgstr "poster"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1107
 #, fuzzy, c-format
 msgid ""
 "Validated %d %ls\n"
@@ -2290,26 +2290,26 @@ msgstr ""
 "\n"
 "Importerede %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1114
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1115
 msgid "XML import not supported in this release"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1117
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1118
 #, c-format
 msgid "XML import: Unexpected return code(%d)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1141
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1142
 msgid "Please Choose a KeePass Text File to Import"
 msgstr "Vælg Venligst en KeePass Tekst Fil til Import"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1163
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1164
 #, fuzzy, c-format
 msgid "Text file being imported: %ls"
 msgstr "Text filen der importeres: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1180
-#: ../../../ui/wxWidgets/SyncWizard.cpp:602
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/SyncWizard.cpp:603
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2320,11 +2320,11 @@ msgstr ""
 "\n"
 "Kunne ikke åbne filen for at læse den!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1182
 msgid "File open error"
 msgstr "Fil åbnings fejl"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1195
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1196
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2335,21 +2335,21 @@ msgstr ""
 "\n"
 "Ugyldigt format"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1199
 msgid "Import failed"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1214
 #, fuzzy, c-format
 msgid "Imported %d %ls"
 msgstr "Importeret%d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1265
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1266
 #, fuzzy
 msgid "Merging database: "
 msgstr "Fletter databasen: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1281
 #, fuzzy
 msgid "Merge Complete"
 msgstr "Sammenlign Komplet"
@@ -2445,16 +2445,16 @@ msgid ""
 "Try exiting and restarting program."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #, fuzzy
 msgid " file '"
 msgstr "Håndter Filtre"
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid "' not readable"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #: ../../../ui/wxWidgets/ViewReportDlg.cpp:32
 msgid "View Report"
 msgstr "Se Rapport"
@@ -2502,7 +2502,7 @@ msgid "Please select a valid file"
 msgstr "Vælg venligst den rapport du vil se."
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:123
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:249
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:251
 msgid "None"
 msgstr "Ingen"
 
@@ -2516,7 +2516,7 @@ msgid "Incremented Number [001-999]"
 msgstr "Gradvis stigende Tal [001-999]"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:132
-#: ../../../core/core_st.cpp:66
+#: ../../../core/core_st.cpp:68
 #, fuzzy
 msgid "Copy password to clipboard"
 msgstr "Kopier Adgangskode til klipbord"
@@ -2528,37 +2528,37 @@ msgstr "Se/Rediger valgte adgang"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:134
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:623
-#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:62
+#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:64
 msgid "Autotype"
 msgstr "Autoindsæt"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:135
-#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:63
+#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:65
 msgid "Browse to URL"
 msgstr "Gennemse efter URL"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:136
-#: ../../../core/core_st.cpp:65
+#: ../../../core/core_st.cpp:67
 msgid "Copy notes to clipboard"
 msgstr "Kopier notater til klipbord"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:137
-#: ../../../core/core_st.cpp:68
+#: ../../../core/core_st.cpp:70
 msgid "Copy username to clipboard"
 msgstr "Kopier brugernavn til klipbord"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:138
-#: ../../../core/core_st.cpp:67
+#: ../../../core/core_st.cpp:69
 msgid "Copy password to clipboard, minimize"
 msgstr "Kopier adgangskode til klipbord, minimer"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:139
-#: ../../../core/core_st.cpp:64
+#: ../../../core/core_st.cpp:66
 msgid "Browse to URL + Autotype"
 msgstr "Gennemse efter URL + Autoindsæt"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:140
-#: ../../../core/core_st.cpp:69 ../../../core/core_st.cpp:144
+#: ../../../core/core_st.cpp:71 ../../../core/core_st.cpp:146
 msgid "Run Command"
 msgstr "Kør Kommando"
 
@@ -2989,24 +2989,24 @@ msgstr ""
 msgid "Don't show this warning again"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:849
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:854
 msgid "Missing help definition for page \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:850
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
 msgid "\" of \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:860
 msgid "Missing help definition for window \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:866
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:871
 #, fuzzy
 msgid "Please inform the developers."
 msgstr "Navngiv venligst dette filter."
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:867
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:872
 msgid "Help Undefined"
 msgstr ""
 
@@ -3739,6 +3739,7 @@ msgid "search"
 msgstr "Søg"
 
 #: ../../../ui/wxWidgets/PasswordSafeSearch.cpp:427
+#: ../../../core/core_st.cpp:280
 msgid "Find"
 msgstr "Find"
 
@@ -3859,20 +3860,20 @@ msgstr "vurdering"
 msgid " empty)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:306
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:322
 #, fuzzy, c-format
 msgid "%ls on %ls"
 msgstr "%ls på %ls"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:341
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:357
 msgid "Yes"
 msgstr "Ja"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:244
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:246
 msgid "No"
 msgstr "Ingen"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:302
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:318
 #, fuzzy, c-format
 msgid "In Headers(%ls)/In Entries("
 msgstr "I Overskrifter(%ls)/I Adgange("
@@ -4053,7 +4054,7 @@ msgstr "Kunne ikke åbne filen for at læse den!"
 
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:457
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:269
-#: ../../../core/core_st.cpp:276
+#: ../../../core/core_st.cpp:290
 msgid "Warning"
 msgstr "Advarsel"
 
@@ -4127,11 +4128,11 @@ msgstr "Indsæt venligst nøglen og bekræft den."
 msgid "Please try another"
 msgstr "Prøv venligst en anden"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:96
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:98
 msgid "equals"
 msgstr "lige store"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:83
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:85
 msgid "does not equal"
 msgstr "er ikke lig med"
 
@@ -4139,23 +4140,23 @@ msgstr "er ikke lig med"
 msgid "begins with"
 msgstr "begynder med"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:78
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:80
 msgid "does not begin with"
 msgstr "begynder ikke med"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:90
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:92
 msgid "ends with"
 msgstr "ender med"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:82
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:84
 msgid "does not end with"
 msgstr "ender ikke med"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:56
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:58
 msgid "contains"
 msgstr "indeholder"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:79
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:81
 msgid "does not contain"
 msgstr "indeholder ikke"
 
@@ -4214,79 +4215,79 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Afbryd"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:143
+#: ../../../ui/wxWidgets/SyncWizard.cpp:144
 #, fuzzy
 msgid "synchronize"
 msgstr "Synkroniser"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:220
+#: ../../../ui/wxWidgets/SyncWizard.cpp:221
 #, fuzzy
 msgid "Synchronize another database with currently open database"
 msgstr "Vælg Venligst en Database til Sammenligning med den åbne database"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:349
+#: ../../../ui/wxWidgets/SyncWizard.cpp:350
 msgid "Introduction"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:353
+#: ../../../ui/wxWidgets/SyncWizard.cpp:354
 msgid ""
 "Synchronizing with another database will update the entries in your\n"
 "database with matching entries from the other database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:356
+#: ../../../ui/wxWidgets/SyncWizard.cpp:357
 msgid "More Info"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:359
+#: ../../../ui/wxWidgets/SyncWizard.cpp:360
 msgid ""
 "1. Two entries from different databases match if their Group, Title\n"
 "and User fields match."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:360
+#: ../../../ui/wxWidgets/SyncWizard.cpp:361
 msgid ""
 "2. You can select the fields to update, as well as filter the entries\n"
 "for synchronization."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:361
+#: ../../../ui/wxWidgets/SyncWizard.cpp:362
 msgid ""
 "3. Only existing entries in your database are updated.  No new entries are\n"
 "added or existing entries removed during this process."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:362
+#: ../../../ui/wxWidgets/SyncWizard.cpp:363
 msgid ""
 "4. You can undo the operation once it is complete, but won't be\n"
 "able to abort it mid-way."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:379
+#: ../../../ui/wxWidgets/SyncWizard.cpp:380
 #, fuzzy
 msgid "Select another database"
 msgstr "Åben en Anden Database"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:381
+#: ../../../ui/wxWidgets/SyncWizard.cpp:382
 msgid "Choose Database to Synchronize with \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:382
+#: ../../../ui/wxWidgets/SyncWizard.cpp:383
 #, fuzzy
 msgid "Please Choose a Database to Synchronize with current database"
 msgstr "Vælg Venligst en Database til Sammenligning med den åbne database"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:405
+#: ../../../ui/wxWidgets/SyncWizard.cpp:406
 #, fuzzy
 msgid "Synchronization options"
 msgstr "Synkronisering fejlede"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:429
+#: ../../../ui/wxWidgets/SyncWizard.cpp:430
 #, fuzzy
 msgid "Options Summary"
 msgstr "Muligheder"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:454
+#: ../../../ui/wxWidgets/SyncWizard.cpp:455
 msgid ""
 "WARNING!!\n"
 "\n"
@@ -4294,58 +4295,58 @@ msgid ""
 "from your selected input database"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:471
+#: ../../../ui/wxWidgets/SyncWizard.cpp:472
 msgid " will be updated with corresponding entries from \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:478
+#: ../../../ui/wxWidgets/SyncWizard.cpp:479
 msgid "All fields in matching entries will be updated"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:484
+#: ../../../ui/wxWidgets/SyncWizard.cpp:485
 msgid "Following fields in matching entries will be updated:"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:488
+#: ../../../ui/wxWidgets/SyncWizard.cpp:489
 #, fuzzy
 msgid "Following fields will not be updated:"
 msgstr "De følgende kolonner vil blive behandlet:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:507
+#: ../../../ui/wxWidgets/SyncWizard.cpp:508
 #, fuzzy
 msgid "Synchronization status"
 msgstr "Synkronisering fejlede"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:525
+#: ../../../ui/wxWidgets/SyncWizard.cpp:526
 msgid "See a detailed report"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:561
+#: ../../../ui/wxWidgets/SyncWizard.cpp:562
 msgid "Your database is being synchronized with \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:571
+#: ../../../ui/wxWidgets/SyncWizard.cpp:572
 msgid "There was an error during synchronization"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:585
+#: ../../../ui/wxWidgets/SyncWizard.cpp:586
 #, c-format
 msgid "Your database has been synchronized with \"%ls\""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:586
+#: ../../../ui/wxWidgets/SyncWizard.cpp:587
 #, fuzzy, c-format
 msgid "%ld %ls updated"
 msgstr ""
 "\n"
 "De følgende %ls %ls er opdateret:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:589
 #, fuzzy
 msgid "Synchronization completed successfully"
 msgstr "Fuldført succesfuldt"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:604
+#: ../../../ui/wxWidgets/SyncWizard.cpp:605
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4358,7 +4359,7 @@ msgstr ""
 "Filen er forvansket eller afkortet!\n"
 "Data kan være mistet eller ændret."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:606
+#: ../../../ui/wxWidgets/SyncWizard.cpp:607
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4369,24 +4370,24 @@ msgstr ""
 "\n"
 "Ukendt fejl"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:640
+#: ../../../ui/wxWidgets/SyncWizard.cpp:641
 #, fuzzy, c-format
 msgid "Synchronizing from database: %ls\n"
 msgstr "Synkroniserer fra database: %ls\n"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:643
+#: ../../../ui/wxWidgets/SyncWizard.cpp:644
 msgid "synchronized"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:322
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:338
 msgid "was"
 msgstr "var"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:323
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:339
 msgid "were"
 msgstr "blev"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:298
+#: ../../../ui/wxWidgets/SyncWizard.cpp:733 ../../../core/core_st.cpp:314
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4395,7 +4396,7 @@ msgstr ""
 "\n"
 "De følgende %ls %ls er opdateret:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:297
+#: ../../../ui/wxWidgets/SyncWizard.cpp:749 ../../../core/core_st.cpp:313
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4567,7 +4568,7 @@ msgstr ""
 "Denne genvejs mål [%s:%s:%s] er ikke en normal post elller allerede en basis "
 "genvej."
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:94
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:96
 #, c-format
 msgid ""
 "The following entries had a policy name that already existed in this "
@@ -4672,13 +4673,13 @@ msgstr ""
 "Data kan være mistet eller ændret.\n"
 "Fortsæt alligevel?"
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:381
+#: ../../../ui/wxWidgets/wxUtilities.cpp:390
 msgid ""
 "An error occurred while trying to get the image data from database item.\n"
 "Therefore, the image cannot be displayed in the preview."
 msgstr ""
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:394
+#: ../../../ui/wxWidgets/wxUtilities.cpp:403
 msgid ""
 "An error occurred while trying to load the image data into the preview "
 "area.\n"
@@ -4810,7 +4811,7 @@ msgstr "Gem Databasen"
 msgid "Copy Password to Clipboard"
 msgstr "Kopier Adgangskode til Klipbord"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:149
+#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:151
 #, fuzzy
 msgid "Username"
 msgstr "Brugernavn:"
@@ -4820,7 +4821,7 @@ msgstr "Brugernavn:"
 msgid "Copy Username to Clipboard"
 msgstr "Kopier Brugernavn til Klipbord"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:136
+#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:138
 #, fuzzy
 msgid "Notes"
 msgstr "Notater:"
@@ -4850,7 +4851,7 @@ msgstr "Udfør Autoindsæt"
 msgid "Browse URL"
 msgstr "Gennemse efter URL"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:70
+#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:72
 #, fuzzy
 msgid "Send Email"
 msgstr "Send email"
@@ -5042,69 +5043,87 @@ msgid "(case sensitive)"
 msgstr "(Følsom over for store eller små bogst.)"
 
 #: ../../../core/core_st.cpp:50
+#, fuzzy, c-format
+msgid ""
+"Compare complete of current database:\n"
+"\t %ls\n"
+" and:\n"
+"\t %ls\n"
+msgstr ""
+"fuldstændigt den nuværende database:\n"
+"\t %s\n"
+"og:\n"
+"\t %s"
+
+#: ../../../core/core_st.cpp:51
+#, fuzzy, c-format
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGruppe:'%s'; Titel:'%s'; Bruger:'%s'"
+
+#: ../../../core/core_st.cpp:52
 msgid "C:F[R-O]"
 msgstr "C:F[R-O]"
 
-#: ../../../core/core_st.cpp:51
+#: ../../../core/core_st.cpp:53
 msgid "C:F[R/W]"
 msgstr "C:F[R/W]"
 
-#: ../../../core/core_st.cpp:52
+#: ../../../core/core_st.cpp:54
 msgid "C:None  "
 msgstr "C:Ingen  "
 
-#: ../../../core/core_st.cpp:53
+#: ../../../core/core_st.cpp:55
 msgid "C:Reg   "
 msgstr "C:Reg   "
 
-#: ../../../core/core_st.cpp:54
+#: ../../../core/core_st.cpp:56
 msgid "conflict"
 msgstr "konflikt"
 
-#: ../../../core/core_st.cpp:55
+#: ../../../core/core_st.cpp:57
 msgid "conflicts"
 msgstr "konflikter"
 
-#: ../../../core/core_st.cpp:57
+#: ../../../core/core_st.cpp:59
 #, fuzzy
 msgid "contains all of"
 msgstr "indeholder"
 
-#: ../../../core/core_st.cpp:58
+#: ../../../core/core_st.cpp:60
 #, fuzzy
 msgid "contains any of"
 msgstr "indeholder"
 
-#: ../../../core/core_st.cpp:59
+#: ../../../core/core_st.cpp:61
 #, fuzzy
 msgid "copied"
 msgstr "URL kopieret "
 
-#: ../../../core/core_st.cpp:60
+#: ../../../core/core_st.cpp:62
 #, fuzzy, c-format
 msgid "%ls - Copied %ls"
 msgstr "%ls - Kopieret %s"
 
-#: ../../../core/core_st.cpp:61
+#: ../../../core/core_st.cpp:63
 #, fuzzy, c-format
 msgid " Current default (%ls)"
 msgstr "Nuværende standart (%ls)"
 
-#: ../../../core/core_st.cpp:71
+#: ../../../core/core_st.cpp:73
 msgid "View/Edit selected entry"
 msgstr "Se/Rediger valgte adgang"
 
-#: ../../../core/core_st.cpp:72
+#: ../../../core/core_st.cpp:74
 #, fuzzy
 msgid " (application default)"
 msgstr "Bruger programmet:"
 
-#: ../../../core/core_st.cpp:73
+#: ../../../core/core_st.cpp:75
 #, fuzzy
 msgid "default symbol set"
 msgstr "Standart Brugernavn"
 
-#: ../../../core/core_st.cpp:75
+#: ../../../core/core_st.cpp:77
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5113,12 +5132,12 @@ msgid ""
 "entry's password)?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:76
+#: ../../../core/core_st.cpp:78
 #, fuzzy
 msgid "Delete Base Entry Confirmation"
 msgstr "Slet en Base Adgangs Bekræftelse?"
 
-#: ../../../core/core_st.cpp:77
+#: ../../../core/core_st.cpp:79
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5126,42 +5145,42 @@ msgid ""
 "Please confirm to continue (All shortcuts to this entry will be deleted)?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:80
+#: ../../../core/core_st.cpp:82
 #, fuzzy
 msgid "does not contain all of"
 msgstr "indeholder ikke"
 
-#: ../../../core/core_st.cpp:81
+#: ../../../core/core_st.cpp:83
 #, fuzzy
 msgid "does not contain any of"
 msgstr "indeholder ikke"
 
-#: ../../../core/core_st.cpp:84
+#: ../../../core/core_st.cpp:86
 #, c-format
 msgid " Drag # %d"
 msgstr "Træk # %d"
 
-#: ../../../core/core_st.cpp:85
-#, c-format
-msgid "%s - Drag & Drop %s"
-msgstr ""
+#: ../../../core/core_st.cpp:87
+#, fuzzy, c-format
+msgid "%ls - Drag & Drop %ls"
+msgstr "%ls - Kopieret %s"
 
-#: ../../../core/core_st.cpp:86
+#: ../../../core/core_st.cpp:88
 #, c-format
 msgid " Duplicate # %d"
 msgstr "Dupliker # %d"
 
-#: ../../../core/core_st.cpp:87
+#: ../../../core/core_st.cpp:89
 #, fuzzy
 msgid "empty group"
 msgstr "Importer under Gruppe?"
 
-#: ../../../core/core_st.cpp:88
+#: ../../../core/core_st.cpp:90
 #, fuzzy
 msgid "empty groups"
 msgstr "#grupper"
 
-#: ../../../core/core_st.cpp:89
+#: ../../../core/core_st.cpp:91
 #, fuzzy, c-format
 msgid ""
 "Trouble with a non-textual (e.g., time) field in record '%ls' - please check "
@@ -5170,128 +5189,128 @@ msgstr ""
 "Problem med et ikke-tekst-ordret (f.eks., tid) felt i posten '%ls' - tjek "
 "venligst data omhyggeligt."
 
-#: ../../../core/core_st.cpp:91
+#: ../../../core/core_st.cpp:93
 msgid "End Report"
 msgstr "Slut På Rapport"
 
-#: ../../../core/core_st.cpp:92
+#: ../../../core/core_st.cpp:94
 msgid "--------------------------------------------------------------------------------"
 msgstr "--------------------------------------------------------------------------------..."
 
-#: ../../../core/core_st.cpp:97
+#: ../../../core/core_st.cpp:99
 msgid "has expired"
 msgstr "er udløbet"
 
-#: ../../../core/core_st.cpp:98
+#: ../../../core/core_st.cpp:100
 msgid "Entries with a password expiry"
 msgstr ""
 
-#: ../../../core/core_st.cpp:99
+#: ../../../core/core_st.cpp:101
 #, c-format
 msgid "within %d day(s)"
 msgstr "indenfor%d dag(e)"
 
-#: ../../../core/core_st.cpp:100
+#: ../../../core/core_st.cpp:102
 #, fuzzy, c-format
 msgid "DB Export from database: '%s'"
 msgstr "Fletter databasen: "
 
-#: ../../../core/core_st.cpp:101
+#: ../../../core/core_st.cpp:103
 msgid "First character of variable name must be alphabetic"
 msgstr "Første tegn i variable navne skal være alfabetisk"
 
-#: ../../../core/core_st.cpp:102
+#: ../../../core/core_st.cpp:104
 msgid "Index not numeric"
 msgstr "Indeks er ikke tal"
 
-#: ../../../core/core_st.cpp:103
+#: ../../../core/core_st.cpp:105
 msgid "Input string is empty"
 msgstr "Indlæste streng er tom"
 
-#: ../../../core/core_st.cpp:104
+#: ../../../core/core_st.cpp:106
 msgid "Characters present between end of index ']' and '}'"
 msgstr "Nuværende tegn mellen enden af index ']' og '}'"
 
-#: ../../../core/core_st.cpp:105
+#: ../../../core/core_st.cpp:107
 msgid "Index is invalid or missing"
 msgstr "indekset er ugyldig eller mangler"
 
-#: ../../../core/core_st.cpp:106
+#: ../../../core/core_st.cpp:108
 msgid "Missing ending curly bracket for variable name"
 msgstr "Manglende krøllet slut klamme for variable navne"
 
-#: ../../../core/core_st.cpp:107
+#: ../../../core/core_st.cpp:109
 msgid "Missing ending round bracket for Autotype value"
 msgstr "Manglende rund slut klamme ending for Autoindsæt værdi"
 
-#: ../../../core/core_st.cpp:108
+#: ../../../core/core_st.cpp:110
 msgid "Missing ending square bracket for index value"
 msgstr "Manglende slut kasse klamme for index værdi"
 
-#: ../../../core/core_st.cpp:109
+#: ../../../core/core_st.cpp:111
 msgid "There are unmatched quotes in the run command"
 msgstr "Der er uforlignelig anførelsestegn i kør kommandoen"
 
-#: ../../../core/core_st.cpp:110
+#: ../../../core/core_st.cpp:112
 msgid "Variable name is empty"
 msgstr "Variabel navn er tom"
 
-#: ../../../core/core_st.cpp:111
+#: ../../../core/core_st.cpp:113
 msgid "Variable name must be alphanumeric"
 msgstr "Variabel navn skal være alphanumerisk"
 
-#: ../../../core/core_st.cpp:112
+#: ../../../core/core_st.cpp:114
 msgid "an alias entry"
 msgstr "en alias post"
 
-#: ../../../core/core_st.cpp:113
+#: ../../../core/core_st.cpp:115
 msgid "a base entry of an alias"
 msgstr "en basis post af et alias"
 
-#: ../../../core/core_st.cpp:114
+#: ../../../core/core_st.cpp:116
 msgid "  Field is too long."
 msgstr "Feltet er for langt."
 
-#: ../../../core/core_st.cpp:115
+#: ../../../core/core_st.cpp:117
 msgid "  Field is too short."
 msgstr "Feltet er for kort."
 
-#: ../../../core/core_st.cpp:116
+#: ../../../core/core_st.cpp:118
 msgid "Error: A file with this name already exists"
 msgstr "Fejl: En fil med dette navn eksisterer allerede"
 
-#: ../../../core/core_st.cpp:117
+#: ../../../core/core_st.cpp:119
 msgid "The file was not found."
 msgstr "Filen blev ikke fundet."
 
-#: ../../../core/core_st.cpp:118
+#: ../../../core/core_st.cpp:120
 msgid "Error: File is read-only"
 msgstr "Fejl: Filen kan kun læses"
 
-#: ../../../core/core_st.cpp:119
+#: ../../../core/core_st.cpp:121
 msgid "Error while writing file! Try saving in a different location"
 msgstr "Fejl ved skrivning af fil! Prøv at gemme et andet sted"
 
-#: ../../../core/core_st.cpp:120
+#: ../../../core/core_st.cpp:122
 #, fuzzy
 msgid "File is too big."
 msgstr "Feltet er for langt."
 
-#: ../../../core/core_st.cpp:121
+#: ../../../core/core_st.cpp:123
 #, fuzzy
 msgid "File is too short."
 msgstr "Feltet er for kort."
 
-#: ../../../core/core_st.cpp:122
+#: ../../../core/core_st.cpp:124
 msgid "File is truncated or otherwise corrupt. Please use backup database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:123
+#: ../../../core/core_st.cpp:125
 #, fuzzy
 msgid "Cannot read file. Please check file permissions."
 msgstr "Kan ikke oprette låse fil - ingen tilladelse i biblioteket."
 
-#: ../../../core/core_st.cpp:124
+#: ../../../core/core_st.cpp:126
 #, fuzzy, c-format
 msgid ""
 "Filter %ls already exists in the database, do you wish to replace it with "
@@ -5299,144 +5318,144 @@ msgid ""
 msgstr ""
 "Filter %ls eksisterer allerede i databasen, vil du erstatte det med dette?"
 
-#: ../../../core/core_st.cpp:125
+#: ../../../core/core_st.cpp:127
 #, fuzzy
 msgid "Current database filters have been exported to this database."
 msgstr "Sammenligner nuværende database med: %s"
 
-#: ../../../core/core_st.cpp:126
-msgid "Stored filters will be unusable until the file's restored."
-msgstr ""
-
-#: ../../../core/core_st.cpp:127
-#, fuzzy
-msgid "Last Access Time"
-msgstr "'Seneste Tilgang'"
-
 #: ../../../core/core_st.cpp:128
-msgid "Attachment Reference"
+msgid "Stored filters will be unusable until the file's restored."
 msgstr ""
 
 #: ../../../core/core_st.cpp:129
 #, fuzzy
+msgid "Last Access Time"
+msgstr "'Seneste Tilgang'"
+
+#: ../../../core/core_st.cpp:130
+msgid "Attachment Reference"
+msgstr ""
+
+#: ../../../core/core_st.cpp:131
+#, fuzzy
 msgid "AutoType"
 msgstr "Autoindsæt"
 
-#: ../../../core/core_st.cpp:130
+#: ../../../core/core_st.cpp:132
 #, fuzzy
 msgid "Created Time"
 msgstr "Oprettet"
 
-#: ../../../core/core_st.cpp:131
+#: ../../../core/core_st.cpp:133
 msgid "DCA"
 msgstr "DCA"
 
-#: ../../../core/core_st.cpp:132
+#: ../../../core/core_st.cpp:134
 #, fuzzy
 msgid "e-mail"
 msgstr "email"
 
-#: ../../../core/core_st.cpp:134
+#: ../../../core/core_st.cpp:136
 msgid "Group/Title"
 msgstr "Gruppe/Titel"
 
-#: ../../../core/core_st.cpp:135
+#: ../../../core/core_st.cpp:137
 #, fuzzy
 msgid "Keyboard Shortcut"
 msgstr "Opret Genvej"
 
-#: ../../../core/core_st.cpp:138
+#: ../../../core/core_st.cpp:140
 #, fuzzy
 msgid "Password Modified Time"
 msgstr "Adgangskode Ændret"
 
-#: ../../../core/core_st.cpp:139
+#: ../../../core/core_st.cpp:141
 #, fuzzy
 msgid "Protected"
 msgstr ""
 "\n"
 "Vælg Post"
 
-#: ../../../core/core_st.cpp:140
+#: ../../../core/core_st.cpp:142
 #, fuzzy
 msgid "History"
 msgstr "Tøm Historik"
 
-#: ../../../core/core_st.cpp:142
+#: ../../../core/core_st.cpp:144
 #, fuzzy
 msgid "Password Policy Name"
 msgstr "Adgangskode Politik"
 
-#: ../../../core/core_st.cpp:143
+#: ../../../core/core_st.cpp:145
 #, fuzzy
 msgid "Record Modified Time"
 msgstr "'Registrer Ændrings Tidspunkt'"
 
-#: ../../../core/core_st.cpp:145
+#: ../../../core/core_st.cpp:147
 #, fuzzy
 msgid "Shift+DCA"
 msgstr "Skift+"
 
-#: ../../../core/core_st.cpp:146
+#: ../../../core/core_st.cpp:148
 #, fuzzy
 msgid "Symbols"
 msgstr "Standart Brugernavn"
 
-#: ../../../core/core_st.cpp:148
+#: ../../../core/core_st.cpp:150
 msgid "URL"
 msgstr "URL"
 
-#: ../../../core/core_st.cpp:150
+#: ../../../core/core_st.cpp:152
 msgid "UUID"
 msgstr ""
 
-#: ../../../core/core_st.cpp:151
+#: ../../../core/core_st.cpp:153
 msgid "Password Expiry Date"
 msgstr "Adgangskode Udløbs Dato"
 
-#: ../../../core/core_st.cpp:152
+#: ../../../core/core_st.cpp:154
 msgid "Password Expiry Interval"
 msgstr "Adgangskode Udløbs Interval"
 
-#: ../../../core/core_st.cpp:153
+#: ../../../core/core_st.cpp:155
 msgid "a normal entry"
 msgstr "en normal post"
 
-#: ../../../core/core_st.cpp:154
+#: ../../../core/core_st.cpp:156
 #, fuzzy
 msgid "Last found entries"
 msgstr "poster"
 
-#: ../../../core/core_st.cpp:155
+#: ../../../core/core_st.cpp:157
 msgid "added but not yet saved to database"
 msgstr "tilføjet men endnu ikke gemt i databasen"
 
-#: ../../../core/core_st.cpp:156
+#: ../../../core/core_st.cpp:158
 #, fuzzy
 msgid "in the database"
 msgstr "i databasen:"
 
-#: ../../../core/core_st.cpp:157
+#: ../../../core/core_st.cpp:159
 msgid "a shortcut entry"
 msgstr "en genvejs post"
 
-#: ../../../core/core_st.cpp:158
+#: ../../../core/core_st.cpp:160
 msgid "a base entry of a shortcut"
 msgstr "en basis post af en genvej"
 
-#: ../../../core/core_st.cpp:159
+#: ../../../core/core_st.cpp:161
 msgid "changed but not yet saved to database"
 msgstr "ændret men endnu ikke gemt i databasen"
 
-#: ../../../core/core_st.cpp:160
+#: ../../../core/core_st.cpp:162
 msgid "greater than"
 msgstr "større end"
 
-#: ../../../core/core_st.cpp:161
+#: ../../../core/core_st.cpp:163
 msgid "greater than or equal to"
 msgstr "større end eller lig med"
 
-#: ../../../core/core_st.cpp:162
+#: ../../../core/core_st.cpp:164
 #, c-format
 msgid ""
 "Invalid input on line %d.  Number of fields separated by '%c' is not as "
@@ -5445,12 +5464,12 @@ msgstr ""
 "Ugyldige indlæsning på linie %d.  Antal af felter adskildt af '%c' er ikke "
 "som ventet."
 
-#: ../../../core/core_st.cpp:163
+#: ../../../core/core_st.cpp:165
 #, c-format
 msgid "Line %d: "
 msgstr "Linie %d: "
 
-#: ../../../core/core_st.cpp:164
+#: ../../../core/core_st.cpp:166
 #, c-format
 msgid ""
 "File ends on line %d before ending double quote of last entry's note field."
@@ -5458,11 +5477,11 @@ msgstr ""
 "Filen slutter på linie %d før slutningen af dobbelt anførelses tegn i "
 "seneste adgangs note felt."
 
-#: ../../../core/core_st.cpp:165
+#: ../../../core/core_st.cpp:167
 msgid "Import aborted. Please see report."
 msgstr ""
 
-#: ../../../core/core_st.cpp:166
+#: ../../../core/core_st.cpp:168
 msgid ""
 "The TXT or CSV file was not imported as required as entry records span "
 "multiple lines in the CSV file.\n"
@@ -5470,7 +5489,7 @@ msgid ""
 "Import aborted."
 msgstr ""
 
-#: ../../../core/core_st.cpp:167
+#: ../../../core/core_st.cpp:169
 #, fuzzy, c-format
 msgid ""
 "%ls, Title=\"%ls\", User=\"%ls\" already exists in your database or in the "
@@ -5479,69 +5498,69 @@ msgstr ""
 "%ls, Titel=\"%ls\", Bruger=\"%ls\" eksisterer allerede i din database eller "
 "i den importerede fil. Ekstra importeret adgang med titlen=\"%ls\".\n"
 
-#: ../../../core/core_st.cpp:168
+#: ../../../core/core_st.cpp:170
 #, fuzzy, c-format
 msgid "Entry on line %d with Group=\"%ls\""
 msgstr "Posten i linie %d med Gruppe=\"%ls\""
 
-#: ../../../core/core_st.cpp:169
+#: ../../../core/core_st.cpp:171
 #, c-format
 msgid "Entry on line %d with no group"
 msgstr "Posten i linie %d uden gruppe"
 
-#: ../../../core/core_st.cpp:170
+#: ../../../core/core_st.cpp:172
 #, fuzzy, c-format
 msgid "Entry with Group=\"%ls\""
 msgstr "Post med Gruppe=\"%ls\""
 
-#: ../../../core/core_st.cpp:171
+#: ../../../core/core_st.cpp:173
 msgid "Entry with no group"
 msgstr "Post uden gruppe"
 
-#: ../../../core/core_st.cpp:172
+#: ../../../core/core_st.cpp:174
 #, fuzzy
 msgid "imported"
 msgstr "importer"
 
-#: ../../../core/core_st.cpp:173
+#: ../../../core/core_st.cpp:175
 #, fuzzy, c-format
 msgid "including %d empty group(s)."
 msgstr "#grupper"
 
-#: ../../../core/core_st.cpp:174
+#: ../../../core/core_st.cpp:176
 #, c-format
 msgid "Empty line %d skipped"
 msgstr "Tom linie %d sprunget over"
 
-#: ../../../core/core_st.cpp:175
+#: ../../../core/core_st.cpp:177
 #, fuzzy, c-format
 msgid "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 msgstr "Post %ls%d med Gruppe=\"%ls\", Titel=\"%ls\", Bruger=\"%ls\""
 
-#: ../../../core/core_st.cpp:176
+#: ../../../core/core_st.cpp:178
 msgid "Internal error. Import failed. No records imported."
 msgstr "Intern fejl. Import fejlede. Ingen optegnelser importeret."
 
-#: ../../../core/core_st.cpp:177
+#: ../../../core/core_st.cpp:179
 #, c-format
 msgid "Found %d known column headers:"
 msgstr "Fandt %d kendt kolonne overskrift:"
 
-#: ../../../core/core_st.cpp:178
+#: ../../../core/core_st.cpp:180
 msgid "Invalid field delimiter: must be within ASCII range."
 msgstr ""
 
-#: ../../../core/core_st.cpp:179
+#: ../../../core/core_st.cpp:181
 #, fuzzy, c-format
 msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
 msgstr ""
 "Posten i linie %d har et ugyldigt \"%ls\" felt. Det er blevet ignoreret."
 
-#: ../../../core/core_st.cpp:180
+#: ../../../core/core_st.cpp:182
 msgid "The following columns will be processed: "
 msgstr "De følgende kolonner vil blive behandlet: "
 
-#: ../../../core/core_st.cpp:181
+#: ../../../core/core_st.cpp:183
 msgid ""
 "The following columns were recognised but only Group/Title, Username and "
 "Password will be processed:"
@@ -5549,7 +5568,7 @@ msgstr ""
 "De følgende kolonner blev genkendt men kun Gruppe/Titel, Brugernavn og "
 "Adgangskode vil blive behandlet:"
 
-#: ../../../core/core_st.cpp:182
+#: ../../../core/core_st.cpp:184
 #, c-format
 msgid ""
 "Line %d skipped - Only %d fields found, whereas parsing the Header says "
@@ -5558,7 +5577,7 @@ msgstr ""
 "Linie %d sprunget over - Kun %d felter fundet, medens analysering af "
 "Overskriften siger der skulle være %d."
 
-#: ../../../core/core_st.cpp:183
+#: ../../../core/core_st.cpp:185
 msgid ""
 "Either or both of the Group/Title and Password columns are missing. No "
 "records imported."
@@ -5566,43 +5585,43 @@ msgstr ""
 "Den ene eller begge af Grupoe/Titel og Adgangskode kolonner mangler. Intet "
 "arkiv importeret."
 
-#: ../../../core/core_st.cpp:184
+#: ../../../core/core_st.cpp:186
 msgid ""
 "Could not find the next entry's title field in the KeePass V1 TXT (should be "
 "within square brackets)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:185
+#: ../../../core/core_st.cpp:187
 msgid "Column header row not recognised as first record. No records imported."
 msgstr ""
 "Kolonne overskrift rækken ikke genkendt som første registrering. Ingen "
 "poster er importeret."
 
-#: ../../../core/core_st.cpp:186
+#: ../../../core/core_st.cpp:188
 msgid "No records in import file!"
 msgstr "Ingen optegnelser i den importerede fil!"
 
-#: ../../../core/core_st.cpp:187
+#: ../../../core/core_st.cpp:189
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Password field."
 msgstr "Linie %d sprunget over. Den har et tomt obligatorisk Adgangskode felt."
 
-#: ../../../core/core_st.cpp:188
+#: ../../../core/core_st.cpp:190
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Title field."
 msgstr "Linie %d sprunget over. Den har et tomt obligatorisk Titel felt."
 
-#: ../../../core/core_st.cpp:189
+#: ../../../core/core_st.cpp:191
 #, c-format
 msgid " Import # %d"
 msgstr "Importer # %d"
 
-#: ../../../core/core_st.cpp:190
+#: ../../../core/core_st.cpp:192
 #, fuzzy, c-format
 msgid "%ls - Imported %ls"
 msgstr "%ls Importeret %ls"
 
-#: ../../../core/core_st.cpp:191
+#: ../../../core/core_st.cpp:193
 msgid ""
 "To replace passwords of existing entries, all the following columns must be "
 "present: Group/Title, Username and Password.  One or more are missing and no "
@@ -5612,17 +5631,17 @@ msgstr ""
 "kolonner skal være til stede: Gruppe/Titel, Brugernavn og Adgangskode.  En "
 "eller flere mangler og ingen adgange er blevet opdateret."
 
-#: ../../../core/core_st.cpp:192
+#: ../../../core/core_st.cpp:194
 #, fuzzy, c-format
 msgid "%ls not found. Cannot update entry's password.\n"
 msgstr "%ls ikke fundet. Kan ikke opdatere postens adgangskode.\n"
 
-#: ../../../core/core_st.cpp:193
+#: ../../../core/core_st.cpp:195
 #, fuzzy, c-format
 msgid "%ls has an empty %ls.\n"
 msgstr "%ls har en tom %ls.\n"
 
-#: ../../../core/core_st.cpp:194
+#: ../../../core/core_st.cpp:196
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5631,11 +5650,11 @@ msgstr ""
 "Posten \"%ls, %ls, %ls\" har en adgangskode i det rigtige format for et "
 "alias, men basis posten er allerede et alias."
 
-#: ../../../core/core_st.cpp:195
+#: ../../../core/core_st.cpp:197
 msgid "\tThis entry has been made an alias of associated base entry."
 msgstr "\tDenne post har lavet et alias af en tilknyttet basis adgang."
 
-#: ../../../core/core_st.cpp:196
+#: ../../../core/core_st.cpp:198
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5644,14 +5663,14 @@ msgstr ""
 "Posten \"%ls, %ls, %ls\" har en adgangskode i det rigtige  format for et "
 "alias, men basis posten eksisterer ikke."
 
-#: ../../../core/core_st.cpp:197
+#: ../../../core/core_st.cpp:199
 msgid ""
 "\tThis entry remains a normal entry and the password has not been changed."
 msgstr ""
 "\tDenne post efterlader en normal post og adgangskoden er ikke  blevet "
 "ændret."
 
-#: ../../../core/core_st.cpp:198
+#: ../../../core/core_st.cpp:200
 #, fuzzy, c-format
 msgid ""
 "The %ls entry \"%ls, %ls, %ls\" doesn't point to a normal or existing %ls "
@@ -5660,69 +5679,69 @@ msgstr ""
 "Denne %ls post \"%ls, %ls, %ls\" peger ikke på en normal eller eksisterende "
 "%ls basis post. Den kan ikke importeres."
 
-#: ../../../core/core_st.cpp:199
+#: ../../../core/core_st.cpp:201
 msgid "Entry import warnings"
 msgstr "Post import advarsler"
 
-#: ../../../core/core_st.cpp:200
+#: ../../../core/core_st.cpp:202
 msgid "id="
 msgstr "id="
 
-#: ../../../core/core_st.cpp:201
+#: ../../../core/core_st.cpp:203
 msgid "on line "
 msgstr "på linie"
 
-#: ../../../core/core_st.cpp:202
+#: ../../../core/core_st.cpp:204
 msgid "Internal error: Invalid oflag or pmode argument"
 msgstr "Intern fejl: Ugyldig omærke eller ptilstand argument"
 
-#: ../../../core/core_st.cpp:203
+#: ../../../core/core_st.cpp:205
 msgid "invalid!"
 msgstr "ugyldig!"
 
-#: ../../../core/core_st.cpp:204
+#: ../../../core/core_st.cpp:206
 msgid "  Invalid date/time value."
 msgstr "Ugyldig dato/tids værdi."
 
-#: ../../../core/core_st.cpp:205
+#: ../../../core/core_st.cpp:207
 #, fuzzy
 msgid "  Field length is incorrect."
 msgstr "Feltet er for kort."
 
-#: ../../../core/core_st.cpp:206
+#: ../../../core/core_st.cpp:208
 msgid "Internal error: An invalid flag was specified"
 msgstr "Intern fejl: Et ugyldigt mærke blev specificeret"
 
-#: ../../../core/core_st.cpp:207
+#: ../../../core/core_st.cpp:209
 #, c-format
 msgid "  Invalid header: '%ls' (must be 5 hexadecimal characters)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:208
+#: ../../../core/core_st.cpp:210
 #, fuzzy, c-format
 msgid "Invalid lock file \"%ls\"."
 msgstr "Ugyldig Filter skema."
 
-#: ../../../core/core_st.cpp:209
+#: ../../../core/core_st.cpp:211
 #, c-format
 msgid "  Invalid number of saved old passwords %d."
 msgstr "Ugyldigt antal af ældre gemte adgangskoder %d."
 
-#: ../../../core/core_st.cpp:210
+#: ../../../core/core_st.cpp:212
 #, c-format
 msgid "  Invalid status value: %d (must be either 0 or 1)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:211
+#: ../../../core/core_st.cpp:213
 msgid "  Invalid password length found (not a hexadecimal number)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:212
+#: ../../../core/core_st.cpp:214
 msgid ""
 "  Invalid password length found (differs from length of following password)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:213
+#: ../../../core/core_st.cpp:215
 msgid ""
 "  Invalid field separator character found - only a single blank is allowed "
 "between fields."
@@ -5730,20 +5749,20 @@ msgstr ""
 "Ugyldig felt adskilleses karakter fundet - kun et enkelt tomt er tilladt "
 "mellem felter."
 
-#: ../../../core/core_st.cpp:214
+#: ../../../core/core_st.cpp:216
 msgid "Invalid Filter schema."
 msgstr "Ugyldig Filter skema."
 
-#: ../../../core/core_st.cpp:215
+#: ../../../core/core_st.cpp:217
 msgid "Schema does not have a version number."
 msgstr "Skemaet har ikke et versions nummer."
 
-#: ../../../core/core_st.cpp:216
+#: ../../../core/core_st.cpp:218
 #, c-format
 msgid "The filter XML version (%d) is greater than the current schema (%d)."
 msgstr "Filteret XML version (%d) er større end det nuværende skema (%d)."
 
-#: ../../../core/core_st.cpp:217
+#: ../../../core/core_st.cpp:219
 #, c-format
 msgid ""
 "The filter XML version (%d) is greater than that supported by this instance "
@@ -5752,57 +5771,57 @@ msgstr ""
 "Filteret XML version (%d) er større end understøttelsen fra denne udgave af "
 "PasswordSafe (%d)."
 
-#: ../../../core/core_st.cpp:218
+#: ../../../core/core_st.cpp:220
 msgid "is"
 msgstr "er"
 
-#: ../../../core/core_st.cpp:219
+#: ../../../core/core_st.cpp:221
 msgid "is active"
 msgstr "er aktive"
 
-#: ../../../core/core_st.cpp:220
+#: ../../../core/core_st.cpp:222
 msgid "is inactive"
 msgstr "er inaktive"
 
-#: ../../../core/core_st.cpp:221
+#: ../../../core/core_st.cpp:223
 msgid "is not"
 msgstr "er ikke"
 
-#: ../../../core/core_st.cpp:222
+#: ../../../core/core_st.cpp:224
 msgid "is not present"
 msgstr "er ikke tilstedeværende"
 
-#: ../../../core/core_st.cpp:223
+#: ../../../core/core_st.cpp:225
 msgid "is present"
 msgstr "er nærværende"
 
-#: ../../../core/core_st.cpp:224
+#: ../../../core/core_st.cpp:226
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to entry %ls. It "
 "has been removed from the %ls entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:225
+#: ../../../core/core_st.cpp:227
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to the "
 "PasswordSafe application. It has been removed from the entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:226
+#: ../../../core/core_st.cpp:228
 msgid "less than"
 msgstr "mindre end"
 
-#: ../../../core/core_st.cpp:227
+#: ../../../core/core_st.cpp:229
 msgid "less than or equal to"
 msgstr "mindre end eller lig med"
 
-#: ../../../core/core_st.cpp:228
+#: ../../../core/core_st.cpp:230
 msgid "File or path not found"
 msgstr "Fil eller sti ikke fundet"
 
-#: ../../../core/core_st.cpp:229
+#: ../../../core/core_st.cpp:231
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5811,14 +5830,14 @@ msgstr ""
 "\n"
 "De følgende nye %ls %ls er flettet ind i denne database:"
 
-#: ../../../core/core_st.cpp:230
+#: ../../../core/core_st.cpp:232
 #, c-format
 msgid ""
 "\n"
 "Merge completed: %d %ls added (%d %ls, %d %ls, %d %ls, %d %ls)"
 msgstr ""
 
-#: ../../../core/core_st.cpp:231
+#: ../../../core/core_st.cpp:233
 #, fuzzy, c-format
 msgid ""
 "Conflicting entries for \"%ls\" \"%ls\" \"%ls\".\n"
@@ -5829,60 +5848,60 @@ msgstr ""
 "  Tilføjet flettet post som «%ls» «%ls» «%ls».\n"
 "    Afvigende felt(er): %ls"
 
-#: ../../../core/core_st.cpp:232
+#: ../../../core/core_st.cpp:234
 #, fuzzy
 msgid "merged"
 msgstr "Flet"
 
-#: ../../../core/core_st.cpp:233
+#: ../../../core/core_st.cpp:235
 #, fuzzy, c-format
 msgid "%ls - Merged %ls"
 msgstr "%ls - Flet %s"
 
-#: ../../../core/core_st.cpp:234
+#: ../../../core/core_st.cpp:236
 msgid "MISSING PASSWORD"
 msgstr ""
 
-#: ../../../core/core_st.cpp:235
+#: ../../../core/core_st.cpp:237
 #, c-format
 msgid "\tPassword policy name '%ls' is not in the database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:236
+#: ../../../core/core_st.cpp:238
 msgid ""
 "\tOne or more Password Policy Names were not found in the database. The "
 "affected entries have been changed to use the database's default policy."
 msgstr ""
 
-#: ../../../core/core_st.cpp:237
+#: ../../../core/core_st.cpp:239
 #, c-format
 msgid "MISSING TITLE # %d"
 msgstr ""
 
-#: ../../../core/core_st.cpp:239
+#: ../../../core/core_st.cpp:241
 msgid "Can't obtain the schema version."
 msgstr "Kan ikke hente skema versionen."
 
-#: ../../../core/core_st.cpp:240
+#: ../../../core/core_st.cpp:242
 msgid "The filter XML version is missing."
 msgstr "Filteret XML version mangler."
 
-#: ../../../core/core_st.cpp:241
+#: ../../../core/core_st.cpp:243
 #, fuzzy, c-format
 msgid "Create SchemaCache60 Error 0x%08X during %ls."
 msgstr "Opret SkemaCache%2d Fejl 0x%08X under %ls."
 
-#: ../../../core/core_st.cpp:242
+#: ../../../core/core_st.cpp:244
 #, fuzzy, c-format
 msgid "SAX Parse60 Error 0x%08X during %ls."
 msgstr "SAX Analyse%2d Fejl 0x%08X under %ls."
 
-#: ../../../core/core_st.cpp:243
+#: ../../../core/core_st.cpp:245
 #, fuzzy, c-format
 msgid "Error (%08X): line %d character %d %ls"
 msgstr "Fejl (%08X): linie %d tegn %d %ls"
 
-#: ../../../core/core_st.cpp:245
+#: ../../../core/core_st.cpp:247
 msgid ""
 "Unable to get configuration file lock.\n"
 "\n"
@@ -5892,15 +5911,15 @@ msgstr ""
 "\n"
 "Vil bruge registret."
 
-#: ../../../core/core_st.cpp:246
+#: ../../../core/core_st.cpp:248
 msgid "Cannot create lock file - no permission in directory?"
 msgstr "Kan ikke oprette låse fil - ingen tilladelse i biblioteket?"
 
-#: ../../../core/core_st.cpp:247
+#: ../../../core/core_st.cpp:249
 msgid "Internal error: Out of file handles"
 msgstr "Intern fejl: Ude af fil behandling"
 
-#: ../../../core/core_st.cpp:248
+#: ../../../core/core_st.cpp:250
 msgid ""
 "Unable to use a MS XML reader on your system.  Neither MS XML V3, V4 or V6 "
 "seems available."
@@ -5908,16 +5927,16 @@ msgstr ""
 "Ude af stand til at  bruge som en MS XML læser på dit system.  Hverken MS "
 "XML V3, V4 eller V6 syntes tilgængelige."
 
-#: ../../../core/core_st.cpp:250
+#: ../../../core/core_st.cpp:252
 #, fuzzy
 msgid "Unsaved changes"
 msgstr "Vis &Ugemte Ændringer"
 
-#: ../../../core/core_st.cpp:251
+#: ../../../core/core_st.cpp:253
 msgid "is not set"
 msgstr "er ikke sat"
 
-#: ../../../core/core_st.cpp:252
+#: ../../../core/core_st.cpp:254
 #, fuzzy, c-format
 msgid ""
 "Number of entries processed: %d\n"
@@ -5953,99 +5972,146 @@ msgstr ""
 "Antal af adgange med felter der ikke kan vises fuldt ud: %d\n"
 "Recommend that the database is now saved."
 
-#: ../../../core/core_st.cpp:254
+#: ../../../core/core_st.cpp:256
 msgid ""
 "Password should be mixed case, with at least one digit or punctuation "
 "character"
 msgstr ""
 "Adgangskode bør være mixede tegn, med mindst et tal eller tegnsætnings tegn"
 
-#: ../../../core/core_st.cpp:255
+#: ../../../core/core_st.cpp:257
 msgid "Password is too short"
 msgstr "Adgangskode er for kort"
 
-#: ../../../core/core_st.cpp:256
+#: ../../../core/core_st.cpp:258
 msgid "Easyvision characters"
 msgstr "Easyvision tegn"
 
-#: ../../../core/core_st.cpp:257
+#: ../../../core/core_st.cpp:259
 msgid "Hexadecimal characters"
 msgstr "Hexadecimal tegn"
 
-#: ../../../core/core_st.cpp:258
+#: ../../../core/core_st.cpp:260
 #, fuzzy
 msgid "Password length"
 msgstr "Adgangskode længde:"
 
-#: ../../../core/core_st.cpp:259
+#: ../../../core/core_st.cpp:261
 msgid "Pronounceable passwords"
 msgstr "Udtal-bare adgangskoder"
 
-#: ../../../core/core_st.cpp:261
+#: ../../../core/core_st.cpp:263
 #, fuzzy
 msgid "Use lowercase characters"
 msgstr "Minimum store tegn"
 
-#: ../../../core/core_st.cpp:263
+#: ../../../core/core_st.cpp:265
 #, fuzzy
 msgid "Use uppercase characters"
 msgstr "Minimum store tegn"
 
-#: ../../../core/core_st.cpp:264
+#: ../../../core/core_st.cpp:266
 #, fuzzy, c-format
 msgid "Error in a Password History %ls:"
 msgstr "Fejl i Adgangskode Historik for adgangen %ls: "
 
-#: ../../../core/core_st.cpp:265
+#: ../../../core/core_st.cpp:267
 #, c-format
 msgid "sub-field starting at position %d (within the History field): "
 msgstr ""
 
-#: ../../../core/core_st.cpp:266
+#: ../../../core/core_st.cpp:268
 msgid "  All Password History ignored."
 msgstr "Al Adgangskode Historik ignoreret."
 
-#: ../../../core/core_st.cpp:267
+#: ../../../core/core_st.cpp:269
 msgid "Read Error"
 msgstr "Læse Fejl"
 
-#: ../../../core/core_st.cpp:268
+#: ../../../core/core_st.cpp:270
+#, fuzzy
+msgid "Relative"
+msgstr "Aktiv Felt"
+
+#: ../../../core/core_st.cpp:271
 #, c-format
 msgid ""
 "\tOne or more entry keyboard shortcuts were already assigned to entries in "
 "this database. They have been removed from the %ls entries."
 msgstr ""
 
-#: ../../../core/core_st.cpp:269
+#: ../../../core/core_st.cpp:272
 msgid ""
 "\tOne or more Password Policy Names were already in this database but had "
 "different settings. They have been renamed."
 msgstr ""
 
-#: ../../../core/core_st.cpp:270
+#: ../../../core/core_st.cpp:273
 #, fuzzy, c-format
 msgid "%ls%ls%ls_Report.txt"
 msgstr "%ls%ls%ls_Rapport.txt"
 
-#: ../../../core/core_st.cpp:271
+#: ../../../core/core_st.cpp:274
 #, fuzzy, c-format
 msgid "Report of %ls function started at %ls"
 msgstr "Rapport af %ls funktion startede ved %ls"
 
-#: ../../../core/core_st.cpp:272
+#: ../../../core/core_st.cpp:275
 #, fuzzy, c-format
 msgid "on database %ls"
 msgstr "i databasen %ls"
 
-#: ../../../core/core_st.cpp:273
+#: ../../../core/core_st.cpp:276
+#, fuzzy
+msgid "Compare"
+msgstr "&Sammenlign"
+
+#: ../../../core/core_st.cpp:277
+#, fuzzy
+msgid "Export_DB"
+msgstr "&Eksporter"
+
+#: ../../../core/core_st.cpp:278
+#, fuzzy
+msgid "Export_Text"
+msgstr "Eksporter Tekst"
+
+#: ../../../core/core_st.cpp:279
+#, fuzzy
+msgid "Export_XML"
+msgstr "Eksporter XML"
+
+#: ../../../core/core_st.cpp:281
+#, fuzzy
+msgid "Import_KeePassV1_CSV"
+msgstr "Importer &Tekst"
+
+#: ../../../core/core_st.cpp:282
+#, fuzzy
+msgid "Import_KeePassV1_TXT"
+msgstr "Importer &Tekst"
+
+#: ../../../core/core_st.cpp:283
+msgid "Import_Text"
+msgstr "Importer_Tekst"
+
+#: ../../../core/core_st.cpp:284
+msgid "Import_XML"
+msgstr "Importer_XML"
+
+#: ../../../core/core_st.cpp:285
+msgid "Merge"
+msgstr "Flet"
+
+#: ../../../core/core_st.cpp:287
 msgid "Validate"
 msgstr "Vurder"
 
-#: ../../../core/core_st.cpp:275
+#: ../../../core/core_st.cpp:289
 msgid "Fatal Error"
 msgstr "Alvorlig Fejl"
 
-#: ../../../core/core_st.cpp:277
+#: ../../../core/core_st.cpp:291
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -6054,117 +6120,129 @@ msgstr ""
 "\n"
 "Fejl i Adgangskode Historik for adgangen: »%ls»%ls»%ls»: "
 
-#: ../../../core/core_st.cpp:278
+#: ../../../core/core_st.cpp:292
+#, c-format
+msgid "\tNo entries were found containing search string '%ls' %ls"
+msgstr ""
+
+#: ../../../core/core_st.cpp:293
+#, fuzzy, c-format
+msgid "\tThe following entries contain search string '%ls' %ls"
+msgstr ""
+"\tDe følgende begrænsninger blev valgt:\n"
+"\t\t %s"
+
+#: ../../../core/core_st.cpp:294
 msgid "See Attachment filters"
 msgstr ""
 
-#: ../../../core/core_st.cpp:279
+#: ../../../core/core_st.cpp:295
 msgid "See Password History filters"
 msgstr "Se Adgangskode Historik filtrene"
 
-#: ../../../core/core_st.cpp:280
+#: ../../../core/core_st.cpp:296
 msgid "See Password Policy filters"
 msgstr "Se Adgangskode Politik filtrene"
 
-#: ../../../core/core_st.cpp:281
+#: ../../../core/core_st.cpp:297
 msgid "is set"
 msgstr "er sat"
 
-#: ../../../core/core_st.cpp:282
+#: ../../../core/core_st.cpp:298
 msgid "shortcut"
 msgstr "genvej"
 
-#: ../../../core/core_st.cpp:283
+#: ../../../core/core_st.cpp:299
 msgid "shortcuts"
 msgstr "genveje"
 
-#: ../../../core/core_st.cpp:284
+#: ../../../core/core_st.cpp:300
 msgid "policy specific symbols"
 msgstr ""
 
-#: ../../../core/core_st.cpp:285
+#: ../../../core/core_st.cpp:301
 msgid "Start Report"
 msgstr "Start Rapport"
 
-#: ../../../core/core_st.cpp:286
+#: ../../../core/core_st.cpp:302
 msgid "Double-Click on entry to Autotype"
 msgstr "Dobbelt Klik på post for at Autoindsætte"
 
-#: ../../../core/core_st.cpp:287
+#: ../../../core/core_st.cpp:303
 msgid "Double-Click on entry to Browse to URL"
 msgstr "Dobbelt Klik på post for at Browse til URL"
 
-#: ../../../core/core_st.cpp:288
+#: ../../../core/core_st.cpp:304
 msgid "Double-Click on entry to Browse to URL + Autotype"
 msgstr "Dobbelt Klik på post for at Browse til URL + Autoindsætte"
 
-#: ../../../core/core_st.cpp:289
+#: ../../../core/core_st.cpp:305
 #, fuzzy
 msgid "https://pwsafe.org/"
 msgstr "https://pwsafe.org/"
 
-#: ../../../core/core_st.cpp:290
+#: ../../../core/core_st.cpp:306
 msgid "Double-Click on entry to Copy Notes"
 msgstr "Dobbelt Klik på post for at Kopiere Notater"
 
-#: ../../../core/core_st.cpp:291
+#: ../../../core/core_st.cpp:307
 msgid "Double-Click on entry to Copy Password"
 msgstr "Dobbelt Klik på post for at Kopiere Adgangskode"
 
-#: ../../../core/core_st.cpp:292
+#: ../../../core/core_st.cpp:308
 msgid "Double-Click on entry to Copy Password and Minimize"
 msgstr "Dobbelt Klik på post for at Kopiere Adgangskode og Minimere"
 
-#: ../../../core/core_st.cpp:293
+#: ../../../core/core_st.cpp:309
 msgid "Double-Click on entry to Copy Username"
 msgstr "Dobbelt Klik på post for at Kopiere Brugernavn"
 
-#: ../../../core/core_st.cpp:294
+#: ../../../core/core_st.cpp:310
 msgid "Double-Click on entry to Run Command"
 msgstr "Dobbelt Klik på post for Kør Kommando"
 
-#: ../../../core/core_st.cpp:295
+#: ../../../core/core_st.cpp:311
 #, fuzzy
 msgid "Double-Click on entry to Send Email"
 msgstr "Dobbelt Klik på post for at Sende email"
 
-#: ../../../core/core_st.cpp:296
+#: ../../../core/core_st.cpp:312
 msgid "Double-Click on entry to View/Edit it"
 msgstr "Dobbelt Klik på post for at Se/Redigere den"
 
-#: ../../../core/core_st.cpp:299
+#: ../../../core/core_st.cpp:315
 #, fuzzy, c-format
 msgid "%ls - Sync'd %ls"
 msgstr "%ls - Importeret %ls"
 
-#: ../../../core/core_st.cpp:300
+#: ../../../core/core_st.cpp:316
 msgid "System error: No more file handles available"
 msgstr "System fejl: Ikke flere fil håndteringer tilgængelige"
 
-#: ../../../core/core_st.cpp:303
+#: ../../../core/core_st.cpp:319
 msgid "Unknown function"
 msgstr "Ukendt funktion"
 
-#: ../../../core/core_st.cpp:304
+#: ../../../core/core_st.cpp:320
 msgid "Unknown object"
 msgstr "Ukendt object"
 
-#: ../../../core/core_st.cpp:305
+#: ../../../core/core_st.cpp:321
 msgid "Internal error: Unexpected error number"
 msgstr "Intern fejl: Uventet fejl antal"
 
-#: ../../../core/core_st.cpp:307
+#: ../../../core/core_st.cpp:323
 #, c-format
 msgid "\tName: %s; Filename: %s"
 msgstr ""
 
-#: ../../../core/core_st.cpp:308
+#: ../../../core/core_st.cpp:324
 msgid ""
 "The following entries had an invalid UUID field.  This has been corrected."
 msgstr ""
 "De følgende poster havde et ugyldigt UUID felt. Disse er blevet rettet."
 
-#: ../../../core/core_st.cpp:309
+#: ../../../core/core_st.cpp:325
 #, fuzzy, c-format
 msgid ""
 "The following entries have passwords in the correct form for %ls, but the "
@@ -6173,18 +6251,18 @@ msgstr ""
 "De følgende poster havdehar en adgangskode i det rigtige  format for %ls, "
 "men basis posten eksisterer ikke."
 
-#: ../../../core/core_st.cpp:310
+#: ../../../core/core_st.cpp:326
 msgid "The following entries were duplicates of an existing entry."
 msgstr "De følgende poster var dupletter af en eksisterende post."
 
-#: ../../../core/core_st.cpp:311
+#: ../../../core/core_st.cpp:327
 #, fuzzy
 msgid ""
 "The following entries had a duplicate UUID field.  This has been corrected."
 msgstr ""
 "De følgende poster havde et ugyldigt UUID felt. Disse er blevet rettet."
 
-#: ../../../core/core_st.cpp:312
+#: ../../../core/core_st.cpp:328
 #, fuzzy, c-format
 msgid ""
 "The following entries had an empty Password field, which is not permitted. "
@@ -6192,37 +6270,37 @@ msgid ""
 msgstr ""
 "De følgende poster havde et ugyldigt Title felt. Disse er blevet rettet."
 
-#: ../../../core/core_st.cpp:313
+#: ../../../core/core_st.cpp:329
 #, fuzzy
 msgid "The following entries had an empty Title field, which is not permitted."
 msgstr ""
 "De følgende poster havde et ugyldigt Title felt. Disse er blevet rettet."
 
-#: ../../../core/core_st.cpp:314
+#: ../../../core/core_st.cpp:330
 #, fuzzy, c-format
 msgid "\tGroup='%ls', Title='%ls', User='%ls' %ls"
 msgstr "\tGruppe='%ls', Titel='%ls', Bruger='%ls' %ls"
 
-#: ../../../core/core_st.cpp:315
+#: ../../../core/core_st.cpp:331
 #, fuzzy, c-format
 msgid "- Its title has been changed to:'%ls'"
 msgstr "- Dets titel er blevet ændret til:'%ls'"
 
-#: ../../../core/core_st.cpp:316
+#: ../../../core/core_st.cpp:332
 msgid "The following ERRORS were detected and were FIXED."
 msgstr ""
 
-#: ../../../core/core_st.cpp:317
+#: ../../../core/core_st.cpp:333
 #, fuzzy
 msgid "The following entries refer to missing attachments."
 msgstr "De følgende poster var dupletter af en eksisterende post."
 
-#: ../../../core/core_st.cpp:318
+#: ../../../core/core_st.cpp:334
 #, fuzzy
 msgid "The following attachments are not referred to by any entry."
 msgstr "De følgende poster var dupletter af en eksisterende post."
 
-#: ../../../core/core_st.cpp:319
+#: ../../../core/core_st.cpp:335
 msgid ""
 "The following entries had an invalid Password History.  This has been "
 "rebuilt with available data.  There may be some loss of history."
@@ -6230,24 +6308,24 @@ msgstr ""
 "De følgende poster havde en ugyldig Adgangskode Historik.  Disse er blevet "
 "genopbygget med tilgængelige data.  Der kan være mistet noget af historiken."
 
-#: ../../../core/core_st.cpp:320
+#: ../../../core/core_st.cpp:336
 #, c-format
 msgid ""
 "The following entries have one or more text fields too long to display or "
 "edit (over %d characters).  The largest entry size found was ~%d %ls."
 msgstr ""
 
-#: ../../../core/core_st.cpp:321
+#: ../../../core/core_st.cpp:337
 msgid ""
 "The following WARNINGS were detected - you should review and fix them "
 "manually."
 msgstr ""
 
-#: ../../../core/core_st.cpp:324
+#: ../../../core/core_st.cpp:340
 msgid "will expire"
 msgstr "vil udløbe"
 
-#: ../../../core/core_st.cpp:325
+#: ../../../core/core_st.cpp:341
 #, fuzzy, c-format
 msgid ""
 "SAX Parse Error during %ls\n"
@@ -6256,21 +6334,21 @@ msgstr ""
 "SAX Analyse Fejl under %ls\n"
 "%ls."
 
-#: ../../../core/core_st.cpp:326
+#: ../../../core/core_st.cpp:342
 #, fuzzy, c-format
 msgid "XML %ls: line %d character %d: %ls"
 msgstr "XML %ls: linie %d tegn %d: %ls"
 
-#: ../../../core/core_st.cpp:327
+#: ../../../core/core_st.cpp:343
 msgid ""
 "*** Invalid XML characters found - see exported XML file for more details ***"
 msgstr ""
 
-#: ../../../core/core_st.cpp:328
+#: ../../../core/core_st.cpp:344
 msgid "Internal error: Couldn't initialize config file XML structure"
 msgstr "Intern fejl: Kunne ikke initialisere konfig filen XML strukturen"
 
-#: ../../../core/core_st.cpp:329
+#: ../../../core/core_st.cpp:345
 msgid ""
 "A filter was active. Export of data was restricted to include only those "
 "displayed."
@@ -6278,34 +6356,34 @@ msgstr ""
 "Et filter var aktiv. Eksport af data blev begrænset til kun at inkludere de "
 "viste."
 
-#: ../../../core/core_st.cpp:330
+#: ../../../core/core_st.cpp:346
 msgid "Export of data was restricted to certain fields by the user."
 msgstr "Eksport af data blev begrænset til bestemte felter af bruger."
 
-#: ../../../core/core_st.cpp:331
+#: ../../../core/core_st.cpp:347
 msgid ""
 "Note: These Password Policies will not replace existing policies with the "
 "same name in the current database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:332
+#: ../../../core/core_st.cpp:348
 msgid ""
 "Note: These preferences are only used when importing into an empty database."
 msgstr ""
 "Bemærk: Disse præferencer bliver kun brugt ved import til en tom database."
 
-#: ../../../core/core_st.cpp:333
+#: ../../../core/core_st.cpp:349
 msgid "Subset of entries restricted by the following rule:"
 msgstr "Delmængde af adgange begrænset af følgende regel:"
 
-#: ../../../core/core_st.cpp:334
+#: ../../../core/core_st.cpp:350
 msgid ""
 "The user specified that the following fields be excluded from the export:"
 msgstr ""
 "Bruger har specificeret at de følgende felter skal udelukkes fra denne "
 "eksport:"
 
-#: ../../../core/core_st.cpp:335
+#: ../../../core/core_st.cpp:351
 #, fuzzy, c-format
 msgid ""
 "Configuration file error:\n"
@@ -6318,15 +6396,15 @@ msgstr ""
 "%ls\n"
 "linie %d kolonne %d"
 
-#: ../../../core/core_st.cpp:336
+#: ../../../core/core_st.cpp:352
 msgid "import"
 msgstr "importer"
 
-#: ../../../core/core_st.cpp:337
+#: ../../../core/core_st.cpp:353
 msgid "Unable to load configuration file"
 msgstr "Ude af stand til at indlæse konfigurations fil"
 
-#: ../../../core/core_st.cpp:338
+#: ../../../core/core_st.cpp:354
 msgid ""
 "Failed to lock configuration file - opened by another instance of "
 "PasswordSafe?"
@@ -6334,105 +6412,49 @@ msgstr ""
 "Fejl ved låsning af konfigurations filen - åbnet af en anden instans af "
 "PasswordSafe?"
 
-#: ../../../core/core_st.cpp:339
+#: ../../../core/core_st.cpp:355
 msgid "Unable to save configuration file"
 msgstr "Ude af stand til at gemme konfigurations fil"
 
-#: ../../../core/core_st.cpp:340
+#: ../../../core/core_st.cpp:356
 #, fuzzy
 msgid "validation"
 msgstr "vurdering"
 
-#: ../../../core/core_st.cpp:342
+#: ../../../core/core_st.cpp:358
 msgid " (EasyVision Symbols)"
 msgstr ""
 
-#: ../../../core/core_st.cpp:343
+#: ../../../core/core_st.cpp:359
 #, fuzzy, c-format
 msgid "Yes (at least %d)"
 msgstr "Skal være mindst %d"
 
-#: ../../../core/core_st.cpp:344
+#: ../../../core/core_st.cpp:360
 #, fuzzy
 msgid " (Pronounceable Symbols)"
 msgstr "Udtal-bare adgangskoder"
 
-#: ../../../core/core_st.cpp:345
+#: ../../../core/core_st.cpp:361
 #, fuzzy, c-format
 msgid "Yes - At least %d from %ls: %ls%ls"
 msgstr "Skal være mindst %d from %ls: %ls"
 
-#: ../../../core/core_st.cpp:346
 #, fuzzy, c-format
-msgid "\tGroup='%ls', Title='%ls', User='%ls'"
-msgstr "\tGruppe='%ls', Titel='%ls', Bruger='%ls' %ls"
+#~ msgid "\tGroup='%ls', Title='%ls', User='%ls'"
+#~ msgstr "\tGruppe='%ls', Titel='%ls', Bruger='%ls' %ls"
 
-#: ../../../core/core_st.cpp:347
-#, fuzzy, c-format
-msgid ""
-"Compare complete of current database:\n"
-"\t %ls\n"
-" and:\n"
-"\t %ls\n"
-msgstr ""
-"fuldstændigt den nuværende database:\n"
-"\t %s\n"
-"og:\n"
-"\t %s"
-
-#: ../../../core/core_st.cpp:348
-#, c-format
-msgid "\tNo entries were found containing search string '%ls' %ls"
-msgstr ""
-
-#: ../../../core/core_st.cpp:349
-#, fuzzy, c-format
-msgid "\tThe following entries contain search string '%ls' %ls"
-msgstr ""
-"\tDe følgende begrænsninger blev valgt:\n"
-"\t\t %s"
-
-#: ../../../core/core_st.cpp:350
 #, fuzzy
-msgid "Export DB"
-msgstr "&Eksporter"
+#~ msgid "Import XML"
+#~ msgstr ""
+#~ "\n"
+#~ "Importer XML"
 
-#: ../../../core/core_st.cpp:351
-msgid "Import KeePassV1 CSV"
-msgstr ""
-
-#: ../../../core/core_st.cpp:352
-msgid "Import KeePassV1 TXT"
-msgstr ""
-
-#: ../../../core/core_st.cpp:353
 #, fuzzy
-msgid "Import XML"
-msgstr ""
-"\n"
-"Importer XML"
-
-#: ../../../core/core_st.cpp:354
-#, fuzzy
-msgid "Import Text"
-msgstr ""
-"\n"
-"Importer Tekst"
-
-#: ../../../core/core_st.cpp:355
-msgid "Merge"
-msgstr "Flet"
-
-#: ../../../core/core_st.cpp:356
-#, fuzzy
-msgid "Compare"
-msgstr "&Sammenlign"
-
-#~ msgid "Import_Text"
-#~ msgstr "Importer_Tekst"
-
-#~ msgid "Import_XML"
-#~ msgstr "Importer_XML"
+#~ msgid "Import Text"
+#~ msgstr ""
+#~ "\n"
+#~ "Importer Tekst"
 
 #, fuzzy
 #~ msgid "Advanced..."
@@ -7631,9 +7653,6 @@ msgstr "&Sammenlign"
 
 #~ msgid "Failsafe Backup Files"
 #~ msgstr "Fejlsikret Sikkerheds File"
-
-#~ msgid "Field active"
-#~ msgstr "Aktiv Felt"
 
 #~ msgid "Field present"
 #~ msgstr "Indeværende Felt"
@@ -9383,9 +9402,6 @@ msgstr "&Sammenlign"
 #~ msgstr ""
 #~ "\tPost - Gruppe:\"%s\"; Titel:\"%s\"; Bruger:\"%s\"\n"
 #~ "\t\thar forskelle i de følgende felter:"
-
-#~ msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-#~ msgstr "\tGruppe:'%s'; Titel:'%s'; Bruger:'%s'"
 
 #~ msgid "an unnamed file"
 #~ msgstr "en udøbt fil"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Password Safe\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-28 12:52+0100\n"
+"POT-Creation-Date: 2021-03-19 21:58+0100\n"
 "PO-Revision-Date: 2018-05-18 12:55+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -219,7 +219,7 @@ msgstr "Datum und Uhrzeit"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:348
 #: ../../../ui/wxWidgets/HelpMap.h:41 ../../../ui/wxWidgets/HelpMap.h:49
-#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:141
+#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:143
 msgid "Password Policy"
 msgstr "Passwortrichtlinie"
 
@@ -232,7 +232,7 @@ msgid "Set Date/Time"
 msgstr "Datum/Uhrzeit setzen"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:370
-#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:137
+#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:139
 msgid "Password"
 msgstr "Passwort"
 
@@ -503,13 +503,13 @@ msgstr "Großbuchstaben verwenden"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:747
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:281
-#: ../../../core/core_st.cpp:260
+#: ../../../core/core_st.cpp:262
 msgid "Use digits"
 msgstr "Ziffern verwenden"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:771
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:305
-#: ../../../core/core_st.cpp:262
+#: ../../../core/core_st.cpp:264
 msgid "Use symbols"
 msgstr "Symbole verwenden"
 
@@ -540,7 +540,7 @@ msgstr "Aussprechbare Passwörter generieren"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:815
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:350
-#: ../../../core/core_st.cpp:253
+#: ../../../core/core_st.cpp:255
 msgid "Or"
 msgstr "oder"
 
@@ -584,7 +584,7 @@ msgstr "Eigenschaften"
 #: ../../../ui/wxWidgets/CreateShortcutDlg.cpp:219
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:269
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:274
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
 msgid "Text"
 msgstr "Text"
 
@@ -636,7 +636,7 @@ msgstr "Kein Anhang verfügbar"
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:160
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:173
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:192
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:301
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:317
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -743,7 +743,7 @@ msgstr "[Notizen sind versteckt - Klicken Sie hier um diese anzuzeigen]"
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:1653
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2145
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2820
-#: ../../../core/core_st.cpp:74
+#: ../../../core/core_st.cpp:76
 msgid "Default Policy"
 msgstr "Standard Richtlinie"
 
@@ -764,7 +764,7 @@ msgstr "Passwort konnte nicht generiert werden - Ungültige Richtlinie"
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:144
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:151
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:159
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:200
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:201
 #: ../../../ui/wxWidgets/PWSafeApp.cpp:367
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:737
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:756
@@ -788,7 +788,7 @@ msgstr "Passwort konnte nicht generiert werden - Ungültige Richtlinie"
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:249
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:277
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:316
-#: ../../../core/core_st.cpp:274
+#: ../../../core/core_st.cpp:288
 msgid "Error"
 msgstr "Fehler"
 
@@ -944,7 +944,7 @@ msgid "Synchronize this item..."
 msgstr "Dieses Element synchronisieren..."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:482
-#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:357
+#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:286
 msgid "Synchronize"
 msgstr "Synchronisieren"
 
@@ -1014,8 +1014,8 @@ msgid "Current safe was opened read-only"
 msgstr "Aktueller Safe wurde im Nur-Lese-Modus geöffnet"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:793
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:996
-#: ../../../ui/wxWidgets/SyncWizard.cpp:618
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
+#: ../../../ui/wxWidgets/SyncWizard.cpp:619
 #, c-format
 msgid ""
 "The database:\n"
@@ -1033,7 +1033,7 @@ msgstr ""
 "bereinigen Sie das durch Überprüfen der Datenbank."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:794
-#: ../../../ui/wxWidgets/SyncWizard.cpp:617
+#: ../../../ui/wxWidgets/SyncWizard.cpp:618
 msgid "Synchronization failed"
 msgstr "Synchronisation fehlgeschlagen"
 
@@ -1382,7 +1382,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/GridCtrl.cpp:164
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:292
-#: ../../../core/core_st.cpp:147
+#: ../../../core/core_st.cpp:149
 msgid "Title"
 msgstr "Titel"
 
@@ -1582,7 +1582,7 @@ msgid "Value"
 msgstr "Wert"
 
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:291
-#: ../../../core/core_st.cpp:133
+#: ../../../core/core_st.cpp:135
 msgid "Group"
 msgstr "Gruppe"
 
@@ -1665,23 +1665,23 @@ msgstr ""
 msgid "Error parsing Run Command"
 msgstr "Fehler beim Parsen des auszuführenden Kommandos"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:56
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:57
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:355
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:362
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:166
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:623
 msgid "Write Error"
 msgstr "Schreibfehler"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:61
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:62
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:165
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:622
 msgid "Could not open file for writing!"
 msgstr "Kann Datei nicht zum Schreiben öffnen!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:64
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:65
 msgid ""
 "Write operation failed!\n"
 "File may have been corrupted.\n"
@@ -1691,55 +1691,55 @@ msgstr ""
 "Die Datei könnte zerstört sein.\n"
 "Versuchen Sie diese woanders zu speichern."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:69
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:70
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "Unknown error"
 msgstr "Unbekannter Fehler"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:90
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:91
 msgid "Do you want to save changes to the password database: "
 msgstr "Möchten Sie die Änderungen an der Passwortdatenbank speichern: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:145
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:146
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:557
 msgid "Please choose a name for the new database"
 msgstr "Bitte wählen Sie einen Namen für die neue Datenbank aus"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:155
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:156
 msgid "psafe3 files (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 msgstr "psafe3 Dateien (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Lock is done by yourself"
 msgstr "Sperre wurde durch sie selber erstellt"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Remove Lock?"
 msgstr "Lösche Sperre?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:194
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:195
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:602
 msgid "Could not lock file.\n"
 msgstr "Konnte die Datei nicht Sperren.\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:196
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:197
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:452
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:604
 msgid "Locked by "
 msgstr "Gesperrt durch "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:236
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:237
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:515
 msgid "Please Choose a Database to Open:"
 msgstr "Bitte wählen Sie eine Datenbank zum Öffnen aus:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:353
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
 msgid ""
 "Unable to create intermediate backup.  Save database elsewhere or with "
 "another name?\n"
@@ -1751,7 +1751,7 @@ msgstr ""
 "\n"
 "Wählen Sie 'Nein' zum Beenden ohne zu speichern."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:360
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
 msgid ""
 "Unable to create intermediate backup.  Do you wish to save changes to your "
 "database without it?"
@@ -1759,12 +1759,12 @@ msgstr ""
 "Konnte die Zwischensicherungsdatei nicht anlegen. Möchten Sie die Änderungen "
 "in der Datenbank ohne diese Datei speichern?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 msgid "Unable to create intermediate backup."
 msgstr "Kann die Zwischensicherung nicht anlegen."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:386
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:387
 #, c-format
 msgid ""
 "The original database, \"%ls\", is in pre-3.0 format. It will be unchanged.\n"
@@ -1779,12 +1779,12 @@ msgstr ""
 "alten Dateiformat zu speichern, benutzen Sie \"Datei -> Exportieren nach -> "
 "Altes (1.x oder 2) Format\"."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:388
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:389
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:447
 msgid "File version warning"
 msgstr "Dateiversionswarnung"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:445
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
 #, c-format
 msgid ""
 "The original database, '%ls', is in pre-3.0 format. The data will now be "
@@ -1798,15 +1798,15 @@ msgstr ""
 "im alten Dateiformat zu speichern, benutzen Sie 'Datei -> Exportieren nach -"
 "> Altes (1.x oder 2) Format'."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:458
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
 msgid "Please choose a name for the current (Untitled) database:"
 msgstr "Bitte wählen Sie einen Namen für die aktuell unbenannte Datenbank aus:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:460
 msgid "Please choose a new name for the current database:"
 msgstr "Bitte wählen Sie einen neuen Namen für die aktuelle Datenbank aus:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:467
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:468
 msgid ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|"
 "*.*;*"
@@ -1814,7 +1814,7 @@ msgstr ""
 "Password Safe Datenbanken (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; "
 "*)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:479
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
 #, c-format
 msgid ""
 "%ls\n"
@@ -1825,117 +1825,117 @@ msgstr ""
 "\n"
 "Datei ist aktuell gesperrt durch %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:481
 msgid "File lock error"
 msgstr "Fehler beim Sperren der Datei"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:547
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
 msgid "Do you wish to save this restored database as new database?"
 msgstr ""
 "Möchten Sie die wiederhergestellte Datenbank als neue Passwortdatenbank "
 "speichern?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:549
 msgid "Unsaved restored database"
 msgstr "Nicht gespeicherte wiederhergestellte Datenbank"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:580
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:581
 msgid "Do you want to save changes to the password database"
 msgstr "Möchten Sie die Änderungen an der Passwortdatenbank speichern"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:617
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:618
 msgid "Export Text"
 msgstr "Exportiere Text"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:621
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:622
 msgid "Export Text failed"
 msgstr "Text-Import fehlgeschlagen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:623
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
 msgid "Please name the plaintext file"
 msgstr "Bitte wählen Sie einen Namen für die Klartextdatei aus"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1143
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:625
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1144
 msgid ""
 "Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
 msgstr ""
 "Textdateien (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:634
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:635
 msgid "Advanced Text Export Options"
 msgstr "Erweiterte Optionen für Text Export"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:654
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:697
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:655
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:698
 msgid "export"
 msgstr "Exportieren"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:660
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:661
 msgid "Export XML"
 msgstr "Exportiere XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:664
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:665
 msgid "Export XML failed"
 msgstr "XML-Import fehlgeschlagen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:666
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
 msgid "Please name the XML file"
 msgstr "Bitte wählen Sie einen Namen für die XML-Datei aus"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:668
 msgid "XML files (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 msgstr "XML Dateien (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:678
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:679
 msgid "Advanced XML Export Options"
 msgstr "Erweiterte Optionen für XML Export"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:712
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:716
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:713
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:717
 msgid "Password Safe Databases (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 msgstr "Password Safe Datenbanken (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:720
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:721
 msgid "Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 msgstr "Password Safe Datenbanken (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:731
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:732
 msgid "Please name the exported database"
 msgstr "Bitte wählen Sie einen Namen für die exportierte Datenbank aus"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:748
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:749
 msgid "Could not figure out why PasswordSafeFrame::OnExportVx was invoked"
 msgstr ""
 "Konnte nicht ermitteln warum PasswordSafeFrame::OnExportVx ausgeführt wurde"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:782
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:783
 msgid "You must save this database before it can be exported."
 msgstr ""
 "Diese Datenbank muss zuerst gespeichert werden, bevor sie exportiert werden "
 "kann."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid "Exporting database: "
 msgstr "Exportiere Datenbank: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid " to "
 msgstr " nach "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:841
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:842
 msgid "Export complete.  Do you wish to see a detailed report?"
 msgstr "Export beendet. Möchten Sie einen ausführlichen Bericht sehen?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:852
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:853
 msgid "No entries satisfied your selection criteria and so none were exported!"
 msgstr "Kein Eintrag entspricht Ihren Auswahlkriterien, darum werden keine %s!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:865
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:866
 msgid "Passkey incorrect"
 msgstr "Master-Passwort ungültig"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:873
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
 msgid ""
 "The current database was opened in read-only mode.  You cannot import into "
 "it."
@@ -1943,114 +1943,114 @@ msgstr ""
 "Die aktuelle Datenbank wurde im Nur-Lesen-Modus geöffnet. Sie können somit "
 "nichts importieren."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:875
 msgid "Import text"
 msgstr "Text importieren"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:882
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
 msgid "The database:"
 msgstr "Die Datenbank:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
 msgid "has duplicate entries with the same group/title/user combination."
 msgstr ""
 "hat doppelte Einträge mit derselben Gruppe/Titel/Benutzer Kombination. Bitte "
 "bereinigen Sie das durch Überprüfen der Datenbank."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
 msgid "  Please fix by validating database."
 msgstr "Bitte beheben Sie dies durch Überprüfen der Datenbank."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:931
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:886
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:932
 msgid "Import Text failed"
 msgstr "Text-Import fehlgeschlagen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 #, c-format
 msgid "%ls file being imported: %ls"
 msgstr "Importierte %ls Datei: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:921
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:926
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:223
-#: ../../../ui/wxWidgets/SyncWizard.cpp:572
+#: ../../../ui/wxWidgets/SyncWizard.cpp:573
 #: ../../../ui/wxWidgets/wxUtilities.cpp:59
 #: ../../../ui/wxWidgets/wxUtilities.cpp:64
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "File Read Error"
 msgstr "Dateilesefehler"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:923
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:222
 #: ../../../ui/wxWidgets/wxUtilities.cpp:58
 msgid "Could not open file for reading!"
 msgstr "Konnte Datei nicht zum Lesen öffnen!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:928
 msgid "Invalid format"
 msgstr "Ungültiges Format"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 msgid "Updated "
 msgstr "Aktualisiert "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 msgid "Imported "
 msgstr "Importiert "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 msgid " entry"
 msgstr " Eintrag"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 msgid " entries"
 msgstr " Einträge"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
 msgid "Skipped "
 msgstr "Übersprungen "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:957
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:958
 msgid "with Password History errors "
 msgstr "mit Passworthistoriefehler "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 msgid "Renamed "
 msgstr "Umbennant "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed successfully"
 msgstr "Erfolgreich beendet"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed but ...."
 msgstr "Fertig aber ...."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:981
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1127
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1197
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1218
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1279
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:982
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1128
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1219
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
 msgid "Do you wish to see a detailed report?"
 msgstr "Möchten Sie einen ausführlichen Bericht sehen?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1045
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:998
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1046
 msgid "Import XML failed"
 msgstr "XML-Import fehlgeschlagen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1007
-#: ../../../core/core_st.cpp:238
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../core/core_st.cpp:240
 #, c-format
 msgid ""
 "Can't find XML Schema Definition file (%ls) in your PasswordSafe Application "
@@ -2062,19 +2062,19 @@ msgstr ""
 "Bitte von der Installationsdatei kopieren, oder PasswordSafe nochmal "
 "installieren."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid "Missing XSD File - "
 msgstr "Fehlende XSD-Datei - "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid " Build"
 msgstr " Build"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 msgid "XML"
 msgstr "XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1051
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1052
 #, c-format
 msgid ""
 "File: %ls failed validation against XML Schema:\n"
@@ -2085,7 +2085,7 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1057
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1058
 #, c-format
 msgid ""
 "File: %ls passed Validation but had the following errors during import:\n"
@@ -2097,25 +2097,25 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1078
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1079
 msgid "The following records were skipped:"
 msgstr "Folgende Datensätze wurden übersprungen:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1080
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1081
 #, c-format
 msgid " / skipped %d"
 msgstr " / %d übersprungen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1085
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1086
 msgid "The following records had errors in their Password History:"
 msgstr "Folgende Datensätze hatten Fehler in die Passworthistorie:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1087
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1088
 #, c-format
 msgid " / with Password History errors %d"
 msgstr "  / mit Passworthistorie Fehler %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1092
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1093
 msgid ""
 "The following records were renamed as an entry already exists in your "
 "database or in the Import file:"
@@ -2123,12 +2123,12 @@ msgstr ""
 "Folgende Datensätze wurden umbenannt, weil schon so ein Eintrag in der "
 "Datenbank oder in der Importdatei besteht:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1094
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1095
 #, c-format
 msgid " / renamed %d"
 msgstr " / umbenannt %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1099
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1100
 #, c-format
 msgid ""
 "File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See "
@@ -2137,25 +2137,25 @@ msgstr ""
 "Datei: %ls wurde importiert (Überprüfte Einträge %d / importiert %d%ls%ls"
 "%ls). Siehe Bericht für Details."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:95
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:97
 msgid "entry"
 msgstr "Eintrag"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:93
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:95
 msgid "entries"
 msgstr "Einträge"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1107
 #, c-format
 msgid ""
 "Validated %d %ls\n"
@@ -2166,26 +2166,26 @@ msgstr ""
 "\n"
 "Importiert %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1114
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1115
 msgid "XML import not supported in this release"
 msgstr "XML-Import wird von dieser Version nicht unterstützt"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1117
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1118
 #, c-format
 msgid "XML import: Unexpected return code(%d)"
 msgstr "XML-Import: Unerwarteter Rückgabewert (%d)"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1141
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1142
 msgid "Please Choose a KeePass Text File to Import"
 msgstr "Bitte wählen Sie die zu importierende KeePass-Textdatei aus"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1163
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1164
 #, c-format
 msgid "Text file being imported: %ls"
 msgstr "Importierte Textdatei: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1180
-#: ../../../ui/wxWidgets/SyncWizard.cpp:602
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/SyncWizard.cpp:603
 #, c-format
 msgid ""
 "%ls\n"
@@ -2196,11 +2196,11 @@ msgstr ""
 "\n"
 "Konnte Datei nicht zum Lesen öffnen!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1182
 msgid "File open error"
 msgstr "Fehler beim Öffnen der Datei"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1195
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1196
 #, c-format
 msgid ""
 "%ls\n"
@@ -2211,20 +2211,20 @@ msgstr ""
 "\n"
 "Ungültiges Format"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1199
 msgid "Import failed"
 msgstr "Import fehlgeschlagen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1214
 #, c-format
 msgid "Imported %d %ls"
 msgstr "Importiert %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1265
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1266
 msgid "Merging database: "
 msgstr "Zusammenführung von Datenbank: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1281
 msgid "Merge Complete"
 msgstr "Zusammenführung beendet"
 
@@ -2281,8 +2281,9 @@ msgid ""
 "Please close the database and re-open it in R/W mode."
 msgstr ""
 "Die Datenbank wurde geändert seit sie in Modus R-O geöffnet wurde. Somit ist "
-"es nicht möglich zum Modus R/W umzuschalten.\n\nBitte schliessen Sie die "
-"Datenbank, und öffnen Sie sie wieder in Modus R/W."
+"es nicht möglich zum Modus R/W umzuschalten.\n"
+"\n"
+"Bitte schliessen Sie die Datenbank, und öffnen Sie sie wieder in Modus R/W."
 
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:433
 #, c-format
@@ -2298,8 +2299,9 @@ msgid ""
 "(Only one R/W access at a time is allowed)"
 msgstr ""
 "Umschalten von R-O nach R/W fehlgeschlagen, weil die Datenbank schon in R/W "
-"Modus geöffnet ist von:\n%ls %ls\n(Nur ein R/W Zugriff ist gleichzeitig "
-"erlaubt)"
+"Modus geöffnet ist von:\n"
+"%ls %ls\n"
+"(Nur ein R/W Zugriff ist gleichzeitig erlaubt)"
 
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:445
 msgid ""
@@ -2320,8 +2322,8 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:453
 msgid "Given path is a directory or file is read-only"
-msgstr "Angegebener Pfad ist ein Verzeichnis oder die Datei kann nur gelesen "
-"werden"
+msgstr ""
+"Angegebener Pfad ist ein Verzeichnis oder die Datei kann nur gelesen werden"
 
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:461
 msgid ""
@@ -2329,17 +2331,18 @@ msgid ""
 "Try exiting and restarting program."
 msgstr ""
 "Umschalten von R/W nach R-O fehlgeschlagen: konnte die Datenbanksperre nicht "
-"aufheben.\nVersuchen Sie das Programm zu beenden und starten es erneut."
+"aufheben.\n"
+"Versuchen Sie das Programm zu beenden und starten es erneut."
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid " file '"
 msgstr " Datei '"
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid "' not readable"
 msgstr "' ist nicht lesbar"
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #: ../../../ui/wxWidgets/ViewReportDlg.cpp:32
 msgid "View Report"
 msgstr "Zeige Bericht"
@@ -2383,7 +2386,7 @@ msgid "Please select a valid file"
 msgstr "Bitte wählen Sie eine gültige Datei aus"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:123
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:249
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:251
 msgid "None"
 msgstr "Keine"
 
@@ -2396,7 +2399,7 @@ msgid "Incremented Number [001-999]"
 msgstr "Inkrementierte Nummer [001-999]"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:132
-#: ../../../core/core_st.cpp:66
+#: ../../../core/core_st.cpp:68
 msgid "Copy password to clipboard"
 msgstr "Passwort in Zwischenablage kopieren"
 
@@ -2406,37 +2409,37 @@ msgstr "Ausgewählten Eintrag bearbeiten/anzeigen"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:134
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:623
-#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:62
+#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:64
 msgid "Autotype"
 msgstr "Autom. Eingabe"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:135
-#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:63
+#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:65
 msgid "Browse to URL"
 msgstr "URL aufrufen"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:136
-#: ../../../core/core_st.cpp:65
+#: ../../../core/core_st.cpp:67
 msgid "Copy notes to clipboard"
 msgstr "Notizen in Zwischenablage kopieren"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:137
-#: ../../../core/core_st.cpp:68
+#: ../../../core/core_st.cpp:70
 msgid "Copy username to clipboard"
 msgstr "Benutzername in Zwischenablage kopieren"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:138
-#: ../../../core/core_st.cpp:67
+#: ../../../core/core_st.cpp:69
 msgid "Copy password to clipboard, minimize"
 msgstr "Passwort in Zwischenablage kopieren, minimieren"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:139
-#: ../../../core/core_st.cpp:64
+#: ../../../core/core_st.cpp:66
 msgid "Browse to URL + Autotype"
 msgstr "URL aufrufen + Autom. Eingabe ausführen"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:140
-#: ../../../core/core_st.cpp:69 ../../../core/core_st.cpp:144
+#: ../../../core/core_st.cpp:71 ../../../core/core_st.cpp:146
 msgid "Run Command"
 msgstr "Kommando ausführen"
 
@@ -2853,23 +2856,23 @@ msgstr "Password Safe: Fehler beim Initialisieren der Hilfe"
 msgid "Don't show this warning again"
 msgstr "Diese Warnung nicht nochmals anzeigen"
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:849
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:854
 msgid "Missing help definition for page \""
 msgstr "Fehlende Definition der Hilfe für die Seite \""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:850
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
 msgid "\" of \""
 msgstr "\" von \""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:860
 msgid "Missing help definition for window \""
 msgstr "Fehlende Definition der Hilfe für das Fenster \""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:866
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:871
 msgid "Please inform the developers."
 msgstr "Bitte informieren Sie die Entwickler."
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:867
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:872
 msgid "Help Undefined"
 msgstr "Undefinierte Hilfe"
 
@@ -3526,6 +3529,7 @@ msgid "search"
 msgstr "Suche"
 
 #: ../../../ui/wxWidgets/PasswordSafeSearch.cpp:427
+#: ../../../core/core_st.cpp:280
 msgid "Find"
 msgstr "Suchen"
 
@@ -3638,20 +3642,20 @@ msgstr "Ungültige Position"
 msgid " empty)"
 msgstr " leer)"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:306
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:322
 #, c-format
 msgid "%ls on %ls"
 msgstr "%ls auf %ls"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:341
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:357
 msgid "Yes"
 msgstr "Ja"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:244
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:246
 msgid "No"
 msgstr "Nein"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:302
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:318
 #, c-format
 msgid "In Headers(%ls)/In Entries("
 msgstr "In Headers(%ls)/In Einträge("
@@ -3818,7 +3822,7 @@ msgstr "Konnte die Datei nicht Sperren. Nur zum Lesen geöffnet.\n"
 
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:457
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:269
-#: ../../../core/core_st.cpp:276
+#: ../../../core/core_st.cpp:290
 msgid "Warning"
 msgstr "Warnung"
 
@@ -3887,11 +3891,11 @@ msgstr "Bitte den Schlüssel eingeben und überprüfen Sie ihn."
 msgid "Please try another"
 msgstr "Bitte probieren Sie andere"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:96
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:98
 msgid "equals"
 msgstr "gleicht"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:83
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:85
 msgid "does not equal"
 msgstr "gleicht nicht"
 
@@ -3899,23 +3903,23 @@ msgstr "gleicht nicht"
 msgid "begins with"
 msgstr "beginnt mit"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:78
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:80
 msgid "does not begin with"
 msgstr "beginnt nicht mit"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:90
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:92
 msgid "ends with"
 msgstr "endet mit"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:82
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:84
 msgid "does not end with"
 msgstr "endet nicht mit"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:56
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:58
 msgid "contains"
 msgstr "enthält"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:79
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:81
 msgid "does not contain"
 msgstr "enthält nicht"
 
@@ -3969,20 +3973,20 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:143
+#: ../../../ui/wxWidgets/SyncWizard.cpp:144
 msgid "synchronize"
 msgstr "Synchronisiere"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:220
+#: ../../../ui/wxWidgets/SyncWizard.cpp:221
 msgid "Synchronize another database with currently open database"
 msgstr ""
 "Synchronisiere eine andere Datendank mit der aktuell geöffneten Datenbank"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:349
+#: ../../../ui/wxWidgets/SyncWizard.cpp:350
 msgid "Introduction"
 msgstr "Einführung"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:353
+#: ../../../ui/wxWidgets/SyncWizard.cpp:354
 msgid ""
 "Synchronizing with another database will update the entries in your\n"
 "database with matching entries from the other database."
@@ -3991,11 +3995,11 @@ msgstr ""
 "Datenbank mit übereinstimmenden Einträgen aus der anderen Datenbank "
 "aktualisieren."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:356
+#: ../../../ui/wxWidgets/SyncWizard.cpp:357
 msgid "More Info"
 msgstr "Mehr Informationen"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:359
+#: ../../../ui/wxWidgets/SyncWizard.cpp:360
 msgid ""
 "1. Two entries from different databases match if their Group, Title\n"
 "and User fields match."
@@ -4003,7 +4007,7 @@ msgstr ""
 "1. Zwei Einträge aus unterschiedlichen Datenbanken stimmen dann überein,\n"
 "wenn ihre Gruppe, der Titel und das Benutzerfeld übereinstimmen."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:360
+#: ../../../ui/wxWidgets/SyncWizard.cpp:361
 msgid ""
 "2. You can select the fields to update, as well as filter the entries\n"
 "for synchronization."
@@ -4011,7 +4015,7 @@ msgstr ""
 "2. Sie könnenn die zu aktualisierenden Felder auswählen,\n"
 "wie aber auch nach Einträgen zur Synchronization filtern."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:361
+#: ../../../ui/wxWidgets/SyncWizard.cpp:362
 msgid ""
 "3. Only existing entries in your database are updated.  No new entries are\n"
 "added or existing entries removed during this process."
@@ -4019,7 +4023,7 @@ msgstr ""
 "3. Nur die existierenden Einträge Ihrer Datenbank werden aktualisiert.\n"
 "Es werden weder neue Einträge hinzugefügt, noch bestehende entfernt."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:362
+#: ../../../ui/wxWidgets/SyncWizard.cpp:363
 msgid ""
 "4. You can undo the operation once it is complete, but won't be\n"
 "able to abort it mid-way."
@@ -4027,29 +4031,29 @@ msgstr ""
 "4. Sie können nach Abschluß der Prozedur diese wieder Rückgängig machen.\n"
 "Während die Prozedur jedoch läuft, kann diese nicht abgebrochen werden."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:379
+#: ../../../ui/wxWidgets/SyncWizard.cpp:380
 msgid "Select another database"
 msgstr "Wählen Sie eine andere Datenbank aus"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:381
+#: ../../../ui/wxWidgets/SyncWizard.cpp:382
 msgid "Choose Database to Synchronize with \""
 msgstr "Wählen Sie eine Datenbank zum Synchronisieren mit \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:382
+#: ../../../ui/wxWidgets/SyncWizard.cpp:383
 msgid "Please Choose a Database to Synchronize with current database"
 msgstr ""
 "Bitte wählen Sie eine Datenbank zum Synchronisieren mit der aktuellen "
 "Datenbank"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:405
+#: ../../../ui/wxWidgets/SyncWizard.cpp:406
 msgid "Synchronization options"
 msgstr "Optionen zur Synchronisation"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:429
+#: ../../../ui/wxWidgets/SyncWizard.cpp:430
 msgid "Options Summary"
 msgstr "Zusammenfassung der Optionen"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:454
+#: ../../../ui/wxWidgets/SyncWizard.cpp:455
 msgid ""
 "WARNING!!\n"
 "\n"
@@ -4059,53 +4063,53 @@ msgstr ""
 "ACHTUNG: Wenn Sie fortfahren, werden die Felder der Einträge in der "
 "bestehenden Datenbank aus der von Ihnen ausgewählten Datenbank aktualisiert."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:471
+#: ../../../ui/wxWidgets/SyncWizard.cpp:472
 msgid " will be updated with corresponding entries from \""
 msgstr " wird mit entsprechenden Einträgen aktualisiert aus \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:478
+#: ../../../ui/wxWidgets/SyncWizard.cpp:479
 msgid "All fields in matching entries will be updated"
 msgstr "Alle Felder übereinstimmender Einträge werden aktualisiert"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:484
+#: ../../../ui/wxWidgets/SyncWizard.cpp:485
 msgid "Following fields in matching entries will be updated:"
 msgstr "Die folgenden Felder übereinstimmender Einträge werden aktualisiert:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:488
+#: ../../../ui/wxWidgets/SyncWizard.cpp:489
 msgid "Following fields will not be updated:"
 msgstr "Folgende Felder werden nicht aktualisiert:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:507
+#: ../../../ui/wxWidgets/SyncWizard.cpp:508
 msgid "Synchronization status"
 msgstr "Synchronisationstatus"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:525
+#: ../../../ui/wxWidgets/SyncWizard.cpp:526
 msgid "See a detailed report"
 msgstr "Siehe detailierter Bericht"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:561
+#: ../../../ui/wxWidgets/SyncWizard.cpp:562
 msgid "Your database is being synchronized with \""
 msgstr "Ihre Datenbank wurde synchronisiert mit \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:571
+#: ../../../ui/wxWidgets/SyncWizard.cpp:572
 msgid "There was an error during synchronization"
 msgstr "Beim Synchronisieren ist eine Fehler aufgetreten"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:585
+#: ../../../ui/wxWidgets/SyncWizard.cpp:586
 #, c-format
 msgid "Your database has been synchronized with \"%ls\""
 msgstr "Ihre Datenbank wurde synchronisiert mit \"%ls\""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:586
+#: ../../../ui/wxWidgets/SyncWizard.cpp:587
 #, c-format
 msgid "%ld %ls updated"
 msgstr "%ld %ls aktualisiert"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:589
 msgid "Synchronization completed successfully"
 msgstr "Synchronisation erfolgreich beendet"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:604
+#: ../../../ui/wxWidgets/SyncWizard.cpp:605
 #, c-format
 msgid ""
 "%ls\n"
@@ -4118,7 +4122,7 @@ msgstr ""
 "Datei ist beschädigt oder abgeschnitten!\n"
 "Möglicherweise sind Daten verloren oder verändert."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:606
+#: ../../../ui/wxWidgets/SyncWizard.cpp:607
 #, c-format
 msgid ""
 "%ls\n"
@@ -4129,24 +4133,24 @@ msgstr ""
 "\n"
 "Unbekannter Fehler"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:640
+#: ../../../ui/wxWidgets/SyncWizard.cpp:641
 #, c-format
 msgid "Synchronizing from database: %ls\n"
 msgstr "Synchronisieren mit Datenbank: %ls\n"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:643
+#: ../../../ui/wxWidgets/SyncWizard.cpp:644
 msgid "synchronized"
 msgstr "synchronisiert"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:322
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:338
 msgid "was"
 msgstr "wurde"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:323
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:339
 msgid "were"
 msgstr "wurden"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:298
+#: ../../../ui/wxWidgets/SyncWizard.cpp:733 ../../../core/core_st.cpp:314
 #, c-format
 msgid ""
 "\n"
@@ -4155,7 +4159,7 @@ msgstr ""
 "\n"
 "Folgende(r) %ls %ls aktualisiert:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:297
+#: ../../../ui/wxWidgets/SyncWizard.cpp:749 ../../../core/core_st.cpp:313
 #, c-format
 msgid ""
 "\n"
@@ -4316,7 +4320,7 @@ msgstr "Das Alias-Ziel [%s:%s:%s] ist kein normaler Eintrag."
 msgid "This shortcut's target [%s:%s:%s] is not a normal entry."
 msgstr "Das Verküpfungsziel [%s:%s:%s] ist kein normaler Eintrag"
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:94
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:96
 #, c-format
 msgid ""
 "The following entries had a policy name that already existed in this "
@@ -4417,7 +4421,7 @@ msgstr ""
 "Möglicherweise sind Daten verloren oder verändert.\n"
 "Trotzdem fortfahren?"
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:381
+#: ../../../ui/wxWidgets/wxUtilities.cpp:390
 msgid ""
 "An error occurred while trying to get the image data from database item.\n"
 "Therefore, the image cannot be displayed in the preview."
@@ -4426,7 +4430,7 @@ msgstr ""
 "aufgetreten.\n"
 "Daher kann das Bild nicht in der Vorschau angezeigt werden."
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:394
+#: ../../../ui/wxWidgets/wxUtilities.cpp:403
 msgid ""
 "An error occurred while trying to load the image data into the preview "
 "area.\n"
@@ -4548,7 +4552,7 @@ msgstr "Datenbank speichern"
 msgid "Copy Password to Clipboard"
 msgstr "Passwort in Zwischenablage kopieren"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:149
+#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:151
 msgid "Username"
 msgstr "Benutzername"
 
@@ -4556,7 +4560,7 @@ msgstr "Benutzername"
 msgid "Copy Username to Clipboard"
 msgstr "Benutzername in Zwischenablage kopieren"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:136
+#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:138
 msgid "Notes"
 msgstr "Notizen"
 
@@ -4580,7 +4584,7 @@ msgstr "Autom. Eingabe ausführen"
 msgid "Browse URL"
 msgstr "URL aufrufen"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:70
+#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:72
 msgid "Send Email"
 msgstr "E-Mail senden"
 
@@ -4766,64 +4770,82 @@ msgid "(case sensitive)"
 msgstr "(schreibungsabhängig)"
 
 #: ../../../core/core_st.cpp:50
+#, c-format
+msgid ""
+"Compare complete of current database:\n"
+"\t %ls\n"
+" and:\n"
+"\t %ls\n"
+msgstr ""
+"Vollständiger Vergleich zwischen aktueller Datenbank:\n"
+"\t %ls\n"
+" und:\n"
+"\t %ls\n"
+
+#: ../../../core/core_st.cpp:51
+#, fuzzy, c-format
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGruppe='%ls', Titel='%ls', Benutzer='%ls'"
+
+#: ../../../core/core_st.cpp:52
 msgid "C:F[R-O]"
 msgstr "C:F[R-O]"
 
-#: ../../../core/core_st.cpp:51
+#: ../../../core/core_st.cpp:53
 msgid "C:F[R/W]"
 msgstr "C:F[R/W]"
 
-#: ../../../core/core_st.cpp:52
+#: ../../../core/core_st.cpp:54
 msgid "C:None  "
 msgstr "C:None  "
 
-#: ../../../core/core_st.cpp:53
+#: ../../../core/core_st.cpp:55
 msgid "C:Reg   "
 msgstr "C:Reg   "
 
-#: ../../../core/core_st.cpp:54
+#: ../../../core/core_st.cpp:56
 msgid "conflict"
 msgstr "Konflikt"
 
-#: ../../../core/core_st.cpp:55
+#: ../../../core/core_st.cpp:57
 msgid "conflicts"
 msgstr "Konflikte"
 
-#: ../../../core/core_st.cpp:57
+#: ../../../core/core_st.cpp:59
 msgid "contains all of"
 msgstr "enthält sämtliche von"
 
-#: ../../../core/core_st.cpp:58
+#: ../../../core/core_st.cpp:60
 msgid "contains any of"
 msgstr "enthält einige von"
 
-#: ../../../core/core_st.cpp:59
+#: ../../../core/core_st.cpp:61
 msgid "copied"
 msgstr "kopiert"
 
-#: ../../../core/core_st.cpp:60
+#: ../../../core/core_st.cpp:62
 #, c-format
 msgid "%ls - Copied %ls"
 msgstr "%ls - Kopiert %ls"
 
-#: ../../../core/core_st.cpp:61
+#: ../../../core/core_st.cpp:63
 #, c-format
 msgid " Current default (%ls)"
 msgstr " Aktueller Standard (%ls)"
 
-#: ../../../core/core_st.cpp:71
+#: ../../../core/core_st.cpp:73
 msgid "View/Edit selected entry"
 msgstr "Zeige/ändere ausgewählten Eintrag"
 
-#: ../../../core/core_st.cpp:72
+#: ../../../core/core_st.cpp:74
 msgid " (application default)"
 msgstr " (Standardeinstellung)"
 
-#: ../../../core/core_st.cpp:73
+#: ../../../core/core_st.cpp:75
 msgid "default symbol set"
 msgstr "Standard Zeichensatz"
 
-#: ../../../core/core_st.cpp:75
+#: ../../../core/core_st.cpp:77
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -4836,11 +4858,11 @@ msgstr ""
 "Bitte bestätigen Sie, dass Sie fortfahren möchten (Passwörter des Alias-"
 "Eintrages werden durch das Passwort dieses Eintrags ersetzt)?"
 
-#: ../../../core/core_st.cpp:76
+#: ../../../core/core_st.cpp:78
 msgid "Delete Base Entry Confirmation"
 msgstr "Bestätigung zum Löschen des Datenbankeintrages"
 
-#: ../../../core/core_st.cpp:77
+#: ../../../core/core_st.cpp:79
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -4852,38 +4874,38 @@ msgstr ""
 "Bitte bestätigen Sie, dass Sie fortfahren möchten (alle Verknüpfungen zu "
 "diesem Eintrag werden gelöscht)?"
 
-#: ../../../core/core_st.cpp:80
+#: ../../../core/core_st.cpp:82
 msgid "does not contain all of"
 msgstr "enthält nicht alle von"
 
-#: ../../../core/core_st.cpp:81
+#: ../../../core/core_st.cpp:83
 msgid "does not contain any of"
 msgstr "enthält keines von"
 
-#: ../../../core/core_st.cpp:84
+#: ../../../core/core_st.cpp:86
 #, c-format
 msgid " Drag # %d"
 msgstr " Drag # %d"
 
-#: ../../../core/core_st.cpp:85
+#: ../../../core/core_st.cpp:87
 #, c-format
-msgid "%s - Drag & Drop %s"
-msgstr "%s - Drag & Drop %s"
+msgid "%ls - Drag & Drop %ls"
+msgstr "%ls - Drag & Drop %ls"
 
-#: ../../../core/core_st.cpp:86
+#: ../../../core/core_st.cpp:88
 #, c-format
 msgid " Duplicate # %d"
 msgstr " Doppelte Nr. %d"
 
-#: ../../../core/core_st.cpp:87
+#: ../../../core/core_st.cpp:89
 msgid "empty group"
 msgstr "leere Gruppe"
 
-#: ../../../core/core_st.cpp:88
+#: ../../../core/core_st.cpp:90
 msgid "empty groups"
 msgstr "leere Gruppen"
 
-#: ../../../core/core_st.cpp:89
+#: ../../../core/core_st.cpp:91
 #, c-format
 msgid ""
 "Trouble with a non-textual (e.g., time) field in record '%ls' - please check "
@@ -4892,129 +4914,129 @@ msgstr ""
 "Problem mit einem Nicht-Text-Feld (z.B. Uhrzeit) im Datensatz '%ls' - Bitte "
 "überprüfen Sie Ihre Daten sorgfältig."
 
-#: ../../../core/core_st.cpp:91
+#: ../../../core/core_st.cpp:93
 msgid "End Report"
 msgstr "Bericht Ende"
 
-#: ../../../core/core_st.cpp:92
+#: ../../../core/core_st.cpp:94
 msgid "--------------------------------------------------------------------------------"
 msgstr "--------------------------------------------------------------------------------"
 
-#: ../../../core/core_st.cpp:97
+#: ../../../core/core_st.cpp:99
 msgid "has expired"
 msgstr "ist abgelaufen"
 
-#: ../../../core/core_st.cpp:98
+#: ../../../core/core_st.cpp:100
 msgid "Entries with a password expiry"
 msgstr "Einträge mit abgelaufenem Passwort"
 
-#: ../../../core/core_st.cpp:99
+#: ../../../core/core_st.cpp:101
 #, c-format
 msgid "within %d day(s)"
 msgstr "binnen %d Tag(en)"
 
-#: ../../../core/core_st.cpp:100
+#: ../../../core/core_st.cpp:102
 #, c-format
 msgid "DB Export from database: '%s'"
 msgstr "Datenbankexport aus: '%s'"
 
-#: ../../../core/core_st.cpp:101
+#: ../../../core/core_st.cpp:103
 msgid "First character of variable name must be alphabetic"
 msgstr "Erstes Zeichen einer Variablen muss alphabetisch sein"
 
-#: ../../../core/core_st.cpp:102
+#: ../../../core/core_st.cpp:104
 msgid "Index not numeric"
 msgstr "Index nicht numerisch"
 
-#: ../../../core/core_st.cpp:103
+#: ../../../core/core_st.cpp:105
 msgid "Input string is empty"
 msgstr "Eingabestring ist leer"
 
-#: ../../../core/core_st.cpp:104
+#: ../../../core/core_st.cpp:106
 msgid "Characters present between end of index ']' and '}'"
 msgstr "Vorhandene Zeichen zwischen Indexende ']' und '}'"
 
-#: ../../../core/core_st.cpp:105
+#: ../../../core/core_st.cpp:107
 msgid "Index is invalid or missing"
 msgstr "Index ungültig oder nicht vorhanden"
 
-#: ../../../core/core_st.cpp:106
+#: ../../../core/core_st.cpp:108
 msgid "Missing ending curly bracket for variable name"
 msgstr "Keine geschweifte Klammer am Ende des Variablennamens"
 
-#: ../../../core/core_st.cpp:107
+#: ../../../core/core_st.cpp:109
 msgid "Missing ending round bracket for Autotype value"
 msgstr "Keine runde Klammer am Ende des Wertes für die Autom. Eingabe"
 
-#: ../../../core/core_st.cpp:108
+#: ../../../core/core_st.cpp:110
 msgid "Missing ending square bracket for index value"
 msgstr "Keine eckige Klammer am Ende des Indexwertes"
 
-#: ../../../core/core_st.cpp:109
+#: ../../../core/core_st.cpp:111
 msgid "There are unmatched quotes in the run command"
 msgstr "Die Gänsefüßchen im auszuführenden Kommando stimmen nicht überein"
 
-#: ../../../core/core_st.cpp:110
+#: ../../../core/core_st.cpp:112
 msgid "Variable name is empty"
 msgstr "Variablenname ist leer"
 
-#: ../../../core/core_st.cpp:111
+#: ../../../core/core_st.cpp:113
 msgid "Variable name must be alphanumeric"
 msgstr "Variablenname muss alphabetisch sein"
 
-#: ../../../core/core_st.cpp:112
+#: ../../../core/core_st.cpp:114
 msgid "an alias entry"
 msgstr "Alias Eintrag"
 
-#: ../../../core/core_st.cpp:113
+#: ../../../core/core_st.cpp:115
 msgid "a base entry of an alias"
 msgstr "Basiseintrag eines Alias"
 
-#: ../../../core/core_st.cpp:114
+#: ../../../core/core_st.cpp:116
 msgid "  Field is too long."
 msgstr "  Feld ist zu lang."
 
-#: ../../../core/core_st.cpp:115
+#: ../../../core/core_st.cpp:117
 msgid "  Field is too short."
 msgstr "  Feld ist zu kurz."
 
-#: ../../../core/core_st.cpp:116
+#: ../../../core/core_st.cpp:118
 msgid "Error: A file with this name already exists"
 msgstr "Fehler: ein Datei mit diesem Namen besteht bereits"
 
-#: ../../../core/core_st.cpp:117
+#: ../../../core/core_st.cpp:119
 msgid "The file was not found."
 msgstr "Datei nicht gefunden."
 
-#: ../../../core/core_st.cpp:118
+#: ../../../core/core_st.cpp:120
 msgid "Error: File is read-only"
 msgstr "Fehler: Datei ist schreibgeschützt"
 
-#: ../../../core/core_st.cpp:119
+#: ../../../core/core_st.cpp:121
 msgid "Error while writing file! Try saving in a different location"
 msgstr ""
 "Fehler während des Schreibens einer Datei! Versuchen Sie diese an einer "
 "anderen Stelle abzuspeichern"
 
-#: ../../../core/core_st.cpp:120
+#: ../../../core/core_st.cpp:122
 msgid "File is too big."
 msgstr "Datei ist zu groß."
 
-#: ../../../core/core_st.cpp:121
+#: ../../../core/core_st.cpp:123
 msgid "File is too short."
 msgstr "Datei ist zu kurz."
 
-#: ../../../core/core_st.cpp:122
+#: ../../../core/core_st.cpp:124
 msgid "File is truncated or otherwise corrupt. Please use backup database."
 msgstr ""
 "Datei ist abgeschnitten oder anderweitig beschädigt. Bitte verwenden Sie "
 "eine gesicherte Datenbank."
 
-#: ../../../core/core_st.cpp:123
+#: ../../../core/core_st.cpp:125
 msgid "Cannot read file. Please check file permissions."
 msgstr "Kann Datei nicht lesen. Bitte überprüfen sie die Rechte."
 
-#: ../../../core/core_st.cpp:124
+#: ../../../core/core_st.cpp:126
 #, c-format
 msgid ""
 "Filter %ls already exists in the database, do you wish to replace it with "
@@ -5023,129 +5045,129 @@ msgstr ""
 "Filter %ls besteht bereits in der Datenbank, wollen sie es mit diesem "
 "ersetzen?"
 
-#: ../../../core/core_st.cpp:125
+#: ../../../core/core_st.cpp:127
 msgid "Current database filters have been exported to this database."
 msgstr "Die Datenbankfilter wurden in diese Datenbank exportiert."
 
-#: ../../../core/core_st.cpp:126
+#: ../../../core/core_st.cpp:128
 msgid "Stored filters will be unusable until the file's restored."
 msgstr ""
 "Gespeicherte Filter werden unbenutzbar sein bis die Datei wiederhergestellt "
 "wird."
 
-#: ../../../core/core_st.cpp:127
+#: ../../../core/core_st.cpp:129
 msgid "Last Access Time"
 msgstr "Letzte Zugriffszeit"
 
-#: ../../../core/core_st.cpp:128
+#: ../../../core/core_st.cpp:130
 msgid "Attachment Reference"
 msgstr "Referenz zum Anhang"
 
-#: ../../../core/core_st.cpp:129
+#: ../../../core/core_st.cpp:131
 msgid "AutoType"
 msgstr "Autom. Eingabe"
 
-#: ../../../core/core_st.cpp:130
+#: ../../../core/core_st.cpp:132
 msgid "Created Time"
 msgstr "Erstellungszeit"
 
-#: ../../../core/core_st.cpp:131
+#: ../../../core/core_st.cpp:133
 msgid "DCA"
 msgstr "DCA"
 
-#: ../../../core/core_st.cpp:132
+#: ../../../core/core_st.cpp:134
 msgid "e-mail"
 msgstr "E-Mail"
 
-#: ../../../core/core_st.cpp:134
+#: ../../../core/core_st.cpp:136
 msgid "Group/Title"
 msgstr "Gruppe/Titel"
 
-#: ../../../core/core_st.cpp:135
+#: ../../../core/core_st.cpp:137
 msgid "Keyboard Shortcut"
 msgstr "Tastaturkürzel"
 
-#: ../../../core/core_st.cpp:138
+#: ../../../core/core_st.cpp:140
 msgid "Password Modified Time"
 msgstr "Passwort Änderungszeit"
 
-#: ../../../core/core_st.cpp:139
+#: ../../../core/core_st.cpp:141
 msgid "Protected"
 msgstr "Geschützt"
 
-#: ../../../core/core_st.cpp:140
+#: ../../../core/core_st.cpp:142
 msgid "History"
 msgstr "Historie"
 
-#: ../../../core/core_st.cpp:142
+#: ../../../core/core_st.cpp:144
 msgid "Password Policy Name"
 msgstr "Passwortrichtlinienname"
 
-#: ../../../core/core_st.cpp:143
+#: ../../../core/core_st.cpp:145
 msgid "Record Modified Time"
 msgstr "Datensatz Änderungszeit"
 
-#: ../../../core/core_st.cpp:145
+#: ../../../core/core_st.cpp:147
 msgid "Shift+DCA"
 msgstr "Umschalt+DCA"
 
-#: ../../../core/core_st.cpp:146
+#: ../../../core/core_st.cpp:148
 msgid "Symbols"
 msgstr "Symbole"
 
-#: ../../../core/core_st.cpp:148
+#: ../../../core/core_st.cpp:150
 msgid "URL"
 msgstr "URL"
 
-#: ../../../core/core_st.cpp:150
+#: ../../../core/core_st.cpp:152
 msgid "UUID"
 msgstr "UUID"
 
-#: ../../../core/core_st.cpp:151
+#: ../../../core/core_st.cpp:153
 msgid "Password Expiry Date"
 msgstr "Passwortablaufdatum"
 
-#: ../../../core/core_st.cpp:152
+#: ../../../core/core_st.cpp:154
 msgid "Password Expiry Interval"
 msgstr "Passwortablauf-Intervall"
 
-#: ../../../core/core_st.cpp:153
+#: ../../../core/core_st.cpp:155
 msgid "a normal entry"
 msgstr "Normaler Eintrag"
 
-#: ../../../core/core_st.cpp:154
+#: ../../../core/core_st.cpp:156
 msgid "Last found entries"
 msgstr "Zuletzt gefundene Einträge"
 
-#: ../../../core/core_st.cpp:155
+#: ../../../core/core_st.cpp:157
 msgid "added but not yet saved to database"
 msgstr "hinzugefügt, aber noch nicht in der Datenbank gespeichert"
 
-#: ../../../core/core_st.cpp:156
+#: ../../../core/core_st.cpp:158
 msgid "in the database"
 msgstr "in die Datenbank"
 
-#: ../../../core/core_st.cpp:157
+#: ../../../core/core_st.cpp:159
 msgid "a shortcut entry"
 msgstr "ein Verknüpfungseintrag"
 
-#: ../../../core/core_st.cpp:158
+#: ../../../core/core_st.cpp:160
 msgid "a base entry of a shortcut"
 msgstr "ein Basiseintrag einer Verknüpfung"
 
-#: ../../../core/core_st.cpp:159
+#: ../../../core/core_st.cpp:161
 msgid "changed but not yet saved to database"
 msgstr "geändert, aber noch nicht in der Datenbank gespeichert"
 
-#: ../../../core/core_st.cpp:160
+#: ../../../core/core_st.cpp:162
 msgid "greater than"
 msgstr "größer als"
 
-#: ../../../core/core_st.cpp:161
+#: ../../../core/core_st.cpp:163
 msgid "greater than or equal to"
 msgstr "größer als oder gleich mit"
 
-#: ../../../core/core_st.cpp:162
+#: ../../../core/core_st.cpp:164
 #, c-format
 msgid ""
 "Invalid input on line %d.  Number of fields separated by '%c' is not as "
@@ -5154,12 +5176,12 @@ msgstr ""
 "Ungültige Eingabe in Zeile %d. Anzahl der Felder getrennt mit '%c' nicht wie "
 "erwartet."
 
-#: ../../../core/core_st.cpp:163
+#: ../../../core/core_st.cpp:165
 #, c-format
 msgid "Line %d: "
 msgstr "Zeile %d: "
 
-#: ../../../core/core_st.cpp:164
+#: ../../../core/core_st.cpp:166
 #, c-format
 msgid ""
 "File ends on line %d before ending double quote of last entry's note field."
@@ -5167,11 +5189,11 @@ msgstr ""
 "Datei endet in Zeile %d ohne Anführungszeichen am Schluss des letzten Feldes "
 "Notizen."
 
-#: ../../../core/core_st.cpp:165
+#: ../../../core/core_st.cpp:167
 msgid "Import aborted. Please see report."
 msgstr "Import abgebrochen. Beachten sie den Bericht."
 
-#: ../../../core/core_st.cpp:166
+#: ../../../core/core_st.cpp:168
 msgid ""
 "The TXT or CSV file was not imported as required as entry records span "
 "multiple lines in the CSV file.\n"
@@ -5183,7 +5205,7 @@ msgstr ""
 "\n"
 "Der Importierungsvorgang wurde abgebrochen."
 
-#: ../../../core/core_st.cpp:167
+#: ../../../core/core_st.cpp:169
 #, c-format
 msgid ""
 "%ls, Title=\"%ls\", User=\"%ls\" already exists in your database or in the "
@@ -5193,69 +5215,69 @@ msgstr ""
 "in der importierten Datei. Importierten Eintrag mit Titel=\"%ls\" "
 "eingefügt.\n"
 
-#: ../../../core/core_st.cpp:168
+#: ../../../core/core_st.cpp:170
 #, c-format
 msgid "Entry on line %d with Group=\"%ls\""
 msgstr "Eintrag in Zeile %d mit Gruppe=\"%ls\""
 
-#: ../../../core/core_st.cpp:169
+#: ../../../core/core_st.cpp:171
 #, c-format
 msgid "Entry on line %d with no group"
 msgstr "Eintrag in Zeile %d ohne Gruppe"
 
-#: ../../../core/core_st.cpp:170
+#: ../../../core/core_st.cpp:172
 #, c-format
 msgid "Entry with Group=\"%ls\""
 msgstr "Eintrag mit Gruppe=\"%ls\""
 
-#: ../../../core/core_st.cpp:171
+#: ../../../core/core_st.cpp:173
 msgid "Entry with no group"
 msgstr "Eintrag ohne Gruppe"
 
-#: ../../../core/core_st.cpp:172
+#: ../../../core/core_st.cpp:174
 msgid "imported"
 msgstr "importiert"
 
-#: ../../../core/core_st.cpp:173
+#: ../../../core/core_st.cpp:175
 #, c-format
 msgid "including %d empty group(s)."
 msgstr "beinhaltet %d leere Gruppe(n)."
 
-#: ../../../core/core_st.cpp:174
+#: ../../../core/core_st.cpp:176
 #, c-format
 msgid "Empty line %d skipped"
 msgstr "Leere Zeile %d übersprungen"
 
-#: ../../../core/core_st.cpp:175
+#: ../../../core/core_st.cpp:177
 #, c-format
 msgid "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 msgstr "Eintrag %ls%d mit Gruppe=\"%ls\", Titel=\"%ls\", Benutzer=\"%ls\""
 
-#: ../../../core/core_st.cpp:176
+#: ../../../core/core_st.cpp:178
 msgid "Internal error. Import failed. No records imported."
 msgstr "Interner Fehler. Import fehlgeschlagen. Keine Datensätze importiert."
 
-#: ../../../core/core_st.cpp:177
+#: ../../../core/core_st.cpp:179
 #, c-format
 msgid "Found %d known column headers:"
 msgstr "%d bekannte Spaltenköpfe gefunden:"
 
-#: ../../../core/core_st.cpp:178
+#: ../../../core/core_st.cpp:180
 msgid "Invalid field delimiter: must be within ASCII range."
 msgstr "Ungültiges Feldbegrenzungszeichen: muss im ASCII-Bereich liegen."
 
-#: ../../../core/core_st.cpp:179
+#: ../../../core/core_st.cpp:181
 #, c-format
 msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
 msgstr ""
 "Eintrag der Zeile %d enthält ein ungültiges Feld \"%ls \". Es wurde "
 "ignoriert."
 
-#: ../../../core/core_st.cpp:180
+#: ../../../core/core_st.cpp:182
 msgid "The following columns will be processed: "
 msgstr "Folgende Spalten werden verarbeitet: "
 
-#: ../../../core/core_st.cpp:181
+#: ../../../core/core_st.cpp:183
 msgid ""
 "The following columns were recognised but only Group/Title, Username and "
 "Password will be processed:"
@@ -5263,7 +5285,7 @@ msgstr ""
 "Folgende Spalten wurden erkannt, aber nur Gruppe/Titel, Benutzername und "
 "Passwort werden bearbeitet:"
 
-#: ../../../core/core_st.cpp:182
+#: ../../../core/core_st.cpp:184
 #, c-format
 msgid ""
 "Line %d skipped - Only %d fields found, whereas parsing the Header says "
@@ -5272,7 +5294,7 @@ msgstr ""
 "Zeile %d ausgelassen - Nur %d Felder gefunden, obwohl nach dem Parsen der "
 "Kopfzeilen %d da sein sollten."
 
-#: ../../../core/core_st.cpp:183
+#: ../../../core/core_st.cpp:185
 msgid ""
 "Either or both of the Group/Title and Password columns are missing. No "
 "records imported."
@@ -5280,7 +5302,7 @@ msgstr ""
 "Eines oder beide von Gruppe/Titel und Passwortspalten fehlen. Keine "
 "Datensätze importiert."
 
-#: ../../../core/core_st.cpp:184
+#: ../../../core/core_st.cpp:186
 msgid ""
 "Could not find the next entry's title field in the KeePass V1 TXT (should be "
 "within square brackets)."
@@ -5288,37 +5310,37 @@ msgstr ""
 "Konnte das Titel-Feld vom nächsten Eintrag in KeePass V1 TXT nicht finden "
 "(sollte in eckigen Klammern stehen)."
 
-#: ../../../core/core_st.cpp:185
+#: ../../../core/core_st.cpp:187
 msgid "Column header row not recognised as first record. No records imported."
 msgstr ""
 "Zeile mit Spaltenkopf nicht als erste Datensatz erkannt. Keine Datensätze "
 "importiert."
 
-#: ../../../core/core_st.cpp:186
+#: ../../../core/core_st.cpp:188
 msgid "No records in import file!"
 msgstr "Keine Datensätze in der Importdatei enthalten!"
 
-#: ../../../core/core_st.cpp:187
+#: ../../../core/core_st.cpp:189
 #, c-format
 msgid "Line %d skipped: Empty mandatory Password field."
 msgstr "Zeile %d übersprungen: Pflichtfeld Passwort ist leer."
 
-#: ../../../core/core_st.cpp:188
+#: ../../../core/core_st.cpp:190
 #, c-format
 msgid "Line %d skipped: Empty mandatory Title field."
 msgstr "Zeile %d übersprungen: Pflichtfeld Titel ist leer."
 
-#: ../../../core/core_st.cpp:189
+#: ../../../core/core_st.cpp:191
 #, c-format
 msgid " Import # %d"
 msgstr " Importieren # %d"
 
-#: ../../../core/core_st.cpp:190
+#: ../../../core/core_st.cpp:192
 #, c-format
 msgid "%ls - Imported %ls"
 msgstr "%ls  - Importiert %ls"
 
-#: ../../../core/core_st.cpp:191
+#: ../../../core/core_st.cpp:193
 msgid ""
 "To replace passwords of existing entries, all the following columns must be "
 "present: Group/Title, Username and Password.  One or more are missing and no "
@@ -5328,19 +5350,19 @@ msgstr ""
 "vorhanden sein: Gruppe/Titel, Benutzername und Passwort. Mindestens eines "
 "fehlt, und es wurde kein Eintrag aktualisiert."
 
-#: ../../../core/core_st.cpp:192
+#: ../../../core/core_st.cpp:194
 #, c-format
 msgid "%ls not found. Cannot update entry's password.\n"
 msgstr ""
 "%ls nicht gefunden. Das Passwort des Eintrages kann nicht aktualisiert "
 "werden.\n"
 
-#: ../../../core/core_st.cpp:193
+#: ../../../core/core_st.cpp:195
 #, c-format
 msgid "%ls has an empty %ls.\n"
 msgstr "%ls hat ein leeres %ls.\n"
 
-#: ../../../core/core_st.cpp:194
+#: ../../../core/core_st.cpp:196
 #, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5349,12 +5371,12 @@ msgstr ""
 "Eintrag \"%ls, %ls, %ls\" hat ein Passwort im richtigen Format für einen "
 "Alias, jedoch ist der Basiseintrag bereits ein Alias."
 
-#: ../../../core/core_st.cpp:195
+#: ../../../core/core_st.cpp:197
 msgid "\tThis entry has been made an alias of associated base entry."
 msgstr ""
 "\tDieser Eintrag wurde zum Alias des zugehörigen Basiseintrags gemacht."
 
-#: ../../../core/core_st.cpp:196
+#: ../../../core/core_st.cpp:198
 #, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5363,14 +5385,14 @@ msgstr ""
 "Eintrag \"%ls, %ls, %ls\" hat ein Passwort im richtigen Format für einen "
 "Alias, jedoch existiert der Basiseintrag  nicht."
 
-#: ../../../core/core_st.cpp:197
+#: ../../../core/core_st.cpp:199
 msgid ""
 "\tThis entry remains a normal entry and the password has not been changed."
 msgstr ""
 "\tDieser Eintrag bleibt ein normaler Eintrag und das Passwort wurde nicht "
 "geändert."
 
-#: ../../../core/core_st.cpp:198
+#: ../../../core/core_st.cpp:200
 #, c-format
 msgid ""
 "The %ls entry \"%ls, %ls, %ls\" doesn't point to a normal or existing %ls "
@@ -5379,69 +5401,69 @@ msgstr ""
 "Der %ls Eintrag \"%ls, %ls, %ls\" verweist nicht auf einen normalen oder "
 "bestehenden %ls Basiseintrag und kann somit nicht importiert werden."
 
-#: ../../../core/core_st.cpp:199
+#: ../../../core/core_st.cpp:201
 msgid "Entry import warnings"
 msgstr "Warnungen bzgl. des Importierens von Einträgen"
 
-#: ../../../core/core_st.cpp:200
+#: ../../../core/core_st.cpp:202
 msgid "id="
 msgstr "id="
 
-#: ../../../core/core_st.cpp:201
+#: ../../../core/core_st.cpp:203
 msgid "on line "
 msgstr "in Zeile"
 
-#: ../../../core/core_st.cpp:202
+#: ../../../core/core_st.cpp:204
 msgid "Internal error: Invalid oflag or pmode argument"
 msgstr "Interner Fehler: ungültiges oflag oder pmode Argument"
 
-#: ../../../core/core_st.cpp:203
+#: ../../../core/core_st.cpp:205
 msgid "invalid!"
 msgstr "ungültig!"
 
-#: ../../../core/core_st.cpp:204
+#: ../../../core/core_st.cpp:206
 msgid "  Invalid date/time value."
 msgstr "  Datum bzw. Uhrzeit ungültig."
 
-#: ../../../core/core_st.cpp:205
+#: ../../../core/core_st.cpp:207
 msgid "  Field length is incorrect."
 msgstr "  Feldlänge ist nicht richtig."
 
-#: ../../../core/core_st.cpp:206
+#: ../../../core/core_st.cpp:208
 msgid "Internal error: An invalid flag was specified"
 msgstr "Interner Fehler: ungültiges Flag definiert"
 
-#: ../../../core/core_st.cpp:207
+#: ../../../core/core_st.cpp:209
 #, c-format
 msgid "  Invalid header: '%ls' (must be 5 hexadecimal characters)."
 msgstr "  Ungültiger Header: '%ls' (müssen 5 hexadezimale Zeichen sein)."
 
-#: ../../../core/core_st.cpp:208
+#: ../../../core/core_st.cpp:210
 #, c-format
 msgid "Invalid lock file \"%ls\"."
 msgstr "Ungültige Datei-Sperre \"%ls\"."
 
-#: ../../../core/core_st.cpp:209
+#: ../../../core/core_st.cpp:211
 #, c-format
 msgid "  Invalid number of saved old passwords %d."
 msgstr "  Ungültige Anzahl alter gespeicherter Passwörter %d."
 
-#: ../../../core/core_st.cpp:210
+#: ../../../core/core_st.cpp:212
 #, c-format
 msgid "  Invalid status value: %d (must be either 0 or 1)."
 msgstr "  Ungültiger Statuswert: %d (muss 0 oder 1 sein)."
 
-#: ../../../core/core_st.cpp:211
+#: ../../../core/core_st.cpp:213
 msgid "  Invalid password length found (not a hexadecimal number)."
 msgstr "  Ungültige Passwortlänge gefunden (ist keine hexadezimale Zahl)."
 
-#: ../../../core/core_st.cpp:212
+#: ../../../core/core_st.cpp:214
 msgid ""
 "  Invalid password length found (differs from length of following password)."
 msgstr ""
 "  Ungültige Passwortlänge gefunden (Längenunterschied zu folgendem Passwort)."
 
-#: ../../../core/core_st.cpp:213
+#: ../../../core/core_st.cpp:215
 msgid ""
 "  Invalid field separator character found - only a single blank is allowed "
 "between fields."
@@ -5449,20 +5471,20 @@ msgstr ""
 "  Ungültiges Feldtrennzeichen gefunden - nur ein einzelnes Leerzeichen ist "
 "zwischen Feldern erlaubt."
 
-#: ../../../core/core_st.cpp:214
+#: ../../../core/core_st.cpp:216
 msgid "Invalid Filter schema."
 msgstr "Ungültiges Filterschema."
 
-#: ../../../core/core_st.cpp:215
+#: ../../../core/core_st.cpp:217
 msgid "Schema does not have a version number."
 msgstr "Schema hat keine Versionsnummer."
 
-#: ../../../core/core_st.cpp:216
+#: ../../../core/core_st.cpp:218
 #, c-format
 msgid "The filter XML version (%d) is greater than the current schema (%d)."
 msgstr "XML Version (%d) des Filters größer als das aktuelle Schema (%d)."
 
-#: ../../../core/core_st.cpp:217
+#: ../../../core/core_st.cpp:219
 #, c-format
 msgid ""
 "The filter XML version (%d) is greater than that supported by this instance "
@@ -5471,31 +5493,31 @@ msgstr ""
 "Die Filter XML Version (%d) ist größer als die von PasswordSafe unterstützte "
 "(%d)."
 
-#: ../../../core/core_st.cpp:218
+#: ../../../core/core_st.cpp:220
 msgid "is"
 msgstr "ist"
 
-#: ../../../core/core_st.cpp:219
+#: ../../../core/core_st.cpp:221
 msgid "is active"
 msgstr "ist aktiv"
 
-#: ../../../core/core_st.cpp:220
+#: ../../../core/core_st.cpp:222
 msgid "is inactive"
 msgstr "ist inaktiv"
 
-#: ../../../core/core_st.cpp:221
+#: ../../../core/core_st.cpp:223
 msgid "is not"
 msgstr "ist nicht"
 
-#: ../../../core/core_st.cpp:222
+#: ../../../core/core_st.cpp:224
 msgid "is not present"
 msgstr "ist nicht vorhanden"
 
-#: ../../../core/core_st.cpp:223
+#: ../../../core/core_st.cpp:225
 msgid "is present"
 msgstr "ist vorhanden"
 
-#: ../../../core/core_st.cpp:224
+#: ../../../core/core_st.cpp:226
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to entry %ls. It "
@@ -5504,7 +5526,7 @@ msgstr ""
 "Tastaturkürzel %ls zu Eintrag %ls ist bereits mit Eintrag %ls assoziiert. "
 "Wurde bereits von Eintrag %ls entfernt."
 
-#: ../../../core/core_st.cpp:225
+#: ../../../core/core_st.cpp:227
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to the "
@@ -5513,19 +5535,19 @@ msgstr ""
 "Tastaturkürzel %ls zu Eintrag %ls ist bereits mit der PasswordSafe Anwendung "
 "assoziiert. Wurde bereits vom Eintrag entfernt."
 
-#: ../../../core/core_st.cpp:226
+#: ../../../core/core_st.cpp:228
 msgid "less than"
 msgstr "weniger als"
 
-#: ../../../core/core_st.cpp:227
+#: ../../../core/core_st.cpp:229
 msgid "less than or equal to"
 msgstr "kleiner als oder gleich mit"
 
-#: ../../../core/core_st.cpp:228
+#: ../../../core/core_st.cpp:230
 msgid "File or path not found"
 msgstr "Datei oder Pfad nicht gefunden"
 
-#: ../../../core/core_st.cpp:229
+#: ../../../core/core_st.cpp:231
 #, c-format
 msgid ""
 "\n"
@@ -5534,7 +5556,7 @@ msgstr ""
 "\n"
 "Folgender neue %ls %ls zusammengeführt mit dieser Datenbank:"
 
-#: ../../../core/core_st.cpp:230
+#: ../../../core/core_st.cpp:232
 #, c-format
 msgid ""
 "\n"
@@ -5544,7 +5566,7 @@ msgstr ""
 "Zusammenführen abgeschlossen: %d %ls hinzugefügt (%d %ls, %d %ls, %d %ls, %d "
 "%ls)"
 
-#: ../../../core/core_st.cpp:231
+#: ../../../core/core_st.cpp:233
 #, c-format
 msgid ""
 "Conflicting entries for \"%ls\" \"%ls\" \"%ls\".\n"
@@ -5555,25 +5577,25 @@ msgstr ""
 "  Zusammengefügter Eintrag hinzugefügt als \"%ls\" \"%ls\" \"%ls\".\n"
 "    Unterschiedliche Felder: %ls"
 
-#: ../../../core/core_st.cpp:232
+#: ../../../core/core_st.cpp:234
 msgid "merged"
 msgstr "zusammengefügt"
 
-#: ../../../core/core_st.cpp:233
+#: ../../../core/core_st.cpp:235
 #, c-format
 msgid "%ls - Merged %ls"
 msgstr "%ls - Zusammengeführt %ls"
 
-#: ../../../core/core_st.cpp:234
+#: ../../../core/core_st.cpp:236
 msgid "MISSING PASSWORD"
 msgstr "KEIN PASSWORT"
 
-#: ../../../core/core_st.cpp:235
+#: ../../../core/core_st.cpp:237
 #, c-format
 msgid "\tPassword policy name '%ls' is not in the database."
 msgstr "\tPasswortrichtlinienname '%ls' ist nicht in der Datenbank."
 
-#: ../../../core/core_st.cpp:236
+#: ../../../core/core_st.cpp:238
 msgid ""
 "\tOne or more Password Policy Names were not found in the database. The "
 "affected entries have been changed to use the database's default policy."
@@ -5582,35 +5604,35 @@ msgstr ""
 "Die betroffenen Einträge wurden modifiziert und verwenden jetzt die Standard-"
 "Richtlinie dieser Datenbank."
 
-#: ../../../core/core_st.cpp:237
+#: ../../../core/core_st.cpp:239
 #, c-format
 msgid "MISSING TITLE # %d"
 msgstr "KEIN TITEL # %d"
 
-#: ../../../core/core_st.cpp:239
+#: ../../../core/core_st.cpp:241
 msgid "Can't obtain the schema version."
 msgstr "Kann die Version des Schema nicht ermitteln."
 
-#: ../../../core/core_st.cpp:240
+#: ../../../core/core_st.cpp:242
 msgid "The filter XML version is missing."
 msgstr "Die Filter XML Version fehlt."
 
-#: ../../../core/core_st.cpp:241
+#: ../../../core/core_st.cpp:243
 #, c-format
 msgid "Create SchemaCache60 Error 0x%08X during %ls."
 msgstr "Create SchemaCache60 Fehler 0x%08X während %ls."
 
-#: ../../../core/core_st.cpp:242
+#: ../../../core/core_st.cpp:244
 #, c-format
 msgid "SAX Parse60 Error 0x%08X during %ls."
 msgstr "SAX Parse60 Fehler 0x%08X während %ls."
 
-#: ../../../core/core_st.cpp:243
+#: ../../../core/core_st.cpp:245
 #, c-format
 msgid "Error (%08X): line %d character %d %ls"
 msgstr "Fehler (%08X): Zeile %d Zeichen %d %ls"
 
-#: ../../../core/core_st.cpp:245
+#: ../../../core/core_st.cpp:247
 msgid ""
 "Unable to get configuration file lock.\n"
 "\n"
@@ -5620,15 +5642,15 @@ msgstr ""
 "\n"
 "Benutze die Registrierungsdatenbank."
 
-#: ../../../core/core_st.cpp:246
+#: ../../../core/core_st.cpp:248
 msgid "Cannot create lock file - no permission in directory?"
 msgstr "Kann keine lock-Datei erzeugen - keine Rechte im Verzeichnis?"
 
-#: ../../../core/core_st.cpp:247
+#: ../../../core/core_st.cpp:249
 msgid "Internal error: Out of file handles"
 msgstr "Interner Fehler: kein Dateihandler mehr"
 
-#: ../../../core/core_st.cpp:248
+#: ../../../core/core_st.cpp:250
 msgid ""
 "Unable to use a MS XML reader on your system.  Neither MS XML V3, V4 or V6 "
 "seems available."
@@ -5636,15 +5658,15 @@ msgstr ""
 "Kann die MS XML-Unterstützung nicht benutzen. Keine der Versionen 3, 4 oder "
 "6 scheinen verfügbar."
 
-#: ../../../core/core_st.cpp:250
+#: ../../../core/core_st.cpp:252
 msgid "Unsaved changes"
 msgstr "Ungesicherte Änderungen"
 
-#: ../../../core/core_st.cpp:251
+#: ../../../core/core_st.cpp:253
 msgid "is not set"
 msgstr "ist nicht gesetzt"
 
-#: ../../../core/core_st.cpp:252
+#: ../../../core/core_st.cpp:254
 #, c-format
 msgid ""
 "Number of entries processed: %d\n"
@@ -5682,7 +5704,7 @@ msgstr ""
 "Anzahl der Einträge mit Felder die nicht ganz angezeigt werden können: %d\"\n"
 "Die Datenbank ist nun gespeichert."
 
-#: ../../../core/core_st.cpp:254
+#: ../../../core/core_st.cpp:256
 msgid ""
 "Password should be mixed case, with at least one digit or punctuation "
 "character"
@@ -5690,53 +5712,57 @@ msgstr ""
 "Das Passwort sollte Klein- und Großbuchstaben sowie mindestens eine Ziffer "
 "oder ein Sonderzeichen enthalten"
 
-#: ../../../core/core_st.cpp:255
+#: ../../../core/core_st.cpp:257
 msgid "Password is too short"
 msgstr "Passwort ist zu kurz"
 
-#: ../../../core/core_st.cpp:256
+#: ../../../core/core_st.cpp:258
 msgid "Easyvision characters"
 msgstr "Easyvision Zeichen"
 
-#: ../../../core/core_st.cpp:257
+#: ../../../core/core_st.cpp:259
 msgid "Hexadecimal characters"
 msgstr "Hexadezimale Zeichen"
 
-#: ../../../core/core_st.cpp:258
+#: ../../../core/core_st.cpp:260
 msgid "Password length"
 msgstr "Passwortlänge"
 
-#: ../../../core/core_st.cpp:259
+#: ../../../core/core_st.cpp:261
 msgid "Pronounceable passwords"
 msgstr "Aussprechbare Passwörter"
 
-#: ../../../core/core_st.cpp:261
+#: ../../../core/core_st.cpp:263
 msgid "Use lowercase characters"
 msgstr "Verwende Kleinbuchstaben"
 
-#: ../../../core/core_st.cpp:263
+#: ../../../core/core_st.cpp:265
 msgid "Use uppercase characters"
 msgstr "Verwende Großbuchstaben"
 
-#: ../../../core/core_st.cpp:264
+#: ../../../core/core_st.cpp:266
 #, c-format
 msgid "Error in a Password History %ls:"
 msgstr "Fehler in der Passworthistorie %ls:"
 
-#: ../../../core/core_st.cpp:265
+#: ../../../core/core_st.cpp:267
 #, c-format
 msgid "sub-field starting at position %d (within the History field): "
 msgstr "Unterfeld beginnend bei Position %d (im Feld Historie): "
 
-#: ../../../core/core_st.cpp:266
+#: ../../../core/core_st.cpp:268
 msgid "  All Password History ignored."
 msgstr "  Gesamte Passworthistorie ignoriert."
 
-#: ../../../core/core_st.cpp:267
+#: ../../../core/core_st.cpp:269
 msgid "Read Error"
 msgstr "Lesefehler"
 
-#: ../../../core/core_st.cpp:268
+#: ../../../core/core_st.cpp:270
+msgid "Relative"
+msgstr "ralativ"
+
+#: ../../../core/core_st.cpp:271
 #, c-format
 msgid ""
 "\tOne or more entry keyboard shortcuts were already assigned to entries in "
@@ -5745,7 +5771,7 @@ msgstr ""
 "\tEin oder mehrere Tastaturkürzel sind bereits Einträgen in dieser Datenbank "
 "zugewiesen. Diese wurden vom Eintrag %ls entfernt."
 
-#: ../../../core/core_st.cpp:269
+#: ../../../core/core_st.cpp:272
 msgid ""
 "\tOne or more Password Policy Names were already in this database but had "
 "different settings. They have been renamed."
@@ -5753,30 +5779,71 @@ msgstr ""
 "Ein oder mehrere Namen von Passwortrichtlinien befinden sich bereits in "
 "dieser Datenbank, jedoch mit anderen Einstellungen. Diese wurden umbenannt."
 
-#: ../../../core/core_st.cpp:270
+#: ../../../core/core_st.cpp:273
 #, c-format
 msgid "%ls%ls%ls_Report.txt"
 msgstr ""
 
-#: ../../../core/core_st.cpp:271
+#: ../../../core/core_st.cpp:274
 #, c-format
 msgid "Report of %ls function started at %ls"
 msgstr "Bericht von %ls Funktion begonnen am %ls"
 
-#: ../../../core/core_st.cpp:272
+#: ../../../core/core_st.cpp:275
 #, c-format
 msgid "on database %ls"
 msgstr "auf Datenbank %ls"
 
-#: ../../../core/core_st.cpp:273
+#: ../../../core/core_st.cpp:276
+msgid "Compare"
+msgstr "Vergleichen"
+
+#: ../../../core/core_st.cpp:277
+#, fuzzy
+msgid "Export_DB"
+msgstr "Exportiere DB"
+
+#: ../../../core/core_st.cpp:278
+#, fuzzy
+msgid "Export_Text"
+msgstr "Exportiere Text"
+
+#: ../../../core/core_st.cpp:279
+#, fuzzy
+msgid "Export_XML"
+msgstr "Exportiere XML"
+
+#: ../../../core/core_st.cpp:281
+#, fuzzy
+msgid "Import_KeePassV1_CSV"
+msgstr "Importiere KeePassV1 CSV"
+
+#: ../../../core/core_st.cpp:282
+#, fuzzy
+msgid "Import_KeePassV1_TXT"
+msgstr "Importiere KeePassV1 TXT"
+
+#: ../../../core/core_st.cpp:283
+msgid "Import_Text"
+msgstr "Import_Text"
+
+#: ../../../core/core_st.cpp:284
+msgid "Import_XML"
+msgstr "Import_XML"
+
+#: ../../../core/core_st.cpp:285
+msgid "Merge"
+msgstr "Zusammenführen"
+
+#: ../../../core/core_st.cpp:287
 msgid "Validate"
 msgstr "Überprüfen"
 
-#: ../../../core/core_st.cpp:275
+#: ../../../core/core_st.cpp:289
 msgid "Fatal Error"
 msgstr "Fataler Fehler"
 
-#: ../../../core/core_st.cpp:277
+#: ../../../core/core_st.cpp:291
 #, c-format
 msgid ""
 "\n"
@@ -5785,115 +5852,125 @@ msgstr ""
 "\n"
 "Fehler in Passworthistorie für Eintrag: \"%ls\"%ls\"%ls\": "
 
-#: ../../../core/core_st.cpp:278
+#: ../../../core/core_st.cpp:292
+#, c-format
+msgid "\tNo entries were found containing search string '%ls' %ls"
+msgstr "\tKeine Einträge enthalten den Suchtext '%ls' %ls"
+
+#: ../../../core/core_st.cpp:293
+#, c-format
+msgid "\tThe following entries contain search string '%ls' %ls"
+msgstr "\tFolgende Einträge enthalten den Suchtext '%ls' %ls"
+
+#: ../../../core/core_st.cpp:294
 msgid "See Attachment filters"
 msgstr "Siehe Anhangfilter"
 
-#: ../../../core/core_st.cpp:279
+#: ../../../core/core_st.cpp:295
 msgid "See Password History filters"
 msgstr "Siehe Passworthistoriefilter"
 
-#: ../../../core/core_st.cpp:280
+#: ../../../core/core_st.cpp:296
 msgid "See Password Policy filters"
 msgstr "Siehe Passwortrichtlinienfilter"
 
-#: ../../../core/core_st.cpp:281
+#: ../../../core/core_st.cpp:297
 msgid "is set"
 msgstr "ist gesetzt"
 
-#: ../../../core/core_st.cpp:282
+#: ../../../core/core_st.cpp:298
 msgid "shortcut"
 msgstr "Verknüpfung"
 
-#: ../../../core/core_st.cpp:283
+#: ../../../core/core_st.cpp:299
 msgid "shortcuts"
 msgstr "Verknüpfungen"
 
-#: ../../../core/core_st.cpp:284
+#: ../../../core/core_st.cpp:300
 msgid "policy specific symbols"
 msgstr "Richtlinienspezifischer Zeichensatz"
 
-#: ../../../core/core_st.cpp:285
+#: ../../../core/core_st.cpp:301
 msgid "Start Report"
 msgstr "Starte Bericht"
 
-#: ../../../core/core_st.cpp:286
+#: ../../../core/core_st.cpp:302
 msgid "Double-Click on entry to Autotype"
 msgstr "Eintrag doppelklicken für autom. Eingabe"
 
-#: ../../../core/core_st.cpp:287
+#: ../../../core/core_st.cpp:303
 msgid "Double-Click on entry to Browse to URL"
 msgstr "Eintrag doppelklicken um URL aufzurufen"
 
-#: ../../../core/core_st.cpp:288
+#: ../../../core/core_st.cpp:304
 msgid "Double-Click on entry to Browse to URL + Autotype"
 msgstr "Eintrag doppelklicken um URL aufzurufen + autom. Eingabe"
 
-#: ../../../core/core_st.cpp:289
+#: ../../../core/core_st.cpp:305
 msgid "https://pwsafe.org/"
 msgstr ""
 
-#: ../../../core/core_st.cpp:290
+#: ../../../core/core_st.cpp:306
 msgid "Double-Click on entry to Copy Notes"
 msgstr "Eintrag doppelklicken um Notizen zu kopieren"
 
-#: ../../../core/core_st.cpp:291
+#: ../../../core/core_st.cpp:307
 msgid "Double-Click on entry to Copy Password"
 msgstr "Eintrag doppelklicken um Passwort zu kopieren"
 
-#: ../../../core/core_st.cpp:292
+#: ../../../core/core_st.cpp:308
 msgid "Double-Click on entry to Copy Password and Minimize"
 msgstr "Eintrag doppelklicken um Passwort zu kopieren und minimieren"
 
-#: ../../../core/core_st.cpp:293
+#: ../../../core/core_st.cpp:309
 msgid "Double-Click on entry to Copy Username"
 msgstr "Eintrag doppelklicken um Benutzername zu kopieren"
 
-#: ../../../core/core_st.cpp:294
+#: ../../../core/core_st.cpp:310
 msgid "Double-Click on entry to Run Command"
 msgstr "Eintrag doppelklicken um Kommando auszuführen"
 
-#: ../../../core/core_st.cpp:295
+#: ../../../core/core_st.cpp:311
 msgid "Double-Click on entry to Send Email"
 msgstr "Eintrag doppelklicken um Email zu schreiben"
 
-#: ../../../core/core_st.cpp:296
+#: ../../../core/core_st.cpp:312
 msgid "Double-Click on entry to View/Edit it"
 msgstr "Eintrag doppelklicken zum Anzeigen/Bearbeiten"
 
-#: ../../../core/core_st.cpp:299
+#: ../../../core/core_st.cpp:315
 #, c-format
 msgid "%ls - Sync'd %ls"
 msgstr "%ls - Sync't %ls"
 
-#: ../../../core/core_st.cpp:300
+#: ../../../core/core_st.cpp:316
 msgid "System error: No more file handles available"
 msgstr "Systemfehler: kein Dateihandle mehr verfügbar"
 
-#: ../../../core/core_st.cpp:303
+#: ../../../core/core_st.cpp:319
 msgid "Unknown function"
 msgstr "Unbekannte Funktion"
 
-#: ../../../core/core_st.cpp:304
+#: ../../../core/core_st.cpp:320
 msgid "Unknown object"
 msgstr "Unbekanntes Objekt"
 
-#: ../../../core/core_st.cpp:305
+#: ../../../core/core_st.cpp:321
 msgid "Internal error: Unexpected error number"
 msgstr "Interner Fehler: unerwartete Fehlernummer"
 
-#: ../../../core/core_st.cpp:307
+#: ../../../core/core_st.cpp:323
 #, c-format
 msgid "\tName: %s; Filename: %s"
 msgstr "\tName: %s; Dateiname: %s"
 
-#: ../../../core/core_st.cpp:308
+#: ../../../core/core_st.cpp:324
 msgid ""
 "The following entries had an invalid UUID field.  This has been corrected."
 msgstr ""
 "Folgende Einträge hatten ein ungültiges UUID Feld. Das wurde korrigiert."
 
-#: ../../../core/core_st.cpp:309
+#: ../../../core/core_st.cpp:325
 #, c-format
 msgid ""
 "The following entries have passwords in the correct form for %ls, but the "
@@ -5902,16 +5979,16 @@ msgstr ""
 "Folgende Einträge besitzen Passwörter im richtigen Format für %ls, jedoch "
 "existiert hierzu kein Basiseintrag."
 
-#: ../../../core/core_st.cpp:310
+#: ../../../core/core_st.cpp:326
 msgid "The following entries were duplicates of an existing entry."
 msgstr "Folgende Einträge waren Duplikate eines bestehenden Eintrages."
 
-#: ../../../core/core_st.cpp:311
+#: ../../../core/core_st.cpp:327
 msgid ""
 "The following entries had a duplicate UUID field.  This has been corrected."
 msgstr "Folgende Einträge hatten ein gleiches UUID Feld. Das wurde korrigiert."
 
-#: ../../../core/core_st.cpp:312
+#: ../../../core/core_st.cpp:328
 #, c-format
 msgid ""
 "The following entries had an empty Password field, which is not permitted. "
@@ -5920,34 +5997,34 @@ msgstr ""
 "Folgende Einträge hatten ein leeres Passwortfeld, was nicht erlaubt ist. Das "
 "Passwort wurde auf '%ls' gesetzt"
 
-#: ../../../core/core_st.cpp:313
+#: ../../../core/core_st.cpp:329
 msgid "The following entries had an empty Title field, which is not permitted."
 msgstr ""
 "Folgende Einträge hatten ein leeres Titelfeld Titel, was nicht erlaubt ist."
 
-#: ../../../core/core_st.cpp:314
+#: ../../../core/core_st.cpp:330
 #, c-format
 msgid "\tGroup='%ls', Title='%ls', User='%ls' %ls"
 msgstr "\tGruppe='%ls'; Titel='%ls'; Benutzer='%ls' %ls"
 
-#: ../../../core/core_st.cpp:315
+#: ../../../core/core_st.cpp:331
 #, c-format
 msgid "- Its title has been changed to:'%ls'"
 msgstr "- Der Titel wurde geändert in: '%ls'"
 
-#: ../../../core/core_st.cpp:316
+#: ../../../core/core_st.cpp:332
 msgid "The following ERRORS were detected and were FIXED."
 msgstr "Folgende FEHLER wurden festgestellt und BEREINIGT."
 
-#: ../../../core/core_st.cpp:317
+#: ../../../core/core_st.cpp:333
 msgid "The following entries refer to missing attachments."
 msgstr "Die folgende Einträge verweisen auf fehlende Anhänge."
 
-#: ../../../core/core_st.cpp:318
+#: ../../../core/core_st.cpp:334
 msgid "The following attachments are not referred to by any entry."
 msgstr "Auf die folgende Anhänge wird von keinen Einträgen verwiesen."
 
-#: ../../../core/core_st.cpp:319
+#: ../../../core/core_st.cpp:335
 msgid ""
 "The following entries had an invalid Password History.  This has been "
 "rebuilt with available data.  There may be some loss of history."
@@ -5956,7 +6033,7 @@ msgstr ""
 "vorhandenen Daten wieder aufgebaut. Ein Teil der Historie könnte verloren "
 "gegangen sein."
 
-#: ../../../core/core_st.cpp:320
+#: ../../../core/core_st.cpp:336
 #, c-format
 msgid ""
 "The following entries have one or more text fields too long to display or "
@@ -5966,7 +6043,7 @@ msgstr ""
 "zum Anzeigen oder Bearbeiten (mehr als %d Zeichen). Der längste Eintrag hat ~"
 "%d %ls."
 
-#: ../../../core/core_st.cpp:321
+#: ../../../core/core_st.cpp:337
 msgid ""
 "The following WARNINGS were detected - you should review and fix them "
 "manually."
@@ -5974,11 +6051,11 @@ msgstr ""
 "Folgende WARNUNGEN wurden festgestellt - Sie sollten sich diese anschauen "
 "und händisch bereinigen."
 
-#: ../../../core/core_st.cpp:324
+#: ../../../core/core_st.cpp:340
 msgid "will expire"
 msgstr "wird ablaufen"
 
-#: ../../../core/core_st.cpp:325
+#: ../../../core/core_st.cpp:341
 #, c-format
 msgid ""
 "SAX Parse Error during %ls\n"
@@ -5987,23 +6064,23 @@ msgstr ""
 "SAX Parse Fehler während %ls\n"
 "%ls."
 
-#: ../../../core/core_st.cpp:326
+#: ../../../core/core_st.cpp:342
 #, c-format
 msgid "XML %ls: line %d character %d: %ls"
 msgstr "XML %ls: Zeile %d Zeichen %d: %ls"
 
-#: ../../../core/core_st.cpp:327
+#: ../../../core/core_st.cpp:343
 msgid ""
 "*** Invalid XML characters found - see exported XML file for more details ***"
 msgstr ""
 "*** Unzulässige XML-Zeichen gefunden - siehe exportierte XML-Datei für mehr "
 "Details"
 
-#: ../../../core/core_st.cpp:328
+#: ../../../core/core_st.cpp:344
 msgid "Internal error: Couldn't initialize config file XML structure"
 msgstr "Interner Fehler: Couldn't initialize config file XML structure"
 
-#: ../../../core/core_st.cpp:329
+#: ../../../core/core_st.cpp:345
 msgid ""
 "A filter was active. Export of data was restricted to include only those "
 "displayed."
@@ -6011,11 +6088,11 @@ msgstr ""
 "Ein Filter war aktiv. Der Export wurde beschränkt auf die angezeigten "
 "Elemente."
 
-#: ../../../core/core_st.cpp:330
+#: ../../../core/core_st.cpp:346
 msgid "Export of data was restricted to certain fields by the user."
 msgstr "Der Export wurde von Benutzer auf bestimmte Felder eingeschänkt."
 
-#: ../../../core/core_st.cpp:331
+#: ../../../core/core_st.cpp:347
 msgid ""
 "Note: These Password Policies will not replace existing policies with the "
 "same name in the current database."
@@ -6023,24 +6100,24 @@ msgstr ""
 "Hinweis: Diese Passwortrichtlinien ersetzen nicht die bestehenden "
 "Richtlinien mit dem selben Namen in der aktuellen Datenbank."
 
-#: ../../../core/core_st.cpp:332
+#: ../../../core/core_st.cpp:348
 msgid ""
 "Note: These preferences are only used when importing into an empty database."
 msgstr ""
 "Hinweis: Diese Präferenzen werden nur beim Importieren in einer leeren "
 "Datenbank verwendet."
 
-#: ../../../core/core_st.cpp:333
+#: ../../../core/core_st.cpp:349
 msgid "Subset of entries restricted by the following rule:"
 msgstr "Untermenge der Einträge, eingeschränkt nach folgender Regel:"
 
-#: ../../../core/core_st.cpp:334
+#: ../../../core/core_st.cpp:350
 msgid ""
 "The user specified that the following fields be excluded from the export:"
 msgstr ""
 "Vom Benutzer wurde festgelegt folgende Felder vom Export auszuschließen:"
 
-#: ../../../core/core_st.cpp:335
+#: ../../../core/core_st.cpp:351
 #, c-format
 msgid ""
 "Configuration file error:\n"
@@ -6053,15 +6130,15 @@ msgstr ""
 "%ls\n"
 "Offset ungefähr bei %d"
 
-#: ../../../core/core_st.cpp:336
+#: ../../../core/core_st.cpp:352
 msgid "import"
 msgstr "importiere"
 
-#: ../../../core/core_st.cpp:337
+#: ../../../core/core_st.cpp:353
 msgid "Unable to load configuration file"
 msgstr "Kann die Konfigurationsdatei nicht öffnen"
 
-#: ../../../core/core_st.cpp:338
+#: ../../../core/core_st.cpp:354
 msgid ""
 "Failed to lock configuration file - opened by another instance of "
 "PasswordSafe?"
@@ -6069,93 +6146,37 @@ msgstr ""
 "Sperrung der Konfigurationsdatei fehlgeschlagen - geöffnet von einer anderen "
 "Instanz von PasswordSafe?"
 
-#: ../../../core/core_st.cpp:339
+#: ../../../core/core_st.cpp:355
 msgid "Unable to save configuration file"
 msgstr "Kann Konfigurationsdatei nicht speichern"
 
-#: ../../../core/core_st.cpp:340
+#: ../../../core/core_st.cpp:356
 msgid "validation"
 msgstr "Überprüfung"
 
-#: ../../../core/core_st.cpp:342
+#: ../../../core/core_st.cpp:358
 msgid " (EasyVision Symbols)"
 msgstr " (Zeichen zum einfachen Erkennen)"
 
-#: ../../../core/core_st.cpp:343
+#: ../../../core/core_st.cpp:359
 #, c-format
 msgid "Yes (at least %d)"
 msgstr "Ja (mindestens %d)"
 
-#: ../../../core/core_st.cpp:344
+#: ../../../core/core_st.cpp:360
 msgid " (Pronounceable Symbols)"
 msgstr " (Aussprechbare Symbole)"
 
-#: ../../../core/core_st.cpp:345
+#: ../../../core/core_st.cpp:361
 #, c-format
 msgid "Yes - At least %d from %ls: %ls%ls"
 msgstr "Ja - Mindestens %d von %ls: %ls%ls"
 
-#: ../../../core/core_st.cpp:346
-#, c-format
-msgid "\tGroup='%ls', Title='%ls', User='%ls'"
-msgstr "\tGruppe='%ls', Titel='%ls', Benutzer='%ls'"
+#~ msgid "Import XML"
+#~ msgstr "&XML importieren"
 
-#: ../../../core/core_st.cpp:347
-#, c-format
-msgid ""
-"Compare complete of current database:\n"
-"\t %ls\n"
-" and:\n"
-"\t %ls\n"
-msgstr ""
-"Vollständiger Vergleich zwischen aktueller Datenbank:\n"
-"\t %ls\n"
-" und:\n"
-"\t %ls\n"
-
-#: ../../../core/core_st.cpp:348
-#, c-format
-msgid "\tNo entries were found containing search string '%ls' %ls"
-msgstr "\tKeine Einträge enthalten den Suchtext '%ls' %ls"
-
-#: ../../../core/core_st.cpp:349
-#, c-format
-msgid "\tThe following entries contain search string '%ls' %ls"
-msgstr "\tFolgende Einträge enthalten den Suchtext '%ls' %ls"
-
-#: ../../../core/core_st.cpp:350
-msgid "Export DB"
-msgstr "Exportiere DB"
-
-#: ../../../core/core_st.cpp:351
-msgid "Import KeePassV1 CSV"
-msgstr "Importiere KeePassV1 CSV"
-
-#: ../../../core/core_st.cpp:352
-msgid "Import KeePassV1 TXT"
-msgstr "Importiere KeePassV1 TXT"
-
-#: ../../../core/core_st.cpp:353
-msgid "Import XML"
-msgstr "&XML importieren"
-
-#: ../../../core/core_st.cpp:354
-msgid "Import Text"
-msgstr "Text importieren"
-
-#: ../../../core/core_st.cpp:355
-msgid "Merge"
-msgstr "Zusammenführen"
-
-#: ../../../core/core_st.cpp:356
-msgid "Compare"
-msgstr "Vergleichen"
-
-#~ msgid "Import_Text"
-#~ msgstr "Import_Text"
-
-#~ msgid "Import_XML"
-#~ msgstr "Import_XML"
+#~ msgid "Import Text"
+#~ msgstr "Text importieren"
 
 #~ msgid "Advanced..."
 #~ msgstr "Erweitert..."

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-28 12:52+0100\n"
+"POT-Creation-Date: 2021-03-19 21:58+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -237,7 +237,7 @@ msgstr "Fechas y horas"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:348
 #: ../../../ui/wxWidgets/HelpMap.h:41 ../../../ui/wxWidgets/HelpMap.h:49
-#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:141
+#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:143
 msgid "Password Policy"
 msgstr "Política de contraseñas"
 
@@ -251,7 +251,7 @@ msgid "Set Date/Time"
 msgstr "Establecer fecha/hora"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:370
-#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:137
+#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:139
 msgid "Password"
 msgstr "Contraseña"
 
@@ -535,14 +535,14 @@ msgstr "Usar letras MAY&USCULAS"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:747
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:281
-#: ../../../core/core_st.cpp:260
+#: ../../../core/core_st.cpp:262
 #, fuzzy
 msgid "Use digits"
 msgstr "Usar &números"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:771
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:305
-#: ../../../core/core_st.cpp:262
+#: ../../../core/core_st.cpp:264
 #, fuzzy
 msgid "Use symbols"
 msgstr "símbolos"
@@ -577,7 +577,7 @@ msgstr "Generar contraseña &pronunciable"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:815
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:350
-#: ../../../core/core_st.cpp:253
+#: ../../../core/core_st.cpp:255
 msgid "Or"
 msgstr "O"
 
@@ -625,7 +625,7 @@ msgstr "Propiedades"
 #: ../../../ui/wxWidgets/CreateShortcutDlg.cpp:219
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:269
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:274
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
 msgid "Text"
 msgstr "Texto"
 
@@ -681,7 +681,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:160
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:173
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:192
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:301
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:317
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -796,7 +796,7 @@ msgstr "[Notas escondidas - clic aquí para mostrarlas]"
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:1653
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2145
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2820
-#: ../../../core/core_st.cpp:74
+#: ../../../core/core_st.cpp:76
 #, fuzzy
 msgid "Default Policy"
 msgstr "Valor predeterminado"
@@ -818,7 +818,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:144
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:151
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:159
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:200
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:201
 #: ../../../ui/wxWidgets/PWSafeApp.cpp:367
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:737
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:756
@@ -842,7 +842,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:249
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:277
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:316
-#: ../../../core/core_st.cpp:274
+#: ../../../core/core_st.cpp:288
 msgid "Error"
 msgstr "Error"
 
@@ -1014,7 +1014,7 @@ msgid "Synchronize this item..."
 msgstr "S&incronizar..."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:482
-#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:357
+#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:286
 msgid "Synchronize"
 msgstr "Sincronizar"
 
@@ -1096,8 +1096,8 @@ msgid "Current safe was opened read-only"
 msgstr "Abrir como sólo lectura"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:793
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:996
-#: ../../../ui/wxWidgets/SyncWizard.cpp:618
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
+#: ../../../ui/wxWidgets/SyncWizard.cpp:619
 #, fuzzy, c-format
 msgid ""
 "The database:\n"
@@ -1115,7 +1115,7 @@ msgstr ""
 "favor, corrija mediante la validación de la base de datos."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:794
-#: ../../../ui/wxWidgets/SyncWizard.cpp:617
+#: ../../../ui/wxWidgets/SyncWizard.cpp:618
 msgid "Synchronization failed"
 msgstr "Error de sincronización"
 
@@ -1484,7 +1484,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/GridCtrl.cpp:164
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:292
-#: ../../../core/core_st.cpp:147
+#: ../../../core/core_st.cpp:149
 msgid "Title"
 msgstr "Título"
 
@@ -1709,7 +1709,7 @@ msgid "Value"
 msgstr "Valor:"
 
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:291
-#: ../../../core/core_st.cpp:133
+#: ../../../core/core_st.cpp:135
 msgid "Group"
 msgstr "Grupo"
 
@@ -1794,17 +1794,17 @@ msgstr ""
 msgid "Error parsing Run Command"
 msgstr "Error al analizar el comando a ejecutar"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:56
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:57
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:355
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:362
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:166
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:623
 msgid "Write Error"
 msgstr "Error de escritura"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:61
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:62
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:165
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:622
 #, fuzzy
@@ -1814,7 +1814,7 @@ msgstr ""
 "\n"
 "¡No se puede abrir el archivo para escritura!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:64
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:65
 msgid ""
 "Write operation failed!\n"
 "File may have been corrupted.\n"
@@ -1824,7 +1824,7 @@ msgstr ""
 "El archivo puede haberse corrompido.\n"
 "Trata de grabarlo en otra ubicación"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:69
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:70
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 #, fuzzy
 msgid "Unknown error"
@@ -1833,38 +1833,38 @@ msgstr ""
 "\n"
 "Error desconocido"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:90
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:91
 #, fuzzy
 msgid "Do you want to save changes to the password database: "
 msgstr "¿Desea guardar los cambios en la base de datos: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:145
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:146
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:557
 msgid "Please choose a name for the new database"
 msgstr "Escoger nombre para la nueva base de datos"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:155
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:156
 #, fuzzy
 msgid "psafe3 files (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 msgstr ""
 "Bases de datos Password Safe (*.psafe3)|*.psafe3|Todos los archivos (*.*)|*."
 "*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Lock is done by yourself"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Remove Lock?"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:194
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:195
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:602
 #, fuzzy
 msgid "Could not lock file.\n"
@@ -1873,18 +1873,18 @@ msgstr ""
 "\n"
 "¡No se puede abrir el archivo para lectura!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:196
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:197
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:452
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:604
 msgid "Locked by "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:236
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:237
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:515
 msgid "Please Choose a Database to Open:"
 msgstr "Escoger base de datos a abrir:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:353
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Save database elsewhere or with "
@@ -1894,7 +1894,7 @@ msgid ""
 msgstr ""
 "%s. Trata de grabar la base de datos con otro nombre o salir sin grabar."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:360
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Do you wish to save changes to your "
@@ -1902,12 +1902,12 @@ msgid ""
 msgstr ""
 "%s. Trata de grabar la base de datos con otro nombre o salir sin grabar."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 msgid "Unable to create intermediate backup."
 msgstr "No ha sido posible crear respaldo intermedio."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:386
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:387
 #, fuzzy, c-format
 msgid ""
 "The original database, \"%ls\", is in pre-3.0 format. It will be unchanged.\n"
@@ -1922,12 +1922,12 @@ msgstr ""
 "en el formato antiguo, usa el comando \"Archivo->Exportar a->Formato (1.x or "
 "2)\" command."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:388
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:389
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:447
 msgid "File version warning"
 msgstr "Aviso de versión de archivo"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:445
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
 #, fuzzy, c-format
 msgid ""
 "The original database, '%ls', is in pre-3.0 format. The data will now be "
@@ -1940,15 +1940,15 @@ msgstr ""
 "antiguas de PasswordSafe. Para guardar los datos en el antiguo formato, usa "
 "el comando \"Archivo->Exportar a->Formato (1.x or 2)\" command."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:458
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
 msgid "Please choose a name for the current (Untitled) database:"
 msgstr "Escoger nombre para la base de datos actual:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:460
 msgid "Please choose a new name for the current database:"
 msgstr "Escoger un nombre nuevo para la base de datos actual:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:467
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:468
 #, fuzzy
 msgid ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|"
@@ -1957,7 +1957,7 @@ msgstr ""
 "Bases de datos Password (*.psafe3; *.dat)|*.psafe3; *.dat|Todos los archivos "
 "(*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:479
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -1968,40 +1968,40 @@ msgstr ""
 "\n"
 "El archivo está bloqueado por %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:481
 msgid "File lock error"
 msgstr "Error de bloqueo de archivo"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:547
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
 #, fuzzy
 msgid "Do you wish to save this restored database as new database?"
 msgstr "¿Desea guardar los cambios en la base de datos: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:549
 #, fuzzy
 msgid "Unsaved restored database"
 msgstr "en la base de datos"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:580
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:581
 #, fuzzy
 msgid "Do you want to save changes to the password database"
 msgstr "¿Desea guardar los cambios en la base de datos: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:617
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:618
 msgid "Export Text"
 msgstr "Exportar texto"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:621
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:622
 #, fuzzy
 msgid "Export Text failed"
 msgstr "Falló la importación de texto"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:623
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
 msgid "Please name the plaintext file"
 msgstr "Introduzca el nombre del archivo de texto plano"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1143
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:625
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1144
 #, fuzzy
 msgid ""
 "Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
@@ -2009,106 +2009,106 @@ msgstr ""
 "Archivos de texto (*.txt)|*.txt|archivos CSV  (*.csv)|*.csv|Todos los "
 "archivos (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:634
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:635
 msgid "Advanced Text Export Options"
 msgstr "Opciones avanzadas de exportación de texto"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:654
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:697
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:655
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:698
 #, fuzzy
 msgid "export"
 msgstr "exportado"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:660
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:661
 msgid "Export XML"
 msgstr "Exportar XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:664
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:665
 #, fuzzy
 msgid "Export XML failed"
 msgstr "Falló la importación de XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:666
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
 msgid "Please name the XML file"
 msgstr "Introduzca el nombre del archivo XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:668
 #, fuzzy
 msgid "XML files (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 msgstr "archivos XML (*.xml)|*.xml|Todos los archivos (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:678
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:679
 msgid "Advanced XML Export Options"
 msgstr "Opciones avanzadas de exportación de XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:712
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:716
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:713
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:717
 #, fuzzy
 msgid "Password Safe Databases (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 msgstr ""
 "Bases de datos Password (*.psafe3; *.dat)|*.psafe3; *.dat|Todos los archivos "
 "(*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:720
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:721
 #, fuzzy
 msgid "Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 msgstr ""
 "Bases de datos Password (*.psafe3; *.dat)|*.psafe3; *.dat|Todos los archivos "
 "(*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:731
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:732
 msgid "Please name the exported database"
 msgstr "Introduzca el nombre de la base de datos exportada"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:748
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:749
 msgid "Could not figure out why PasswordSafeFrame::OnExportVx was invoked"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:782
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:783
 msgid "You must save this database before it can be exported."
 msgstr "Debes guardar la base de datos antes de poder exportarla."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 #, fuzzy
 msgid "Exporting database: "
 msgstr "Combinando base de datos: %s\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid " to "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:841
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:842
 #, fuzzy
 msgid "Export complete.  Do you wish to see a detailed report?"
 msgstr "¿Desea reemplazarlo?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:852
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:853
 #, fuzzy
 msgid "No entries satisfied your selection criteria and so none were exported!"
 msgstr ""
 "Ninguna entrada satisface los criterios de selección, ¡ninguna puede ser %s!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:865
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:866
 msgid "Passkey incorrect"
 msgstr "Contraseña incorrecta"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:873
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
 msgid ""
 "The current database was opened in read-only mode.  You cannot import into "
 "it."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:875
 #, fuzzy
 msgid "Import text"
 msgstr "Importar &Texto"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:882
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
 #, fuzzy
 msgid "The database:"
 msgstr "en la base de datos"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
 #, fuzzy
 msgid "has duplicate entries with the same group/title/user combination."
 msgstr ""
@@ -2119,33 +2119,33 @@ msgstr ""
 "tiene entradas duplicadas con la misma combinación grupo/título/usuario. Por "
 "favor, corrija mediante la validación de la base de datos."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
 msgid "  Please fix by validating database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:931
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:886
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:932
 #, fuzzy
 msgid "Import Text failed"
 msgstr "Falló la importación de texto"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 #, fuzzy, c-format
 msgid "%ls file being imported: %ls"
 msgstr "%ls está siendo importado: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:921
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:926
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:223
-#: ../../../ui/wxWidgets/SyncWizard.cpp:572
+#: ../../../ui/wxWidgets/SyncWizard.cpp:573
 #: ../../../ui/wxWidgets/wxUtilities.cpp:59
 #: ../../../ui/wxWidgets/wxUtilities.cpp:64
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "File Read Error"
 msgstr "Error de lectura de archivo"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:923
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:222
 #: ../../../ui/wxWidgets/wxUtilities.cpp:58
 #, fuzzy
@@ -2155,7 +2155,7 @@ msgstr ""
 "\n"
 "¡No se puede abrir el archivo para lectura!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:928
 #, fuzzy
 msgid "Invalid format"
 msgstr ""
@@ -2163,77 +2163,77 @@ msgstr ""
 "\n"
 "Formato incorrecto"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Updated "
 msgstr "Actualizado %d %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Imported "
 msgstr "Importado"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entry"
 msgstr "entrada"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entries"
 msgstr "entradas"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
 #, fuzzy
 msgid "Skipped "
 msgstr ""
 "\n"
 "ignorado %d %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:957
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:958
 #, fuzzy
 msgid "with Password History errors "
 msgstr ""
 "\n"
 "con errores en histórico de contraseñas %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid "Renamed "
 msgstr "Renombrar"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed successfully"
 msgstr "Completado con éxito"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed but ...."
 msgstr "Completado pero ...."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:981
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1127
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1197
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1218
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1279
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:982
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1128
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1219
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
 #, fuzzy
 msgid "Do you wish to see a detailed report?"
 msgstr "¿Desea reemplazarlo?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1045
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:998
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1046
 msgid "Import XML failed"
 msgstr "Falló la importación de XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1007
-#: ../../../core/core_st.cpp:238
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../core/core_st.cpp:240
 #, fuzzy, c-format
 msgid ""
 "Can't find XML Schema Definition file (%ls) in your PasswordSafe Application "
@@ -2244,20 +2244,20 @@ msgstr ""
 "directorio de aplicaciones PasswordSafe.\n"
 "Copielo de su archivo de instalación o reinstale PasswordSafe."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 #, fuzzy
 msgid "Missing XSD File - "
 msgstr "Falta archivo XSD"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid " Build"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 msgid "XML"
 msgstr "XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1051
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1052
 #, fuzzy, c-format
 msgid ""
 "File: %ls failed validation against XML Schema:\n"
@@ -2268,7 +2268,7 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1057
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1058
 #, fuzzy, c-format
 msgid ""
 "File: %ls passed Validation but had the following errors during import:\n"
@@ -2279,26 +2279,26 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1078
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1079
 msgid "The following records were skipped:"
 msgstr "Los siguientes registros se han omitido:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1080
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1081
 #, c-format
 msgid " / skipped %d"
 msgstr " / ignorado %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1085
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1086
 msgid "The following records had errors in their Password History:"
 msgstr ""
 "Los siguientes registros tenían errores en su historial de contraseñas:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1087
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1088
 #, c-format
 msgid " / with Password History errors %d"
 msgstr " / con errores en historico de contraseñas %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1092
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1093
 msgid ""
 "The following records were renamed as an entry already exists in your "
 "database or in the Import file:"
@@ -2306,12 +2306,12 @@ msgstr ""
 "Los siguientes registros fueron renombrados como una entrada ya existente en "
 "su base de datos o en el archivo de importación:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1094
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1095
 #, c-format
 msgid " / renamed %d"
 msgstr " / %d renombrado"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1099
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1100
 #, fuzzy, c-format
 msgid ""
 "File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See "
@@ -2320,25 +2320,25 @@ msgstr ""
 "Archivo: %ls se importó (entradas validadas %d / importadas %d%ls%ls%ls). "
 "Ver informe para más detalles."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:95
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:97
 msgid "entry"
 msgstr "entrada"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:93
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:95
 msgid "entries"
 msgstr "entradas"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1107
 #, fuzzy, c-format
 msgid ""
 "Validated %d %ls\n"
@@ -2349,26 +2349,26 @@ msgstr ""
 "\n"
 "Importados %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1114
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1115
 msgid "XML import not supported in this release"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1117
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1118
 #, c-format
 msgid "XML import: Unexpected return code(%d)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1141
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1142
 msgid "Please Choose a KeePass Text File to Import"
 msgstr "Escoger archivo de texto de KeePass a importar"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1163
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1164
 #, fuzzy, c-format
 msgid "Text file being imported: %ls"
 msgstr "Text file está siendo importado: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1180
-#: ../../../ui/wxWidgets/SyncWizard.cpp:602
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/SyncWizard.cpp:603
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2379,11 +2379,11 @@ msgstr ""
 "\n"
 "¡No se puede abrir el archivo para lectura!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1182
 msgid "File open error"
 msgstr "Error al abrir archivo"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1195
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1196
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2394,21 +2394,21 @@ msgstr ""
 "\n"
 "Formato incorrecto"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1199
 msgid "Import failed"
 msgstr "Importación fallida"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1214
 #, fuzzy, c-format
 msgid "Imported %d %ls"
 msgstr "Importado %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1265
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1266
 #, fuzzy
 msgid "Merging database: "
 msgstr "Combinando base de datos: %s\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1281
 #, fuzzy
 msgid "Merge Complete"
 msgstr "Comparación completada"
@@ -2518,16 +2518,16 @@ msgstr ""
 "datos.\n"
 "Prueba a salir y reiniciar el programa."
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #, fuzzy
 msgid " file '"
 msgstr "Administrar filtros"
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid "' not readable"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #: ../../../ui/wxWidgets/ViewReportDlg.cpp:32
 msgid "View Report"
 msgstr "Ver informe"
@@ -2577,7 +2577,7 @@ msgid "Please select a valid file"
 msgstr "Escoja el informe que quiere ver"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:123
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:249
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:251
 msgid "None"
 msgstr "Ninguno"
 
@@ -2591,7 +2591,7 @@ msgid "Incremented Number [001-999]"
 msgstr "Número Incrementado [001-999]"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:132
-#: ../../../core/core_st.cpp:66
+#: ../../../core/core_st.cpp:68
 #, fuzzy
 msgid "Copy password to clipboard"
 msgstr "&Copiar contraseña al portapapeles"
@@ -2603,37 +2603,37 @@ msgstr "Ver/Editar entrada seleccionada"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:134
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:623
-#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:62
+#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:64
 msgid "Autotype"
 msgstr "Autoescritura"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:135
-#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:63
+#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:65
 msgid "Browse to URL"
 msgstr "Abrir URL"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:136
-#: ../../../core/core_st.cpp:65
+#: ../../../core/core_st.cpp:67
 msgid "Copy notes to clipboard"
 msgstr "Copiar notas al portapapeles"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:137
-#: ../../../core/core_st.cpp:68
+#: ../../../core/core_st.cpp:70
 msgid "Copy username to clipboard"
 msgstr "Copiar usuario al portapapeles"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:138
-#: ../../../core/core_st.cpp:67
+#: ../../../core/core_st.cpp:69
 msgid "Copy password to clipboard, minimize"
 msgstr "Copiar contraseña al portapapeles, minimizar"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:139
-#: ../../../core/core_st.cpp:64
+#: ../../../core/core_st.cpp:66
 msgid "Browse to URL + Autotype"
 msgstr "Ir a URL + Autoescritura"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:140
-#: ../../../core/core_st.cpp:69 ../../../core/core_st.cpp:144
+#: ../../../core/core_st.cpp:71 ../../../core/core_st.cpp:146
 msgid "Run Command"
 msgstr "Ejecutar comando"
 
@@ -3058,24 +3058,24 @@ msgstr ""
 msgid "Don't show this warning again"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:849
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:854
 msgid "Missing help definition for page \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:850
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
 msgid "\" of \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:860
 msgid "Missing help definition for window \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:866
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:871
 #, fuzzy
 msgid "Please inform the developers."
 msgstr "Nombra este filtro"
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:867
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:872
 msgid "Help Undefined"
 msgstr ""
 
@@ -3813,6 +3813,7 @@ msgid "search"
 msgstr "&Buscar"
 
 #: ../../../ui/wxWidgets/PasswordSafeSearch.cpp:427
+#: ../../../core/core_st.cpp:280
 msgid "Find"
 msgstr "Buscar"
 
@@ -3934,20 +3935,20 @@ msgstr "validación"
 msgid " empty)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:306
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:322
 #, fuzzy, c-format
 msgid "%ls on %ls"
 msgstr "%ls en %ls"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:341
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:357
 msgid "Yes"
 msgstr "Si"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:244
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:246
 msgid "No"
 msgstr "No"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:302
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:318
 #, fuzzy, c-format
 msgid "In Headers(%ls)/In Entries("
 msgstr "En cabeceras(%ls)/En entradas("
@@ -4136,7 +4137,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:457
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:269
-#: ../../../core/core_st.cpp:276
+#: ../../../core/core_st.cpp:290
 msgid "Warning"
 msgstr "Atención"
 
@@ -4213,11 +4214,11 @@ msgstr ""
 "\n"
 "Por favor, prueba otro"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:96
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:98
 msgid "equals"
 msgstr "igual a"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:83
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:85
 msgid "does not equal"
 msgstr "distinto"
 
@@ -4225,23 +4226,23 @@ msgstr "distinto"
 msgid "begins with"
 msgstr "empieza con"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:78
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:80
 msgid "does not begin with"
 msgstr "no empieza con"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:90
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:92
 msgid "ends with"
 msgstr "termina con"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:82
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:84
 msgid "does not end with"
 msgstr "no termina con"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:56
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:58
 msgid "contains"
 msgstr "contiene"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:79
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:81
 msgid "does not contain"
 msgstr "no contiene"
 
@@ -4300,80 +4301,80 @@ msgstr "Aceptar"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:143
+#: ../../../ui/wxWidgets/SyncWizard.cpp:144
 #, fuzzy
 msgid "synchronize"
 msgstr "sincronizado"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:220
+#: ../../../ui/wxWidgets/SyncWizard.cpp:221
 #, fuzzy
 msgid "Synchronize another database with currently open database"
 msgstr "Fusionando esta base de datos en la base de datos activa:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:349
+#: ../../../ui/wxWidgets/SyncWizard.cpp:350
 msgid "Introduction"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:353
+#: ../../../ui/wxWidgets/SyncWizard.cpp:354
 msgid ""
 "Synchronizing with another database will update the entries in your\n"
 "database with matching entries from the other database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:356
+#: ../../../ui/wxWidgets/SyncWizard.cpp:357
 msgid "More Info"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:359
+#: ../../../ui/wxWidgets/SyncWizard.cpp:360
 msgid ""
 "1. Two entries from different databases match if their Group, Title\n"
 "and User fields match."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:360
+#: ../../../ui/wxWidgets/SyncWizard.cpp:361
 msgid ""
 "2. You can select the fields to update, as well as filter the entries\n"
 "for synchronization."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:361
+#: ../../../ui/wxWidgets/SyncWizard.cpp:362
 msgid ""
 "3. Only existing entries in your database are updated.  No new entries are\n"
 "added or existing entries removed during this process."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:362
+#: ../../../ui/wxWidgets/SyncWizard.cpp:363
 msgid ""
 "4. You can undo the operation once it is complete, but won't be\n"
 "able to abort it mid-way."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:379
+#: ../../../ui/wxWidgets/SyncWizard.cpp:380
 #, fuzzy
 msgid "Select another database"
 msgstr "Selecciona base de datos"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:381
+#: ../../../ui/wxWidgets/SyncWizard.cpp:382
 #, fuzzy
 msgid "Choose Database to Synchronize with \""
 msgstr "Elige una base de datos a sincronizar con la actual"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:382
+#: ../../../ui/wxWidgets/SyncWizard.cpp:383
 #, fuzzy
 msgid "Please Choose a Database to Synchronize with current database"
 msgstr "Elige una base de datos a sincronizar con la actual"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:405
+#: ../../../ui/wxWidgets/SyncWizard.cpp:406
 #, fuzzy
 msgid "Synchronization options"
 msgstr "Error de sincronización"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:429
+#: ../../../ui/wxWidgets/SyncWizard.cpp:430
 #, fuzzy
 msgid "Options Summary"
 msgstr "Opciones"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:454
+#: ../../../ui/wxWidgets/SyncWizard.cpp:455
 #, fuzzy
 msgid ""
 "WARNING!!\n"
@@ -4384,58 +4385,58 @@ msgstr ""
 "ATENCIÓN: Si continúa, los campos de tu base de datos se actualizarán con "
 "las entradas de la base de datos de entrada seleccionada."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:471
+#: ../../../ui/wxWidgets/SyncWizard.cpp:472
 msgid " will be updated with corresponding entries from \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:478
+#: ../../../ui/wxWidgets/SyncWizard.cpp:479
 msgid "All fields in matching entries will be updated"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:484
+#: ../../../ui/wxWidgets/SyncWizard.cpp:485
 msgid "Following fields in matching entries will be updated:"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:488
+#: ../../../ui/wxWidgets/SyncWizard.cpp:489
 #, fuzzy
 msgid "Following fields will not be updated:"
 msgstr "Se procesarán las siguientes columnas:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:507
+#: ../../../ui/wxWidgets/SyncWizard.cpp:508
 #, fuzzy
 msgid "Synchronization status"
 msgstr "Error de sincronización"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:525
+#: ../../../ui/wxWidgets/SyncWizard.cpp:526
 msgid "See a detailed report"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:561
+#: ../../../ui/wxWidgets/SyncWizard.cpp:562
 msgid "Your database is being synchronized with \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:571
+#: ../../../ui/wxWidgets/SyncWizard.cpp:572
 msgid "There was an error during synchronization"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:585
+#: ../../../ui/wxWidgets/SyncWizard.cpp:586
 #, fuzzy, c-format
 msgid "Your database has been synchronized with \"%ls\""
 msgstr "Elige una base de datos a sincronizar con la \"%ls\""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:586
+#: ../../../ui/wxWidgets/SyncWizard.cpp:587
 #, fuzzy, c-format
 msgid "%ld %ls updated"
 msgstr ""
 "\n"
 "El siguiente %ls %ls actualizado:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:589
 #, fuzzy
 msgid "Synchronization completed successfully"
 msgstr "Completado con éxito"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:604
+#: ../../../ui/wxWidgets/SyncWizard.cpp:605
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4449,7 +4450,7 @@ msgstr ""
 "Posible pérdida o modificación de los datos.\n"
 "¿Desea continuar?"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:606
+#: ../../../ui/wxWidgets/SyncWizard.cpp:607
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4460,24 +4461,24 @@ msgstr ""
 "\n"
 "Error desconocido"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:640
+#: ../../../ui/wxWidgets/SyncWizard.cpp:641
 #, fuzzy, c-format
 msgid "Synchronizing from database: %ls\n"
 msgstr "Sincronizar desde base de datos: %ls\n"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:643
+#: ../../../ui/wxWidgets/SyncWizard.cpp:644
 msgid "synchronized"
 msgstr "sincronizado"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:322
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:338
 msgid "was"
 msgstr "fue"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:323
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:339
 msgid "were"
 msgstr "fueron"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:298
+#: ../../../ui/wxWidgets/SyncWizard.cpp:733 ../../../core/core_st.cpp:314
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4486,7 +4487,7 @@ msgstr ""
 "\n"
 "El siguiente %ls %ls actualizado:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:297
+#: ../../../ui/wxWidgets/SyncWizard.cpp:749 ../../../core/core_st.cpp:313
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4657,7 +4658,7 @@ msgid "This shortcut's target [%s:%s:%s] is not a normal entry."
 msgstr ""
 "El destino del atajo [%s:%s:%s] no es una entrada normal o ya es un atajo."
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:94
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:96
 #, c-format
 msgid ""
 "The following entries had a policy name that already existed in this "
@@ -4762,13 +4763,13 @@ msgstr ""
 "Posible pérdida o modificación de los datos.\n"
 "¿Desea continuar?"
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:381
+#: ../../../ui/wxWidgets/wxUtilities.cpp:390
 msgid ""
 "An error occurred while trying to get the image data from database item.\n"
 "Therefore, the image cannot be displayed in the preview."
 msgstr ""
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:394
+#: ../../../ui/wxWidgets/wxUtilities.cpp:403
 msgid ""
 "An error occurred while trying to load the image data into the preview "
 "area.\n"
@@ -4910,7 +4911,7 @@ msgstr ""
 "\n"
 "Copiar contraseña al portapapeles"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:149
+#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:151
 msgid "Username"
 msgstr "Usuario"
 
@@ -4921,7 +4922,7 @@ msgstr ""
 "\n"
 "Copiar usuario al portapapeles"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:136
+#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:138
 #, fuzzy
 msgid "Notes"
 msgstr "&Notas:"
@@ -4957,7 +4958,7 @@ msgstr ""
 msgid "Browse URL"
 msgstr "Abrir URL"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:70
+#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:72
 #, fuzzy
 msgid "Send Email"
 msgstr "Enviar correo"
@@ -5156,67 +5157,85 @@ msgid "(case sensitive)"
 msgstr "(distingue entre mayúsculas y minúsculas)"
 
 #: ../../../core/core_st.cpp:50
+#, fuzzy, c-format
+msgid ""
+"Compare complete of current database:\n"
+"\t %ls\n"
+" and:\n"
+"\t %ls\n"
+msgstr ""
+"Comparación completa de la base de datos actual:\n"
+"\t %s\n"
+" y:\n"
+"\t %s"
+
+#: ../../../core/core_st.cpp:51
+#, fuzzy, c-format
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGrupo:'%s'; Título:'%s'; Usuario:'%s'"
+
+#: ../../../core/core_st.cpp:52
 msgid "C:F[R-O]"
 msgstr "C:F[R-O]"
 
-#: ../../../core/core_st.cpp:51
+#: ../../../core/core_st.cpp:53
 msgid "C:F[R/W]"
 msgstr "C:F[R/W]"
 
-#: ../../../core/core_st.cpp:52
+#: ../../../core/core_st.cpp:54
 msgid "C:None  "
 msgstr "C:None  "
 
-#: ../../../core/core_st.cpp:53
+#: ../../../core/core_st.cpp:55
 msgid "C:Reg   "
 msgstr "C:Reg   "
 
-#: ../../../core/core_st.cpp:54
+#: ../../../core/core_st.cpp:56
 msgid "conflict"
 msgstr "conflicto"
 
-#: ../../../core/core_st.cpp:55
+#: ../../../core/core_st.cpp:57
 msgid "conflicts"
 msgstr "colisiona"
 
-#: ../../../core/core_st.cpp:57
+#: ../../../core/core_st.cpp:59
 msgid "contains all of"
 msgstr "contiene todos"
 
-#: ../../../core/core_st.cpp:58
+#: ../../../core/core_st.cpp:60
 msgid "contains any of"
 msgstr "contiene algún"
 
-#: ../../../core/core_st.cpp:59
+#: ../../../core/core_st.cpp:61
 #, fuzzy
 msgid "copied"
 msgstr "URL copiada"
 
-#: ../../../core/core_st.cpp:60
+#: ../../../core/core_st.cpp:62
 #, fuzzy, c-format
 msgid "%ls - Copied %ls"
 msgstr "%ls - Copiada %ls"
 
-#: ../../../core/core_st.cpp:61
+#: ../../../core/core_st.cpp:63
 #, fuzzy, c-format
 msgid " Current default (%ls)"
 msgstr " Actual valor por defecto (%ls)"
 
-#: ../../../core/core_st.cpp:71
+#: ../../../core/core_st.cpp:73
 msgid "View/Edit selected entry"
 msgstr "Ver/Editar entrada seleccionada"
 
-#: ../../../core/core_st.cpp:72
+#: ../../../core/core_st.cpp:74
 #, fuzzy
 msgid " (application default)"
 msgstr "Usar aplicación:"
 
-#: ../../../core/core_st.cpp:73
+#: ../../../core/core_st.cpp:75
 #, fuzzy
 msgid "default symbol set"
 msgstr "Valor predeterminado"
 
-#: ../../../core/core_st.cpp:75
+#: ../../../core/core_st.cpp:77
 #, fuzzy, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5229,12 +5248,12 @@ msgstr ""
 "Confirma para continuar (contraseñas del alias se reemplazará con la "
 "contraseña de esta entrada)"
 
-#: ../../../core/core_st.cpp:76
+#: ../../../core/core_st.cpp:78
 #, fuzzy
 msgid "Delete Base Entry Confirmation"
 msgstr "¿Confirma eliminar una entrada?"
 
-#: ../../../core/core_st.cpp:77
+#: ../../../core/core_st.cpp:79
 #, fuzzy, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5246,40 +5265,40 @@ msgstr ""
 "Confirma para continuar (Todos los accesos directos a esta entrada se "
 "borrarán)?"
 
-#: ../../../core/core_st.cpp:80
+#: ../../../core/core_st.cpp:82
 msgid "does not contain all of"
 msgstr "no contiene todos"
 
-#: ../../../core/core_st.cpp:81
+#: ../../../core/core_st.cpp:83
 msgid "does not contain any of"
 msgstr "no contiene ningún"
 
-#: ../../../core/core_st.cpp:84
+#: ../../../core/core_st.cpp:86
 #, c-format
 msgid " Drag # %d"
 msgstr " Arrastrar # %d"
 
-#: ../../../core/core_st.cpp:85
-#, c-format
-msgid "%s - Drag & Drop %s"
-msgstr ""
+#: ../../../core/core_st.cpp:87
+#, fuzzy, c-format
+msgid "%ls - Drag & Drop %ls"
+msgstr "%ls - Copiada %ls"
 
-#: ../../../core/core_st.cpp:86
+#: ../../../core/core_st.cpp:88
 #, c-format
 msgid " Duplicate # %d"
 msgstr " Duplicado # %d"
 
-#: ../../../core/core_st.cpp:87
+#: ../../../core/core_st.cpp:89
 #, fuzzy
 msgid "empty group"
 msgstr "¿Importar sobre un grupo?"
 
-#: ../../../core/core_st.cpp:88
+#: ../../../core/core_st.cpp:90
 #, fuzzy
 msgid "empty groups"
 msgstr "#groups"
 
-#: ../../../core/core_st.cpp:89
+#: ../../../core/core_st.cpp:91
 #, fuzzy, c-format
 msgid ""
 "Trouble with a non-textual (e.g., time) field in record '%ls' - please check "
@@ -5288,130 +5307,130 @@ msgstr ""
 "Hay un problema con un campo no textual (hora, fecha) en el registro '%ls' - "
 "compruebe los datos detenidamente."
 
-#: ../../../core/core_st.cpp:91
+#: ../../../core/core_st.cpp:93
 msgid "End Report"
 msgstr "Informe final"
 
-#: ../../../core/core_st.cpp:92
+#: ../../../core/core_st.cpp:94
 msgid "--------------------------------------------------------------------------------"
 msgstr "--------------------------------------------------------------------------------"
 
-#: ../../../core/core_st.cpp:97
+#: ../../../core/core_st.cpp:99
 msgid "has expired"
 msgstr "ha caducado"
 
-#: ../../../core/core_st.cpp:98
+#: ../../../core/core_st.cpp:100
 msgid "Entries with a password expiry"
 msgstr "Entradas con contraseña caducada"
 
-#: ../../../core/core_st.cpp:99
+#: ../../../core/core_st.cpp:101
 #, c-format
 msgid "within %d day(s)"
 msgstr "durante %d día(s)"
 
-#: ../../../core/core_st.cpp:100
+#: ../../../core/core_st.cpp:102
 #, fuzzy, c-format
 msgid "DB Export from database: '%s'"
 msgstr "Combinando base de datos: %s\n"
 
-#: ../../../core/core_st.cpp:101
+#: ../../../core/core_st.cpp:103
 msgid "First character of variable name must be alphabetic"
 msgstr "El primer caracter del nombre de variable debe ser alfabético"
 
-#: ../../../core/core_st.cpp:102
+#: ../../../core/core_st.cpp:104
 msgid "Index not numeric"
 msgstr "Índice no numérico"
 
-#: ../../../core/core_st.cpp:103
+#: ../../../core/core_st.cpp:105
 msgid "Input string is empty"
 msgstr "La cadena de entrada está vacía"
 
-#: ../../../core/core_st.cpp:104
+#: ../../../core/core_st.cpp:106
 msgid "Characters present between end of index ']' and '}'"
 msgstr "Caracteres presentes entre el final del índice de ']' y ')'"
 
-#: ../../../core/core_st.cpp:105
+#: ../../../core/core_st.cpp:107
 msgid "Index is invalid or missing"
 msgstr "Índice es invalido o no se encuentra"
 
-#: ../../../core/core_st.cpp:106
+#: ../../../core/core_st.cpp:108
 msgid "Missing ending curly bracket for variable name"
 msgstr "Falta terminador de llaves para el nombre de la variable"
 
-#: ../../../core/core_st.cpp:107
+#: ../../../core/core_st.cpp:109
 msgid "Missing ending round bracket for Autotype value"
 msgstr "Falta terminador de paréntesis en valor de autoescritura"
 
-#: ../../../core/core_st.cpp:108
+#: ../../../core/core_st.cpp:110
 msgid "Missing ending square bracket for index value"
 msgstr "Falta terminador de corchete en valor índice"
 
-#: ../../../core/core_st.cpp:109
+#: ../../../core/core_st.cpp:111
 msgid "There are unmatched quotes in the run command"
 msgstr "Hay comillas desemparejadas en el comando ejecutar"
 
-#: ../../../core/core_st.cpp:110
+#: ../../../core/core_st.cpp:112
 msgid "Variable name is empty"
 msgstr "Nombre de variable vacío"
 
-#: ../../../core/core_st.cpp:111
+#: ../../../core/core_st.cpp:113
 msgid "Variable name must be alphanumeric"
 msgstr "El nombre de variable debe ser alfanumérico"
 
-#: ../../../core/core_st.cpp:112
+#: ../../../core/core_st.cpp:114
 msgid "an alias entry"
 msgstr "una entrada de alias"
 
-#: ../../../core/core_st.cpp:113
+#: ../../../core/core_st.cpp:115
 msgid "a base entry of an alias"
 msgstr "una entrada de un alias"
 
-#: ../../../core/core_st.cpp:114
+#: ../../../core/core_st.cpp:116
 msgid "  Field is too long."
 msgstr "  Campo demasiado largo."
 
-#: ../../../core/core_st.cpp:115
+#: ../../../core/core_st.cpp:117
 msgid "  Field is too short."
 msgstr "  Campo demasiado corto."
 
-#: ../../../core/core_st.cpp:116
+#: ../../../core/core_st.cpp:118
 msgid "Error: A file with this name already exists"
 msgstr "Error: ya existe un archivo con ese nombre"
 
-#: ../../../core/core_st.cpp:117
+#: ../../../core/core_st.cpp:119
 msgid "The file was not found."
 msgstr "No se encontró el fichero."
 
-#: ../../../core/core_st.cpp:118
+#: ../../../core/core_st.cpp:120
 msgid "Error: File is read-only"
 msgstr "Error: archivo de sólo lectura"
 
-#: ../../../core/core_st.cpp:119
+#: ../../../core/core_st.cpp:121
 msgid "Error while writing file! Try saving in a different location"
 msgstr ""
 "¡Error al escribir el archivo! Trate de grabarlo en una ubicación diferente"
 
-#: ../../../core/core_st.cpp:120
+#: ../../../core/core_st.cpp:122
 #, fuzzy
 msgid "File is too big."
 msgstr "  Campo demasiado largo."
 
-#: ../../../core/core_st.cpp:121
+#: ../../../core/core_st.cpp:123
 #, fuzzy
 msgid "File is too short."
 msgstr "  Campo demasiado corto."
 
-#: ../../../core/core_st.cpp:122
+#: ../../../core/core_st.cpp:124
 msgid "File is truncated or otherwise corrupt. Please use backup database."
 msgstr ""
 "El archivo está truncado o corrupto. Usa la copia de seguridad de la base de "
 "datos."
 
-#: ../../../core/core_st.cpp:123
+#: ../../../core/core_st.cpp:125
 msgid "Cannot read file. Please check file permissions."
 msgstr "No se puede leer el archivo. Comprueba los permisos de archivo."
 
-#: ../../../core/core_st.cpp:124
+#: ../../../core/core_st.cpp:126
 #, fuzzy, c-format
 msgid ""
 "Filter %ls already exists in the database, do you wish to replace it with "
@@ -5419,135 +5438,135 @@ msgid ""
 msgstr ""
 "Filtro %ls ya existe en la base de datos, ¿quieres remplazarlo con este?"
 
-#: ../../../core/core_st.cpp:125
+#: ../../../core/core_st.cpp:127
 #, fuzzy
 msgid "Current database filters have been exported to this database."
 msgstr "Comparando base de datos actual con: %s"
 
-#: ../../../core/core_st.cpp:126
+#: ../../../core/core_st.cpp:128
 msgid "Stored filters will be unusable until the file's restored."
 msgstr ""
 "Los filtros almacenados no se podrá utilizar hasta que el archivo sea "
 "restaurado."
 
-#: ../../../core/core_st.cpp:127
+#: ../../../core/core_st.cpp:129
 msgid "Last Access Time"
 msgstr "Fecha de último acceso"
 
-#: ../../../core/core_st.cpp:128
+#: ../../../core/core_st.cpp:130
 msgid "Attachment Reference"
 msgstr ""
 
-#: ../../../core/core_st.cpp:129
+#: ../../../core/core_st.cpp:131
 msgid "AutoType"
 msgstr "Autoescritura"
 
-#: ../../../core/core_st.cpp:130
+#: ../../../core/core_st.cpp:132
 msgid "Created Time"
 msgstr "Hora de creación"
 
-#: ../../../core/core_st.cpp:131
+#: ../../../core/core_st.cpp:133
 msgid "DCA"
 msgstr "ADC"
 
-#: ../../../core/core_st.cpp:132
+#: ../../../core/core_st.cpp:134
 msgid "e-mail"
 msgstr "correo"
 
-#: ../../../core/core_st.cpp:134
+#: ../../../core/core_st.cpp:136
 msgid "Group/Title"
 msgstr "Grupo/Título"
 
-#: ../../../core/core_st.cpp:135
+#: ../../../core/core_st.cpp:137
 #, fuzzy
 msgid "Keyboard Shortcut"
 msgstr "Crear acceso directo"
 
-#: ../../../core/core_st.cpp:138
+#: ../../../core/core_st.cpp:140
 msgid "Password Modified Time"
 msgstr "Hora de modificación de contraseña"
 
-#: ../../../core/core_st.cpp:139
+#: ../../../core/core_st.cpp:141
 msgid "Protected"
 msgstr "Protegido"
 
-#: ../../../core/core_st.cpp:140
+#: ../../../core/core_st.cpp:142
 msgid "History"
 msgstr "Historial"
 
-#: ../../../core/core_st.cpp:142
+#: ../../../core/core_st.cpp:144
 #, fuzzy
 msgid "Password Policy Name"
 msgstr "Política de contraseñas"
 
-#: ../../../core/core_st.cpp:143
+#: ../../../core/core_st.cpp:145
 msgid "Record Modified Time"
 msgstr "Hora de modificación del registro"
 
-#: ../../../core/core_st.cpp:145
+#: ../../../core/core_st.cpp:147
 #, fuzzy
 msgid "Shift+DCA"
 msgstr "Mays.+"
 
-#: ../../../core/core_st.cpp:146
+#: ../../../core/core_st.cpp:148
 msgid "Symbols"
 msgstr "Símbolos"
 
-#: ../../../core/core_st.cpp:148
+#: ../../../core/core_st.cpp:150
 msgid "URL"
 msgstr "URL"
 
-#: ../../../core/core_st.cpp:150
+#: ../../../core/core_st.cpp:152
 msgid "UUID"
 msgstr "UUID"
 
-#: ../../../core/core_st.cpp:151
+#: ../../../core/core_st.cpp:153
 msgid "Password Expiry Date"
 msgstr "Caducidad de contraseña"
 
-#: ../../../core/core_st.cpp:152
+#: ../../../core/core_st.cpp:154
 msgid "Password Expiry Interval"
 msgstr "Intervalo de caducidad de contraseña"
 
-#: ../../../core/core_st.cpp:153
+#: ../../../core/core_st.cpp:155
 msgid "a normal entry"
 msgstr "una entrada normal"
 
-#: ../../../core/core_st.cpp:154
+#: ../../../core/core_st.cpp:156
 #, fuzzy
 msgid "Last found entries"
 msgstr "entradas"
 
-#: ../../../core/core_st.cpp:155
+#: ../../../core/core_st.cpp:157
 msgid "added but not yet saved to database"
 msgstr "añadido pero aun no guardado en la base de datos"
 
-#: ../../../core/core_st.cpp:156
+#: ../../../core/core_st.cpp:158
 #, fuzzy
 msgid "in the database"
 msgstr "en la base de datos"
 
-#: ../../../core/core_st.cpp:157
+#: ../../../core/core_st.cpp:159
 msgid "a shortcut entry"
 msgstr "una entrada de atajo"
 
-#: ../../../core/core_st.cpp:158
+#: ../../../core/core_st.cpp:160
 msgid "a base entry of a shortcut"
 msgstr "una entrada de un atajo"
 
-#: ../../../core/core_st.cpp:159
+#: ../../../core/core_st.cpp:161
 msgid "changed but not yet saved to database"
 msgstr "cambiado pero aun no guardado en la base de datos"
 
-#: ../../../core/core_st.cpp:160
+#: ../../../core/core_st.cpp:162
 msgid "greater than"
 msgstr "mayor que"
 
-#: ../../../core/core_st.cpp:161
+#: ../../../core/core_st.cpp:163
 msgid "greater than or equal to"
 msgstr "mayor o igual que"
 
-#: ../../../core/core_st.cpp:162
+#: ../../../core/core_st.cpp:164
 #, c-format
 msgid ""
 "Invalid input on line %d.  Number of fields separated by '%c' is not as "
@@ -5556,12 +5575,12 @@ msgstr ""
 "Entrada no válida en la línea %d.  El número de campos separados por '%c' no "
 "es el esperado."
 
-#: ../../../core/core_st.cpp:163
+#: ../../../core/core_st.cpp:165
 #, c-format
 msgid "Line %d: "
 msgstr "Línea %d:"
 
-#: ../../../core/core_st.cpp:164
+#: ../../../core/core_st.cpp:166
 #, c-format
 msgid ""
 "File ends on line %d before ending double quote of last entry's note field."
@@ -5569,11 +5588,11 @@ msgstr ""
 "El archivo termina en la línea %d antes de las dobles comillas finales o del "
 "campo notas de un entrada."
 
-#: ../../../core/core_st.cpp:165
+#: ../../../core/core_st.cpp:167
 msgid "Import aborted. Please see report."
 msgstr "Importacion abortada. Mira el informe."
 
-#: ../../../core/core_st.cpp:166
+#: ../../../core/core_st.cpp:168
 #, fuzzy
 msgid ""
 "The TXT or CSV file was not imported as required as entry records span "
@@ -5586,7 +5605,7 @@ msgstr ""
 "\n"
 "Exportación abortada."
 
-#: ../../../core/core_st.cpp:167
+#: ../../../core/core_st.cpp:169
 #, fuzzy, c-format
 msgid ""
 "%ls, Title=\"%ls\", User=\"%ls\" already exists in your database or in the "
@@ -5595,69 +5614,69 @@ msgstr ""
 "%ls, Titulo=\"%ls\", Usuario=\"%ls\" ya existe en tu base de datos o en el "
 "archivo importado. Añadida entrada importada con el título=\"%ls\".\n"
 
-#: ../../../core/core_st.cpp:168
+#: ../../../core/core_st.cpp:170
 #, fuzzy, c-format
 msgid "Entry on line %d with Group=\"%ls\""
 msgstr "Entrada en línea %d con Grupo=\"%ls\""
 
-#: ../../../core/core_st.cpp:169
+#: ../../../core/core_st.cpp:171
 #, c-format
 msgid "Entry on line %d with no group"
 msgstr "Entrada en línea %d sin grupo"
 
-#: ../../../core/core_st.cpp:170
+#: ../../../core/core_st.cpp:172
 #, fuzzy, c-format
 msgid "Entry with Group=\"%ls\""
 msgstr "Entrada con grupo=\"%ls\""
 
-#: ../../../core/core_st.cpp:171
+#: ../../../core/core_st.cpp:173
 msgid "Entry with no group"
 msgstr "Entrada sin grupo"
 
-#: ../../../core/core_st.cpp:172
+#: ../../../core/core_st.cpp:174
 #, fuzzy
 msgid "imported"
 msgstr "importar"
 
-#: ../../../core/core_st.cpp:173
+#: ../../../core/core_st.cpp:175
 #, fuzzy, c-format
 msgid "including %d empty group(s)."
 msgstr "#groups"
 
-#: ../../../core/core_st.cpp:174
+#: ../../../core/core_st.cpp:176
 #, c-format
 msgid "Empty line %d skipped"
 msgstr "Ignorada línea %d vacía"
 
-#: ../../../core/core_st.cpp:175
+#: ../../../core/core_st.cpp:177
 #, fuzzy, c-format
 msgid "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 msgstr "Entrada %ls%d con Grupo=\"%ls\", Título=\"%ls\", Usuario=\"%ls\""
 
-#: ../../../core/core_st.cpp:176
+#: ../../../core/core_st.cpp:178
 msgid "Internal error. Import failed. No records imported."
 msgstr "Error interno. Fallo en la importación. No se han importado registros."
 
-#: ../../../core/core_st.cpp:177
+#: ../../../core/core_st.cpp:179
 #, c-format
 msgid "Found %d known column headers:"
 msgstr "Encontradas %d cabeceras de columnas conocidas:"
 
-#: ../../../core/core_st.cpp:178
+#: ../../../core/core_st.cpp:180
 msgid "Invalid field delimiter: must be within ASCII range."
 msgstr ""
 
-#: ../../../core/core_st.cpp:179
+#: ../../../core/core_st.cpp:181
 #, fuzzy, c-format
 msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
 msgstr ""
 "La entrada de la línea %d tiene el campo \"%ls\" incorrecto. Se ha ignorado."
 
-#: ../../../core/core_st.cpp:180
+#: ../../../core/core_st.cpp:182
 msgid "The following columns will be processed: "
 msgstr "Se procesarán las siguientes columnas:"
 
-#: ../../../core/core_st.cpp:181
+#: ../../../core/core_st.cpp:183
 msgid ""
 "The following columns were recognised but only Group/Title, Username and "
 "Password will be processed:"
@@ -5665,7 +5684,7 @@ msgstr ""
 "Las siguientes columnas fueron reconocidas, pero sólo Grupo/Título, nombre "
 "de usuario y contraseña serán procesados:"
 
-#: ../../../core/core_st.cpp:182
+#: ../../../core/core_st.cpp:184
 #, c-format
 msgid ""
 "Line %d skipped - Only %d fields found, whereas parsing the Header says "
@@ -5674,7 +5693,7 @@ msgstr ""
 "Línea %d ignorada - Encontrados %d campos, mientras que el encabezado dice "
 "que debería haber %d."
 
-#: ../../../core/core_st.cpp:183
+#: ../../../core/core_st.cpp:185
 msgid ""
 "Either or both of the Group/Title and Password columns are missing. No "
 "records imported."
@@ -5682,7 +5701,7 @@ msgstr ""
 "Alguna o ambas columnas Grupo/Título y Contraseña no existen. No se han "
 "importado registros."
 
-#: ../../../core/core_st.cpp:184
+#: ../../../core/core_st.cpp:186
 msgid ""
 "Could not find the next entry's title field in the KeePass V1 TXT (should be "
 "within square brackets)."
@@ -5690,35 +5709,35 @@ msgstr ""
 "No se encuentra el título de la siguiente entrada en KeePass V1 TXT (debe "
 "estar entre corchetes)."
 
-#: ../../../core/core_st.cpp:185
+#: ../../../core/core_st.cpp:187
 msgid "Column header row not recognised as first record. No records imported."
 msgstr "No se reconoce el primer registro. No se han importado registros."
 
-#: ../../../core/core_st.cpp:186
+#: ../../../core/core_st.cpp:188
 msgid "No records in import file!"
 msgstr "¡No se han importado registros!"
 
-#: ../../../core/core_st.cpp:187
+#: ../../../core/core_st.cpp:189
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Password field."
 msgstr "Línea %d ignorada. El campo obligatorio Contraseña está vacío."
 
-#: ../../../core/core_st.cpp:188
+#: ../../../core/core_st.cpp:190
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Title field."
 msgstr "Línea %d ignorada. El campo obligatorio Título está vacío."
 
-#: ../../../core/core_st.cpp:189
+#: ../../../core/core_st.cpp:191
 #, c-format
 msgid " Import # %d"
 msgstr " Importar # %d"
 
-#: ../../../core/core_st.cpp:190
+#: ../../../core/core_st.cpp:192
 #, fuzzy, c-format
 msgid "%ls - Imported %ls"
 msgstr "%ls - Importado %ls"
 
-#: ../../../core/core_st.cpp:191
+#: ../../../core/core_st.cpp:193
 msgid ""
 "To replace passwords of existing entries, all the following columns must be "
 "present: Group/Title, Username and Password.  One or more are missing and no "
@@ -5728,18 +5747,18 @@ msgstr ""
 "las siguientes columnas: Grupo/Título, Usuario y Contraseña.  Falta al menos "
 "uno de ellos y no se han actualizado las entradas."
 
-#: ../../../core/core_st.cpp:192
+#: ../../../core/core_st.cpp:194
 #, fuzzy, c-format
 msgid "%ls not found. Cannot update entry's password.\n"
 msgstr ""
 "%ls no encontrado. No se puede actualizar la contraseña de la entrada.\n"
 
-#: ../../../core/core_st.cpp:193
+#: ../../../core/core_st.cpp:195
 #, fuzzy, c-format
 msgid "%ls has an empty %ls.\n"
 msgstr "%ls tiene un %ls vacío.\n"
 
-#: ../../../core/core_st.cpp:194
+#: ../../../core/core_st.cpp:196
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5748,11 +5767,11 @@ msgstr ""
 "La entrada \"%ls, %ls, %ls\" tiene una contraseñas con el formato de un "
 "alias, pero la entrada base también es un alias."
 
-#: ../../../core/core_st.cpp:195
+#: ../../../core/core_st.cpp:197
 msgid "\tThis entry has been made an alias of associated base entry."
 msgstr "\tEsta entrada se ha convertido en un alias de la entrada asociada."
 
-#: ../../../core/core_st.cpp:196
+#: ../../../core/core_st.cpp:198
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5761,12 +5780,12 @@ msgstr ""
 "La entrada \"%ls, %ls, %ls\" tiene una contraseña con el formato de un "
 "alias, pero la entrada base no existe."
 
-#: ../../../core/core_st.cpp:197
+#: ../../../core/core_st.cpp:199
 msgid ""
 "\tThis entry remains a normal entry and the password has not been changed."
 msgstr "\tEsta entrada sigue siendo normal y no se ha cambiado la contraseña."
 
-#: ../../../core/core_st.cpp:198
+#: ../../../core/core_st.cpp:200
 #, fuzzy, c-format
 msgid ""
 "The %ls entry \"%ls, %ls, %ls\" doesn't point to a normal or existing %ls "
@@ -5775,71 +5794,71 @@ msgstr ""
 "La entrada %ls \"%ls, %ls, %ls\" no apunta a una %ls normal o existente "
 "entrada base. No se pueden importar."
 
-#: ../../../core/core_st.cpp:199
+#: ../../../core/core_st.cpp:201
 msgid "Entry import warnings"
 msgstr "Avisos de importación de entradas"
 
-#: ../../../core/core_st.cpp:200
+#: ../../../core/core_st.cpp:202
 msgid "id="
 msgstr "id="
 
-#: ../../../core/core_st.cpp:201
+#: ../../../core/core_st.cpp:203
 msgid "on line "
 msgstr "en línea"
 
-#: ../../../core/core_st.cpp:202
+#: ../../../core/core_st.cpp:204
 msgid "Internal error: Invalid oflag or pmode argument"
 msgstr "Error interno: Argumento oflag o pmode no válido"
 
-#: ../../../core/core_st.cpp:203
+#: ../../../core/core_st.cpp:205
 msgid "invalid!"
 msgstr "¡invalido!"
 
-#: ../../../core/core_st.cpp:204
+#: ../../../core/core_st.cpp:206
 msgid "  Invalid date/time value."
 msgstr "  Fecha u hora incorrectas."
 
-#: ../../../core/core_st.cpp:205
+#: ../../../core/core_st.cpp:207
 msgid "  Field length is incorrect."
 msgstr "  La longitud del campo es incorrecta."
 
-#: ../../../core/core_st.cpp:206
+#: ../../../core/core_st.cpp:208
 msgid "Internal error: An invalid flag was specified"
 msgstr "Error interno: Se especificó una bandera incorrecta"
 
-#: ../../../core/core_st.cpp:207
+#: ../../../core/core_st.cpp:209
 #, fuzzy, c-format
 msgid "  Invalid header: '%ls' (must be 5 hexadecimal characters)."
 msgstr "  Encabezado no válido: '%ls' (debe ser 5 caracteres hexadecimales)."
 
-#: ../../../core/core_st.cpp:208
+#: ../../../core/core_st.cpp:210
 #, fuzzy, c-format
 msgid "Invalid lock file \"%ls\"."
 msgstr "Esquema de filtro no válido"
 
-#: ../../../core/core_st.cpp:209
+#: ../../../core/core_st.cpp:211
 #, c-format
 msgid "  Invalid number of saved old passwords %d."
 msgstr "  Numero de contraseñas guardadas no válido %d."
 
-#: ../../../core/core_st.cpp:210
+#: ../../../core/core_st.cpp:212
 #, c-format
 msgid "  Invalid status value: %d (must be either 0 or 1)."
 msgstr "  Valor de estado incorrecto: %d (must be either 0 or 1)."
 
-#: ../../../core/core_st.cpp:211
+#: ../../../core/core_st.cpp:213
 msgid "  Invalid password length found (not a hexadecimal number)."
 msgstr ""
 "  Encontrada longitud de contraseña incorrecta (no es un número hexadecimal)."
 
-#: ../../../core/core_st.cpp:212
+#: ../../../core/core_st.cpp:214
 msgid ""
 "  Invalid password length found (differs from length of following password)."
 msgstr ""
 "  Encontrada longitud de contraseña incorrecta (difiere de la longitud de la "
 "siguiente contraseña)."
 
-#: ../../../core/core_st.cpp:213
+#: ../../../core/core_st.cpp:215
 msgid ""
 "  Invalid field separator character found - only a single blank is allowed "
 "between fields."
@@ -5847,20 +5866,20 @@ msgstr ""
 "  Encontrado carácter de separación de campos no válido - sólo se permite un "
 "espacio en blanco."
 
-#: ../../../core/core_st.cpp:214
+#: ../../../core/core_st.cpp:216
 msgid "Invalid Filter schema."
 msgstr "Esquema de filtro no válido"
 
-#: ../../../core/core_st.cpp:215
+#: ../../../core/core_st.cpp:217
 msgid "Schema does not have a version number."
 msgstr "El esquema no tiene un número de versión."
 
-#: ../../../core/core_st.cpp:216
+#: ../../../core/core_st.cpp:218
 #, c-format
 msgid "The filter XML version (%d) is greater than the current schema (%d)."
 msgstr "La versión de filtro XML (%d) es mayor que el actual esquema (%d)."
 
-#: ../../../core/core_st.cpp:217
+#: ../../../core/core_st.cpp:219
 #, c-format
 msgid ""
 "The filter XML version (%d) is greater than that supported by this instance "
@@ -5869,57 +5888,57 @@ msgstr ""
 "La versión de filtro XML (%d) es mayor que la soportada por esta versión de "
 "PasswordSafe (%d)."
 
-#: ../../../core/core_st.cpp:218
+#: ../../../core/core_st.cpp:220
 msgid "is"
 msgstr "está"
 
-#: ../../../core/core_st.cpp:219
+#: ../../../core/core_st.cpp:221
 msgid "is active"
 msgstr "está activo"
 
-#: ../../../core/core_st.cpp:220
+#: ../../../core/core_st.cpp:222
 msgid "is inactive"
 msgstr "está inactivo"
 
-#: ../../../core/core_st.cpp:221
+#: ../../../core/core_st.cpp:223
 msgid "is not"
 msgstr "no está"
 
-#: ../../../core/core_st.cpp:222
+#: ../../../core/core_st.cpp:224
 msgid "is not present"
 msgstr "no está presente"
 
-#: ../../../core/core_st.cpp:223
+#: ../../../core/core_st.cpp:225
 msgid "is present"
 msgstr "está presente"
 
-#: ../../../core/core_st.cpp:224
+#: ../../../core/core_st.cpp:226
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to entry %ls. It "
 "has been removed from the %ls entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:225
+#: ../../../core/core_st.cpp:227
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to the "
 "PasswordSafe application. It has been removed from the entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:226
+#: ../../../core/core_st.cpp:228
 msgid "less than"
 msgstr "menor que"
 
-#: ../../../core/core_st.cpp:227
+#: ../../../core/core_st.cpp:229
 msgid "less than or equal to"
 msgstr "menor o igual que"
 
-#: ../../../core/core_st.cpp:228
+#: ../../../core/core_st.cpp:230
 msgid "File or path not found"
 msgstr "Ruta o archivo no encontrado"
 
-#: ../../../core/core_st.cpp:229
+#: ../../../core/core_st.cpp:231
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5928,7 +5947,7 @@ msgstr ""
 "\n"
 "El siguiente nuevo %ls %ls fusionado en esta base de datos:"
 
-#: ../../../core/core_st.cpp:230
+#: ../../../core/core_st.cpp:232
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5937,7 +5956,7 @@ msgstr ""
 "\n"
 "Fusión completada: %d %ls añadidas (%d %ls, %d %ls, %d %ls)"
 
-#: ../../../core/core_st.cpp:231
+#: ../../../core/core_st.cpp:233
 #, fuzzy, c-format
 msgid ""
 "Conflicting entries for \"%ls\" \"%ls\" \"%ls\".\n"
@@ -5948,60 +5967,60 @@ msgstr ""
 "  Entrada fusionada añadida como «%ls» «%ls» «%ls».\n"
 "    Campo(s) diferentes(s): %ls"
 
-#: ../../../core/core_st.cpp:232
+#: ../../../core/core_st.cpp:234
 #, fuzzy
 msgid "merged"
 msgstr "Fusionar"
 
-#: ../../../core/core_st.cpp:233
+#: ../../../core/core_st.cpp:235
 #, fuzzy, c-format
 msgid "%ls - Merged %ls"
 msgstr "%ls - Fusionar %ls"
 
-#: ../../../core/core_st.cpp:234
+#: ../../../core/core_st.cpp:236
 msgid "MISSING PASSWORD"
 msgstr ""
 
-#: ../../../core/core_st.cpp:235
+#: ../../../core/core_st.cpp:237
 #, c-format
 msgid "\tPassword policy name '%ls' is not in the database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:236
+#: ../../../core/core_st.cpp:238
 msgid ""
 "\tOne or more Password Policy Names were not found in the database. The "
 "affected entries have been changed to use the database's default policy."
 msgstr ""
 
-#: ../../../core/core_st.cpp:237
+#: ../../../core/core_st.cpp:239
 #, c-format
 msgid "MISSING TITLE # %d"
 msgstr ""
 
-#: ../../../core/core_st.cpp:239
+#: ../../../core/core_st.cpp:241
 msgid "Can't obtain the schema version."
 msgstr "No se puede obtener la versión del esquema."
 
-#: ../../../core/core_st.cpp:240
+#: ../../../core/core_st.cpp:242
 msgid "The filter XML version is missing."
 msgstr "Falta la versión de filtro XML."
 
-#: ../../../core/core_st.cpp:241
+#: ../../../core/core_st.cpp:243
 #, fuzzy, c-format
 msgid "Create SchemaCache60 Error 0x%08X during %ls."
 msgstr "Crear SchemaCache%2d Error 0x%08X durante %ls."
 
-#: ../../../core/core_st.cpp:242
+#: ../../../core/core_st.cpp:244
 #, fuzzy, c-format
 msgid "SAX Parse60 Error 0x%08X during %ls."
 msgstr "SAX Análisis%2d Error 0x%08X mientras %ls."
 
-#: ../../../core/core_st.cpp:243
+#: ../../../core/core_st.cpp:245
 #, fuzzy, c-format
 msgid "Error (%08X): line %d character %d %ls"
 msgstr "Error (%08X): línea %d carácter %d %ls"
 
-#: ../../../core/core_st.cpp:245
+#: ../../../core/core_st.cpp:247
 msgid ""
 "Unable to get configuration file lock.\n"
 "\n"
@@ -6011,16 +6030,16 @@ msgstr ""
 "\n"
 "Se usará el registro."
 
-#: ../../../core/core_st.cpp:246
+#: ../../../core/core_st.cpp:248
 msgid "Cannot create lock file - no permission in directory?"
 msgstr ""
 "No se pudo crear fichero de bloqueo - ¿faltan permisos en el directorio?"
 
-#: ../../../core/core_st.cpp:247
+#: ../../../core/core_st.cpp:249
 msgid "Internal error: Out of file handles"
 msgstr "Error interno: Fuera de manejador de fichero"
 
-#: ../../../core/core_st.cpp:248
+#: ../../../core/core_st.cpp:250
 msgid ""
 "Unable to use a MS XML reader on your system.  Neither MS XML V3, V4 or V6 "
 "seems available."
@@ -6028,15 +6047,15 @@ msgstr ""
 "No puede usarse un lector MS XML en tu sistema.  MS XML V3, V4 o V6 no "
 "disponibles."
 
-#: ../../../core/core_st.cpp:250
+#: ../../../core/core_st.cpp:252
 msgid "Unsaved changes"
 msgstr "Cambios no guardados"
 
-#: ../../../core/core_st.cpp:251
+#: ../../../core/core_st.cpp:253
 msgid "is not set"
 msgstr "no está fijado"
 
-#: ../../../core/core_st.cpp:252
+#: ../../../core/core_st.cpp:254
 #, fuzzy, c-format
 msgid ""
 "Number of entries processed: %d\n"
@@ -6071,7 +6090,7 @@ msgstr ""
 "\n"
 "Número de entradas con campos que no pueden mostrarse completamente: %d"
 
-#: ../../../core/core_st.cpp:254
+#: ../../../core/core_st.cpp:256
 msgid ""
 "Password should be mixed case, with at least one digit or punctuation "
 "character"
@@ -6079,92 +6098,135 @@ msgstr ""
 "La contraseña debería tener mayúsculas y minúsculas con al menos un dígito o "
 "símbolo"
 
-#: ../../../core/core_st.cpp:255
+#: ../../../core/core_st.cpp:257
 msgid "Password is too short"
 msgstr "La contraseña es demasiado corta"
 
-#: ../../../core/core_st.cpp:256
+#: ../../../core/core_st.cpp:258
 msgid "Easyvision characters"
 msgstr "Caracteres Easyvision"
 
-#: ../../../core/core_st.cpp:257
+#: ../../../core/core_st.cpp:259
 msgid "Hexadecimal characters"
 msgstr "Caracteres hexadecimales"
 
-#: ../../../core/core_st.cpp:258
+#: ../../../core/core_st.cpp:260
 #, fuzzy
 msgid "Password length"
 msgstr "Longitud de la contraseña:"
 
-#: ../../../core/core_st.cpp:259
+#: ../../../core/core_st.cpp:261
 msgid "Pronounceable passwords"
 msgstr "Contraseñas pronunciables"
 
-#: ../../../core/core_st.cpp:261
+#: ../../../core/core_st.cpp:263
 #, fuzzy
 msgid "Use lowercase characters"
 msgstr "Mínimo de mayúsculas"
 
-#: ../../../core/core_st.cpp:263
+#: ../../../core/core_st.cpp:265
 #, fuzzy
 msgid "Use uppercase characters"
 msgstr "Mínimo de mayúsculas"
 
-#: ../../../core/core_st.cpp:264
+#: ../../../core/core_st.cpp:266
 #, fuzzy, c-format
 msgid "Error in a Password History %ls:"
 msgstr "Error en historial de contraseñas %ls:"
 
-#: ../../../core/core_st.cpp:265
+#: ../../../core/core_st.cpp:267
 #, c-format
 msgid "sub-field starting at position %d (within the History field): "
 msgstr "subcampo empezando en posición %d (en el campo historia): "
 
-#: ../../../core/core_st.cpp:266
+#: ../../../core/core_st.cpp:268
 msgid "  All Password History ignored."
 msgstr "  Historial de Contraseñas ignorado."
 
-#: ../../../core/core_st.cpp:267
+#: ../../../core/core_st.cpp:269
 msgid "Read Error"
 msgstr "Error de lectura"
 
-#: ../../../core/core_st.cpp:268
+#: ../../../core/core_st.cpp:270
+msgid "Relative"
+msgstr "Relativo"
+
+#: ../../../core/core_st.cpp:271
 #, c-format
 msgid ""
 "\tOne or more entry keyboard shortcuts were already assigned to entries in "
 "this database. They have been removed from the %ls entries."
 msgstr ""
 
-#: ../../../core/core_st.cpp:269
+#: ../../../core/core_st.cpp:272
 msgid ""
 "\tOne or more Password Policy Names were already in this database but had "
 "different settings. They have been renamed."
 msgstr ""
 
-#: ../../../core/core_st.cpp:270
+#: ../../../core/core_st.cpp:273
 #, fuzzy, c-format
 msgid "%ls%ls%ls_Report.txt"
 msgstr "%ls%ls%ls_Report.txt"
 
-#: ../../../core/core_st.cpp:271
+#: ../../../core/core_st.cpp:274
 #, fuzzy, c-format
 msgid "Report of %ls function started at %ls"
 msgstr "Informe de %ls función empezada en %ls"
 
-#: ../../../core/core_st.cpp:272
+#: ../../../core/core_st.cpp:275
 #, fuzzy, c-format
 msgid "on database %ls"
 msgstr "en la base de datos %ls"
 
-#: ../../../core/core_st.cpp:273
+#: ../../../core/core_st.cpp:276
+msgid "Compare"
+msgstr "Comparar"
+
+#: ../../../core/core_st.cpp:277
+#, fuzzy
+msgid "Export_DB"
+msgstr "&Exportar"
+
+#: ../../../core/core_st.cpp:278
+msgid "Export_Text"
+msgstr "Export_Text"
+
+#: ../../../core/core_st.cpp:279
+msgid "Export_XML"
+msgstr "Export_XML"
+
+#: ../../../core/core_st.cpp:281
+#, fuzzy
+msgid "Import_KeePassV1_CSV"
+msgstr "Import_KeePassV1_CSV"
+
+#: ../../../core/core_st.cpp:282
+#, fuzzy
+msgid "Import_KeePassV1_TXT"
+msgstr "Import_KeePassV1_TXT"
+
+#: ../../../core/core_st.cpp:283
+msgid "Import_Text"
+msgstr "Importar_Texto"
+
+#: ../../../core/core_st.cpp:284
+msgid "Import_XML"
+msgstr "Importar_XML"
+
+#: ../../../core/core_st.cpp:285
+msgid "Merge"
+msgstr "Fusionar"
+
+#: ../../../core/core_st.cpp:287
 msgid "Validate"
 msgstr "Validar"
 
-#: ../../../core/core_st.cpp:275
+#: ../../../core/core_st.cpp:289
 msgid "Fatal Error"
 msgstr "Error fatal"
 
-#: ../../../core/core_st.cpp:277
+#: ../../../core/core_st.cpp:291
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -6173,117 +6235,127 @@ msgstr ""
 "\n"
 "Error en el historial de contraseñas de la entrada: »%ls»%ls»%ls»: "
 
-#: ../../../core/core_st.cpp:278
+#: ../../../core/core_st.cpp:292
+#, fuzzy, c-format
+msgid "\tNo entries were found containing search string '%ls' %ls"
+msgstr "\tNo se encontraron entradas con la cadena de búsqueda '%s'"
+
+#: ../../../core/core_st.cpp:293
+#, fuzzy, c-format
+msgid "\tThe following entries contain search string '%ls' %ls"
+msgstr "\tLas siguientes entradas contiene la cadena de búsqueda '%s'"
+
+#: ../../../core/core_st.cpp:294
 msgid "See Attachment filters"
 msgstr ""
 
-#: ../../../core/core_st.cpp:279
+#: ../../../core/core_st.cpp:295
 msgid "See Password History filters"
 msgstr "Ver filtros de historial de contraseñas"
 
-#: ../../../core/core_st.cpp:280
+#: ../../../core/core_st.cpp:296
 msgid "See Password Policy filters"
 msgstr "Ver filtros de políticas de contraseñas"
 
-#: ../../../core/core_st.cpp:281
+#: ../../../core/core_st.cpp:297
 msgid "is set"
 msgstr "está fijado"
 
-#: ../../../core/core_st.cpp:282
+#: ../../../core/core_st.cpp:298
 msgid "shortcut"
 msgstr "atajo"
 
-#: ../../../core/core_st.cpp:283
+#: ../../../core/core_st.cpp:299
 msgid "shortcuts"
 msgstr "atajos"
 
-#: ../../../core/core_st.cpp:284
+#: ../../../core/core_st.cpp:300
 msgid "policy specific symbols"
 msgstr ""
 
-#: ../../../core/core_st.cpp:285
+#: ../../../core/core_st.cpp:301
 msgid "Start Report"
 msgstr "Informe de Inicio"
 
-#: ../../../core/core_st.cpp:286
+#: ../../../core/core_st.cpp:302
 msgid "Double-Click on entry to Autotype"
 msgstr "Doble clic en la entrada para autoescritura"
 
-#: ../../../core/core_st.cpp:287
+#: ../../../core/core_st.cpp:303
 msgid "Double-Click on entry to Browse to URL"
 msgstr "Doble clic en la entrada para abrir la URL"
 
-#: ../../../core/core_st.cpp:288
+#: ../../../core/core_st.cpp:304
 msgid "Double-Click on entry to Browse to URL + Autotype"
 msgstr "Doble clic en la entrada para ir a la URL + autoescritura"
 
-#: ../../../core/core_st.cpp:289
+#: ../../../core/core_st.cpp:305
 #, fuzzy
 msgid "https://pwsafe.org/"
 msgstr "https://pwsafe.org/"
 
-#: ../../../core/core_st.cpp:290
+#: ../../../core/core_st.cpp:306
 msgid "Double-Click on entry to Copy Notes"
 msgstr "Doble clic en la entrada para copiar notas"
 
-#: ../../../core/core_st.cpp:291
+#: ../../../core/core_st.cpp:307
 msgid "Double-Click on entry to Copy Password"
 msgstr "Doble clic en la entrada para copiar contraseña"
 
-#: ../../../core/core_st.cpp:292
+#: ../../../core/core_st.cpp:308
 msgid "Double-Click on entry to Copy Password and Minimize"
 msgstr "Doble clic en la entrada para copiar la contraseña y minimizar"
 
-#: ../../../core/core_st.cpp:293
+#: ../../../core/core_st.cpp:309
 msgid "Double-Click on entry to Copy Username"
 msgstr "Doble clic en la entrada para copiar usuario"
 
-#: ../../../core/core_st.cpp:294
+#: ../../../core/core_st.cpp:310
 msgid "Double-Click on entry to Run Command"
 msgstr "Doble clic en la entrada para ejecutar comando"
 
-#: ../../../core/core_st.cpp:295
+#: ../../../core/core_st.cpp:311
 #, fuzzy
 msgid "Double-Click on entry to Send Email"
 msgstr "Doble clic en la entrada para enviar correo"
 
-#: ../../../core/core_st.cpp:296
+#: ../../../core/core_st.cpp:312
 msgid "Double-Click on entry to View/Edit it"
 msgstr "Doble clic en la entrada para ver/editar"
 
-#: ../../../core/core_st.cpp:299
+#: ../../../core/core_st.cpp:315
 #, fuzzy, c-format
 msgid "%ls - Sync'd %ls"
 msgstr "%ls en %ls"
 
-#: ../../../core/core_st.cpp:300
+#: ../../../core/core_st.cpp:316
 msgid "System error: No more file handles available"
 msgstr "Error de sistema: No quedan manejadores de fichero disponibles"
 
-#: ../../../core/core_st.cpp:303
+#: ../../../core/core_st.cpp:319
 msgid "Unknown function"
 msgstr "Función desconocida"
 
-#: ../../../core/core_st.cpp:304
+#: ../../../core/core_st.cpp:320
 msgid "Unknown object"
 msgstr "Objeto desconocido"
 
-#: ../../../core/core_st.cpp:305
+#: ../../../core/core_st.cpp:321
 msgid "Internal error: Unexpected error number"
 msgstr "Error interno: Número de error inesperado"
 
-#: ../../../core/core_st.cpp:307
+#: ../../../core/core_st.cpp:323
 #, c-format
 msgid "\tName: %s; Filename: %s"
 msgstr ""
 
-#: ../../../core/core_st.cpp:308
+#: ../../../core/core_st.cpp:324
 msgid ""
 "The following entries had an invalid UUID field.  This has been corrected."
 msgstr ""
 "Las siguientes entradas tenían un campo no válido UUID. Esto se ha corregido."
 
-#: ../../../core/core_st.cpp:309
+#: ../../../core/core_st.cpp:325
 #, fuzzy, c-format
 msgid ""
 "The following entries have passwords in the correct form for %ls, but the "
@@ -6292,18 +6364,18 @@ msgstr ""
 "La entrada \"%ls, %ls, %ls\" tiene una contraseña con el formato de un "
 "alias, pero la entrada base no existe."
 
-#: ../../../core/core_st.cpp:310
+#: ../../../core/core_st.cpp:326
 msgid "The following entries were duplicates of an existing entry."
 msgstr "Las siguientes entradas eran duplicados de una entrada existente."
 
-#: ../../../core/core_st.cpp:311
+#: ../../../core/core_st.cpp:327
 #, fuzzy
 msgid ""
 "The following entries had a duplicate UUID field.  This has been corrected."
 msgstr ""
 "Las siguientes entradas tenían un campo no válido UUID. Esto se ha corregido."
 
-#: ../../../core/core_st.cpp:312
+#: ../../../core/core_st.cpp:328
 #, fuzzy, c-format
 msgid ""
 "The following entries had an empty Password field, which is not permitted. "
@@ -6311,37 +6383,37 @@ msgid ""
 msgstr ""
 "Las siguientes entradas tenían un campo no válido UUID. Esto se ha corregido."
 
-#: ../../../core/core_st.cpp:313
+#: ../../../core/core_st.cpp:329
 #, fuzzy
 msgid "The following entries had an empty Title field, which is not permitted."
 msgstr ""
 "Las siguientes entradas tenían un campo no válido UUID. Esto se ha corregido."
 
-#: ../../../core/core_st.cpp:314
+#: ../../../core/core_st.cpp:330
 #, fuzzy, c-format
 msgid "\tGroup='%ls', Title='%ls', User='%ls' %ls"
 msgstr "\tGrupo='%ls', Título='%ls', Usuario='%ls' %ls"
 
-#: ../../../core/core_st.cpp:315
+#: ../../../core/core_st.cpp:331
 #, fuzzy, c-format
 msgid "- Its title has been changed to:'%ls'"
 msgstr "- Su título ha cambiado a:'%ls'"
 
-#: ../../../core/core_st.cpp:316
+#: ../../../core/core_st.cpp:332
 msgid "The following ERRORS were detected and were FIXED."
 msgstr ""
 
-#: ../../../core/core_st.cpp:317
+#: ../../../core/core_st.cpp:333
 #, fuzzy
 msgid "The following entries refer to missing attachments."
 msgstr "Las siguientes entradas eran duplicados de una entrada existente."
 
-#: ../../../core/core_st.cpp:318
+#: ../../../core/core_st.cpp:334
 #, fuzzy
 msgid "The following attachments are not referred to by any entry."
 msgstr "Las siguientes entradas eran duplicados de una entrada existente."
 
-#: ../../../core/core_st.cpp:319
+#: ../../../core/core_st.cpp:335
 msgid ""
 "The following entries had an invalid Password History.  This has been "
 "rebuilt with available data.  There may be some loss of history."
@@ -6350,7 +6422,7 @@ msgstr ""
 "sido reconstruido con los datos disponibles. Puede haber alguna pérdida en "
 "el historial."
 
-#: ../../../core/core_st.cpp:320
+#: ../../../core/core_st.cpp:336
 #, fuzzy, c-format
 msgid ""
 "The following entries have one or more text fields too long to display or "
@@ -6360,17 +6432,17 @@ msgstr ""
 "para mostrar o editar (más de %d caracteres). The largest entry size found "
 "was ~%d %ls."
 
-#: ../../../core/core_st.cpp:321
+#: ../../../core/core_st.cpp:337
 msgid ""
 "The following WARNINGS were detected - you should review and fix them "
 "manually."
 msgstr ""
 
-#: ../../../core/core_st.cpp:324
+#: ../../../core/core_st.cpp:340
 msgid "will expire"
 msgstr "caducará"
 
-#: ../../../core/core_st.cpp:325
+#: ../../../core/core_st.cpp:341
 #, fuzzy, c-format
 msgid ""
 "SAX Parse Error during %ls\n"
@@ -6379,23 +6451,23 @@ msgstr ""
 "SAX Error de análisis mientras %ls\n"
 "%ls."
 
-#: ../../../core/core_st.cpp:326
+#: ../../../core/core_st.cpp:342
 #, fuzzy, c-format
 msgid "XML %ls: line %d character %d: %ls"
 msgstr "XML %ls: línea %d caracter %d: %ls"
 
-#: ../../../core/core_st.cpp:327
+#: ../../../core/core_st.cpp:343
 msgid ""
 "*** Invalid XML characters found - see exported XML file for more details ***"
 msgstr ""
 
-#: ../../../core/core_st.cpp:328
+#: ../../../core/core_st.cpp:344
 msgid "Internal error: Couldn't initialize config file XML structure"
 msgstr ""
 "Error interno: no se pudo iniciar el archivo de configuración de la "
 "estructura XML"
 
-#: ../../../core/core_st.cpp:329
+#: ../../../core/core_st.cpp:345
 msgid ""
 "A filter was active. Export of data was restricted to include only those "
 "displayed."
@@ -6403,36 +6475,36 @@ msgstr ""
 "Se activó un filtro. La exportación está restringida a los datos que se "
 "muestran."
 
-#: ../../../core/core_st.cpp:330
+#: ../../../core/core_st.cpp:346
 msgid "Export of data was restricted to certain fields by the user."
 msgstr ""
 "La exportación de datos estaba limitada por el usuarioa a ciertos campos."
 
-#: ../../../core/core_st.cpp:331
+#: ../../../core/core_st.cpp:347
 msgid ""
 "Note: These Password Policies will not replace existing policies with the "
 "same name in the current database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:332
+#: ../../../core/core_st.cpp:348
 msgid ""
 "Note: These preferences are only used when importing into an empty database."
 msgstr ""
 "Nota: Estas preferencias sólo se usan para la importación en una base de "
 "datos vacía."
 
-#: ../../../core/core_st.cpp:333
+#: ../../../core/core_st.cpp:349
 msgid "Subset of entries restricted by the following rule:"
 msgstr "Subconjunto de entradas limitado por la regla siguiente:"
 
-#: ../../../core/core_st.cpp:334
+#: ../../../core/core_st.cpp:350
 msgid ""
 "The user specified that the following fields be excluded from the export:"
 msgstr ""
 "El usuario ha especificado que los siguientes campos queden excluidos de la "
 "exportación:"
 
-#: ../../../core/core_st.cpp:335
+#: ../../../core/core_st.cpp:351
 #, fuzzy, c-format
 msgid ""
 "Configuration file error:\n"
@@ -6445,15 +6517,15 @@ msgstr ""
 "%ls\n"
 "línea %d columna %d"
 
-#: ../../../core/core_st.cpp:336
+#: ../../../core/core_st.cpp:352
 msgid "import"
 msgstr "importar"
 
-#: ../../../core/core_st.cpp:337
+#: ../../../core/core_st.cpp:353
 msgid "Unable to load configuration file"
 msgstr "No ha sido posible cargar el fichero de configuración"
 
-#: ../../../core/core_st.cpp:338
+#: ../../../core/core_st.cpp:354
 msgid ""
 "Failed to lock configuration file - opened by another instance of "
 "PasswordSafe?"
@@ -6461,112 +6533,57 @@ msgstr ""
 "Error al bloquear archivo de configuración - ¿Está abierto por otra "
 "instancia de PasswordSafe?"
 
-#: ../../../core/core_st.cpp:339
+#: ../../../core/core_st.cpp:355
 msgid "Unable to save configuration file"
 msgstr "No ha sido posible guardar el fichero de configuración"
 
-#: ../../../core/core_st.cpp:340
+#: ../../../core/core_st.cpp:356
 #, fuzzy
 msgid "validation"
 msgstr "validación"
 
-#: ../../../core/core_st.cpp:342
+#: ../../../core/core_st.cpp:358
 msgid " (EasyVision Symbols)"
 msgstr ""
 
-#: ../../../core/core_st.cpp:343
+#: ../../../core/core_st.cpp:359
 #, fuzzy, c-format
 msgid "Yes (at least %d)"
 msgstr "Al menos debe ser %d"
 
-#: ../../../core/core_st.cpp:344
+#: ../../../core/core_st.cpp:360
 #, fuzzy
 msgid " (Pronounceable Symbols)"
 msgstr "Contraseñas pronunciables"
 
-#: ../../../core/core_st.cpp:345
+#: ../../../core/core_st.cpp:361
 #, fuzzy, c-format
 msgid "Yes - At least %d from %ls: %ls%ls"
 msgstr "Al menos debe ser %d from %ls: %ls"
 
-#: ../../../core/core_st.cpp:346
 #, fuzzy, c-format
-msgid "\tGroup='%ls', Title='%ls', User='%ls'"
-msgstr "\tGrupo='%ls', Título='%ls', Usuario='%ls' %ls"
-
-#: ../../../core/core_st.cpp:347
-#, fuzzy, c-format
-msgid ""
-"Compare complete of current database:\n"
-"\t %ls\n"
-" and:\n"
-"\t %ls\n"
-msgstr ""
-"Comparación completa de la base de datos actual:\n"
-"\t %s\n"
-" y:\n"
-"\t %s"
-
-#: ../../../core/core_st.cpp:348
-#, fuzzy, c-format
-msgid "\tNo entries were found containing search string '%ls' %ls"
-msgstr "\tNo se encontraron entradas con la cadena de búsqueda '%s'"
-
-#: ../../../core/core_st.cpp:349
-#, fuzzy, c-format
-msgid "\tThe following entries contain search string '%ls' %ls"
-msgstr "\tLas siguientes entradas contiene la cadena de búsqueda '%s'"
-
-#: ../../../core/core_st.cpp:350
-#, fuzzy
-msgid "Export DB"
-msgstr "&Exportar"
-
-#: ../../../core/core_st.cpp:351
-#, fuzzy
-msgid "Import KeePassV1 CSV"
-msgstr "Importar KeePass V1 CSV"
-
-#: ../../../core/core_st.cpp:352
-#, fuzzy
-msgid "Import KeePassV1 TXT"
-msgstr "Importar KeePass V1 TXT"
-
-#: ../../../core/core_st.cpp:353
-#, fuzzy
-msgid "Import XML"
-msgstr ""
-"\n"
-"Importar XML"
-
-#: ../../../core/core_st.cpp:354
-#, fuzzy
-msgid "Import Text"
-msgstr ""
-"\n"
-"Importar Texto"
-
-#: ../../../core/core_st.cpp:355
-msgid "Merge"
-msgstr "Fusionar"
-
-#: ../../../core/core_st.cpp:356
-msgid "Compare"
-msgstr "Comparar"
-
-#~ msgid "Import_Text"
-#~ msgstr "Importar_Texto"
-
-#~ msgid "Import_XML"
-#~ msgstr "Importar_XML"
+#~ msgid "\tGroup='%ls', Title='%ls', User='%ls'"
+#~ msgstr "\tGrupo='%ls', Título='%ls', Usuario='%ls' %ls"
 
 #, fuzzy
-#~ msgid "Import_KeePassV1_CSV"
-#~ msgstr "Import_KeePassV1_CSV"
+#~ msgid "Import KeePassV1 CSV"
+#~ msgstr "Importar KeePass V1 CSV"
 
 #, fuzzy
-#~ msgid "Import_KeePassV1_TXT"
-#~ msgstr "Import_KeePassV1_TXT"
+#~ msgid "Import KeePassV1 TXT"
+#~ msgstr "Importar KeePass V1 TXT"
+
+#, fuzzy
+#~ msgid "Import XML"
+#~ msgstr ""
+#~ "\n"
+#~ "Importar XML"
+
+#, fuzzy
+#~ msgid "Import Text"
+#~ msgstr ""
+#~ "\n"
+#~ "Importar Texto"
 
 #, fuzzy
 #~ msgid "Advanced..."
@@ -8007,12 +8024,6 @@ msgstr "Comparar"
 #~ "Archivo a exportar: '%s' ya existe.\n"
 #~ "¿Quieres reemplazarlo?"
 
-#~ msgid "Export_Text"
-#~ msgstr "Export_Text"
-
-#~ msgid "Export_XML"
-#~ msgstr "Export_XML"
-
 #~ msgid "Exporting to file:"
 #~ msgstr "Exportando al archivo:"
 
@@ -8780,9 +8791,6 @@ msgstr "Comparar"
 #~ "Recuperar los documentos guardados automáticamente\n"
 #~ "Abre las versiones guardadas automáticamente en lugar de las guardadas "
 #~ "explicitamente"
-
-#~ msgid "Relative"
-#~ msgstr "Relativo"
 
 #~ msgid ""
 #~ "Relative dates are in days relative to today e.g. '-1' is yesterday and "
@@ -10081,9 +10089,6 @@ msgstr "Comparar"
 #~ msgstr ""
 #~ "\tEntrada - Grupo:\"%s\"; Título:\"%s\"; Usuario:\"%s\"\n"
 #~ "\t\t tienen diferencias en los siguientes campos:"
-
-#~ msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-#~ msgstr "\tGrupo:'%s'; Título:'%s'; Usuario:'%s'"
 
 #~ msgid ""
 #~ "\tThe following restrictions were selected:\n"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-28 12:52+0100\n"
+"POT-Creation-Date: 2021-03-19 21:58+0100\n"
 "PO-Revision-Date: 2011-10-12 16:57-0800\n"
 "Last-Translator: François Lamoureux <franklamoureux@hotmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -236,7 +236,7 @@ msgstr "Heures et Dates"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:348
 #: ../../../ui/wxWidgets/HelpMap.h:41 ../../../ui/wxWidgets/HelpMap.h:49
-#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:141
+#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:143
 msgid "Password Policy"
 msgstr "Stratégie de mot de passe"
 
@@ -250,7 +250,7 @@ msgid "Set Date/Time"
 msgstr "Mettre à jour la date/l'heure"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:370
-#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:137
+#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:139
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -531,13 +531,13 @@ msgstr "Utiliser des M&AJUSCULES"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:747
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:281
-#: ../../../core/core_st.cpp:260
+#: ../../../core/core_st.cpp:262
 msgid "Use digits"
 msgstr "Utiliser des chiffres"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:771
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:305
-#: ../../../core/core_st.cpp:262
+#: ../../../core/core_st.cpp:264
 msgid "Use symbols"
 msgstr "Utiliser des symboles"
 
@@ -571,7 +571,7 @@ msgstr "Générer des mots &prononçables"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:815
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:350
-#: ../../../core/core_st.cpp:253
+#: ../../../core/core_st.cpp:255
 msgid "Or"
 msgstr "Ou"
 
@@ -619,7 +619,7 @@ msgstr "Propriétés"
 #: ../../../ui/wxWidgets/CreateShortcutDlg.cpp:219
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:269
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:274
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
 msgid "Text"
 msgstr "Texte"
 
@@ -675,7 +675,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:160
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:173
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:192
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:301
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:317
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -789,7 +789,7 @@ msgstr "[Notes cachées - cliquer ici pour les afficher]"
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:1653
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2145
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2820
-#: ../../../core/core_st.cpp:74
+#: ../../../core/core_st.cpp:76
 msgid "Default Policy"
 msgstr "Stratégie par défaut"
 
@@ -810,7 +810,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:144
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:151
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:159
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:200
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:201
 #: ../../../ui/wxWidgets/PWSafeApp.cpp:367
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:737
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:756
@@ -834,7 +834,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:249
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:277
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:316
-#: ../../../core/core_st.cpp:274
+#: ../../../core/core_st.cpp:288
 msgid "Error"
 msgstr "Erreur"
 
@@ -1010,7 +1010,7 @@ msgid "Synchronize this item..."
 msgstr "S&ynchroniser..."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:482
-#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:357
+#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:286
 msgid "Synchronize"
 msgstr "Synchroniser"
 
@@ -1092,8 +1092,8 @@ msgid "Current safe was opened read-only"
 msgstr "Ouvrir en lecture seule"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:793
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:996
-#: ../../../ui/wxWidgets/SyncWizard.cpp:618
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
+#: ../../../ui/wxWidgets/SyncWizard.cpp:619
 #, fuzzy, c-format
 msgid ""
 "The database:\n"
@@ -1111,7 +1111,7 @@ msgstr ""
 "Veuillez corriger en validant le fichier."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:794
-#: ../../../ui/wxWidgets/SyncWizard.cpp:617
+#: ../../../ui/wxWidgets/SyncWizard.cpp:618
 msgid "Synchronization failed"
 msgstr "La synchronisation a échoué"
 
@@ -1479,7 +1479,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/GridCtrl.cpp:164
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:292
-#: ../../../core/core_st.cpp:147
+#: ../../../core/core_st.cpp:149
 msgid "Title"
 msgstr "Titre"
 
@@ -1698,7 +1698,7 @@ msgid "Value"
 msgstr "Valeur"
 
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:291
-#: ../../../core/core_st.cpp:133
+#: ../../../core/core_st.cpp:135
 msgid "Group"
 msgstr "Groupe"
 
@@ -1782,17 +1782,17 @@ msgstr ""
 msgid "Error parsing Run Command"
 msgstr "Erreur de syntaxe dans l'exécution de la commande"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:56
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:57
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:355
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:362
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:166
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:623
 msgid "Write Error"
 msgstr "Erreur d'écriture"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:61
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:62
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:165
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:622
 #, fuzzy
@@ -1802,7 +1802,7 @@ msgstr ""
 "\n"
 "N'a pas pu ouvrir le fichier en écriture!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:64
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:65
 msgid ""
 "Write operation failed!\n"
 "File may have been corrupted.\n"
@@ -1812,7 +1812,7 @@ msgstr ""
 "Le fichier peut avoir été corrompu.\n"
 "Essayer d'enregistrer dans un autre dossier."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:69
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:70
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 #, fuzzy
 msgid "Unknown error"
@@ -1821,36 +1821,36 @@ msgstr ""
 "\n"
 "Erreur inconnue"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:90
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:91
 #, fuzzy
 msgid "Do you want to save changes to the password database: "
 msgstr "Voulez-vous enregistrer les changements dans le fichier: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:145
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:146
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:557
 msgid "Please choose a name for the new database"
 msgstr "SVP, Choisissez un nom pour le nouveau fichier"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:155
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:156
 #, fuzzy
 msgid "psafe3 files (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 msgstr "Fichier PasswordSafe (*.psafe3)|*.psafe3|Tous fichiers (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Lock is done by yourself"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Remove Lock?"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:194
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:195
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:602
 #, fuzzy
 msgid "Could not lock file.\n"
@@ -1859,18 +1859,18 @@ msgstr ""
 "\n"
 "N'a pas pu ouvrir le fichier en lecture!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:196
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:197
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:452
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:604
 msgid "Locked by "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:236
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:237
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:515
 msgid "Please Choose a Database to Open:"
 msgstr "SVP, Choisissez un fichier à ouvrir:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:353
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Save database elsewhere or with "
@@ -1880,7 +1880,7 @@ msgid ""
 msgstr ""
 "%s. Essayer d'enregistrer avec un nouveau nom ou quittez sans enregistrer."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:360
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Do you wish to save changes to your "
@@ -1888,12 +1888,12 @@ msgid ""
 msgstr ""
 "%s. Essayer d'enregistrer avec un nouveau nom ou quittez sans enregistrer."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 msgid "Unable to create intermediate backup."
 msgstr "Incapable de créer une sauvegarde intermédiaire"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:386
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:387
 #, fuzzy, c-format
 msgid ""
 "The original database, \"%ls\", is in pre-3.0 format. It will be unchanged.\n"
@@ -1908,12 +1908,12 @@ msgstr ""
 "enregistrer vos changements dans l'ancien format, utilisez \"Fichier-"
 ">Exporter vers->Format v1x ou v2\""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:388
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:389
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:447
 msgid "File version warning"
 msgstr "Avertissement de la version du fichier"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:445
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
 #, fuzzy, c-format
 msgid ""
 "The original database, '%ls', is in pre-3.0 format. The data will now be "
@@ -1926,15 +1926,15 @@ msgstr ""
 "versions de PasswordSafe. Pour enregistrer vos changements dans l'ancien "
 "format, utilisez \"Fichier->Exporter vers->Format v1x ou v2\""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:458
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
 msgid "Please choose a name for the current (Untitled) database:"
 msgstr "SVP, Choisissez un nom pour le fichier courant (sans titre)"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:460
 msgid "Please choose a new name for the current database:"
 msgstr "SVP, Choisissez un nouveau nom pour le fichier courant"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:467
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:468
 #, fuzzy
 msgid ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|"
@@ -1943,7 +1943,7 @@ msgstr ""
 "Fichier PasswordSafe (*.psafe3; *.dat)|*.psafe3; *.dat|Tous les fichiers (*."
 "*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:479
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -1954,40 +1954,40 @@ msgstr ""
 "\n"
 "Le fichier est couramment verrouillé par %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:481
 msgid "File lock error"
 msgstr "Erreur de verrouillage de fichier"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:547
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
 #, fuzzy
 msgid "Do you wish to save this restored database as new database?"
 msgstr "Voulez-vous enregistrer les changements dans le fichier: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:549
 #, fuzzy
 msgid "Unsaved restored database"
 msgstr "au fichier"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:580
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:581
 #, fuzzy
 msgid "Do you want to save changes to the password database"
 msgstr "Voulez-vous enregistrer les changements dans le fichier: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:617
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:618
 msgid "Export Text"
 msgstr "Exporter du texte"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:621
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:622
 #, fuzzy
 msgid "Export Text failed"
 msgstr "L'importation de texte a échoué"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:623
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
 msgid "Please name the plaintext file"
 msgstr "Veuillez nommer le fichier texte"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1143
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:625
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1144
 #, fuzzy
 msgid ""
 "Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
@@ -1995,107 +1995,107 @@ msgstr ""
 "Fichiers de texte (*.txt)|*.txt|Fichiers CSV (*.csv)|*.csv|Tous fichiers (*."
 "*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:634
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:635
 msgid "Advanced Text Export Options"
 msgstr "Options avancées d'exportation texte"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:654
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:697
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:655
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:698
 #, fuzzy
 msgid "export"
 msgstr "exporté(es)"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:660
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:661
 msgid "Export XML"
 msgstr "Exporter en XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:664
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:665
 #, fuzzy
 msgid "Export XML failed"
 msgstr "L'importation de XML a échoué"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:666
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
 msgid "Please name the XML file"
 msgstr "Veuillez nommer le fichier XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:668
 #, fuzzy
 msgid "XML files (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 msgstr "Fichiers XML (*.xml)|*.xml|All files (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:678
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:679
 msgid "Advanced XML Export Options"
 msgstr "Options avancées d'exportation XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:712
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:716
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:713
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:717
 #, fuzzy
 msgid "Password Safe Databases (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 msgstr ""
 "Fichier PasswordSafe (*.psafe3; *.dat)|*.psafe3; *.dat|Tous les fichiers (*."
 "*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:720
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:721
 #, fuzzy
 msgid "Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 msgstr ""
 "Fichier PasswordSafe (*.psafe3; *.dat)|*.psafe3; *.dat|Tous les fichiers (*."
 "*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:731
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:732
 msgid "Please name the exported database"
 msgstr "Veuillez nommer la base exportée"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:748
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:749
 msgid "Could not figure out why PasswordSafeFrame::OnExportVx was invoked"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:782
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:783
 msgid "You must save this database before it can be exported."
 msgstr "Vous devez enregistrer ce fichier avant qu'il soit exporté."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 #, fuzzy
 msgid "Exporting database: "
 msgstr "Fusion de : %s\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid " to "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:841
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:842
 #, fuzzy
 msgid "Export complete.  Do you wish to see a detailed report?"
 msgstr "Voulez-vous le remplacer?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:852
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:853
 #, fuzzy
 msgid "No entries satisfied your selection criteria and so none were exported!"
 msgstr ""
 "Aucune entrée ne satisfait aux critères de sélection, donc aucune ne peut "
 "être %s!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:865
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:866
 msgid "Passkey incorrect"
 msgstr "Mot de passe invalide"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:873
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
 msgid ""
 "The current database was opened in read-only mode.  You cannot import into "
 "it."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:875
 #, fuzzy
 msgid "Import text"
 msgstr "Importer du &Texte"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:882
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
 #, fuzzy
 msgid "The database:"
 msgstr "au fichier"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
 #, fuzzy
 msgid "has duplicate entries with the same group/title/user combination."
 msgstr ""
@@ -2106,32 +2106,32 @@ msgstr ""
 "a des entrées similaires ayant la même combinaison groupe/titre/utilisateur. "
 "Veuillez corriger en validant le fichier."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
 msgid "  Please fix by validating database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:931
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:886
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:932
 msgid "Import Text failed"
 msgstr "L'importation de texte a échoué"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 #, fuzzy, c-format
 msgid "%ls file being imported: %ls"
 msgstr "Le fichier %ls est en train d^\"tre importé: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:921
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:926
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:223
-#: ../../../ui/wxWidgets/SyncWizard.cpp:572
+#: ../../../ui/wxWidgets/SyncWizard.cpp:573
 #: ../../../ui/wxWidgets/wxUtilities.cpp:59
 #: ../../../ui/wxWidgets/wxUtilities.cpp:64
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "File Read Error"
 msgstr "Erreur de lecture de fichier"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:923
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:222
 #: ../../../ui/wxWidgets/wxUtilities.cpp:58
 #, fuzzy
@@ -2141,7 +2141,7 @@ msgstr ""
 "\n"
 "N'a pas pu ouvrir le fichier en lecture!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:928
 #, fuzzy
 msgid "Invalid format"
 msgstr ""
@@ -2149,77 +2149,77 @@ msgstr ""
 "\n"
 "Format invalide"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Updated "
 msgstr "%d %s mis à jour"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Imported "
 msgstr "Importé"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entry"
 msgstr "entrée"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entries"
 msgstr "entrées"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
 #, fuzzy
 msgid "Skipped "
 msgstr ""
 "\n"
 "%d %s ignoré(es)"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:957
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:958
 #, fuzzy
 msgid "with Password History errors "
 msgstr ""
 "\n"
 "avec erreur d'historique de mot de passe %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid "Renamed "
 msgstr "Renommer"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed successfully"
 msgstr "Complété avec succes"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed but ...."
 msgstr "Complété mais..."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:981
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1127
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1197
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1218
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1279
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:982
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1128
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1219
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
 #, fuzzy
 msgid "Do you wish to see a detailed report?"
 msgstr "Voulez-vous le remplacer?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1045
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:998
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1046
 msgid "Import XML failed"
 msgstr "L'importation de XML a échoué"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1007
-#: ../../../core/core_st.cpp:238
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../core/core_st.cpp:240
 #, c-format
 msgid ""
 "Can't find XML Schema Definition file (%ls) in your PasswordSafe Application "
@@ -2231,20 +2231,20 @@ msgstr ""
 "Veuillez le copier depuis votre fichier d'installation ou réinstaller "
 "PasswordSafe."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 #, fuzzy
 msgid "Missing XSD File - "
 msgstr "Fichier XSD manquant"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid " Build"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 msgid "XML"
 msgstr "XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1051
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1052
 #, fuzzy, c-format
 msgid ""
 "File: %ls failed validation against XML Schema:\n"
@@ -2255,7 +2255,7 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1057
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1058
 #, fuzzy, c-format
 msgid ""
 "File: %ls passed Validation but had the following errors during import:\n"
@@ -2267,27 +2267,27 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1078
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1079
 msgid "The following records were skipped:"
 msgstr "Les entrées suivantes ont étés ignorés:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1080
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1081
 #, c-format
 msgid " / skipped %d"
 msgstr " / %d sautés"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1085
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1086
 msgid "The following records had errors in their Password History:"
 msgstr ""
 "Les entrées suivantes avaient des erreurs dans leur historique de mot de "
 "passe :"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1087
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1088
 #, c-format
 msgid " / with Password History errors %d"
 msgstr " / %d avec erreurs d'Historique de Mot de Passe"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1092
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1093
 msgid ""
 "The following records were renamed as an entry already exists in your "
 "database or in the Import file:"
@@ -2295,12 +2295,12 @@ msgstr ""
 "Les entrées suivantes ont été renommés car une entrée existe déjà la votre "
 "fichier ou le fichier importé :"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1094
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1095
 #, c-format
 msgid " / renamed %d"
 msgstr " / %d renommé"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1099
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1100
 #, fuzzy, c-format
 msgid ""
 "File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See "
@@ -2309,25 +2309,25 @@ msgstr ""
 "Fichier: %ls a été importé (%d entrées validées / importées %d%ls%ls%ls). "
 "Détails dans le rapport."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:95
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:97
 msgid "entry"
 msgstr "entrée"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:93
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:95
 msgid "entries"
 msgstr "entrées"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1107
 #, fuzzy, c-format
 msgid ""
 "Validated %d %ls\n"
@@ -2338,26 +2338,26 @@ msgstr ""
 "\n"
 "%d %ls importées"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1114
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1115
 msgid "XML import not supported in this release"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1117
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1118
 #, c-format
 msgid "XML import: Unexpected return code(%d)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1141
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1142
 msgid "Please Choose a KeePass Text File to Import"
 msgstr "SVP, Choisissez un fichier texte Keepass à importer"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1163
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1164
 #, fuzzy, c-format
 msgid "Text file being imported: %ls"
 msgstr "Le fichier est en importé: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1180
-#: ../../../ui/wxWidgets/SyncWizard.cpp:602
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/SyncWizard.cpp:603
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2368,11 +2368,11 @@ msgstr ""
 "\n"
 "N'a pas pu ouvrir le fichier en lecture!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1182
 msgid "File open error"
 msgstr "Erreur d'ouverture de fichier"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1195
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1196
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2383,21 +2383,21 @@ msgstr ""
 "\n"
 "Format invalide"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1199
 msgid "Import failed"
 msgstr "L'importation a échoué."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1214
 #, fuzzy, c-format
 msgid "Imported %d %ls"
 msgstr "%d %ls importé"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1265
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1266
 #, fuzzy
 msgid "Merging database: "
 msgstr "Fusion de : %s\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1281
 #, fuzzy
 msgid "Merge Complete"
 msgstr "La comparaison est finie"
@@ -2510,16 +2510,16 @@ msgstr ""
 "fichier.\n"
 "Essayer de redémarrer le programme."
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #, fuzzy
 msgid " file '"
 msgstr "Gestion des filtres"
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid "' not readable"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #: ../../../ui/wxWidgets/ViewReportDlg.cpp:32
 msgid "View Report"
 msgstr "Voir le rapport"
@@ -2569,7 +2569,7 @@ msgid "Please select a valid file"
 msgstr "Veuillez sélectionner un rapport pour l'afficher. "
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:123
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:249
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:251
 msgid "None"
 msgstr "Aucun"
 
@@ -2583,7 +2583,7 @@ msgid "Incremented Number [001-999]"
 msgstr "Nombre incrémenté [001-999]"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:132
-#: ../../../core/core_st.cpp:66
+#: ../../../core/core_st.cpp:68
 #, fuzzy
 msgid "Copy password to clipboard"
 msgstr "&Copier le mot de passe au presse-papier"
@@ -2595,37 +2595,37 @@ msgstr "Voir/Modifier l'entrée sélectionnée"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:134
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:623
-#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:62
+#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:64
 msgid "Autotype"
 msgstr "Autofrappe"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:135
-#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:63
+#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:65
 msgid "Browse to URL"
 msgstr "Aller sur l'URL"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:136
-#: ../../../core/core_st.cpp:65
+#: ../../../core/core_st.cpp:67
 msgid "Copy notes to clipboard"
 msgstr "Copier les notes au presse-papier"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:137
-#: ../../../core/core_st.cpp:68
+#: ../../../core/core_st.cpp:70
 msgid "Copy username to clipboard"
 msgstr "Copier le nom d'utilisateur au presse-papier"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:138
-#: ../../../core/core_st.cpp:67
+#: ../../../core/core_st.cpp:69
 msgid "Copy password to clipboard, minimize"
 msgstr "Copier le mot de passe au presse-papier, réduire"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:139
-#: ../../../core/core_st.cpp:64
+#: ../../../core/core_st.cpp:66
 msgid "Browse to URL + Autotype"
 msgstr "Aller à l'URL + Autofrappe"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:140
-#: ../../../core/core_st.cpp:69 ../../../core/core_st.cpp:144
+#: ../../../core/core_st.cpp:71 ../../../core/core_st.cpp:146
 msgid "Run Command"
 msgstr "Exécuter la commande"
 
@@ -3056,24 +3056,24 @@ msgstr ""
 msgid "Don't show this warning again"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:849
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:854
 msgid "Missing help definition for page \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:850
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
 msgid "\" of \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:860
 msgid "Missing help definition for window \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:866
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:871
 #, fuzzy
 msgid "Please inform the developers."
 msgstr "Veuillez nommer ce filtre"
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:867
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:872
 msgid "Help Undefined"
 msgstr ""
 
@@ -3799,6 +3799,7 @@ msgid "search"
 msgstr "&Rechercher"
 
 #: ../../../ui/wxWidgets/PasswordSafeSearch.cpp:427
+#: ../../../core/core_st.cpp:280
 msgid "Find"
 msgstr "Chercher"
 
@@ -3920,20 +3921,20 @@ msgstr "validation"
 msgid " empty)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:306
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:322
 #, c-format
 msgid "%ls on %ls"
 msgstr "%ls sur %ls"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:341
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:357
 msgid "Yes"
 msgstr "Oui"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:244
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:246
 msgid "No"
 msgstr "Non"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:302
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:318
 #, c-format
 msgid "In Headers(%ls)/In Entries("
 msgstr "Dans les entêtes(%ls)/Dans les entrées("
@@ -4119,7 +4120,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:457
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:269
-#: ../../../core/core_st.cpp:276
+#: ../../../core/core_st.cpp:290
 msgid "Warning"
 msgstr "Attention"
 
@@ -4194,11 +4195,11 @@ msgstr ""
 "\n"
 "SVP, essayez-en un autre"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:96
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:98
 msgid "equals"
 msgstr "égale"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:83
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:85
 msgid "does not equal"
 msgstr "n'est pas égal à"
 
@@ -4206,23 +4207,23 @@ msgstr "n'est pas égal à"
 msgid "begins with"
 msgstr "commence par"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:78
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:80
 msgid "does not begin with"
 msgstr "ne commence pas avec"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:90
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:92
 msgid "ends with"
 msgstr "se termine par"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:82
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:84
 msgid "does not end with"
 msgstr "ne se termine pas par"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:56
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:58
 msgid "contains"
 msgstr "contient"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:79
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:81
 msgid "does not contain"
 msgstr "ne contient pas"
 
@@ -4279,80 +4280,80 @@ msgstr "&OK"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:143
+#: ../../../ui/wxWidgets/SyncWizard.cpp:144
 #, fuzzy
 msgid "synchronize"
 msgstr "synchronisé"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:220
+#: ../../../ui/wxWidgets/SyncWizard.cpp:221
 #, fuzzy
 msgid "Synchronize another database with currently open database"
 msgstr "Fusion de ce fichier au fichier courant:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:349
+#: ../../../ui/wxWidgets/SyncWizard.cpp:350
 msgid "Introduction"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:353
+#: ../../../ui/wxWidgets/SyncWizard.cpp:354
 msgid ""
 "Synchronizing with another database will update the entries in your\n"
 "database with matching entries from the other database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:356
+#: ../../../ui/wxWidgets/SyncWizard.cpp:357
 msgid "More Info"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:359
+#: ../../../ui/wxWidgets/SyncWizard.cpp:360
 msgid ""
 "1. Two entries from different databases match if their Group, Title\n"
 "and User fields match."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:360
+#: ../../../ui/wxWidgets/SyncWizard.cpp:361
 msgid ""
 "2. You can select the fields to update, as well as filter the entries\n"
 "for synchronization."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:361
+#: ../../../ui/wxWidgets/SyncWizard.cpp:362
 msgid ""
 "3. Only existing entries in your database are updated.  No new entries are\n"
 "added or existing entries removed during this process."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:362
+#: ../../../ui/wxWidgets/SyncWizard.cpp:363
 msgid ""
 "4. You can undo the operation once it is complete, but won't be\n"
 "able to abort it mid-way."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:379
+#: ../../../ui/wxWidgets/SyncWizard.cpp:380
 #, fuzzy
 msgid "Select another database"
 msgstr "Sélectionner le fichier"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:381
+#: ../../../ui/wxWidgets/SyncWizard.cpp:382
 #, fuzzy
 msgid "Choose Database to Synchronize with \""
 msgstr "Veuillez choisir un fichier à synchroniser au fichier courant"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:382
+#: ../../../ui/wxWidgets/SyncWizard.cpp:383
 #, fuzzy
 msgid "Please Choose a Database to Synchronize with current database"
 msgstr "Veuillez choisir un fichier à synchroniser au fichier courant"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:405
+#: ../../../ui/wxWidgets/SyncWizard.cpp:406
 #, fuzzy
 msgid "Synchronization options"
 msgstr "La synchronisation a échoué"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:429
+#: ../../../ui/wxWidgets/SyncWizard.cpp:430
 #, fuzzy
 msgid "Options Summary"
 msgstr "Options"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:454
+#: ../../../ui/wxWidgets/SyncWizard.cpp:455
 #, fuzzy
 msgid ""
 "WARNING!!\n"
@@ -4363,58 +4364,58 @@ msgstr ""
 "ATTENTION: Si vous continuez, les champs du fichier courant seront mis-à-"
 "jour avec ceux du fichier d'entrée sélectionné."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:471
+#: ../../../ui/wxWidgets/SyncWizard.cpp:472
 msgid " will be updated with corresponding entries from \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:478
+#: ../../../ui/wxWidgets/SyncWizard.cpp:479
 msgid "All fields in matching entries will be updated"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:484
+#: ../../../ui/wxWidgets/SyncWizard.cpp:485
 msgid "Following fields in matching entries will be updated:"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:488
+#: ../../../ui/wxWidgets/SyncWizard.cpp:489
 #, fuzzy
 msgid "Following fields will not be updated:"
 msgstr "Les colonnes suivantes seront traitées:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:507
+#: ../../../ui/wxWidgets/SyncWizard.cpp:508
 #, fuzzy
 msgid "Synchronization status"
 msgstr "La synchronisation a échoué"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:525
+#: ../../../ui/wxWidgets/SyncWizard.cpp:526
 msgid "See a detailed report"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:561
+#: ../../../ui/wxWidgets/SyncWizard.cpp:562
 msgid "Your database is being synchronized with \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:571
+#: ../../../ui/wxWidgets/SyncWizard.cpp:572
 msgid "There was an error during synchronization"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:585
+#: ../../../ui/wxWidgets/SyncWizard.cpp:586
 #, fuzzy, c-format
 msgid "Your database has been synchronized with \"%ls\""
 msgstr "Veuillez choisir un fichier à synchroniser avec \"%ls\""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:586
+#: ../../../ui/wxWidgets/SyncWizard.cpp:587
 #, fuzzy, c-format
 msgid "%ld %ls updated"
 msgstr ""
 "\n"
 "Les %ls %ls suivants mis-à-jour:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:589
 #, fuzzy
 msgid "Synchronization completed successfully"
 msgstr "Complété avec succes"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:604
+#: ../../../ui/wxWidgets/SyncWizard.cpp:605
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4428,7 +4429,7 @@ msgstr ""
 "Les données ont pu être perdues ou modifiées.\n"
 "Continuer de toute façon?"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:606
+#: ../../../ui/wxWidgets/SyncWizard.cpp:607
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4439,24 +4440,24 @@ msgstr ""
 "\n"
 "Erreur inconnue"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:640
+#: ../../../ui/wxWidgets/SyncWizard.cpp:641
 #, fuzzy, c-format
 msgid "Synchronizing from database: %ls\n"
 msgstr "Synchronisation à partir du fichier: %ls\n"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:643
+#: ../../../ui/wxWidgets/SyncWizard.cpp:644
 msgid "synchronized"
 msgstr "synchronisé"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:322
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:338
 msgid "was"
 msgstr "a été"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:323
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:339
 msgid "were"
 msgstr "ont été"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:298
+#: ../../../ui/wxWidgets/SyncWizard.cpp:733 ../../../core/core_st.cpp:314
 #, c-format
 msgid ""
 "\n"
@@ -4465,7 +4466,7 @@ msgstr ""
 "\n"
 "Les %ls %ls suivants mis-à-jour:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:297
+#: ../../../ui/wxWidgets/SyncWizard.cpp:749 ../../../core/core_st.cpp:313
 #, c-format
 msgid ""
 "\n"
@@ -4638,7 +4639,7 @@ msgstr ""
 "La cible de ce raccourci [%s:%s:%s] n'est pas une entrée normale ou est déjà "
 "une base de raccourci."
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:94
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:96
 #, c-format
 msgid ""
 "The following entries had a policy name that already existed in this "
@@ -4746,13 +4747,13 @@ msgstr ""
 "Les données ont pu être perdues ou modifiées.\n"
 "Continuer de toute façon?"
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:381
+#: ../../../ui/wxWidgets/wxUtilities.cpp:390
 msgid ""
 "An error occurred while trying to get the image data from database item.\n"
 "Therefore, the image cannot be displayed in the preview."
 msgstr ""
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:394
+#: ../../../ui/wxWidgets/wxUtilities.cpp:403
 msgid ""
 "An error occurred while trying to load the image data into the preview "
 "area.\n"
@@ -4888,7 +4889,7 @@ msgstr ""
 "\n"
 "Copier le mot de passe au presse-papier"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:149
+#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:151
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
@@ -4899,7 +4900,7 @@ msgstr ""
 "\n"
 "Copier le nom d'utilisateur au presse-papier"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:136
+#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:138
 #, fuzzy
 msgid "Notes"
 msgstr "&Notes:"
@@ -4935,7 +4936,7 @@ msgstr ""
 msgid "Browse URL"
 msgstr "Aller sur l'URL"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:70
+#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:72
 #, fuzzy
 msgid "Send Email"
 msgstr "Envoyer un courriel"
@@ -5135,65 +5136,83 @@ msgid "(case sensitive)"
 msgstr "(sensible à la casse)"
 
 #: ../../../core/core_st.cpp:50
+#, fuzzy, c-format
+msgid ""
+"Compare complete of current database:\n"
+"\t %ls\n"
+" and:\n"
+"\t %ls\n"
+msgstr ""
+"Comparaison complète de la base courante:\n"
+"\t %s\n"
+" et:\n"
+"\t %s"
+
+#: ../../../core/core_st.cpp:51
+#, fuzzy, c-format
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGroupe:'%s'; Titre:'%s'; Usager:'%s'"
+
+#: ../../../core/core_st.cpp:52
 msgid "C:F[R-O]"
 msgstr "C:F[R-O]"
 
-#: ../../../core/core_st.cpp:51
+#: ../../../core/core_st.cpp:53
 msgid "C:F[R/W]"
 msgstr "C:F[R/W]"
 
-#: ../../../core/core_st.cpp:52
+#: ../../../core/core_st.cpp:54
 msgid "C:None  "
 msgstr "C:Aucun  "
 
-#: ../../../core/core_st.cpp:53
+#: ../../../core/core_st.cpp:55
 msgid "C:Reg   "
 msgstr "C:Reg   "
 
-#: ../../../core/core_st.cpp:54
+#: ../../../core/core_st.cpp:56
 msgid "conflict"
 msgstr "conflit"
 
-#: ../../../core/core_st.cpp:55
+#: ../../../core/core_st.cpp:57
 msgid "conflicts"
 msgstr "conflits"
 
-#: ../../../core/core_st.cpp:57
+#: ../../../core/core_st.cpp:59
 msgid "contains all of"
 msgstr "contient tout de"
 
-#: ../../../core/core_st.cpp:58
+#: ../../../core/core_st.cpp:60
 msgid "contains any of"
 msgstr "contient aucun de"
 
-#: ../../../core/core_st.cpp:59
+#: ../../../core/core_st.cpp:61
 msgid "copied"
 msgstr "copié"
 
-#: ../../../core/core_st.cpp:60
+#: ../../../core/core_st.cpp:62
 #, c-format
 msgid "%ls - Copied %ls"
 msgstr "%ls - Copié %ls"
 
-#: ../../../core/core_st.cpp:61
+#: ../../../core/core_st.cpp:63
 #, c-format
 msgid " Current default (%ls)"
 msgstr " Défaut courant (%ls)"
 
-#: ../../../core/core_st.cpp:71
+#: ../../../core/core_st.cpp:73
 msgid "View/Edit selected entry"
 msgstr "Voir/Modifier l'entrée sélectionnée"
 
-#: ../../../core/core_st.cpp:72
+#: ../../../core/core_st.cpp:74
 #, fuzzy
 msgid " (application default)"
 msgstr "Application utilisée:"
 
-#: ../../../core/core_st.cpp:73
+#: ../../../core/core_st.cpp:75
 msgid "default symbol set"
 msgstr "liste de symboles par défaut"
 
-#: ../../../core/core_st.cpp:75
+#: ../../../core/core_st.cpp:77
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5206,11 +5225,11 @@ msgstr ""
 "Veuillez confirmer pour continuer (tous mots de passe de cet alias seront "
 "remplacés par le mot de passe de cette entrée)?"
 
-#: ../../../core/core_st.cpp:76
+#: ../../../core/core_st.cpp:78
 msgid "Delete Base Entry Confirmation"
 msgstr "Confirmation de supression de l'entrée de base"
 
-#: ../../../core/core_st.cpp:77
+#: ../../../core/core_st.cpp:79
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5222,40 +5241,40 @@ msgstr ""
 "Veuillez confirmer pour continuer (Tous les raccourcis vers cette entrée "
 "seont supprimés)"
 
-#: ../../../core/core_st.cpp:80
+#: ../../../core/core_st.cpp:82
 msgid "does not contain all of"
 msgstr "ne contient pas tout de"
 
-#: ../../../core/core_st.cpp:81
+#: ../../../core/core_st.cpp:83
 msgid "does not contain any of"
 msgstr "ne contient aucun de"
 
-#: ../../../core/core_st.cpp:84
+#: ../../../core/core_st.cpp:86
 #, c-format
 msgid " Drag # %d"
 msgstr " Glisser # %d"
 
-#: ../../../core/core_st.cpp:85
-#, c-format
-msgid "%s - Drag & Drop %s"
-msgstr ""
+#: ../../../core/core_st.cpp:87
+#, fuzzy, c-format
+msgid "%ls - Drag & Drop %ls"
+msgstr "%ls - Copié %ls"
 
-#: ../../../core/core_st.cpp:86
+#: ../../../core/core_st.cpp:88
 #, c-format
 msgid " Duplicate # %d"
 msgstr " %d # Identique"
 
-#: ../../../core/core_st.cpp:87
+#: ../../../core/core_st.cpp:89
 #, fuzzy
 msgid "empty group"
 msgstr "Importer dans le groupe?"
 
-#: ../../../core/core_st.cpp:88
+#: ../../../core/core_st.cpp:90
 #, fuzzy
 msgid "empty groups"
 msgstr "#groups"
 
-#: ../../../core/core_st.cpp:89
+#: ../../../core/core_st.cpp:91
 #, c-format
 msgid ""
 "Trouble with a non-textual (e.g., time) field in record '%ls' - please check "
@@ -5264,130 +5283,130 @@ msgstr ""
 "Problème avec un champ non-textuel dans l'enregistrement '%ls' - veuillez "
 "vérifier soigneusement les données."
 
-#: ../../../core/core_st.cpp:91
+#: ../../../core/core_st.cpp:93
 msgid "End Report"
 msgstr "Fin du rapport"
 
-#: ../../../core/core_st.cpp:92
+#: ../../../core/core_st.cpp:94
 msgid "--------------------------------------------------------------------------------"
 msgstr "--------------------------------------------------------------------------------"
 
-#: ../../../core/core_st.cpp:97
+#: ../../../core/core_st.cpp:99
 msgid "has expired"
 msgstr "a expiré"
 
-#: ../../../core/core_st.cpp:98
+#: ../../../core/core_st.cpp:100
 msgid "Entries with a password expiry"
 msgstr "Entrées ayant une expiration de mot de passe"
 
-#: ../../../core/core_st.cpp:99
+#: ../../../core/core_st.cpp:101
 #, c-format
 msgid "within %d day(s)"
 msgstr "dans %d jour(s)"
 
-#: ../../../core/core_st.cpp:100
+#: ../../../core/core_st.cpp:102
 #, fuzzy, c-format
 msgid "DB Export from database: '%s'"
 msgstr "Fusion de : %s\n"
 
-#: ../../../core/core_st.cpp:101
+#: ../../../core/core_st.cpp:103
 msgid "First character of variable name must be alphabetic"
 msgstr "Le premeir caractère du nom de la variable doit être alphabétique"
 
-#: ../../../core/core_st.cpp:102
+#: ../../../core/core_st.cpp:104
 msgid "Index not numeric"
 msgstr "Index non numerique"
 
-#: ../../../core/core_st.cpp:103
+#: ../../../core/core_st.cpp:105
 msgid "Input string is empty"
 msgstr "La chaîne d'entrée est vide"
 
-#: ../../../core/core_st.cpp:104
+#: ../../../core/core_st.cpp:106
 msgid "Characters present between end of index ']' and '}'"
 msgstr "Caractères présents entre la fin de l'index ']' et '}'"
 
-#: ../../../core/core_st.cpp:105
+#: ../../../core/core_st.cpp:107
 msgid "Index is invalid or missing"
 msgstr "L'index est invalide ou manquant"
 
-#: ../../../core/core_st.cpp:106
+#: ../../../core/core_st.cpp:108
 msgid "Missing ending curly bracket for variable name"
 msgstr "Accolade finale manquante pour un nom de variable"
 
-#: ../../../core/core_st.cpp:107
+#: ../../../core/core_st.cpp:109
 msgid "Missing ending round bracket for Autotype value"
 msgstr "Parenthèse finale manquante pour une valeur d'autofrappe"
 
-#: ../../../core/core_st.cpp:108
+#: ../../../core/core_st.cpp:110
 msgid "Missing ending square bracket for index value"
 msgstr "Crochet final manquant pour une valeur d'index"
 
-#: ../../../core/core_st.cpp:109
+#: ../../../core/core_st.cpp:111
 msgid "There are unmatched quotes in the run command"
 msgstr "Des guillemets sont désappareillés dans la commande lancée"
 
-#: ../../../core/core_st.cpp:110
+#: ../../../core/core_st.cpp:112
 msgid "Variable name is empty"
 msgstr "Le nom de la variable est vide"
 
-#: ../../../core/core_st.cpp:111
+#: ../../../core/core_st.cpp:113
 msgid "Variable name must be alphanumeric"
 msgstr "Le nom de la variable doit être alphanumérique"
 
-#: ../../../core/core_st.cpp:112
+#: ../../../core/core_st.cpp:114
 msgid "an alias entry"
 msgstr "une entrée alias"
 
-#: ../../../core/core_st.cpp:113
+#: ../../../core/core_st.cpp:115
 msgid "a base entry of an alias"
 msgstr "entrée de base pour un alias"
 
-#: ../../../core/core_st.cpp:114
+#: ../../../core/core_st.cpp:116
 msgid "  Field is too long."
 msgstr "  Le champ est trop long."
 
-#: ../../../core/core_st.cpp:115
+#: ../../../core/core_st.cpp:117
 msgid "  Field is too short."
 msgstr "  Le champ est trop court."
 
-#: ../../../core/core_st.cpp:116
+#: ../../../core/core_st.cpp:118
 msgid "Error: A file with this name already exists"
 msgstr "Erreur: un fic hier de ce nom existe déjà"
 
-#: ../../../core/core_st.cpp:117
+#: ../../../core/core_st.cpp:119
 msgid "The file was not found."
 msgstr "Le fichier n'a pas été trouvé."
 
-#: ../../../core/core_st.cpp:118
+#: ../../../core/core_st.cpp:120
 msgid "Error: File is read-only"
 msgstr "Erreur: le fichier est seulement en lecture"
 
-#: ../../../core/core_st.cpp:119
+#: ../../../core/core_st.cpp:121
 msgid "Error while writing file! Try saving in a different location"
 msgstr ""
 "Error lors de l'écriture du fichier! Essayer d'enregistrer dans un dossier "
 "différent."
 
-#: ../../../core/core_st.cpp:120
+#: ../../../core/core_st.cpp:122
 msgid "File is too big."
 msgstr "Fichier trop gros"
 
-#: ../../../core/core_st.cpp:121
+#: ../../../core/core_st.cpp:123
 msgid "File is too short."
 msgstr "Fichier trop petit"
 
-#: ../../../core/core_st.cpp:122
+#: ../../../core/core_st.cpp:124
 msgid "File is truncated or otherwise corrupt. Please use backup database."
 msgstr ""
 "Le fichier est tronqué ou corrompu. Veuillez utiliser une copie de "
 "sauvegarde."
 
-#: ../../../core/core_st.cpp:123
+#: ../../../core/core_st.cpp:125
 msgid "Cannot read file. Please check file permissions."
 msgstr ""
 "Impossible de lire le fichier. Veuillez vérifier les permissions du fichier."
 
-#: ../../../core/core_st.cpp:124
+#: ../../../core/core_st.cpp:126
 #, c-format
 msgid ""
 "Filter %ls already exists in the database, do you wish to replace it with "
@@ -5395,132 +5414,132 @@ msgid ""
 msgstr ""
 "Le filtre %ls existe déjà dans la base, voulez-vous le remplacer avec ça?"
 
-#: ../../../core/core_st.cpp:125
+#: ../../../core/core_st.cpp:127
 #, fuzzy
 msgid "Current database filters have been exported to this database."
 msgstr "Comparant la base courante avec: %s"
 
-#: ../../../core/core_st.cpp:126
+#: ../../../core/core_st.cpp:128
 msgid "Stored filters will be unusable until the file's restored."
 msgstr ""
 "Les filtres enregistrés seront inutilisables jusqu'à ce que le fichier soit "
 "récupéré."
 
-#: ../../../core/core_st.cpp:127
+#: ../../../core/core_st.cpp:129
 msgid "Last Access Time"
 msgstr "Heure du dernier accès"
 
-#: ../../../core/core_st.cpp:128
+#: ../../../core/core_st.cpp:130
 msgid "Attachment Reference"
 msgstr ""
 
-#: ../../../core/core_st.cpp:129
+#: ../../../core/core_st.cpp:131
 msgid "AutoType"
 msgstr "Auto-frappe"
 
-#: ../../../core/core_st.cpp:130
+#: ../../../core/core_st.cpp:132
 msgid "Created Time"
 msgstr "Date de création"
 
-#: ../../../core/core_st.cpp:131
+#: ../../../core/core_st.cpp:133
 msgid "DCA"
 msgstr "ACD"
 
-#: ../../../core/core_st.cpp:132
+#: ../../../core/core_st.cpp:134
 msgid "e-mail"
 msgstr "courrier"
 
-#: ../../../core/core_st.cpp:134
+#: ../../../core/core_st.cpp:136
 msgid "Group/Title"
 msgstr "Groupe/Titre"
 
-#: ../../../core/core_st.cpp:135
+#: ../../../core/core_st.cpp:137
 msgid "Keyboard Shortcut"
 msgstr "Raccourci Clavier"
 
-#: ../../../core/core_st.cpp:138
+#: ../../../core/core_st.cpp:140
 msgid "Password Modified Time"
 msgstr "Heure de modification du mot de passe"
 
-#: ../../../core/core_st.cpp:139
+#: ../../../core/core_st.cpp:141
 msgid "Protected"
 msgstr "Protégé"
 
-#: ../../../core/core_st.cpp:140
+#: ../../../core/core_st.cpp:142
 msgid "History"
 msgstr "Historique"
 
-#: ../../../core/core_st.cpp:142
+#: ../../../core/core_st.cpp:144
 msgid "Password Policy Name"
 msgstr "Nom de stratégie de mot de passe"
 
-#: ../../../core/core_st.cpp:143
+#: ../../../core/core_st.cpp:145
 msgid "Record Modified Time"
 msgstr "Enregistrer l'heure de modification"
 
-#: ../../../core/core_st.cpp:145
+#: ../../../core/core_st.cpp:147
 msgid "Shift+DCA"
 msgstr "Maj + ACD"
 
-#: ../../../core/core_st.cpp:146
+#: ../../../core/core_st.cpp:148
 msgid "Symbols"
 msgstr "Symboles"
 
-#: ../../../core/core_st.cpp:148
+#: ../../../core/core_st.cpp:150
 msgid "URL"
 msgstr "URL"
 
-#: ../../../core/core_st.cpp:150
+#: ../../../core/core_st.cpp:152
 msgid "UUID"
 msgstr "UUID"
 
-#: ../../../core/core_st.cpp:151
+#: ../../../core/core_st.cpp:153
 msgid "Password Expiry Date"
 msgstr "Date d'expiration du mot de passe"
 
-#: ../../../core/core_st.cpp:152
+#: ../../../core/core_st.cpp:154
 msgid "Password Expiry Interval"
 msgstr "Délai d'expiration du mot de passe"
 
-#: ../../../core/core_st.cpp:153
+#: ../../../core/core_st.cpp:155
 msgid "a normal entry"
 msgstr "une entrée normale"
 
-#: ../../../core/core_st.cpp:154
+#: ../../../core/core_st.cpp:156
 #, fuzzy
 msgid "Last found entries"
 msgstr "entrées"
 
-#: ../../../core/core_st.cpp:155
+#: ../../../core/core_st.cpp:157
 msgid "added but not yet saved to database"
 msgstr "ajoutés mais pas encore enregistré au fichier"
 
-#: ../../../core/core_st.cpp:156
+#: ../../../core/core_st.cpp:158
 #, fuzzy
 msgid "in the database"
 msgstr "au fichier"
 
-#: ../../../core/core_st.cpp:157
+#: ../../../core/core_st.cpp:159
 msgid "a shortcut entry"
 msgstr "une entrée raccourci"
 
-#: ../../../core/core_st.cpp:158
+#: ../../../core/core_st.cpp:160
 msgid "a base entry of a shortcut"
 msgstr "entrée de base pour un raccourci"
 
-#: ../../../core/core_st.cpp:159
+#: ../../../core/core_st.cpp:161
 msgid "changed but not yet saved to database"
 msgstr "modifié mais pas encore enregistré au fichier"
 
-#: ../../../core/core_st.cpp:160
+#: ../../../core/core_st.cpp:162
 msgid "greater than"
 msgstr "plus grand que"
 
-#: ../../../core/core_st.cpp:161
+#: ../../../core/core_st.cpp:163
 msgid "greater than or equal to"
 msgstr "est plus grand ou égal à"
 
-#: ../../../core/core_st.cpp:162
+#: ../../../core/core_st.cpp:164
 #, c-format
 msgid ""
 "Invalid input on line %d.  Number of fields separated by '%c' is not as "
@@ -5529,12 +5548,12 @@ msgstr ""
 "Entrée invalide sur la ligne %d.  Le nombre de champs séparés par '%c' n'est "
 "pas celui attendu."
 
-#: ../../../core/core_st.cpp:163
+#: ../../../core/core_st.cpp:165
 #, c-format
 msgid "Line %d: "
 msgstr "Ligne %d: "
 
-#: ../../../core/core_st.cpp:164
+#: ../../../core/core_st.cpp:166
 #, c-format
 msgid ""
 "File ends on line %d before ending double quote of last entry's note field."
@@ -5542,11 +5561,11 @@ msgstr ""
 "Le fichier finit à la ligne %d avant les guillemets de fin du champ de note "
 "de la dernière entrée."
 
-#: ../../../core/core_st.cpp:165
+#: ../../../core/core_st.cpp:167
 msgid "Import aborted. Please see report."
 msgstr "Importation interrompue. Veuillez voir le rapport."
 
-#: ../../../core/core_st.cpp:166
+#: ../../../core/core_st.cpp:168
 #, fuzzy
 msgid ""
 "The TXT or CSV file was not imported as required as entry records span "
@@ -5559,7 +5578,7 @@ msgstr ""
 "\n"
 "Importation interrompue"
 
-#: ../../../core/core_st.cpp:167
+#: ../../../core/core_st.cpp:169
 #, c-format
 msgid ""
 "%ls, Title=\"%ls\", User=\"%ls\" already exists in your database or in the "
@@ -5568,68 +5587,68 @@ msgstr ""
 "%ls, Titre=\"%ls\", Utilisateur=\"%ls\" existe déjà dans votre fichier ou le "
 "fichier importé. Entrée ajoutée avec le titre \"%ls\".\n"
 
-#: ../../../core/core_st.cpp:168
+#: ../../../core/core_st.cpp:170
 #, c-format
 msgid "Entry on line %d with Group=\"%ls\""
 msgstr "Entrée à la ligne %d avec Groupe=\"%ls\""
 
-#: ../../../core/core_st.cpp:169
+#: ../../../core/core_st.cpp:171
 #, c-format
 msgid "Entry on line %d with no group"
 msgstr "Entrée à la ligne %d sans groupe"
 
-#: ../../../core/core_st.cpp:170
+#: ../../../core/core_st.cpp:172
 #, c-format
 msgid "Entry with Group=\"%ls\""
 msgstr "Entrée avec Groupe=\"%ls\""
 
-#: ../../../core/core_st.cpp:171
+#: ../../../core/core_st.cpp:173
 msgid "Entry with no group"
 msgstr "Entrée sans groupe"
 
-#: ../../../core/core_st.cpp:172
+#: ../../../core/core_st.cpp:174
 msgid "imported"
 msgstr "importé"
 
-#: ../../../core/core_st.cpp:173
+#: ../../../core/core_st.cpp:175
 #, fuzzy, c-format
 msgid "including %d empty group(s)."
 msgstr "#groups"
 
-#: ../../../core/core_st.cpp:174
+#: ../../../core/core_st.cpp:176
 #, c-format
 msgid "Empty line %d skipped"
 msgstr "La ligne vide %d a été sautée"
 
-#: ../../../core/core_st.cpp:175
+#: ../../../core/core_st.cpp:177
 #, c-format
 msgid "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 msgstr "Entrée %ls%d avec Groupe=\"%ls\", Titre=\"%ls\", Utilisateur=\"%ls\""
 
-#: ../../../core/core_st.cpp:176
+#: ../../../core/core_st.cpp:178
 msgid "Internal error. Import failed. No records imported."
 msgstr ""
 "Erreur interne. L'importation a échoué. Aucun enregistrements importés."
 
-#: ../../../core/core_st.cpp:177
+#: ../../../core/core_st.cpp:179
 #, c-format
 msgid "Found %d known column headers:"
 msgstr "%d entêtes de colonne connues:"
 
-#: ../../../core/core_st.cpp:178
+#: ../../../core/core_st.cpp:180
 msgid "Invalid field delimiter: must be within ASCII range."
 msgstr ""
 
-#: ../../../core/core_st.cpp:179
+#: ../../../core/core_st.cpp:181
 #, c-format
 msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
 msgstr "L'entrée de la ligne %d a un champ \"%ls\" invalide. Il a été ignoré."
 
-#: ../../../core/core_st.cpp:180
+#: ../../../core/core_st.cpp:182
 msgid "The following columns will be processed: "
 msgstr "Les colonnes suivantes seront traitées:"
 
-#: ../../../core/core_st.cpp:181
+#: ../../../core/core_st.cpp:183
 msgid ""
 "The following columns were recognised but only Group/Title, Username and "
 "Password will be processed:"
@@ -5637,7 +5656,7 @@ msgstr ""
 "Les colonnes suivantes ont été reconnues mais seulement Groupe/Titre, Nom "
 "d'utilisateur et Mot de passe seront traités :"
 
-#: ../../../core/core_st.cpp:182
+#: ../../../core/core_st.cpp:184
 #, c-format
 msgid ""
 "Line %d skipped - Only %d fields found, whereas parsing the Header says "
@@ -5646,7 +5665,7 @@ msgstr ""
 "Ligne %d sautée. Seulement %d champs on été trouvés alors que l'analyse de "
 "l'entête en détecte %d."
 
-#: ../../../core/core_st.cpp:183
+#: ../../../core/core_st.cpp:185
 msgid ""
 "Either or both of the Group/Title and Password columns are missing. No "
 "records imported."
@@ -5654,7 +5673,7 @@ msgstr ""
 "Soit l'une ou les deux des colonnes Groupe/Titre et Mot de passe sont "
 "manquantes. Aucun enregistrement importé."
 
-#: ../../../core/core_st.cpp:184
+#: ../../../core/core_st.cpp:186
 msgid ""
 "Could not find the next entry's title field in the KeePass V1 TXT (should be "
 "within square brackets)."
@@ -5662,37 +5681,37 @@ msgstr ""
 "Impossible de trouver le titre de l'entrée suivante dans le texte KeePass V1 "
 "(devrait être entre crochets)."
 
-#: ../../../core/core_st.cpp:185
+#: ../../../core/core_st.cpp:187
 msgid "Column header row not recognised as first record. No records imported."
 msgstr ""
 "L'entète de colonne pas reconnue comme premier enregistrement. Aucun "
 "enregistrement importés."
 
-#: ../../../core/core_st.cpp:186
+#: ../../../core/core_st.cpp:188
 msgid "No records in import file!"
 msgstr "Aucun enregistrement dans le fichier importé!"
 
-#: ../../../core/core_st.cpp:187
+#: ../../../core/core_st.cpp:189
 #, c-format
 msgid "Line %d skipped: Empty mandatory Password field."
 msgstr "Ligne %d sautée: Champs mot de passe obligatoire manquant."
 
-#: ../../../core/core_st.cpp:188
+#: ../../../core/core_st.cpp:190
 #, c-format
 msgid "Line %d skipped: Empty mandatory Title field."
 msgstr "Ligne %d sautée: Champs titre obligatoire mannquant."
 
-#: ../../../core/core_st.cpp:189
+#: ../../../core/core_st.cpp:191
 #, c-format
 msgid " Import # %d"
 msgstr " Importer # %d"
 
-#: ../../../core/core_st.cpp:190
+#: ../../../core/core_st.cpp:192
 #, fuzzy, c-format
 msgid "%ls - Imported %ls"
 msgstr "%ls - %ls importés"
 
-#: ../../../core/core_st.cpp:191
+#: ../../../core/core_st.cpp:193
 msgid ""
 "To replace passwords of existing entries, all the following columns must be "
 "present: Group/Title, Username and Password.  One or more are missing and no "
@@ -5702,18 +5721,18 @@ msgstr ""
 "suivantes doivent être présente: Groupe/Titre, Nom d'utilisateur et Mot de "
 "passe. Une ou plusieurs sont manquantes et aucune entrée n'a été mise à jour."
 
-#: ../../../core/core_st.cpp:192
+#: ../../../core/core_st.cpp:194
 #, c-format
 msgid "%ls not found. Cannot update entry's password.\n"
 msgstr ""
 "%ls non trouvé. Impossible de mettre à jour l'entrée de mot de passe.\n"
 
-#: ../../../core/core_st.cpp:193
+#: ../../../core/core_st.cpp:195
 #, c-format
 msgid "%ls has an empty %ls.\n"
 msgstr "%ls a %ls vide.\n"
 
-#: ../../../core/core_st.cpp:194
+#: ../../../core/core_st.cpp:196
 #, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5722,11 +5741,11 @@ msgstr ""
 "L'entrée \"%ls, %ls, %ls\" a un mot de passe dans la forme correcte pour un "
 "alias mais l'entrée de base est déjà un alias."
 
-#: ../../../core/core_st.cpp:195
+#: ../../../core/core_st.cpp:197
 msgid "\tThis entry has been made an alias of associated base entry."
 msgstr "\tCette entrée est devenue un alias de l'entrée de base associée."
 
-#: ../../../core/core_st.cpp:196
+#: ../../../core/core_st.cpp:198
 #, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5735,14 +5754,14 @@ msgstr ""
 "L'entrée \"%ls, %ls, %ls\" a un mot de passe dans la forme correcte pour un "
 "alias mais l'entrée de base n'existe pas."
 
-#: ../../../core/core_st.cpp:197
+#: ../../../core/core_st.cpp:199
 msgid ""
 "\tThis entry remains a normal entry and the password has not been changed."
 msgstr ""
 "\tCette entrée reste une entrée normale et le mot de passe n'a pas été "
 "changé."
 
-#: ../../../core/core_st.cpp:198
+#: ../../../core/core_st.cpp:200
 #, c-format
 msgid ""
 "The %ls entry \"%ls, %ls, %ls\" doesn't point to a normal or existing %ls "
@@ -5751,70 +5770,70 @@ msgstr ""
 "L'entrée %ls \"%ls, %ls, %ls\" ne pointe pas sur une entrée de base %ls "
 "normale ou existante. Elle ne peut être importée."
 
-#: ../../../core/core_st.cpp:199
+#: ../../../core/core_st.cpp:201
 msgid "Entry import warnings"
 msgstr "Avertissements d'importation d'entrées"
 
-#: ../../../core/core_st.cpp:200
+#: ../../../core/core_st.cpp:202
 msgid "id="
 msgstr "id="
 
-#: ../../../core/core_st.cpp:201
+#: ../../../core/core_st.cpp:203
 msgid "on line "
 msgstr "à la ligne"
 
-#: ../../../core/core_st.cpp:202
+#: ../../../core/core_st.cpp:204
 msgid "Internal error: Invalid oflag or pmode argument"
 msgstr "Erreur interne: oflag ou argument du pmode invalide "
 
-#: ../../../core/core_st.cpp:203
+#: ../../../core/core_st.cpp:205
 msgid "invalid!"
 msgstr "invalide!"
 
-#: ../../../core/core_st.cpp:204
+#: ../../../core/core_st.cpp:206
 msgid "  Invalid date/time value."
 msgstr "  Valeur de date ou d'heure invalide."
 
-#: ../../../core/core_st.cpp:205
+#: ../../../core/core_st.cpp:207
 msgid "  Field length is incorrect."
 msgstr "La longueur du champ est invalide."
 
-#: ../../../core/core_st.cpp:206
+#: ../../../core/core_st.cpp:208
 msgid "Internal error: An invalid flag was specified"
 msgstr "Erreur interne: un signal invalide a été spécifié."
 
-#: ../../../core/core_st.cpp:207
+#: ../../../core/core_st.cpp:209
 #, c-format
 msgid "  Invalid header: '%ls' (must be 5 hexadecimal characters)."
 msgstr "En-tête invalide: '%ls' (doit être 5 caractères hexadécimaux)."
 
-#: ../../../core/core_st.cpp:208
+#: ../../../core/core_st.cpp:210
 #, fuzzy, c-format
 msgid "Invalid lock file \"%ls\"."
 msgstr "Schéma de filtre invalide."
 
-#: ../../../core/core_st.cpp:209
+#: ../../../core/core_st.cpp:211
 #, c-format
 msgid "  Invalid number of saved old passwords %d."
 msgstr "  Nombre invalide d'anciens mot de passe enregistrés : %d."
 
-#: ../../../core/core_st.cpp:210
+#: ../../../core/core_st.cpp:212
 #, c-format
 msgid "  Invalid status value: %d (must be either 0 or 1)."
 msgstr "Valeur de statut invalide: %d (doit être 0 ou  1)."
 
-#: ../../../core/core_st.cpp:211
+#: ../../../core/core_st.cpp:213
 msgid "  Invalid password length found (not a hexadecimal number)."
 msgstr "Longueur de mot de passe invalide (nombre non-hexadécimal)."
 
-#: ../../../core/core_st.cpp:212
+#: ../../../core/core_st.cpp:214
 msgid ""
 "  Invalid password length found (differs from length of following password)."
 msgstr ""
 "Longueur de mot de passe invalide (different de la longueur du mot de passe "
 "suivant)."
 
-#: ../../../core/core_st.cpp:213
+#: ../../../core/core_st.cpp:215
 msgid ""
 "  Invalid field separator character found - only a single blank is allowed "
 "between fields."
@@ -5822,21 +5841,21 @@ msgstr ""
 "  Séparateur de champ invalide trouvé - seul un espace blanc est permis "
 "entre les champs."
 
-#: ../../../core/core_st.cpp:214
+#: ../../../core/core_st.cpp:216
 msgid "Invalid Filter schema."
 msgstr "Schéma de filtre invalide."
 
-#: ../../../core/core_st.cpp:215
+#: ../../../core/core_st.cpp:217
 msgid "Schema does not have a version number."
 msgstr "Le schéma n'a pas de numéro de version"
 
-#: ../../../core/core_st.cpp:216
+#: ../../../core/core_st.cpp:218
 #, c-format
 msgid "The filter XML version (%d) is greater than the current schema (%d)."
 msgstr ""
 "La version du filtre XML (%d) est plus grande que le schéma courant (%d)."
 
-#: ../../../core/core_st.cpp:217
+#: ../../../core/core_st.cpp:219
 #, c-format
 msgid ""
 "The filter XML version (%d) is greater than that supported by this instance "
@@ -5845,31 +5864,31 @@ msgstr ""
 "La version du filtre XML (%d) est plus grande que celle indispensable pour "
 "cette instance de PasswordSafe (%d)."
 
-#: ../../../core/core_st.cpp:218
+#: ../../../core/core_st.cpp:220
 msgid "is"
 msgstr "est"
 
-#: ../../../core/core_st.cpp:219
+#: ../../../core/core_st.cpp:221
 msgid "is active"
 msgstr "est actif"
 
-#: ../../../core/core_st.cpp:220
+#: ../../../core/core_st.cpp:222
 msgid "is inactive"
 msgstr "est inactif"
 
-#: ../../../core/core_st.cpp:221
+#: ../../../core/core_st.cpp:223
 msgid "is not"
 msgstr "n'est pas"
 
-#: ../../../core/core_st.cpp:222
+#: ../../../core/core_st.cpp:224
 msgid "is not present"
 msgstr "n'est pas présent"
 
-#: ../../../core/core_st.cpp:223
+#: ../../../core/core_st.cpp:225
 msgid "is present"
 msgstr "est présent"
 
-#: ../../../core/core_st.cpp:224
+#: ../../../core/core_st.cpp:226
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to entry %ls. It "
@@ -5878,7 +5897,7 @@ msgstr ""
 "Le raccourci clavier d'entrée %ls %ls est déjà alloué à l'entrée %ls. Il a "
 "été oté de l'entrée %ls."
 
-#: ../../../core/core_st.cpp:225
+#: ../../../core/core_st.cpp:227
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to the "
@@ -5887,19 +5906,19 @@ msgstr ""
 "Le raccourci clavier d'entrée %ls %ls est déjà alloué à l'application "
 "PasswordSafe. Il a été oté de l'entrée."
 
-#: ../../../core/core_st.cpp:226
+#: ../../../core/core_st.cpp:228
 msgid "less than"
 msgstr "Moins que"
 
-#: ../../../core/core_st.cpp:227
+#: ../../../core/core_st.cpp:229
 msgid "less than or equal to"
 msgstr "Moins que ou égal à"
 
-#: ../../../core/core_st.cpp:228
+#: ../../../core/core_st.cpp:230
 msgid "File or path not found"
 msgstr "Le fichier ou son chemin n'ont pas été trouvés"
 
-#: ../../../core/core_st.cpp:229
+#: ../../../core/core_st.cpp:231
 #, c-format
 msgid ""
 "\n"
@@ -5908,7 +5927,7 @@ msgstr ""
 "\n"
 "Les nouveau %ls %ls suivants seront fusionnés dans ce fichier :"
 
-#: ../../../core/core_st.cpp:230
+#: ../../../core/core_st.cpp:232
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5917,7 +5936,7 @@ msgstr ""
 "\n"
 "Fusion complétée: %d %ls ajoutées (%d %ls, %d %ls, %d %ls)"
 
-#: ../../../core/core_st.cpp:231
+#: ../../../core/core_st.cpp:233
 #, fuzzy, c-format
 msgid ""
 "Conflicting entries for \"%ls\" \"%ls\" \"%ls\".\n"
@@ -5928,25 +5947,25 @@ msgstr ""
 "  Entrée fusionnée ajoutée en tant que «%ls» «%ls» «%ls».\n"
 "    Champ(s) différent(s): %ls"
 
-#: ../../../core/core_st.cpp:232
+#: ../../../core/core_st.cpp:234
 msgid "merged"
 msgstr "fusionné"
 
-#: ../../../core/core_st.cpp:233
+#: ../../../core/core_st.cpp:235
 #, c-format
 msgid "%ls - Merged %ls"
 msgstr "%ls - %ls fusionnés"
 
-#: ../../../core/core_st.cpp:234
+#: ../../../core/core_st.cpp:236
 msgid "MISSING PASSWORD"
 msgstr "MOT DE PASSE MANQUANT"
 
-#: ../../../core/core_st.cpp:235
+#: ../../../core/core_st.cpp:237
 #, c-format
 msgid "\tPassword policy name '%ls' is not in the database."
 msgstr "\tLa stratégie de mot de passe '%ls' n'est pas dans le fichier."
 
-#: ../../../core/core_st.cpp:236
+#: ../../../core/core_st.cpp:238
 msgid ""
 "\tOne or more Password Policy Names were not found in the database. The "
 "affected entries have been changed to use the database's default policy."
@@ -5955,35 +5974,35 @@ msgstr ""
 "fichier. Les entrées touchées ont été modifiées pour utiliser la stratégie "
 "par défaut."
 
-#: ../../../core/core_st.cpp:237
+#: ../../../core/core_st.cpp:239
 #, c-format
 msgid "MISSING TITLE # %d"
 msgstr "TITRE MANQUANT # %d"
 
-#: ../../../core/core_st.cpp:239
+#: ../../../core/core_st.cpp:241
 msgid "Can't obtain the schema version."
 msgstr "Impossible d'obtenir la version du schéma."
 
-#: ../../../core/core_st.cpp:240
+#: ../../../core/core_st.cpp:242
 msgid "The filter XML version is missing."
 msgstr "La version du filtre XML est manquante."
 
-#: ../../../core/core_st.cpp:241
+#: ../../../core/core_st.cpp:243
 #, c-format
 msgid "Create SchemaCache60 Error 0x%08X during %ls."
 msgstr "Erreur Create SchemaCache60 0x%08X lors de %ls."
 
-#: ../../../core/core_st.cpp:242
+#: ../../../core/core_st.cpp:244
 #, c-format
 msgid "SAX Parse60 Error 0x%08X during %ls."
 msgstr "Erreur SAX Parse60 0x%08X lors de %ls. "
 
-#: ../../../core/core_st.cpp:243
+#: ../../../core/core_st.cpp:245
 #, c-format
 msgid "Error (%08X): line %d character %d %ls"
 msgstr "Erreur (%08X): ligne %d caractère %d %ls"
 
-#: ../../../core/core_st.cpp:245
+#: ../../../core/core_st.cpp:247
 msgid ""
 "Unable to get configuration file lock.\n"
 "\n"
@@ -5993,17 +6012,17 @@ msgstr ""
 "\n"
 "Le programme va utiliser le registre."
 
-#: ../../../core/core_st.cpp:246
+#: ../../../core/core_st.cpp:248
 msgid "Cannot create lock file - no permission in directory?"
 msgstr ""
 "Impossible de créer un fichier de verrouillage - aucune permission dans le "
 "dossier?"
 
-#: ../../../core/core_st.cpp:247
+#: ../../../core/core_st.cpp:249
 msgid "Internal error: Out of file handles"
 msgstr "Erreur interne: sorti des pointeurs de fichiers"
 
-#: ../../../core/core_st.cpp:248
+#: ../../../core/core_st.cpp:250
 msgid ""
 "Unable to use a MS XML reader on your system.  Neither MS XML V3, V4 or V6 "
 "seems available."
@@ -6011,15 +6030,15 @@ msgstr ""
 "Impossible d'utiliser le lecteur MS XML sur votre système.  Ni MS XML V3, V4 "
 "ou V6 ne semblent disponibles."
 
-#: ../../../core/core_st.cpp:250
+#: ../../../core/core_st.cpp:252
 msgid "Unsaved changes"
 msgstr "Changements non enregistrés"
 
-#: ../../../core/core_st.cpp:251
+#: ../../../core/core_st.cpp:253
 msgid "is not set"
 msgstr "n'est pas mis"
 
-#: ../../../core/core_st.cpp:252
+#: ../../../core/core_st.cpp:254
 #, c-format
 msgid ""
 "Number of entries processed: %d\n"
@@ -6058,7 +6077,7 @@ msgstr ""
 "\n"
 "Recommendation d'enregistrer le fichier maintenant."
 
-#: ../../../core/core_st.cpp:254
+#: ../../../core/core_st.cpp:256
 msgid ""
 "Password should be mixed case, with at least one digit or punctuation "
 "character"
@@ -6066,54 +6085,58 @@ msgstr ""
 "Le mot de passe devrait comporter des casses différentes avec au moins un "
 "chiffre ou caractère de ponctuation"
 
-#: ../../../core/core_st.cpp:255
+#: ../../../core/core_st.cpp:257
 msgid "Password is too short"
 msgstr "Le mot de passe est trop court"
 
-#: ../../../core/core_st.cpp:256
+#: ../../../core/core_st.cpp:258
 msgid "Easyvision characters"
 msgstr "Gros caractères"
 
-#: ../../../core/core_st.cpp:257
+#: ../../../core/core_st.cpp:259
 msgid "Hexadecimal characters"
 msgstr "Caractères hexadécimaux"
 
-#: ../../../core/core_st.cpp:258
+#: ../../../core/core_st.cpp:260
 msgid "Password length"
 msgstr "Longueur de mot de passe"
 
-#: ../../../core/core_st.cpp:259
+#: ../../../core/core_st.cpp:261
 msgid "Pronounceable passwords"
 msgstr "Mots de passe prononçables"
 
-#: ../../../core/core_st.cpp:261
+#: ../../../core/core_st.cpp:263
 #, fuzzy
 msgid "Use lowercase characters"
 msgstr "Utiliser des majuscules"
 
-#: ../../../core/core_st.cpp:263
+#: ../../../core/core_st.cpp:265
 msgid "Use uppercase characters"
 msgstr "Utiliser des majuscules"
 
-#: ../../../core/core_st.cpp:264
+#: ../../../core/core_st.cpp:266
 #, c-format
 msgid "Error in a Password History %ls:"
 msgstr "Erreur dans l'historique de mot de passe %ls:"
 
-#: ../../../core/core_st.cpp:265
+#: ../../../core/core_st.cpp:267
 #, c-format
 msgid "sub-field starting at position %d (within the History field): "
 msgstr "sous-champ débutant à la position %d (dans le champ Historique): "
 
-#: ../../../core/core_st.cpp:266
+#: ../../../core/core_st.cpp:268
 msgid "  All Password History ignored."
 msgstr "  Tout l'historique de mot de passe ignoré"
 
-#: ../../../core/core_st.cpp:267
+#: ../../../core/core_st.cpp:269
 msgid "Read Error"
 msgstr "Erreur de lecture"
 
-#: ../../../core/core_st.cpp:268
+#: ../../../core/core_st.cpp:270
+msgid "Relative"
+msgstr "Relatif"
+
+#: ../../../core/core_st.cpp:271
 #, c-format
 msgid ""
 "\tOne or more entry keyboard shortcuts were already assigned to entries in "
@@ -6122,7 +6145,7 @@ msgstr ""
 "\tUn ou plusieurs raccourcis clavier ont déjà été assigné à des entrées dans "
 "ce fichier. Ils ont été oté de l'entrée %ls."
 
-#: ../../../core/core_st.cpp:269
+#: ../../../core/core_st.cpp:272
 msgid ""
 "\tOne or more Password Policy Names were already in this database but had "
 "different settings. They have been renamed."
@@ -6130,30 +6153,67 @@ msgstr ""
 "\tUne ou plusieurs stratégies de mot de passe étaient déjà dans ce fichier "
 "mais ayant des paramètres différents. Elles ont été renommées."
 
-#: ../../../core/core_st.cpp:270
+#: ../../../core/core_st.cpp:273
 #, c-format
 msgid "%ls%ls%ls_Report.txt"
 msgstr "%ls%ls%ls_Report.txt"
 
-#: ../../../core/core_st.cpp:271
+#: ../../../core/core_st.cpp:274
 #, c-format
 msgid "Report of %ls function started at %ls"
 msgstr "Rapport de la fonction %ls démarrée à %ls"
 
-#: ../../../core/core_st.cpp:272
+#: ../../../core/core_st.cpp:275
 #, c-format
 msgid "on database %ls"
 msgstr "dans le fichier %ls"
 
-#: ../../../core/core_st.cpp:273
+#: ../../../core/core_st.cpp:276
+msgid "Compare"
+msgstr "Comparer"
+
+#: ../../../core/core_st.cpp:277
+#, fuzzy
+msgid "Export_DB"
+msgstr "&Exporter"
+
+#: ../../../core/core_st.cpp:278
+msgid "Export_Text"
+msgstr "Exporter_Texte"
+
+#: ../../../core/core_st.cpp:279
+msgid "Export_XML"
+msgstr "Exporter_XML"
+
+#: ../../../core/core_st.cpp:281
+msgid "Import_KeePassV1_CSV"
+msgstr "Import_CSV_KeePassV1"
+
+#: ../../../core/core_st.cpp:282
+msgid "Import_KeePassV1_TXT"
+msgstr "Import_TXT_KeePassV1"
+
+#: ../../../core/core_st.cpp:283
+msgid "Import_Text"
+msgstr "Import_Text"
+
+#: ../../../core/core_st.cpp:284
+msgid "Import_XML"
+msgstr "Import_XML"
+
+#: ../../../core/core_st.cpp:285
+msgid "Merge"
+msgstr "Fusionner"
+
+#: ../../../core/core_st.cpp:287
 msgid "Validate"
 msgstr "Valider"
 
-#: ../../../core/core_st.cpp:275
+#: ../../../core/core_st.cpp:289
 msgid "Fatal Error"
 msgstr "Erreur fatale"
 
-#: ../../../core/core_st.cpp:277
+#: ../../../core/core_st.cpp:291
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -6162,116 +6222,126 @@ msgstr ""
 "\n"
 "Erreur dans l'historique du mot de passe pour l'entrée: »%ls»%ls»%ls»: "
 
-#: ../../../core/core_st.cpp:278
+#: ../../../core/core_st.cpp:292
+#, fuzzy, c-format
+msgid "\tNo entries were found containing search string '%ls' %ls"
+msgstr "\tAucune entrée contenant '%s' n'a été trouvé"
+
+#: ../../../core/core_st.cpp:293
+#, fuzzy, c-format
+msgid "\tThe following entries contain search string '%ls' %ls"
+msgstr "\tLes entrées suivantes contiennent le texte recherché '%s'"
+
+#: ../../../core/core_st.cpp:294
 msgid "See Attachment filters"
 msgstr ""
 
-#: ../../../core/core_st.cpp:279
+#: ../../../core/core_st.cpp:295
 msgid "See Password History filters"
 msgstr "Voir les filtres de l'historique des mots de passe"
 
-#: ../../../core/core_st.cpp:280
+#: ../../../core/core_st.cpp:296
 msgid "See Password Policy filters"
 msgstr "Voir les filtres de la stratégie de mots de passe"
 
-#: ../../../core/core_st.cpp:281
+#: ../../../core/core_st.cpp:297
 msgid "is set"
 msgstr "est mis"
 
-#: ../../../core/core_st.cpp:282
+#: ../../../core/core_st.cpp:298
 msgid "shortcut"
 msgstr "raccourci"
 
-#: ../../../core/core_st.cpp:283
+#: ../../../core/core_st.cpp:299
 msgid "shortcuts"
 msgstr "raccourcis"
 
-#: ../../../core/core_st.cpp:284
+#: ../../../core/core_st.cpp:300
 msgid "policy specific symbols"
 msgstr "symboles spécifique à la stratégie"
 
-#: ../../../core/core_st.cpp:285
+#: ../../../core/core_st.cpp:301
 msgid "Start Report"
 msgstr "Commencer le rapport"
 
-#: ../../../core/core_st.cpp:286
+#: ../../../core/core_st.cpp:302
 msgid "Double-Click on entry to Autotype"
 msgstr "Double-cliquez sur l'entrée pour autotaper"
 
-#: ../../../core/core_st.cpp:287
+#: ../../../core/core_st.cpp:303
 msgid "Double-Click on entry to Browse to URL"
 msgstr "Double-cliquez sur l'entrée pour naviguer sur la page"
 
-#: ../../../core/core_st.cpp:288
+#: ../../../core/core_st.cpp:304
 msgid "Double-Click on entry to Browse to URL + Autotype"
 msgstr "Double-cliquez sur l'entrée pour naviguer à l'URL + Autofrappe"
 
-#: ../../../core/core_st.cpp:289
+#: ../../../core/core_st.cpp:305
 #, fuzzy
 msgid "https://pwsafe.org/"
 msgstr "https://pwsafe.org/"
 
-#: ../../../core/core_st.cpp:290
+#: ../../../core/core_st.cpp:306
 msgid "Double-Click on entry to Copy Notes"
 msgstr "Double-cliquez sur l'entrée pour copier des notes"
 
-#: ../../../core/core_st.cpp:291
+#: ../../../core/core_st.cpp:307
 msgid "Double-Click on entry to Copy Password"
 msgstr "Double-cliquez sur l'entrée pour copier le mot de passe"
 
-#: ../../../core/core_st.cpp:292
+#: ../../../core/core_st.cpp:308
 msgid "Double-Click on entry to Copy Password and Minimize"
 msgstr "Double-cliquez sur l'entrée pour copier le mot de passe et réduire"
 
-#: ../../../core/core_st.cpp:293
+#: ../../../core/core_st.cpp:309
 msgid "Double-Click on entry to Copy Username"
 msgstr "Double-cliquez sur l'entrée pour copier le nom d'utilisateur"
 
-#: ../../../core/core_st.cpp:294
+#: ../../../core/core_st.cpp:310
 msgid "Double-Click on entry to Run Command"
 msgstr "Double-cliquez sur l'entrée pour exécuter la commande"
 
-#: ../../../core/core_st.cpp:295
+#: ../../../core/core_st.cpp:311
 #, fuzzy
 msgid "Double-Click on entry to Send Email"
 msgstr "Double-cliquez sur l'entrée pour envoyer un courriel"
 
-#: ../../../core/core_st.cpp:296
+#: ../../../core/core_st.cpp:312
 msgid "Double-Click on entry to View/Edit it"
 msgstr "Double-cliquez sur l'entrée pour la visualiser/l'éditer"
 
-#: ../../../core/core_st.cpp:299
+#: ../../../core/core_st.cpp:315
 #, c-format
 msgid "%ls - Sync'd %ls"
 msgstr "%ls - Synch. %ls"
 
-#: ../../../core/core_st.cpp:300
+#: ../../../core/core_st.cpp:316
 msgid "System error: No more file handles available"
 msgstr "Erreur système: Plus de pointeurs de fichiers disponibles"
 
-#: ../../../core/core_st.cpp:303
+#: ../../../core/core_st.cpp:319
 msgid "Unknown function"
 msgstr "Fonction inconnue"
 
-#: ../../../core/core_st.cpp:304
+#: ../../../core/core_st.cpp:320
 msgid "Unknown object"
 msgstr "Objet inconnu"
 
-#: ../../../core/core_st.cpp:305
+#: ../../../core/core_st.cpp:321
 msgid "Internal error: Unexpected error number"
 msgstr "Erreur interne: Numéro d'erreur inattendu"
 
-#: ../../../core/core_st.cpp:307
+#: ../../../core/core_st.cpp:323
 #, c-format
 msgid "\tName: %s; Filename: %s"
 msgstr ""
 
-#: ../../../core/core_st.cpp:308
+#: ../../../core/core_st.cpp:324
 msgid ""
 "The following entries had an invalid UUID field.  This has been corrected."
 msgstr "Les entrées suivantes avaient un UUID invalide. Ceci a été corrigé."
 
-#: ../../../core/core_st.cpp:309
+#: ../../../core/core_st.cpp:325
 #, c-format
 msgid ""
 "The following entries have passwords in the correct form for %ls, but the "
@@ -6280,18 +6350,18 @@ msgstr ""
 "Les entrées suivantes ont des mots de passe de la bonne forme pour %ls, mais "
 "l'entrée de base n'existe pas."
 
-#: ../../../core/core_st.cpp:310
+#: ../../../core/core_st.cpp:326
 msgid "The following entries were duplicates of an existing entry."
 msgstr "Les entrées suivantes étaient similaires à une entrée déjà existante."
 
-#: ../../../core/core_st.cpp:311
+#: ../../../core/core_st.cpp:327
 msgid ""
 "The following entries had a duplicate UUID field.  This has been corrected."
 msgstr ""
 "Les entrées suivantes avaient un champ UUID en double. Elles ont été "
 "corrigées."
 
-#: ../../../core/core_st.cpp:312
+#: ../../../core/core_st.cpp:328
 #, c-format
 msgid ""
 "The following entries had an empty Password field, which is not permitted. "
@@ -6300,36 +6370,36 @@ msgstr ""
 "Les entrées suivantes avaient un champ Mot de Passe vide, ce qui n'est pas "
 "permi. Le mot de passe a été mis à '%ls'"
 
-#: ../../../core/core_st.cpp:313
+#: ../../../core/core_st.cpp:329
 msgid "The following entries had an empty Title field, which is not permitted."
 msgstr ""
 "Les entrées suivantes avaient un champ titre vide, ce qui n'est pas permi."
 
-#: ../../../core/core_st.cpp:314
+#: ../../../core/core_st.cpp:330
 #, c-format
 msgid "\tGroup='%ls', Title='%ls', User='%ls' %ls"
 msgstr "\tGroupe='%ls', Titre='%ls', Utilisateur='%ls' %ls"
 
-#: ../../../core/core_st.cpp:315
+#: ../../../core/core_st.cpp:331
 #, c-format
 msgid "- Its title has been changed to:'%ls'"
 msgstr "- Son titre a été changé pour: '%ls'"
 
-#: ../../../core/core_st.cpp:316
+#: ../../../core/core_st.cpp:332
 msgid "The following ERRORS were detected and were FIXED."
 msgstr "Les ERREURS suivantes ont été détectées et CORRIGÉES."
 
-#: ../../../core/core_st.cpp:317
+#: ../../../core/core_st.cpp:333
 #, fuzzy
 msgid "The following entries refer to missing attachments."
 msgstr "Les entrées suivantes étaient similaires à une entrée déjà existante."
 
-#: ../../../core/core_st.cpp:318
+#: ../../../core/core_st.cpp:334
 #, fuzzy
 msgid "The following attachments are not referred to by any entry."
 msgstr "Les entrées suivantes étaient similaires à une entrée déjà existante."
 
-#: ../../../core/core_st.cpp:319
+#: ../../../core/core_st.cpp:335
 msgid ""
 "The following entries had an invalid Password History.  This has been "
 "rebuilt with available data.  There may be some loss of history."
@@ -6338,7 +6408,7 @@ msgstr ""
 "été corrigé avec l'information disponible. Il y a pu avoir quelques perte "
 "d'historique."
 
-#: ../../../core/core_st.cpp:320
+#: ../../../core/core_st.cpp:336
 #, c-format
 msgid ""
 "The following entries have one or more text fields too long to display or "
@@ -6348,7 +6418,7 @@ msgstr ""
 "l'affichage ou la modificationn (plus de %d charactères). L'entrée la plus "
 "longue est de ~%d %ls."
 
-#: ../../../core/core_st.cpp:321
+#: ../../../core/core_st.cpp:337
 msgid ""
 "The following WARNINGS were detected - you should review and fix them "
 "manually."
@@ -6356,11 +6426,11 @@ msgstr ""
 "Les AVERTISSEMENTS suivant ont été détectés - vous devriez les revoir et les "
 "corriger manuellement."
 
-#: ../../../core/core_st.cpp:324
+#: ../../../core/core_st.cpp:340
 msgid "will expire"
 msgstr "expirera"
 
-#: ../../../core/core_st.cpp:325
+#: ../../../core/core_st.cpp:341
 #, c-format
 msgid ""
 "SAX Parse Error during %ls\n"
@@ -6369,25 +6439,25 @@ msgstr ""
 "Erreur d'analyse SAX durant %ls\n"
 "%ls."
 
-#: ../../../core/core_st.cpp:326
+#: ../../../core/core_st.cpp:342
 #, c-format
 msgid "XML %ls: line %d character %d: %ls"
 msgstr "XML %ls: ligne %d caractère %d: %ls"
 
-#: ../../../core/core_st.cpp:327
+#: ../../../core/core_st.cpp:343
 msgid ""
 "*** Invalid XML characters found - see exported XML file for more details ***"
 msgstr ""
 "*** Caractère XML invalide trouvés - Voir le fichier XML exporté pour plus "
 "de détails ***"
 
-#: ../../../core/core_st.cpp:328
+#: ../../../core/core_st.cpp:344
 msgid "Internal error: Couldn't initialize config file XML structure"
 msgstr ""
 "Erreur interne: N'a pas pu initialiser la structure XML du fichier de "
 "configuration"
 
-#: ../../../core/core_st.cpp:329
+#: ../../../core/core_st.cpp:345
 msgid ""
 "A filter was active. Export of data was restricted to include only those "
 "displayed."
@@ -6395,11 +6465,11 @@ msgstr ""
 "Un filtre était actif. L'exportation a été restreinte pour inclure seulement "
 "les entrées affichées."
 
-#: ../../../core/core_st.cpp:330
+#: ../../../core/core_st.cpp:346
 msgid "Export of data was restricted to certain fields by the user."
 msgstr "L'exportation a été restreinte à certains champ par l'utilisateur."
 
-#: ../../../core/core_st.cpp:331
+#: ../../../core/core_st.cpp:347
 msgid ""
 "Note: These Password Policies will not replace existing policies with the "
 "same name in the current database."
@@ -6407,25 +6477,25 @@ msgstr ""
 "Note: Ces stratégies de mot de passe ne remplaceront pas les stratégies "
 "existantes ayant le même nom dans le fichier courant."
 
-#: ../../../core/core_st.cpp:332
+#: ../../../core/core_st.cpp:348
 msgid ""
 "Note: These preferences are only used when importing into an empty database."
 msgstr ""
 "Note : Ces préférences sont utilisées seulement lors de l'importation dans "
 "un fichier de mots de passe vide."
 
-#: ../../../core/core_st.cpp:333
+#: ../../../core/core_st.cpp:349
 msgid "Subset of entries restricted by the following rule:"
 msgstr "Sous-ensemble des entrées restreint par la règle suivante :"
 
-#: ../../../core/core_st.cpp:334
+#: ../../../core/core_st.cpp:350
 msgid ""
 "The user specified that the following fields be excluded from the export:"
 msgstr ""
 "L'utilisateur a spécifié que les champs suivants soient exclus de "
 "l'exportation :"
 
-#: ../../../core/core_st.cpp:335
+#: ../../../core/core_st.cpp:351
 #, c-format
 msgid ""
 "Configuration file error:\n"
@@ -6438,15 +6508,15 @@ msgstr ""
 "%ls\n"
 "approximativement à %d"
 
-#: ../../../core/core_st.cpp:336
+#: ../../../core/core_st.cpp:352
 msgid "import"
 msgstr "importer"
 
-#: ../../../core/core_st.cpp:337
+#: ../../../core/core_st.cpp:353
 msgid "Unable to load configuration file"
 msgstr "Incapable de charger le fichier de configuration"
 
-#: ../../../core/core_st.cpp:338
+#: ../../../core/core_st.cpp:354
 msgid ""
 "Failed to lock configuration file - opened by another instance of "
 "PasswordSafe?"
@@ -6454,111 +6524,58 @@ msgstr ""
 "Le verrouillage du fichier de configuration a échoué - ouvert par une autre "
 "instance de PasswordSafe?"
 
-#: ../../../core/core_st.cpp:339
+#: ../../../core/core_st.cpp:355
 msgid "Unable to save configuration file"
 msgstr "Incapable d'enregistrer le fichier de configuration"
 
-#: ../../../core/core_st.cpp:340
+#: ../../../core/core_st.cpp:356
 #, fuzzy
 msgid "validation"
 msgstr "validation"
 
-#: ../../../core/core_st.cpp:342
+#: ../../../core/core_st.cpp:358
 #, fuzzy
 msgid " (EasyVision Symbols)"
 msgstr "Oui - Symboles VisionFacile: %ls"
 
-#: ../../../core/core_st.cpp:343
+#: ../../../core/core_st.cpp:359
 #, c-format
 msgid "Yes (at least %d)"
 msgstr "Oui (au moins %d)"
 
-#: ../../../core/core_st.cpp:344
+#: ../../../core/core_st.cpp:360
 #, fuzzy
 msgid " (Pronounceable Symbols)"
 msgstr "Oui - Symboles prononçables: %ls"
 
-#: ../../../core/core_st.cpp:345
+#: ../../../core/core_st.cpp:361
 #, fuzzy, c-format
 msgid "Yes - At least %d from %ls: %ls%ls"
 msgstr "Oui - Au moins %d de %ls: %ls"
 
-#: ../../../core/core_st.cpp:346
 #, fuzzy, c-format
-msgid "\tGroup='%ls', Title='%ls', User='%ls'"
-msgstr "\tGroupe='%ls', Titre='%ls', Utilisateur='%ls' %ls"
+#~ msgid "\tGroup='%ls', Title='%ls', User='%ls'"
+#~ msgstr "\tGroupe='%ls', Titre='%ls', Utilisateur='%ls' %ls"
 
-#: ../../../core/core_st.cpp:347
-#, fuzzy, c-format
-msgid ""
-"Compare complete of current database:\n"
-"\t %ls\n"
-" and:\n"
-"\t %ls\n"
-msgstr ""
-"Comparaison complète de la base courante:\n"
-"\t %s\n"
-" et:\n"
-"\t %s"
-
-#: ../../../core/core_st.cpp:348
-#, fuzzy, c-format
-msgid "\tNo entries were found containing search string '%ls' %ls"
-msgstr "\tAucune entrée contenant '%s' n'a été trouvé"
-
-#: ../../../core/core_st.cpp:349
-#, fuzzy, c-format
-msgid "\tThe following entries contain search string '%ls' %ls"
-msgstr "\tLes entrées suivantes contiennent le texte recherché '%s'"
-
-#: ../../../core/core_st.cpp:350
 #, fuzzy
-msgid "Export DB"
-msgstr "&Exporter"
+#~ msgid "Import KeePassV1 CSV"
+#~ msgstr "Importer CSV KeePass V1"
 
-#: ../../../core/core_st.cpp:351
 #, fuzzy
-msgid "Import KeePassV1 CSV"
-msgstr "Importer CSV KeePass V1"
+#~ msgid "Import KeePassV1 TXT"
+#~ msgstr "Importer TXT KeePass V1"
 
-#: ../../../core/core_st.cpp:352
 #, fuzzy
-msgid "Import KeePassV1 TXT"
-msgstr "Importer TXT KeePass V1"
+#~ msgid "Import XML"
+#~ msgstr ""
+#~ "\n"
+#~ "Importer du XML"
 
-#: ../../../core/core_st.cpp:353
 #, fuzzy
-msgid "Import XML"
-msgstr ""
-"\n"
-"Importer du XML"
-
-#: ../../../core/core_st.cpp:354
-#, fuzzy
-msgid "Import Text"
-msgstr ""
-"\n"
-"Importer du texte"
-
-#: ../../../core/core_st.cpp:355
-msgid "Merge"
-msgstr "Fusionner"
-
-#: ../../../core/core_st.cpp:356
-msgid "Compare"
-msgstr "Comparer"
-
-#~ msgid "Import_Text"
-#~ msgstr "Import_Text"
-
-#~ msgid "Import_XML"
-#~ msgstr "Import_XML"
-
-#~ msgid "Import_KeePassV1_CSV"
-#~ msgstr "Import_CSV_KeePassV1"
-
-#~ msgid "Import_KeePassV1_TXT"
-#~ msgstr "Import_TXT_KeePassV1"
+#~ msgid "Import Text"
+#~ msgstr ""
+#~ "\n"
+#~ "Importer du texte"
 
 #, fuzzy
 #~ msgid "Advanced..."
@@ -8044,12 +8061,6 @@ msgstr "Comparer"
 #~ "Fichier d'exportation: '%s' déjà existant.\n"
 #~ "Voulez-vous le remplacer?"
 
-#~ msgid "Export_Text"
-#~ msgstr "Exporter_Texte"
-
-#~ msgid "Export_XML"
-#~ msgstr "Exporter_XML"
-
 #~ msgid "Exporting to file:"
 #~ msgstr "Export vers le fichier"
 
@@ -8829,9 +8840,6 @@ msgstr "Comparer"
 #~ "Récupérer les documents auto-sauvegardés\n"
 #~ "Ouvrir les versions automatiquement sauvegardés au lieu des versions "
 #~ "explicitement sauvegardés."
-
-#~ msgid "Relative"
-#~ msgstr "Relatif"
 
 #~ msgid ""
 #~ "Relative dates are in days relative to today e.g. '-1' is yesterday and "
@@ -10153,9 +10161,6 @@ msgstr "Comparer"
 #~ msgstr ""
 #~ "\tEntrée - Groupe : \"%s\"; Titre : \"%s\"; Utilisateur : \"%s\"\n"
 #~ "\t\tcontient des différences dans les champs suivants :"
-
-#~ msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-#~ msgstr "\tGroupe:'%s'; Titre:'%s'; Usager:'%s'"
 
 #~ msgid ""
 #~ "\tThe following restrictions were selected:\n"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pwsafe\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-28 12:52+0100\n"
+"POT-Creation-Date: 2021-03-19 21:58+0100\n"
 "PO-Revision-Date: 2020-03-01 22:00+0100\n"
 "Last-Translator: Attila Rajmund Nohl <attila.r.nohl@gmail.com>\n"
 "Language-Team: NAR <attila.r.nohl@gmail.com>\n"
@@ -211,7 +211,7 @@ msgstr "Dátumok és idők"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:348
 #: ../../../ui/wxWidgets/HelpMap.h:41 ../../../ui/wxWidgets/HelpMap.h:49
-#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:141
+#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:143
 msgid "Password Policy"
 msgstr "Jelszószabály"
 
@@ -225,7 +225,7 @@ msgid "Set Date/Time"
 msgstr "Dátum/idő beállítása"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:370
-#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:137
+#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:139
 msgid "Password"
 msgstr "Jelszó"
 
@@ -494,13 +494,13 @@ msgstr "NAGYBETŰK használata"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:747
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:281
-#: ../../../core/core_st.cpp:260
+#: ../../../core/core_st.cpp:262
 msgid "Use digits"
 msgstr "Számjegyek használata"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:771
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:305
-#: ../../../core/core_st.cpp:262
+#: ../../../core/core_st.cpp:264
 msgid "Use symbols"
 msgstr "Szimbólumok használata"
 
@@ -533,7 +533,7 @@ msgstr "Könnyen kiejthető jelszó generálása"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:815
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:350
-#: ../../../core/core_st.cpp:253
+#: ../../../core/core_st.cpp:255
 msgid "Or"
 msgstr "Vagy"
 
@@ -580,7 +580,7 @@ msgstr "Tulajdonságok"
 #: ../../../ui/wxWidgets/CreateShortcutDlg.cpp:219
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:269
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:274
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
 msgid "Text"
 msgstr "Szöveg"
 
@@ -636,7 +636,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:160
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:173
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:192
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:301
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:317
 msgid "Unknown"
 msgstr "Ismeretlen"
 
@@ -751,7 +751,7 @@ msgstr "[Megjegyzések elrejtve - kattintson ide a megjelenítéshez]"
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:1653
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2145
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2820
-#: ../../../core/core_st.cpp:74
+#: ../../../core/core_st.cpp:76
 msgid "Default Policy"
 msgstr "Alapértelmezett szabály"
 
@@ -772,7 +772,7 @@ msgstr "Nem sikerült jelszót generálni - érvénytelen szabály"
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:144
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:151
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:159
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:200
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:201
 #: ../../../ui/wxWidgets/PWSafeApp.cpp:367
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:737
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:756
@@ -796,7 +796,7 @@ msgstr "Nem sikerült jelszót generálni - érvénytelen szabály"
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:249
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:277
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:316
-#: ../../../core/core_st.cpp:274
+#: ../../../core/core_st.cpp:288
 msgid "Error"
 msgstr "Hiba"
 
@@ -956,7 +956,7 @@ msgid "Synchronize this item..."
 msgstr "&Szinkronizálás..."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:482
-#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:357
+#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:286
 msgid "Synchronize"
 msgstr ""
 
@@ -1038,8 +1038,8 @@ msgid "Current safe was opened read-only"
 msgstr "A jelenlegi széf csak olvasásra lett megnyitva"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:793
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:996
-#: ../../../ui/wxWidgets/SyncWizard.cpp:618
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
+#: ../../../ui/wxWidgets/SyncWizard.cpp:619
 #, c-format
 msgid ""
 "The database:\n"
@@ -1051,7 +1051,7 @@ msgid ""
 msgstr ""
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:794
-#: ../../../ui/wxWidgets/SyncWizard.cpp:617
+#: ../../../ui/wxWidgets/SyncWizard.cpp:618
 msgid "Synchronization failed"
 msgstr "Sikertelen szinkronizáció"
 
@@ -1418,7 +1418,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/GridCtrl.cpp:164
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:292
-#: ../../../core/core_st.cpp:147
+#: ../../../core/core_st.cpp:149
 msgid "Title"
 msgstr "Cím"
 
@@ -1627,7 +1627,7 @@ msgid "Value"
 msgstr "Érték"
 
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:291
-#: ../../../core/core_st.cpp:133
+#: ../../../core/core_st.cpp:135
 msgid "Group"
 msgstr "Csoport"
 
@@ -1711,23 +1711,23 @@ msgstr ""
 msgid "Error parsing Run Command"
 msgstr "Hiba a futtatási parancs felolvasásakor"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:56
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:57
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:355
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:362
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:166
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:623
 msgid "Write Error"
 msgstr "Írási hiba"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:61
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:62
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:165
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:622
 msgid "Could not open file for writing!"
 msgstr "A fájl megnyitása írásra sikertelen!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:64
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:65
 msgid ""
 "Write operation failed!\n"
 "File may have been corrupted.\n"
@@ -1737,39 +1737,39 @@ msgstr ""
 "A fájl megsérülhetett.\n"
 "Próbálja meg elmenteni egy másik mappába"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:69
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:70
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "Unknown error"
 msgstr "Ismeretlen hiba"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:90
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:91
 msgid "Do you want to save changes to the password database: "
 msgstr "Menti a jelszóadatbázisban történt változásokat? "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:145
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:146
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:557
 msgid "Please choose a name for the new database"
 msgstr "Kérem válasszon nevet az új adatbázisnak"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:155
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:156
 msgid "psafe3 files (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 msgstr "psafe3 fájlok (*.psafe3)|*.psafe3|Minden fájl(*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Lock is done by yourself"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Remove Lock?"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:194
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:195
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:602
 #, fuzzy
 msgid "Could not lock file.\n"
@@ -1777,18 +1777,18 @@ msgstr ""
 "Nem sikerült a fájl zárolása, megnyitás csak olvashatóként\n"
 "Zárolva "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:196
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:197
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:452
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:604
 msgid "Locked by "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:236
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:237
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:515
 msgid "Please Choose a Database to Open:"
 msgstr "Kérem válasszon egy megnyitandó adatbázist:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:353
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
 msgid ""
 "Unable to create intermediate backup.  Save database elsewhere or with "
 "another name?\n"
@@ -1800,7 +1800,7 @@ msgstr ""
 "\n"
 "Kattintson a \"Nem\"-re a mentés nélküli kilépéshez."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:360
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
 msgid ""
 "Unable to create intermediate backup.  Do you wish to save changes to your "
 "database without it?"
@@ -1808,12 +1808,12 @@ msgstr ""
 "Képtelen közbenső mentést készíteni. El szeretné menteni a változtatásait az "
 "adatbázisba ezek nélkül?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 msgid "Unable to create intermediate backup."
 msgstr "Képtelen közbenső mentést készíteni."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:386
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:387
 #, c-format
 msgid ""
 "The original database, \"%ls\", is in pre-3.0 format. It will be unchanged.\n"
@@ -1822,12 +1822,12 @@ msgid ""
 "the \"File->Export To-> Old (1.x or 2) format\" command."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:388
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:389
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:447
 msgid "File version warning"
 msgstr "Fájlverzió figyelmeztetés"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:445
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
 #, c-format
 msgid ""
 "The original database, '%ls', is in pre-3.0 format. The data will now be "
@@ -1836,15 +1836,15 @@ msgid ""
 "Old (1.x or 2) format' command."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:458
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
 msgid "Please choose a name for the current (Untitled) database:"
 msgstr "Kérem válasszon nevet az aktuális (Névtelen) adatbázisnak:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:460
 msgid "Please choose a new name for the current database:"
 msgstr "Kérem válasszon egy új nevet az aktuális adatbázisnak:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:467
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:468
 msgid ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|"
 "*.*;*"
@@ -1852,7 +1852,7 @@ msgstr ""
 "Password Safe adatbázisok (*.psafe3; *.dat)|*.psafe3;*.dat|Minden fájl (*.*; "
 "*)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:479
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -1863,122 +1863,122 @@ msgstr ""
 "\n"
 "A fájlt jelenleg zárolja %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:481
 msgid "File lock error"
 msgstr "Fájlzárolási hiba"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:547
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
 #, fuzzy
 msgid "Do you wish to save this restored database as new database?"
 msgstr "Menti a jelszóadatbázisban történt változásokat? (%s)"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:549
 msgid "Unsaved restored database"
 msgstr "Elmentetlen visszaállított adatbázis"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:580
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:581
 msgid "Do you want to save changes to the password database"
 msgstr "Menti a változásokat a jelszóadatbázisba"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:617
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:618
 msgid "Export Text"
 msgstr "Exportálás szöveg formátumba"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:621
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:622
 #, fuzzy
 msgid "Export Text failed"
 msgstr "Szöveg importálása sikertelen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:623
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
 msgid "Please name the plaintext file"
 msgstr "Kérem adjon nevet a szövegfájlnak"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1143
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:625
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1144
 msgid ""
 "Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
 msgstr ""
 "Szövegfájlok (*.txt)|*.txt|CSV fájlok (*.csv)|*.csv|Minden fájl (*.*; *)|*.*;"
 "*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:634
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:635
 msgid "Advanced Text Export Options"
 msgstr "Speciális szövegexportálási beállítások"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:654
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:697
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:655
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:698
 #, fuzzy
 msgid "export"
 msgstr "exportálva"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:660
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:661
 msgid "Export XML"
 msgstr "Exportálás XML-be"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:664
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:665
 #, fuzzy
 msgid "Export XML failed"
 msgstr "XML importálása sikertelen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:666
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
 msgid "Please name the XML file"
 msgstr "Kérem adjon nevet az XML fájlnak"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:668
 msgid "XML files (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 msgstr "XML fájlok (*.xml)|*.xml|Minden fájl (*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:678
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:679
 msgid "Advanced XML Export Options"
 msgstr "Speciális XML exportálási beállítások"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:712
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:716
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:713
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:717
 msgid "Password Safe Databases (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 msgstr "Password Safe adatbázisok (*.dat)|*.dat|Minden fájl (*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:720
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:721
 msgid "Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 msgstr ""
 "Password Safe adatbázisok (*.psafe4)|*.psafe4|Minden fájl (*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:731
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:732
 msgid "Please name the exported database"
 msgstr "Kérem adjon nevet az exportált adatbázisnak"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:748
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:749
 msgid "Could not figure out why PasswordSafeFrame::OnExportVx was invoked"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:782
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:783
 msgid "You must save this database before it can be exported."
 msgstr "Exportálás előtt mentenie kell ezt az adatbázist."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid "Exporting database: "
 msgstr "Adatbázis exportálása: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid " to "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:841
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:842
 #, fuzzy
 msgid "Export complete.  Do you wish to see a detailed report?"
 msgstr "Lecseréli?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:852
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:853
 #, fuzzy
 msgid "No entries satisfied your selection criteria and so none were exported!"
 msgstr ""
 "Egyetlen bejegyzés sem felel meg az ön által megadott feltételeknek, így "
 "egyik sem lehet %s!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:865
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:866
 msgid "Passkey incorrect"
 msgstr "Jelszó érvénytelen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:873
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
 msgid ""
 "The current database was opened in read-only mode.  You cannot import into "
 "it."
@@ -1986,46 +1986,46 @@ msgstr ""
 "A jelenlegi adatbázis csak olvasásra lett megnyitva. Nem lehetséges "
 "importálni bele."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:875
 #, fuzzy
 msgid "Import text"
 msgstr "&Szöveg importálása"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:882
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
 #, fuzzy
 msgid "The database:"
 msgstr "az adatbázisban"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
 msgid "has duplicate entries with the same group/title/user combination."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
 msgid "  Please fix by validating database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:931
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:886
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:932
 msgid "Import Text failed"
 msgstr "Szöveg importálása sikertelen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 #, fuzzy, c-format
 msgid "%ls file being imported: %ls"
 msgstr "%s fájl importálása: %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:921
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:926
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:223
-#: ../../../ui/wxWidgets/SyncWizard.cpp:572
+#: ../../../ui/wxWidgets/SyncWizard.cpp:573
 #: ../../../ui/wxWidgets/wxUtilities.cpp:59
 #: ../../../ui/wxWidgets/wxUtilities.cpp:64
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "File Read Error"
 msgstr "Fájlolvasási hiba"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:923
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:222
 #: ../../../ui/wxWidgets/wxUtilities.cpp:58
 #, fuzzy
@@ -2035,7 +2035,7 @@ msgstr ""
 "\n"
 "A fájl megnyitása olvasásra sikertelen!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:928
 #, fuzzy
 msgid "Invalid format"
 msgstr ""
@@ -2043,76 +2043,76 @@ msgstr ""
 "\n"
 "Érvénytelen formátum"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 msgid "Updated "
 msgstr "Frissítve"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Imported "
 msgstr "Importálva"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entry"
 msgstr "bejegyzés"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entries"
 msgstr "bejegyzések"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
 #, fuzzy
 msgid "Skipped "
 msgstr ""
 "\n"
 "Átugorva %d %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:957
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:958
 #, fuzzy
 msgid "with Password History errors "
 msgstr ""
 "\n"
 "Jelszóelőzmény hibákkal  %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid "Renamed "
 msgstr "Átnevezés"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed successfully"
 msgstr "Sikeresen befejezve"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed but ...."
 msgstr "Kész, de ..."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:981
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1127
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1197
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1218
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1279
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:982
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1128
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1219
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
 #, fuzzy
 msgid "Do you wish to see a detailed report?"
 msgstr "Lecseréli?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1045
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:998
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1046
 msgid "Import XML failed"
 msgstr "XML importálása sikertelen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1007
-#: ../../../core/core_st.cpp:238
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../core/core_st.cpp:240
 #, c-format
 msgid ""
 "Can't find XML Schema Definition file (%ls) in your PasswordSafe Application "
@@ -2123,19 +2123,19 @@ msgstr ""
 "alkalmazáskönyvtárában.\n"
 " Másolja ide a telepítési fájlból, vagy telepítse újra a PasswordSafe-et."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid "Missing XSD File - "
 msgstr "Hiányzó XSD fájl - "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid " Build"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 msgid "XML"
 msgstr "XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1051
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1052
 #, fuzzy, c-format
 msgid ""
 "File: %ls failed validation against XML Schema:\n"
@@ -2146,7 +2146,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1057
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1058
 #, fuzzy, c-format
 msgid ""
 "File: %ls passed Validation but had the following errors during import:\n"
@@ -2158,36 +2158,36 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1078
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1079
 msgid "The following records were skipped:"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1080
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1081
 #, c-format
 msgid " / skipped %d"
 msgstr " / %d kihagyva"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1085
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1086
 msgid "The following records had errors in their Password History:"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1087
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1088
 #, c-format
 msgid " / with Password History errors %d"
 msgstr " / %d jelszó előzmények hiba"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1092
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1093
 msgid ""
 "The following records were renamed as an entry already exists in your "
 "database or in the Import file:"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1094
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1095
 #, c-format
 msgid " / renamed %d"
 msgstr " / %d átnevezve"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1099
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1100
 #, fuzzy, c-format
 msgid ""
 "File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See "
@@ -2196,25 +2196,25 @@ msgstr ""
 "%s fájl importálása megtörtént (%d bejegyzés érvényesítve / importálva %d%s%s"
 "%s). Nézze meg a jelentést a részletekért."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:95
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:97
 msgid "entry"
 msgstr "bejegyzés"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:93
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:95
 msgid "entries"
 msgstr "bejegyzések"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1107
 #, c-format
 msgid ""
 "Validated %d %ls\n"
@@ -2222,26 +2222,26 @@ msgid ""
 "Imported %d %ls"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1114
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1115
 msgid "XML import not supported in this release"
 msgstr "Ez a kiadás nem támogatja az XML importálást"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1117
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1118
 #, c-format
 msgid "XML import: Unexpected return code(%d)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1141
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1142
 msgid "Please Choose a KeePass Text File to Import"
 msgstr "Kérem válassza ki az importálandó KeePass szövegfájlt"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1163
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1164
 #, fuzzy, c-format
 msgid "Text file being imported: %ls"
 msgstr "%s fájl importálása: %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1180
-#: ../../../ui/wxWidgets/SyncWizard.cpp:602
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/SyncWizard.cpp:603
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2252,11 +2252,11 @@ msgstr ""
 "\n"
 "A fájl megnyitása olvasásra sikertelen!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1182
 msgid "File open error"
 msgstr "Fájlmegnyitási hiba"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1195
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1196
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2267,20 +2267,20 @@ msgstr ""
 "\n"
 "Érvénytelen formátum"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1199
 msgid "Import failed"
 msgstr "Importálás sikertelen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1214
 #, fuzzy, c-format
 msgid "Imported %d %ls"
 msgstr "%d %s importálva"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1265
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1266
 msgid "Merging database: "
 msgstr "Adatbázis összefűzése: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1281
 msgid "Merge Complete"
 msgstr "Az összefűzés elkészült"
 
@@ -2390,16 +2390,16 @@ msgstr ""
 "zárolás elengedése sikertelen.\n"
 "Próbáljon meg kilépni és újraindítani a programot."
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #, fuzzy
 msgid " file '"
 msgstr "Szűrők kezelése"
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid "' not readable"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #: ../../../ui/wxWidgets/ViewReportDlg.cpp:32
 msgid "View Report"
 msgstr ""
@@ -2442,7 +2442,7 @@ msgid "Please select a valid file"
 msgstr "Kérem válasszon ki egy érvényes fájlt"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:123
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:249
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:251
 msgid "None"
 msgstr "Egyik sem"
 
@@ -2455,7 +2455,7 @@ msgid "Incremented Number [001-999]"
 msgstr "Növekvő szám [001-999]"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:132
-#: ../../../core/core_st.cpp:66
+#: ../../../core/core_st.cpp:68
 msgid "Copy password to clipboard"
 msgstr "Jelszó másolása a vágólapra"
 
@@ -2465,37 +2465,37 @@ msgstr "A kiválasztott bejegyzés megtekintése/szerkesztése"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:134
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:623
-#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:62
+#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:64
 msgid "Autotype"
 msgstr "Autogépelés"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:135
-#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:63
+#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:65
 msgid "Browse to URL"
 msgstr "Navigálás az URL-re"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:136
-#: ../../../core/core_st.cpp:65
+#: ../../../core/core_st.cpp:67
 msgid "Copy notes to clipboard"
 msgstr "Megjegyzés vágólapra másolása"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:137
-#: ../../../core/core_st.cpp:68
+#: ../../../core/core_st.cpp:70
 msgid "Copy username to clipboard"
 msgstr "Felhasználónév vágólapra másolása"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:138
-#: ../../../core/core_st.cpp:67
+#: ../../../core/core_st.cpp:69
 msgid "Copy password to clipboard, minimize"
 msgstr "Jelszó vágólapra másolása, kis méretre váltás"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:139
-#: ../../../core/core_st.cpp:64
+#: ../../../core/core_st.cpp:66
 msgid "Browse to URL + Autotype"
 msgstr "Navigálás az URL-re + Autogépelés"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:140
-#: ../../../core/core_st.cpp:69 ../../../core/core_st.cpp:144
+#: ../../../core/core_st.cpp:71 ../../../core/core_st.cpp:146
 msgid "Run Command"
 msgstr "Parancs futtatása"
 
@@ -2907,23 +2907,23 @@ msgstr "Password Safe: Hiba a súgó indítása közben"
 msgid "Don't show this warning again"
 msgstr "Ne mutassa ezt a figyelmeztetést többé"
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:849
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:854
 msgid "Missing help definition for page \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:850
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
 msgid "\" of \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:860
 msgid "Missing help definition for window \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:866
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:871
 msgid "Please inform the developers."
 msgstr "Kérem értesítse a fejlesztőket."
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:867
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:872
 msgid "Help Undefined"
 msgstr ""
 
@@ -3600,6 +3600,7 @@ msgid "search"
 msgstr "&Keresés"
 
 #: ../../../ui/wxWidgets/PasswordSafeSearch.cpp:427
+#: ../../../core/core_st.cpp:280
 msgid "Find"
 msgstr "Keresés"
 
@@ -3715,20 +3716,20 @@ msgstr "ellenőrzés"
 msgid " empty)"
 msgstr "üres)"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:306
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:322
 #, c-format
 msgid "%ls on %ls"
 msgstr "%ls ezen: %ls"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:341
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:357
 msgid "Yes"
 msgstr "Igen"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:244
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:246
 msgid "No"
 msgstr "Nem"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:302
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:318
 #, c-format
 msgid "In Headers(%ls)/In Entries("
 msgstr "Fejlécekben(%ls)/Bejegyzésekben("
@@ -3899,7 +3900,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:457
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:269
-#: ../../../core/core_st.cpp:276
+#: ../../../core/core_st.cpp:290
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
@@ -3967,11 +3968,11 @@ msgstr "Kérem adja meg a kulcsot és ellenőrizze."
 msgid "Please try another"
 msgstr "Kérem próbáljon másikat"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:96
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:98
 msgid "equals"
 msgstr "egyenlő"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:83
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:85
 msgid "does not equal"
 msgstr "nem egyenlő"
 
@@ -3979,23 +3980,23 @@ msgstr "nem egyenlő"
 msgid "begins with"
 msgstr "ezzel kezdődik:"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:78
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:80
 msgid "does not begin with"
 msgstr "nem ezzel kezdődik:"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:90
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:92
 msgid "ends with"
 msgstr "erre végződik:"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:82
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:84
 msgid "does not end with"
 msgstr "nem erre végződik:"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:56
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:58
 msgid "contains"
 msgstr "tartalmaz"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:79
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:81
 msgid "does not contain"
 msgstr "nem tartalmaz"
 
@@ -4053,20 +4054,20 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Mégse"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:143
+#: ../../../ui/wxWidgets/SyncWizard.cpp:144
 #, fuzzy
 msgid "synchronize"
 msgstr "szinkronizálva"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:220
+#: ../../../ui/wxWidgets/SyncWizard.cpp:221
 msgid "Synchronize another database with currently open database"
 msgstr "Egy másik adatbázis szinkronizálása a jelenleg megnyitott adatbázissal"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:349
+#: ../../../ui/wxWidgets/SyncWizard.cpp:350
 msgid "Introduction"
 msgstr "Bevezetés"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:353
+#: ../../../ui/wxWidgets/SyncWizard.cpp:354
 msgid ""
 "Synchronizing with another database will update the entries in your\n"
 "database with matching entries from the other database."
@@ -4075,11 +4076,11 @@ msgstr ""
 "bejegyzések\n"
 "frissülni fognak a másik adatbázisból származó egyező bejegyzésekkel."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:356
+#: ../../../ui/wxWidgets/SyncWizard.cpp:357
 msgid "More Info"
 msgstr "További információ"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:359
+#: ../../../ui/wxWidgets/SyncWizard.cpp:360
 msgid ""
 "1. Two entries from different databases match if their Group, Title\n"
 "and User fields match."
@@ -4087,7 +4088,7 @@ msgstr ""
 "1. Két, különböző adatbázisból származó bejegyzés akkor egyezik, ha\n"
 "a csoport, a cím és a felhasználó mezők megegyeznek."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:360
+#: ../../../ui/wxWidgets/SyncWizard.cpp:361
 msgid ""
 "2. You can select the fields to update, as well as filter the entries\n"
 "for synchronization."
@@ -4095,7 +4096,7 @@ msgstr ""
 "2. A szinkronizációhoz kiválaszthatja a módosítandó mezőket, illetve\n"
 "szűrhet is a bejegyzésekre."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:361
+#: ../../../ui/wxWidgets/SyncWizard.cpp:362
 msgid ""
 "3. Only existing entries in your database are updated.  No new entries are\n"
 "added or existing entries removed during this process."
@@ -4103,7 +4104,7 @@ msgstr ""
 "3. Csak meglevő bejegyzések módosulnak az adatbázisban. Új bejegyzések\n"
 "nem kerülnek be és meglevő bejegyzések nem törlődnek a művelet során."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:362
+#: ../../../ui/wxWidgets/SyncWizard.cpp:363
 msgid ""
 "4. You can undo the operation once it is complete, but won't be\n"
 "able to abort it mid-way."
@@ -4111,30 +4112,30 @@ msgstr ""
 "4. A műveletet visszavonhatja, amikor az befejeződött, de\n"
 "nem tudja megszakítani azt meg a művelet közben."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:379
+#: ../../../ui/wxWidgets/SyncWizard.cpp:380
 #, fuzzy
 msgid "Select another database"
 msgstr "Válasszon adatbázist"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:381
+#: ../../../ui/wxWidgets/SyncWizard.cpp:382
 msgid "Choose Database to Synchronize with \""
 msgstr ""
 "Kérem válassza ki az aktuális adatbázissal szinkronizálandó adatbázist \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:382
+#: ../../../ui/wxWidgets/SyncWizard.cpp:383
 msgid "Please Choose a Database to Synchronize with current database"
 msgstr "Kérem válassza ki az aktuális adatbázissal szinkronizálandó adatbázist"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:405
+#: ../../../ui/wxWidgets/SyncWizard.cpp:406
 msgid "Synchronization options"
 msgstr "Szinkronizálási beállítások"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:429
+#: ../../../ui/wxWidgets/SyncWizard.cpp:430
 #, fuzzy
 msgid "Options Summary"
 msgstr "Beállítások"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:454
+#: ../../../ui/wxWidgets/SyncWizard.cpp:455
 msgid ""
 "WARNING!!\n"
 "\n"
@@ -4146,56 +4147,56 @@ msgstr ""
 "Ha most folytatja, akkor a jelenlegi adatbázis mezői módosulni\n"
 "fognak a kiválasztott bemeneti adatbázisból"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:471
+#: ../../../ui/wxWidgets/SyncWizard.cpp:472
 msgid " will be updated with corresponding entries from \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:478
+#: ../../../ui/wxWidgets/SyncWizard.cpp:479
 msgid "All fields in matching entries will be updated"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:484
+#: ../../../ui/wxWidgets/SyncWizard.cpp:485
 msgid "Following fields in matching entries will be updated:"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:488
+#: ../../../ui/wxWidgets/SyncWizard.cpp:489
 msgid "Following fields will not be updated:"
 msgstr "Az alábbi mezők nem fognak módosulni:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:507
+#: ../../../ui/wxWidgets/SyncWizard.cpp:508
 #, fuzzy
 msgid "Synchronization status"
 msgstr "Konfigurációs fájl állapota"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:525
+#: ../../../ui/wxWidgets/SyncWizard.cpp:526
 msgid "See a detailed report"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:561
+#: ../../../ui/wxWidgets/SyncWizard.cpp:562
 msgid "Your database is being synchronized with \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:571
+#: ../../../ui/wxWidgets/SyncWizard.cpp:572
 msgid "There was an error during synchronization"
 msgstr "Hiba történt a szinkronizáció közben"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:585
+#: ../../../ui/wxWidgets/SyncWizard.cpp:586
 #, c-format
 msgid "Your database has been synchronized with \"%ls\""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:586
+#: ../../../ui/wxWidgets/SyncWizard.cpp:587
 #, fuzzy, c-format
 msgid "%ld %ls updated"
 msgstr ""
 "\n"
 "Az alábbi %ls %ls módosítva:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:589
 msgid "Synchronization completed successfully"
 msgstr "A szinkronizáció sikeresen befejeződött"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:604
+#: ../../../ui/wxWidgets/SyncWizard.cpp:605
 #, c-format
 msgid ""
 "%ls\n"
@@ -4208,7 +4209,7 @@ msgstr ""
 "A fájl megsérült vagy a tartalma csonkolva van!\n"
 "Adat veszhetett el vagy módosulhatott."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:606
+#: ../../../ui/wxWidgets/SyncWizard.cpp:607
 #, c-format
 msgid ""
 "%ls\n"
@@ -4219,24 +4220,24 @@ msgstr ""
 "\n"
 "Ismeretlen hiba"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:640
+#: ../../../ui/wxWidgets/SyncWizard.cpp:641
 #, c-format
 msgid "Synchronizing from database: %ls\n"
 msgstr "Szinkronizáció adatbázisból: %ls\n"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:643
+#: ../../../ui/wxWidgets/SyncWizard.cpp:644
 msgid "synchronized"
 msgstr "szinkronizálva"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:322
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:338
 msgid "was"
 msgstr "volt"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:323
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:339
 msgid "were"
 msgstr "volt"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:298
+#: ../../../ui/wxWidgets/SyncWizard.cpp:733 ../../../core/core_st.cpp:314
 #, c-format
 msgid ""
 "\n"
@@ -4245,7 +4246,7 @@ msgstr ""
 "\n"
 "Az alábbi %ls %ls módosítva:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:297
+#: ../../../ui/wxWidgets/SyncWizard.cpp:749 ../../../core/core_st.cpp:313
 #, c-format
 msgid ""
 "\n"
@@ -4410,7 +4411,7 @@ msgstr ""
 msgid "This shortcut's target [%s:%s:%s] is not a normal entry."
 msgstr ""
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:94
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:96
 #, c-format
 msgid ""
 "The following entries had a policy name that already existed in this "
@@ -4510,13 +4511,13 @@ msgstr ""
 "Adat veszhetett el vagy módosulhatott.\n"
 "Ennek ellenére folytatja?"
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:381
+#: ../../../ui/wxWidgets/wxUtilities.cpp:390
 msgid ""
 "An error occurred while trying to get the image data from database item.\n"
 "Therefore, the image cannot be displayed in the preview."
 msgstr ""
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:394
+#: ../../../ui/wxWidgets/wxUtilities.cpp:403
 msgid ""
 "An error occurred while trying to load the image data into the preview "
 "area.\n"
@@ -4636,7 +4637,7 @@ msgstr "Adatbázis Mentése"
 msgid "Copy Password to Clipboard"
 msgstr "Jelszó másolása a vágólapra"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:149
+#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:151
 #, fuzzy
 msgid "Username"
 msgstr "Felhasználónév:"
@@ -4645,7 +4646,7 @@ msgstr "Felhasználónév:"
 msgid "Copy Username to Clipboard"
 msgstr "Felhasználónév másolása a vágólapra"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:136
+#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:138
 #, fuzzy
 msgid "Notes"
 msgstr "&Megjegyzések:"
@@ -4672,7 +4673,7 @@ msgstr "Autogépelés"
 msgid "Browse URL"
 msgstr "Navigálás az URL-re"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:70
+#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:72
 msgid "Send Email"
 msgstr "Email küldése"
 
@@ -4857,66 +4858,84 @@ msgid "(case sensitive)"
 msgstr "(kis- és nagybetűk megkülönböztetése)"
 
 #: ../../../core/core_st.cpp:50
+#, fuzzy, c-format
+msgid ""
+"Compare complete of current database:\n"
+"\t %ls\n"
+" and:\n"
+"\t %ls\n"
+msgstr ""
+"Összehasonlítás elkészült az aktuális adatbázisra: \n"
+"\t %s\n"
+" és:\n"
+"\t %s"
+
+#: ../../../core/core_st.cpp:51
+#, fuzzy, c-format
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tCsoport:'%s'; Megnevezés:'%s'; Felhasználó:'%s'"
+
+#: ../../../core/core_st.cpp:52
 msgid "C:F[R-O]"
 msgstr "C:F[R-O]"
 
-#: ../../../core/core_st.cpp:51
+#: ../../../core/core_st.cpp:53
 msgid "C:F[R/W]"
 msgstr "C:F[R/W]"
 
-#: ../../../core/core_st.cpp:52
+#: ../../../core/core_st.cpp:54
 msgid "C:None  "
 msgstr "C:None  "
 
-#: ../../../core/core_st.cpp:53
+#: ../../../core/core_st.cpp:55
 msgid "C:Reg   "
 msgstr "C:Reg   "
 
-#: ../../../core/core_st.cpp:54
+#: ../../../core/core_st.cpp:56
 msgid "conflict"
 msgstr "ütközés"
 
-#: ../../../core/core_st.cpp:55
+#: ../../../core/core_st.cpp:57
 msgid "conflicts"
 msgstr "ütközések"
 
-#: ../../../core/core_st.cpp:57
+#: ../../../core/core_st.cpp:59
 msgid "contains all of"
 msgstr "mindegyiket tartalmazza"
 
-#: ../../../core/core_st.cpp:58
+#: ../../../core/core_st.cpp:60
 msgid "contains any of"
 msgstr "ezek közül bármelyiket tartalmazza:"
 
-#: ../../../core/core_st.cpp:59
+#: ../../../core/core_st.cpp:61
 #, fuzzy
 msgid "copied"
 msgstr "URL másolva "
 
-#: ../../../core/core_st.cpp:60
+#: ../../../core/core_st.cpp:62
 #, c-format
 msgid "%ls - Copied %ls"
 msgstr "%ls - %ls másolva"
 
-#: ../../../core/core_st.cpp:61
+#: ../../../core/core_st.cpp:63
 #, c-format
 msgid " Current default (%ls)"
 msgstr "A jelenlegi alapértelmezett (%ls)"
 
-#: ../../../core/core_st.cpp:71
+#: ../../../core/core_st.cpp:73
 msgid "View/Edit selected entry"
 msgstr "A kiválasztott bejegyzés megtekintése/szerkesztése"
 
-#: ../../../core/core_st.cpp:72
+#: ../../../core/core_st.cpp:74
 #, fuzzy
 msgid " (application default)"
 msgstr "Használt alkalmazás:"
 
-#: ../../../core/core_st.cpp:73
+#: ../../../core/core_st.cpp:75
 msgid "default symbol set"
 msgstr "alapértelmezett szimbólumkészlet"
 
-#: ../../../core/core_st.cpp:75
+#: ../../../core/core_st.cpp:77
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -4925,11 +4944,11 @@ msgid ""
 "entry's password)?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:76
+#: ../../../core/core_st.cpp:78
 msgid "Delete Base Entry Confirmation"
 msgstr "Alapbejegyzés törlésének megerősítése"
 
-#: ../../../core/core_st.cpp:77
+#: ../../../core/core_st.cpp:79
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -4937,303 +4956,303 @@ msgid ""
 "Please confirm to continue (All shortcuts to this entry will be deleted)?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:80
+#: ../../../core/core_st.cpp:82
 msgid "does not contain all of"
 msgstr "nem tartalmazza mindet"
 
-#: ../../../core/core_st.cpp:81
+#: ../../../core/core_st.cpp:83
 msgid "does not contain any of"
 msgstr "egyiket sem tartalmazza"
 
-#: ../../../core/core_st.cpp:84
+#: ../../../core/core_st.cpp:86
 #, c-format
 msgid " Drag # %d"
 msgstr "# %d megragadása"
 
-#: ../../../core/core_st.cpp:85
-#, c-format
-msgid "%s - Drag & Drop %s"
+#: ../../../core/core_st.cpp:87
+#, fuzzy, c-format
+msgid "%ls - Drag & Drop %ls"
 msgstr "%s - Áthúzás %s"
 
-#: ../../../core/core_st.cpp:86
+#: ../../../core/core_st.cpp:88
 #, c-format
 msgid " Duplicate # %d"
 msgstr "# %d megkettőzése"
 
-#: ../../../core/core_st.cpp:87
+#: ../../../core/core_st.cpp:89
 #, fuzzy
 msgid "empty group"
 msgstr "Importálás ezen csoport alá"
 
-#: ../../../core/core_st.cpp:88
+#: ../../../core/core_st.cpp:90
 #, fuzzy
 msgid "empty groups"
 msgstr "#csoportok"
 
-#: ../../../core/core_st.cpp:89
+#: ../../../core/core_st.cpp:91
 #, c-format
 msgid ""
 "Trouble with a non-textual (e.g., time) field in record '%ls' - please check "
 "data carefully."
 msgstr ""
 
-#: ../../../core/core_st.cpp:91
+#: ../../../core/core_st.cpp:93
 msgid "End Report"
 msgstr "Jelentés vége"
 
-#: ../../../core/core_st.cpp:92
+#: ../../../core/core_st.cpp:94
 msgid "--------------------------------------------------------------------------------"
 msgstr "--------------------------------------------------------------------------------"
 
-#: ../../../core/core_st.cpp:97
+#: ../../../core/core_st.cpp:99
 msgid "has expired"
 msgstr "lejárt"
 
-#: ../../../core/core_st.cpp:98
+#: ../../../core/core_st.cpp:100
 msgid "Entries with a password expiry"
 msgstr "Jelszólejárattal rendelkező bejegyzések"
 
-#: ../../../core/core_st.cpp:99
+#: ../../../core/core_st.cpp:101
 #, c-format
 msgid "within %d day(s)"
 msgstr "%d napon belül"
 
-#: ../../../core/core_st.cpp:100
+#: ../../../core/core_st.cpp:102
 #, fuzzy, c-format
 msgid "DB Export from database: '%s'"
 msgstr "Adatbázis összefűzése: %s\n"
 
-#: ../../../core/core_st.cpp:101
+#: ../../../core/core_st.cpp:103
 msgid "First character of variable name must be alphabetic"
 msgstr "A változó nevének első karaktere betű kell, hogy legyen"
 
-#: ../../../core/core_st.cpp:102
+#: ../../../core/core_st.cpp:104
 msgid "Index not numeric"
 msgstr "Az index nem numerikus"
 
-#: ../../../core/core_st.cpp:103
+#: ../../../core/core_st.cpp:105
 msgid "Input string is empty"
 msgstr "A bemeneti szöveg üres"
 
-#: ../../../core/core_st.cpp:104
+#: ../../../core/core_st.cpp:106
 msgid "Characters present between end of index ']' and '}'"
 msgstr "Karakterek találhatók a ']' vagy '}' jelek között. ???"
 
-#: ../../../core/core_st.cpp:105
+#: ../../../core/core_st.cpp:107
 msgid "Index is invalid or missing"
 msgstr "Az index érvénytelen vagy hiányzik"
 
-#: ../../../core/core_st.cpp:106
+#: ../../../core/core_st.cpp:108
 msgid "Missing ending curly bracket for variable name"
 msgstr "Záró kapcsos zárójel hiányzik a változó nevéből"
 
-#: ../../../core/core_st.cpp:107
+#: ../../../core/core_st.cpp:109
 msgid "Missing ending round bracket for Autotype value"
 msgstr "Záró zárójel hiányzik az Autogépelés értékből"
 
-#: ../../../core/core_st.cpp:108
+#: ../../../core/core_st.cpp:110
 msgid "Missing ending square bracket for index value"
 msgstr "Záró szögletes zárójel hiányzik az index értékéből"
 
-#: ../../../core/core_st.cpp:109
+#: ../../../core/core_st.cpp:111
 msgid "There are unmatched quotes in the run command"
 msgstr ""
 
-#: ../../../core/core_st.cpp:110
+#: ../../../core/core_st.cpp:112
 #, fuzzy
 msgid "Variable name is empty"
 msgstr "A változó nevének első karaktere betű kell, hogy legyen"
 
-#: ../../../core/core_st.cpp:111
+#: ../../../core/core_st.cpp:113
 #, fuzzy
 msgid "Variable name must be alphanumeric"
 msgstr "A változó nevének első karaktere betű kell, hogy legyen"
 
-#: ../../../core/core_st.cpp:112
+#: ../../../core/core_st.cpp:114
 msgid "an alias entry"
 msgstr "egy álnév bejegyzés"
 
-#: ../../../core/core_st.cpp:113
+#: ../../../core/core_st.cpp:115
 msgid "a base entry of an alias"
 msgstr "egy álnév alapbejegyzése"
 
-#: ../../../core/core_st.cpp:114
+#: ../../../core/core_st.cpp:116
 msgid "  Field is too long."
 msgstr "  A mező túl hosszú."
 
-#: ../../../core/core_st.cpp:115
+#: ../../../core/core_st.cpp:117
 msgid "  Field is too short."
 msgstr "  A mező túl rövid"
 
-#: ../../../core/core_st.cpp:116
+#: ../../../core/core_st.cpp:118
 msgid "Error: A file with this name already exists"
 msgstr "Hiba: ezen a néven már létezik egy fájl"
 
-#: ../../../core/core_st.cpp:117
+#: ../../../core/core_st.cpp:119
 #, fuzzy
 msgid "The file was not found."
 msgstr "%1 nem található."
 
-#: ../../../core/core_st.cpp:118
+#: ../../../core/core_st.cpp:120
 msgid "Error: File is read-only"
 msgstr "Hiba: a fájl csak olvasható"
 
-#: ../../../core/core_st.cpp:119
+#: ../../../core/core_st.cpp:121
 msgid "Error while writing file! Try saving in a different location"
 msgstr "Hiba a fájl írásakor! Próbálja meg egy másik helyre menteni"
 
-#: ../../../core/core_st.cpp:120
+#: ../../../core/core_st.cpp:122
 #, fuzzy
 msgid "File is too big."
 msgstr "  A mező túl hosszú."
 
-#: ../../../core/core_st.cpp:121
+#: ../../../core/core_st.cpp:123
 #, fuzzy
 msgid "File is too short."
 msgstr "  A mező túl rövid"
 
-#: ../../../core/core_st.cpp:122
+#: ../../../core/core_st.cpp:124
 msgid "File is truncated or otherwise corrupt. Please use backup database."
 msgstr ""
 "A fájlt csonkolták, vagy más módon lett korrupt. Készítsen mentést az "
 "adatabázisról."
 
-#: ../../../core/core_st.cpp:123
+#: ../../../core/core_st.cpp:125
 msgid "Cannot read file. Please check file permissions."
 msgstr "A fájl nem olvasható. Ellenőrizze a jogosultságokat a fájlon."
 
-#: ../../../core/core_st.cpp:124
+#: ../../../core/core_st.cpp:126
 #, c-format
 msgid ""
 "Filter %ls already exists in the database, do you wish to replace it with "
 "this?"
 msgstr "%ls szűrő már létezik az adatbázisban, kívánja lecserélni ezzel?"
 
-#: ../../../core/core_st.cpp:125
+#: ../../../core/core_st.cpp:127
 #, fuzzy
 msgid "Current database filters have been exported to this database."
 msgstr "Aktuális adatbázis összehasonlítása ezzel: %s"
 
-#: ../../../core/core_st.cpp:126
+#: ../../../core/core_st.cpp:128
 msgid "Stored filters will be unusable until the file's restored."
 msgstr ""
 
-#: ../../../core/core_st.cpp:127
+#: ../../../core/core_st.cpp:129
 msgid "Last Access Time"
 msgstr "Utolsó hozzáférés ideje"
 
-#: ../../../core/core_st.cpp:128
+#: ../../../core/core_st.cpp:130
 msgid "Attachment Reference"
 msgstr ""
 
-#: ../../../core/core_st.cpp:129
+#: ../../../core/core_st.cpp:131
 msgid "AutoType"
 msgstr "Autogépelés"
 
-#: ../../../core/core_st.cpp:130
+#: ../../../core/core_st.cpp:132
 msgid "Created Time"
 msgstr "Létrehozás ideje"
 
-#: ../../../core/core_st.cpp:131
+#: ../../../core/core_st.cpp:133
 msgid "DCA"
 msgstr "DCA"
 
-#: ../../../core/core_st.cpp:132
+#: ../../../core/core_st.cpp:134
 msgid "e-mail"
 msgstr "e-mail"
 
-#: ../../../core/core_st.cpp:134
+#: ../../../core/core_st.cpp:136
 msgid "Group/Title"
 msgstr "Csoport/Cím"
 
-#: ../../../core/core_st.cpp:135
+#: ../../../core/core_st.cpp:137
 msgid "Keyboard Shortcut"
 msgstr "Billentyűparancs"
 
-#: ../../../core/core_st.cpp:138
+#: ../../../core/core_st.cpp:140
 msgid "Password Modified Time"
 msgstr "Jelszó módosításának ideje"
 
-#: ../../../core/core_st.cpp:139
+#: ../../../core/core_st.cpp:141
 msgid "Protected"
 msgstr "Védett"
 
-#: ../../../core/core_st.cpp:140
+#: ../../../core/core_st.cpp:142
 msgid "History"
 msgstr "Előzmény"
 
-#: ../../../core/core_st.cpp:142
+#: ../../../core/core_st.cpp:144
 msgid "Password Policy Name"
 msgstr "Jelszószabály neve"
 
-#: ../../../core/core_st.cpp:143
+#: ../../../core/core_st.cpp:145
 #, fuzzy
 msgid "Record Modified Time"
 msgstr "Jelszó módosításának ideje"
 
-#: ../../../core/core_st.cpp:145
+#: ../../../core/core_st.cpp:147
 msgid "Shift+DCA"
 msgstr "Shift+DKM"
 
-#: ../../../core/core_st.cpp:146
+#: ../../../core/core_st.cpp:148
 #, fuzzy
 msgid "Symbols"
 msgstr "'Szimbólumok'"
 
-#: ../../../core/core_st.cpp:148
+#: ../../../core/core_st.cpp:150
 msgid "URL"
 msgstr "URL"
 
-#: ../../../core/core_st.cpp:150
+#: ../../../core/core_st.cpp:152
 msgid "UUID"
 msgstr "UUID"
 
-#: ../../../core/core_st.cpp:151
+#: ../../../core/core_st.cpp:153
 msgid "Password Expiry Date"
 msgstr "Jelszó lejáratának dátuma"
 
-#: ../../../core/core_st.cpp:152
+#: ../../../core/core_st.cpp:154
 msgid "Password Expiry Interval"
 msgstr "Jelszólejárat időköze"
 
-#: ../../../core/core_st.cpp:153
+#: ../../../core/core_st.cpp:155
 msgid "a normal entry"
 msgstr "egy normál bejegyzés"
 
-#: ../../../core/core_st.cpp:154
+#: ../../../core/core_st.cpp:156
 #, fuzzy
 msgid "Last found entries"
 msgstr "bejegyzések"
 
-#: ../../../core/core_st.cpp:155
+#: ../../../core/core_st.cpp:157
 msgid "added but not yet saved to database"
 msgstr "hozzáadva, de még nincs mentve az adatbázisba"
 
-#: ../../../core/core_st.cpp:156
+#: ../../../core/core_st.cpp:158
 msgid "in the database"
 msgstr "az adatbázisban"
 
-#: ../../../core/core_st.cpp:157
+#: ../../../core/core_st.cpp:159
 msgid "a shortcut entry"
 msgstr "egy parancsikon bejegyzés"
 
-#: ../../../core/core_st.cpp:158
+#: ../../../core/core_st.cpp:160
 msgid "a base entry of a shortcut"
 msgstr "egy parancsikon alapbejegyzése"
 
-#: ../../../core/core_st.cpp:159
+#: ../../../core/core_st.cpp:161
 msgid "changed but not yet saved to database"
 msgstr "megváltoztatva, de még nincs mentve az adatbázisba"
 
-#: ../../../core/core_st.cpp:160
+#: ../../../core/core_st.cpp:162
 msgid "greater than"
 msgstr "nagyobb mint"
 
-#: ../../../core/core_st.cpp:161
+#: ../../../core/core_st.cpp:163
 msgid "greater than or equal to"
 msgstr "nagyobb vagy egyenlő mint"
 
-#: ../../../core/core_st.cpp:162
+#: ../../../core/core_st.cpp:164
 #, c-format
 msgid ""
 "Invalid input on line %d.  Number of fields separated by '%c' is not as "
@@ -5242,12 +5261,12 @@ msgstr ""
 "Érvénytelen bevitel a(z) %d. sorban. '%c' karakterrel elválasztott mezők "
 "száma nem az elvárt."
 
-#: ../../../core/core_st.cpp:163
+#: ../../../core/core_st.cpp:165
 #, c-format
 msgid "Line %d: "
 msgstr "%d. sor:"
 
-#: ../../../core/core_st.cpp:164
+#: ../../../core/core_st.cpp:166
 #, c-format
 msgid ""
 "File ends on line %d before ending double quote of last entry's note field."
@@ -5255,11 +5274,11 @@ msgstr ""
 "A fájl véget ér a(z) %d. sorban, mielőtt az utolsó bejegyzés megjegyzését "
 "lezáró dupla idézőjel meglett volna."
 
-#: ../../../core/core_st.cpp:165
+#: ../../../core/core_st.cpp:167
 msgid "Import aborted. Please see report."
 msgstr "Importálás megszakítva. Kérem tekintse meg a jelentést."
 
-#: ../../../core/core_st.cpp:166
+#: ../../../core/core_st.cpp:168
 #, fuzzy
 msgid ""
 "The TXT or CSV file was not imported as required as entry records span "
@@ -5272,7 +5291,7 @@ msgstr ""
 "\n"
 "Importálás megszakítva."
 
-#: ../../../core/core_st.cpp:167
+#: ../../../core/core_st.cpp:169
 #, c-format
 msgid ""
 "%ls, Title=\"%ls\", User=\"%ls\" already exists in your database or in the "
@@ -5281,78 +5300,78 @@ msgstr ""
 "%ls, Cím=\"%ls\", Felhasználó=\"%ls\" már létezik az adatbázisban vagy az "
 "Import fájlban. A beimportált tételnek ez lett a címe:\"%ls\".\n"
 
-#: ../../../core/core_st.cpp:168
+#: ../../../core/core_st.cpp:170
 #, c-format
 msgid "Entry on line %d with Group=\"%ls\""
 msgstr "Bejegyzés a(z) %d. sorban, Csoport=\"%ls\""
 
-#: ../../../core/core_st.cpp:169
+#: ../../../core/core_st.cpp:171
 #, c-format
 msgid "Entry on line %d with no group"
 msgstr "Bejegyzés a(z) %d. sorban Csoport nélkül"
 
-#: ../../../core/core_st.cpp:170
+#: ../../../core/core_st.cpp:172
 #, c-format
 msgid "Entry with Group=\"%ls\""
 msgstr "Bejegyzés, ahol Csoport=\"%ls\""
 
-#: ../../../core/core_st.cpp:171
+#: ../../../core/core_st.cpp:173
 msgid "Entry with no group"
 msgstr "Bejegyzés Csoport nélkül"
 
-#: ../../../core/core_st.cpp:172
+#: ../../../core/core_st.cpp:174
 msgid "imported"
 msgstr "importálva"
 
-#: ../../../core/core_st.cpp:173
+#: ../../../core/core_st.cpp:175
 #, fuzzy, c-format
 msgid "including %d empty group(s)."
 msgstr "#csoportok"
 
-#: ../../../core/core_st.cpp:174
+#: ../../../core/core_st.cpp:176
 #, c-format
 msgid "Empty line %d skipped"
 msgstr "A %d. számú üres sor kihagyva."
 
-#: ../../../core/core_st.cpp:175
+#: ../../../core/core_st.cpp:177
 #, c-format
 msgid "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 msgstr ""
 "Bejegyzés %ls%d ahol Csoport=\"%ls\", Megnevezés=\"%ls\", Felhasználó=\"%ls\""
 
-#: ../../../core/core_st.cpp:176
+#: ../../../core/core_st.cpp:178
 msgid "Internal error. Import failed. No records imported."
 msgstr "Belső hiba. Az importálás sikertelen. Nem lett rekord importálva."
 
-#: ../../../core/core_st.cpp:177
+#: ../../../core/core_st.cpp:179
 #, c-format
 msgid "Found %d known column headers:"
 msgstr "%d ismert oszlopfejlécet találtam:"
 
-#: ../../../core/core_st.cpp:178
+#: ../../../core/core_st.cpp:180
 msgid "Invalid field delimiter: must be within ASCII range."
 msgstr ""
 
-#: ../../../core/core_st.cpp:179
+#: ../../../core/core_st.cpp:181
 #, c-format
 msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
 msgstr ""
 "Sor: %d  A bejegyzés \"%ls\" mezője érvénytelen. Figyelmen kívül lett hagyva."
 
-#: ../../../core/core_st.cpp:180
+#: ../../../core/core_st.cpp:182
 #, fuzzy
 msgid "The following columns will be processed: "
 msgstr ""
 "\n"
 "Az alábbi %ls %ls módosítva:"
 
-#: ../../../core/core_st.cpp:181
+#: ../../../core/core_st.cpp:183
 msgid ""
 "The following columns were recognised but only Group/Title, Username and "
 "Password will be processed:"
 msgstr ""
 
-#: ../../../core/core_st.cpp:182
+#: ../../../core/core_st.cpp:184
 #, c-format
 msgid ""
 "Line %d skipped - Only %d fields found, whereas parsing the Header says "
@@ -5361,7 +5380,7 @@ msgstr ""
 "%d. sor kihagyva - csak %d mezőt találtam, pedig a fejléc adatai alapján %d "
 "mezőt kellett volna."
 
-#: ../../../core/core_st.cpp:183
+#: ../../../core/core_st.cpp:185
 msgid ""
 "Either or both of the Group/Title and Password columns are missing. No "
 "records imported."
@@ -5369,7 +5388,7 @@ msgstr ""
 "A Csoport/Megnevezés és Jelszó oszlopok egyike, vagy mindkettő, hiányzik. "
 "Nem történt importálás."
 
-#: ../../../core/core_st.cpp:184
+#: ../../../core/core_st.cpp:186
 msgid ""
 "Could not find the next entry's title field in the KeePass V1 TXT (should be "
 "within square brackets)."
@@ -5377,53 +5396,53 @@ msgstr ""
 "A következő bejegyzés megnevezés mezője nem található a KeePass V1 "
 "szövegfájlban (szögletes zárójelben kellene lennie)."
 
-#: ../../../core/core_st.cpp:185
+#: ../../../core/core_st.cpp:187
 msgid "Column header row not recognised as first record. No records imported."
 msgstr ""
 "A fejlécsor felismerése sikertelen az első sorban. Importálás nem történt."
 
-#: ../../../core/core_st.cpp:186
+#: ../../../core/core_st.cpp:188
 msgid "No records in import file!"
 msgstr "Az importálandó fájlban nincsenek rekordok!"
 
-#: ../../../core/core_st.cpp:187
+#: ../../../core/core_st.cpp:189
 #, c-format
 msgid "Line %d skipped: Empty mandatory Password field."
 msgstr "%d. sor kihagyva: a kötelezően megadandó jelszó mező üres."
 
-#: ../../../core/core_st.cpp:188
+#: ../../../core/core_st.cpp:190
 #, c-format
 msgid "Line %d skipped: Empty mandatory Title field."
 msgstr "%d. sor kihagyva: a kötelezően megadandó Cím mező üres."
 
-#: ../../../core/core_st.cpp:189
+#: ../../../core/core_st.cpp:191
 #, c-format
 msgid " Import # %d"
 msgstr "# %d importálása"
 
-#: ../../../core/core_st.cpp:190
+#: ../../../core/core_st.cpp:192
 #, fuzzy, c-format
 msgid "%ls - Imported %ls"
 msgstr "%ls - %ls másolva"
 
-#: ../../../core/core_st.cpp:191
+#: ../../../core/core_st.cpp:193
 msgid ""
 "To replace passwords of existing entries, all the following columns must be "
 "present: Group/Title, Username and Password.  One or more are missing and no "
 "entries have been updated."
 msgstr ""
 
-#: ../../../core/core_st.cpp:192
+#: ../../../core/core_st.cpp:194
 #, c-format
 msgid "%ls not found. Cannot update entry's password.\n"
 msgstr "%ls nem található. A bejegyzés jelszava nem módosítható.\n"
 
-#: ../../../core/core_st.cpp:193
+#: ../../../core/core_st.cpp:195
 #, c-format
 msgid "%ls has an empty %ls.\n"
 msgstr "%ls tartalmaz egy üres '%ls'-t.\n"
 
-#: ../../../core/core_st.cpp:194
+#: ../../../core/core_st.cpp:196
 #, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5432,11 +5451,11 @@ msgstr ""
 "A bejegyzés: \"%ls, %ls, %ls\" az álnévnek megfelelő formátumú jelszóval "
 "rendelkezik, de az alapbejegyzés már maga is egy álnév."
 
-#: ../../../core/core_st.cpp:195
+#: ../../../core/core_st.cpp:197
 msgid "\tThis entry has been made an alias of associated base entry."
 msgstr "Egy a bejegyzés a hozzá kapcsolódó alapbejegyzés egy álneve lett."
 
-#: ../../../core/core_st.cpp:196
+#: ../../../core/core_st.cpp:198
 #, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5445,13 +5464,13 @@ msgstr ""
 "A bejegyzés: \"%ls, %ls, %ls\" az álnévnek megfelelő formátumú jelszóval "
 "rendelkezik, de az alapbejegyzés nem létezik."
 
-#: ../../../core/core_st.cpp:197
+#: ../../../core/core_st.cpp:199
 msgid ""
 "\tThis entry remains a normal entry and the password has not been changed."
 msgstr ""
 "Egy a bejegyzés megmarad normál típusúnak és a jelszó nem változott meg."
 
-#: ../../../core/core_st.cpp:198
+#: ../../../core/core_st.cpp:200
 #, c-format
 msgid ""
 "The %ls entry \"%ls, %ls, %ls\" doesn't point to a normal or existing %ls "
@@ -5460,68 +5479,68 @@ msgstr ""
 "%ls bejegyzés \"%ls, %ls, %ls\" nem egy normál vagy létező %ls "
 "alapbejegyzésre mutat. Nem lehet importálni."
 
-#: ../../../core/core_st.cpp:199
+#: ../../../core/core_st.cpp:201
 msgid "Entry import warnings"
 msgstr "Figyelmeztetések a bejegyzés importálásakor"
 
-#: ../../../core/core_st.cpp:200
+#: ../../../core/core_st.cpp:202
 msgid "id="
 msgstr "id="
 
-#: ../../../core/core_st.cpp:201
+#: ../../../core/core_st.cpp:203
 msgid "on line "
 msgstr "sorban"
 
-#: ../../../core/core_st.cpp:202
+#: ../../../core/core_st.cpp:204
 msgid "Internal error: Invalid oflag or pmode argument"
 msgstr "Belső hiba: érvénytelen jelző vagy pmode paraméter."
 
-#: ../../../core/core_st.cpp:203
+#: ../../../core/core_st.cpp:205
 msgid "invalid!"
 msgstr "érvénytelen!"
 
-#: ../../../core/core_st.cpp:204
+#: ../../../core/core_st.cpp:206
 msgid "  Invalid date/time value."
 msgstr "Érvénytelen dátum/idő érték."
 
-#: ../../../core/core_st.cpp:205
+#: ../../../core/core_st.cpp:207
 msgid "  Field length is incorrect."
 msgstr "A mező hossza nem megfelelő."
 
-#: ../../../core/core_st.cpp:206
+#: ../../../core/core_st.cpp:208
 msgid "Internal error: An invalid flag was specified"
 msgstr "Belső hiba: érvénytelen jelző lett megadva"
 
-#: ../../../core/core_st.cpp:207
+#: ../../../core/core_st.cpp:209
 #, c-format
 msgid "  Invalid header: '%ls' (must be 5 hexadecimal characters)."
 msgstr "  Érvénytelen fejléc: '%ls' (5 hexadecimális karakternek kell lennie)."
 
-#: ../../../core/core_st.cpp:208
+#: ../../../core/core_st.cpp:210
 #, fuzzy, c-format
 msgid "Invalid lock file \"%ls\"."
 msgstr "Érvénytelen szűrőséma."
 
-#: ../../../core/core_st.cpp:209
+#: ../../../core/core_st.cpp:211
 #, c-format
 msgid "  Invalid number of saved old passwords %d."
 msgstr "  A régi jelszavak száma érvénytelen: %d."
 
-#: ../../../core/core_st.cpp:210
+#: ../../../core/core_st.cpp:212
 #, c-format
 msgid "  Invalid status value: %d (must be either 0 or 1)."
 msgstr "  Érvénytelen állapotérték: %d (0 vagy 1 lehet)."
 
-#: ../../../core/core_st.cpp:211
+#: ../../../core/core_st.cpp:213
 msgid "  Invalid password length found (not a hexadecimal number)."
 msgstr "  Érvénytelen jelszóhossz (nem hexadecimális karakter)."
 
-#: ../../../core/core_st.cpp:212
+#: ../../../core/core_st.cpp:214
 msgid ""
 "  Invalid password length found (differs from length of following password)."
 msgstr "  Érvénytelen jelszóhossz (különbözöik a következő jelszó hosszától)."
 
-#: ../../../core/core_st.cpp:213
+#: ../../../core/core_st.cpp:215
 msgid ""
 "  Invalid field separator character found - only a single blank is allowed "
 "between fields."
@@ -5529,51 +5548,51 @@ msgstr ""
 "Érvénytelen mezőhatároló karakter - a mezők között csak egyetlen üres "
 "megengedett."
 
-#: ../../../core/core_st.cpp:214
+#: ../../../core/core_st.cpp:216
 msgid "Invalid Filter schema."
 msgstr "Érvénytelen szűrőséma."
 
-#: ../../../core/core_st.cpp:215
+#: ../../../core/core_st.cpp:217
 msgid "Schema does not have a version number."
 msgstr "A sémának nincs verziószáma."
 
-#: ../../../core/core_st.cpp:216
+#: ../../../core/core_st.cpp:218
 #, c-format
 msgid "The filter XML version (%d) is greater than the current schema (%d)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:217
+#: ../../../core/core_st.cpp:219
 #, c-format
 msgid ""
 "The filter XML version (%d) is greater than that supported by this instance "
 "of PasswordSafe (%d)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:218
+#: ../../../core/core_st.cpp:220
 msgid "is"
 msgstr " "
 
-#: ../../../core/core_st.cpp:219
+#: ../../../core/core_st.cpp:221
 msgid "is active"
 msgstr "aktív"
 
-#: ../../../core/core_st.cpp:220
+#: ../../../core/core_st.cpp:222
 msgid "is inactive"
 msgstr "inaktív"
 
-#: ../../../core/core_st.cpp:221
+#: ../../../core/core_st.cpp:223
 msgid "is not"
 msgstr "nem"
 
-#: ../../../core/core_st.cpp:222
+#: ../../../core/core_st.cpp:224
 msgid "is not present"
 msgstr "nem létezik"
 
-#: ../../../core/core_st.cpp:223
+#: ../../../core/core_st.cpp:225
 msgid "is present"
 msgstr "létezik"
 
-#: ../../../core/core_st.cpp:224
+#: ../../../core/core_st.cpp:226
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to entry %ls. It "
@@ -5583,7 +5602,7 @@ msgstr ""
 "ehhez a bejegyzéshez: %ls. A billentyűparancs el lett távolítva erről a "
 "bejegyzésről: %ls."
 
-#: ../../../core/core_st.cpp:225
+#: ../../../core/core_st.cpp:227
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to the "
@@ -5593,19 +5612,19 @@ msgstr ""
 "PasswordSafe alkalmazáshoz. A billentyűparancs el lett távolítva a "
 "bejegyzésről."
 
-#: ../../../core/core_st.cpp:226
+#: ../../../core/core_st.cpp:228
 msgid "less than"
 msgstr "kisebb mint"
 
-#: ../../../core/core_st.cpp:227
+#: ../../../core/core_st.cpp:229
 msgid "less than or equal to"
 msgstr "kisebb vagy egyenlő mint"
 
-#: ../../../core/core_st.cpp:228
+#: ../../../core/core_st.cpp:230
 msgid "File or path not found"
 msgstr "Fájl vagy útvonal nem található"
 
-#: ../../../core/core_st.cpp:229
+#: ../../../core/core_st.cpp:231
 #, c-format
 msgid ""
 "\n"
@@ -5614,14 +5633,14 @@ msgstr ""
 "\n"
 "Az alábbi új %ls %ls befésülve ebbe az adatbázisba:"
 
-#: ../../../core/core_st.cpp:230
+#: ../../../core/core_st.cpp:232
 #, c-format
 msgid ""
 "\n"
 "Merge completed: %d %ls added (%d %ls, %d %ls, %d %ls, %d %ls)"
 msgstr ""
 
-#: ../../../core/core_st.cpp:231
+#: ../../../core/core_st.cpp:233
 #, fuzzy, c-format
 msgid ""
 "Conflicting entries for \"%ls\" \"%ls\" \"%ls\".\n"
@@ -5632,25 +5651,25 @@ msgstr ""
 "  Összefűzött bejegyzés hozzáadása: «%ls» «%ls» «%ls».\n"
 "    Eltérő mező(k): %ls"
 
-#: ../../../core/core_st.cpp:232
+#: ../../../core/core_st.cpp:234
 msgid "merged"
 msgstr "összefésülve"
 
-#: ../../../core/core_st.cpp:233
+#: ../../../core/core_st.cpp:235
 #, c-format
 msgid "%ls - Merged %ls"
 msgstr "%ls - %ls egyesítve"
 
-#: ../../../core/core_st.cpp:234
+#: ../../../core/core_st.cpp:236
 msgid "MISSING PASSWORD"
 msgstr "HIÁNYZÓ JELSZÓ"
 
-#: ../../../core/core_st.cpp:235
+#: ../../../core/core_st.cpp:237
 #, c-format
 msgid "\tPassword policy name '%ls' is not in the database."
 msgstr "\t'%ls' nevű jelszóházirend nem szerepel az adatbázisban."
 
-#: ../../../core/core_st.cpp:236
+#: ../../../core/core_st.cpp:238
 msgid ""
 "\tOne or more Password Policy Names were not found in the database. The "
 "affected entries have been changed to use the database's default policy."
@@ -5659,35 +5678,35 @@ msgstr ""
 "érintett bejegyzéseknél be lett állítva, hogy az adatbázis alapértelmezett "
 "jelszóházirendjét használják."
 
-#: ../../../core/core_st.cpp:237
+#: ../../../core/core_st.cpp:239
 #, c-format
 msgid "MISSING TITLE # %d"
 msgstr "HIÁNYZÓ CÍM # %d"
 
-#: ../../../core/core_st.cpp:239
+#: ../../../core/core_st.cpp:241
 msgid "Can't obtain the schema version."
 msgstr "Nem sikerült kinyerni a séma verzióját."
 
-#: ../../../core/core_st.cpp:240
+#: ../../../core/core_st.cpp:242
 msgid "The filter XML version is missing."
 msgstr ""
 
-#: ../../../core/core_st.cpp:241
+#: ../../../core/core_st.cpp:243
 #, c-format
 msgid "Create SchemaCache60 Error 0x%08X during %ls."
 msgstr "Create SchemaCache60 hiba 0x%08X eközben: %ls."
 
-#: ../../../core/core_st.cpp:242
+#: ../../../core/core_st.cpp:244
 #, c-format
 msgid "SAX Parse60 Error 0x%08X during %ls."
 msgstr "SAX Parse60 hiba 0x%08X %ls közben."
 
-#: ../../../core/core_st.cpp:243
+#: ../../../core/core_st.cpp:245
 #, c-format
 msgid "Error (%08X): line %d character %d %ls"
 msgstr "Hiba (%08X): sor: %d pozíció: %d %ls"
 
-#: ../../../core/core_st.cpp:245
+#: ../../../core/core_st.cpp:247
 #, fuzzy
 msgid ""
 "Unable to get configuration file lock.\n"
@@ -5695,30 +5714,30 @@ msgid ""
 "Will use registry."
 msgstr "Konfigurációs fájl:"
 
-#: ../../../core/core_st.cpp:246
+#: ../../../core/core_st.cpp:248
 msgid "Cannot create lock file - no permission in directory?"
 msgstr "Zárolási fájl létrehozása sikertelen - nincs engedély a mappán?"
 
-#: ../../../core/core_st.cpp:247
+#: ../../../core/core_st.cpp:249
 msgid "Internal error: Out of file handles"
 msgstr "Belső hiba: nincs több szabad fájlkezelő"
 
-#: ../../../core/core_st.cpp:248
+#: ../../../core/core_st.cpp:250
 msgid ""
 "Unable to use a MS XML reader on your system.  Neither MS XML V3, V4 or V6 "
 "seems available."
 msgstr ""
 
-#: ../../../core/core_st.cpp:250
+#: ../../../core/core_st.cpp:252
 #, fuzzy
 msgid "Unsaved changes"
 msgstr "Nem &mentett változtatások mutatása"
 
-#: ../../../core/core_st.cpp:251
+#: ../../../core/core_st.cpp:253
 msgid "is not set"
 msgstr "nincs beállítva"
 
-#: ../../../core/core_st.cpp:252
+#: ../../../core/core_st.cpp:254
 #, c-format
 msgid ""
 "Number of entries processed: %d\n"
@@ -5758,7 +5777,7 @@ msgstr ""
 "\n"
 "Javasolt az adabázis mentése most."
 
-#: ../../../core/core_st.cpp:254
+#: ../../../core/core_st.cpp:256
 msgid ""
 "Password should be mixed case, with at least one digit or punctuation "
 "character"
@@ -5766,41 +5785,41 @@ msgstr ""
 "A jelszó tartalmazzon kis- és nagybetűket, valamint legalább 1 számjegyet "
 "vagy speciális karaktert"
 
-#: ../../../core/core_st.cpp:255
+#: ../../../core/core_st.cpp:257
 msgid "Password is too short"
 msgstr "A jelszó túl rövid"
 
-#: ../../../core/core_st.cpp:256
+#: ../../../core/core_st.cpp:258
 msgid "Easyvision characters"
 msgstr "Könnyen olvasható karakterek"
 
-#: ../../../core/core_st.cpp:257
+#: ../../../core/core_st.cpp:259
 msgid "Hexadecimal characters"
 msgstr "Hexadecimális karakterek"
 
-#: ../../../core/core_st.cpp:258
+#: ../../../core/core_st.cpp:260
 msgid "Password length"
 msgstr "Jelszó hossza"
 
-#: ../../../core/core_st.cpp:259
+#: ../../../core/core_st.cpp:261
 msgid "Pronounceable passwords"
 msgstr "Könnyen kiejthető jelszavak"
 
-#: ../../../core/core_st.cpp:261
+#: ../../../core/core_st.cpp:263
 #, fuzzy
 msgid "Use lowercase characters"
 msgstr "Nagybetűk használata"
 
-#: ../../../core/core_st.cpp:263
+#: ../../../core/core_st.cpp:265
 msgid "Use uppercase characters"
 msgstr "Nagybetűk használata"
 
-#: ../../../core/core_st.cpp:264
+#: ../../../core/core_st.cpp:266
 #, c-format
 msgid "Error in a Password History %ls:"
 msgstr "Hiba egy jelszóelőzményben: %ls:"
 
-#: ../../../core/core_st.cpp:265
+#: ../../../core/core_st.cpp:267
 #, c-format
 msgid "sub-field starting at position %d (within the History field): "
 msgstr "almező a(z) %d. helyen (az előzmény mezőben):"
@@ -5818,15 +5837,19 @@ msgstr "almező a(z) %d. helyen (az előzmény mezőben):"
 # updated i.e. function keys (F2), special keys (Delete, HoMe) etc. will not.
 # ONLY change the msgstr field. Do NOT change any other.
 # If you do not want to change an Accelerator Key, copy msgid to msgstr
-#: ../../../core/core_st.cpp:266
+#: ../../../core/core_st.cpp:268
 msgid "  All Password History ignored."
 msgstr "Az összes jelszóelőzmény figyelmen kívül hagyva."
 
-#: ../../../core/core_st.cpp:267
+#: ../../../core/core_st.cpp:269
 msgid "Read Error"
 msgstr "Olvasási hiba"
 
-#: ../../../core/core_st.cpp:268
+#: ../../../core/core_st.cpp:270
+msgid "Relative"
+msgstr "Relatív"
+
+#: ../../../core/core_st.cpp:271
 #, c-format
 msgid ""
 "\tOne or more entry keyboard shortcuts were already assigned to entries in "
@@ -5836,7 +5859,7 @@ msgstr ""
 "az adatbázisban lévő valamely bejegyzéshez. Az alábbi bejegyzésekről el lett "
 "távolítva a billentyűparancs: %ls."
 
-#: ../../../core/core_st.cpp:269
+#: ../../../core/core_st.cpp:272
 msgid ""
 "\tOne or more Password Policy Names were already in this database but had "
 "different settings. They have been renamed."
@@ -5844,31 +5867,68 @@ msgstr ""
 "\tEgy vagy több jelszóházirend neve megtalálható az adatbázisban, de más "
 "beállításokkal. Az érintett jelszóházirendek át lettek nevezve."
 
-#: ../../../core/core_st.cpp:270
+#: ../../../core/core_st.cpp:273
 #, c-format
 msgid "%ls%ls%ls_Report.txt"
 msgstr "%ls%ls%ls_Report.txt"
 
-#: ../../../core/core_st.cpp:271
+#: ../../../core/core_st.cpp:274
 #, c-format
 msgid "Report of %ls function started at %ls"
 msgstr "Jelentés %ls funkcióról, amely elindult ekkor: %ls"
 
-#: ../../../core/core_st.cpp:272
+#: ../../../core/core_st.cpp:275
 #, c-format
 msgid "on database %ls"
 msgstr "%ls adatbázison"
 
-#: ../../../core/core_st.cpp:273
+#: ../../../core/core_st.cpp:276
+msgid "Compare"
+msgstr "Összehasonlítás"
+
+#: ../../../core/core_st.cpp:277
+#, fuzzy
+msgid "Export_DB"
+msgstr "&Exportálás"
+
+#: ../../../core/core_st.cpp:278
+msgid "Export_Text"
+msgstr "Export_Text"
+
+#: ../../../core/core_st.cpp:279
+msgid "Export_XML"
+msgstr "Export_XML"
+
+#: ../../../core/core_st.cpp:281
+msgid "Import_KeePassV1_CSV"
+msgstr "Import_KeePassV1_CSV"
+
+#: ../../../core/core_st.cpp:282
+msgid "Import_KeePassV1_TXT"
+msgstr "Import_KeePassV1_TXT"
+
+#: ../../../core/core_st.cpp:283
+msgid "Import_Text"
+msgstr "Import_Text"
+
+#: ../../../core/core_st.cpp:284
+msgid "Import_XML"
+msgstr "Import_XML"
+
+#: ../../../core/core_st.cpp:285
+msgid "Merge"
+msgstr "Összefűzés"
+
+#: ../../../core/core_st.cpp:287
 #, fuzzy
 msgid "Validate"
 msgstr "&Érvényesítés"
 
-#: ../../../core/core_st.cpp:275
+#: ../../../core/core_st.cpp:289
 msgid "Fatal Error"
 msgstr "Fatális hiba"
 
-#: ../../../core/core_st.cpp:277
+#: ../../../core/core_st.cpp:291
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5877,123 +5937,135 @@ msgstr ""
 "\n"
 "Hiba a jelszótörténetben ennél a bejegyzésnél: »%ls»%ls»%ls»: "
 
-#: ../../../core/core_st.cpp:278
+#: ../../../core/core_st.cpp:292
+#, fuzzy, c-format
+msgid "\tNo entries were found containing search string '%ls' %ls"
+msgstr ""
+"\tNem található olyan bejegyzés, amely tartalmazza a keresett szöveget: '%s'"
+
+#: ../../../core/core_st.cpp:293
+#, fuzzy, c-format
+msgid "\tThe following entries contain search string '%ls' %ls"
+msgstr ""
+"\tNem található olyan bejegyzés, amely tartalmazza a keresett szöveget: '%s'"
+
+#: ../../../core/core_st.cpp:294
 msgid "See Attachment filters"
 msgstr ""
 
-#: ../../../core/core_st.cpp:279
+#: ../../../core/core_st.cpp:295
 #, fuzzy
 msgid "See Password History filters"
 msgstr "Jelszótörténet szűrő"
 
-#: ../../../core/core_st.cpp:280
+#: ../../../core/core_st.cpp:296
 #, fuzzy
 msgid "See Password Policy filters"
 msgstr "Jelszószabály szűrő"
 
-#: ../../../core/core_st.cpp:281
+#: ../../../core/core_st.cpp:297
 msgid "is set"
 msgstr "beállítva"
 
-#: ../../../core/core_st.cpp:282
+#: ../../../core/core_st.cpp:298
 msgid "shortcut"
 msgstr "parancsikon"
 
-#: ../../../core/core_st.cpp:283
+#: ../../../core/core_st.cpp:299
 msgid "shortcuts"
 msgstr "parancsikonok"
 
-#: ../../../core/core_st.cpp:284
+#: ../../../core/core_st.cpp:300
 msgid "policy specific symbols"
 msgstr "szabályspecifikus szimbólumok"
 
-#: ../../../core/core_st.cpp:285
+#: ../../../core/core_st.cpp:301
 #, fuzzy
 msgid "Start Report"
 msgstr "Jelentés vége"
 
-#: ../../../core/core_st.cpp:286
+#: ../../../core/core_st.cpp:302
 msgid "Double-Click on entry to Autotype"
 msgstr "Kattintson duplán a bejegyzésen az Autogépeléshez"
 
-#: ../../../core/core_st.cpp:287
+#: ../../../core/core_st.cpp:303
 msgid "Double-Click on entry to Browse to URL"
 msgstr "Kattintson duplán a bejegyzésen az URL-re navigáláshoz"
 
-#: ../../../core/core_st.cpp:288
+#: ../../../core/core_st.cpp:304
 msgid "Double-Click on entry to Browse to URL + Autotype"
 msgstr ""
 "Kattintson duplán a bejegyzésen az URL-re navigáláshoz + Autogépeléshez"
 
-#: ../../../core/core_st.cpp:289
+#: ../../../core/core_st.cpp:305
 msgid "https://pwsafe.org/"
 msgstr "https://pwsafe.org/"
 
-#: ../../../core/core_st.cpp:290
+#: ../../../core/core_st.cpp:306
 msgid "Double-Click on entry to Copy Notes"
 msgstr "Kattintson duplán a bejegyzésen a megjegyzés vágólapra másolásához"
 
-#: ../../../core/core_st.cpp:291
+#: ../../../core/core_st.cpp:307
 msgid "Double-Click on entry to Copy Password"
 msgstr "Kattintson duplán a bejegyzésen a jelszó vágólapra másolásához"
 
-#: ../../../core/core_st.cpp:292
+#: ../../../core/core_st.cpp:308
 msgid "Double-Click on entry to Copy Password and Minimize"
 msgstr ""
 "Kattintson duplán a bejegyzésen a jelszó vágólapra másolásához és a kis "
 "mérethez"
 
-#: ../../../core/core_st.cpp:293
+#: ../../../core/core_st.cpp:309
 msgid "Double-Click on entry to Copy Username"
 msgstr "Kattintson duplán a bejegyzésen a felhasználónév vágólapra másolásához"
 
-#: ../../../core/core_st.cpp:294
+#: ../../../core/core_st.cpp:310
 msgid "Double-Click on entry to Run Command"
 msgstr "Kattintson duplán a bejegyzésen parancs futtatásához"
 
-#: ../../../core/core_st.cpp:295
+#: ../../../core/core_st.cpp:311
 msgid "Double-Click on entry to Send Email"
 msgstr "Kattintson duplán a bejegyzésen e-mail küldéséhez"
 
-#: ../../../core/core_st.cpp:296
+#: ../../../core/core_st.cpp:312
 msgid "Double-Click on entry to View/Edit it"
 msgstr "Kattintson duplán a bejegyzésen annak megtekintéséhez/szerkesztéséhez"
 
-#: ../../../core/core_st.cpp:299
+#: ../../../core/core_st.cpp:315
 #, c-format
 msgid "%ls - Sync'd %ls"
 msgstr "%ls - Szinkronizálva %ls"
 
-#: ../../../core/core_st.cpp:300
+#: ../../../core/core_st.cpp:316
 #, fuzzy
 msgid "System error: No more file handles available"
 msgstr "Belső hiba: nincs több szabad fájlkezelő"
 
-#: ../../../core/core_st.cpp:303
+#: ../../../core/core_st.cpp:319
 msgid "Unknown function"
 msgstr "Ismeretlen függvény"
 
-#: ../../../core/core_st.cpp:304
+#: ../../../core/core_st.cpp:320
 msgid "Unknown object"
 msgstr "Ismeretlen objektum"
 
-#: ../../../core/core_st.cpp:305
+#: ../../../core/core_st.cpp:321
 msgid "Internal error: Unexpected error number"
 msgstr "Belső hiba: nem várt hibakód"
 
-#: ../../../core/core_st.cpp:307
+#: ../../../core/core_st.cpp:323
 #, c-format
 msgid "\tName: %s; Filename: %s"
 msgstr ""
 
-#: ../../../core/core_st.cpp:308
+#: ../../../core/core_st.cpp:324
 #, fuzzy
 msgid ""
 "The following entries had an invalid UUID field.  This has been corrected."
 msgstr ""
 "Sor: %d  A bejegyzés \"%ls\" mezője érvénytelen. Figyelmen kívül lett hagyva."
 
-#: ../../../core/core_st.cpp:309
+#: ../../../core/core_st.cpp:325
 #, fuzzy, c-format
 msgid ""
 "The following entries have passwords in the correct form for %ls, but the "
@@ -6002,19 +6074,19 @@ msgstr ""
 "A bejegyzés: \"%ls, %ls, %ls\" az álnévnek megfelelő formátumú jelszóval "
 "rendelkezik, de az alapbejegyzés nem létezik."
 
-#: ../../../core/core_st.cpp:310
+#: ../../../core/core_st.cpp:326
 #, fuzzy
 msgid "The following entries were duplicates of an existing entry."
 msgstr "\tAz alábbi bejegyzések tartalmazzák a keresett szöveget: '%s'"
 
-#: ../../../core/core_st.cpp:311
+#: ../../../core/core_st.cpp:327
 #, fuzzy
 msgid ""
 "The following entries had a duplicate UUID field.  This has been corrected."
 msgstr ""
 "Sor: %d  A bejegyzés \"%ls\" mezője érvénytelen. Figyelmen kívül lett hagyva."
 
-#: ../../../core/core_st.cpp:312
+#: ../../../core/core_st.cpp:328
 #, fuzzy, c-format
 msgid ""
 "The following entries had an empty Password field, which is not permitted. "
@@ -6022,60 +6094,60 @@ msgid ""
 msgstr ""
 "Sor: %d  A bejegyzés \"%ls\" mezője érvénytelen. Figyelmen kívül lett hagyva."
 
-#: ../../../core/core_st.cpp:313
+#: ../../../core/core_st.cpp:329
 #, fuzzy
 msgid "The following entries had an empty Title field, which is not permitted."
 msgstr ""
 "Sor: %d  A bejegyzés \"%ls\" mezője érvénytelen. Figyelmen kívül lett hagyva."
 
-#: ../../../core/core_st.cpp:314
+#: ../../../core/core_st.cpp:330
 #, c-format
 msgid "\tGroup='%ls', Title='%ls', User='%ls' %ls"
 msgstr "\tCsoport='%ls', Megnevezés='%ls', Felhasználó='%ls' %ls"
 
-#: ../../../core/core_st.cpp:315
+#: ../../../core/core_st.cpp:331
 #, c-format
 msgid "- Its title has been changed to:'%ls'"
 msgstr "- A címe megváltozott erre: '%ls' "
 
-#: ../../../core/core_st.cpp:316
+#: ../../../core/core_st.cpp:332
 msgid "The following ERRORS were detected and were FIXED."
 msgstr ""
 
-#: ../../../core/core_st.cpp:317
+#: ../../../core/core_st.cpp:333
 #, fuzzy
 msgid "The following entries refer to missing attachments."
 msgstr "\tAz alábbi bejegyzések tartalmazzák a keresett szöveget: '%s'"
 
-#: ../../../core/core_st.cpp:318
+#: ../../../core/core_st.cpp:334
 #, fuzzy
 msgid "The following attachments are not referred to by any entry."
 msgstr "\tAz alábbi bejegyzések tartalmazzák a keresett szöveget: '%s'"
 
-#: ../../../core/core_st.cpp:319
+#: ../../../core/core_st.cpp:335
 msgid ""
 "The following entries had an invalid Password History.  This has been "
 "rebuilt with available data.  There may be some loss of history."
 msgstr ""
 
-#: ../../../core/core_st.cpp:320
+#: ../../../core/core_st.cpp:336
 #, c-format
 msgid ""
 "The following entries have one or more text fields too long to display or "
 "edit (over %d characters).  The largest entry size found was ~%d %ls."
 msgstr ""
 
-#: ../../../core/core_st.cpp:321
+#: ../../../core/core_st.cpp:337
 msgid ""
 "The following WARNINGS were detected - you should review and fix them "
 "manually."
 msgstr ""
 
-#: ../../../core/core_st.cpp:324
+#: ../../../core/core_st.cpp:340
 msgid "will expire"
 msgstr "le fog járni"
 
-#: ../../../core/core_st.cpp:325
+#: ../../../core/core_st.cpp:341
 #, c-format
 msgid ""
 "SAX Parse Error during %ls\n"
@@ -6084,35 +6156,35 @@ msgstr ""
 "SAX elemzési hiba %ls közben\n"
 "%ls."
 
-#: ../../../core/core_st.cpp:326
+#: ../../../core/core_st.cpp:342
 #, c-format
 msgid "XML %ls: line %d character %d: %ls"
 msgstr "XML %ls: sor: %d pozíció: %d: %ls"
 
-#: ../../../core/core_st.cpp:327
+#: ../../../core/core_st.cpp:343
 msgid ""
 "*** Invalid XML characters found - see exported XML file for more details ***"
 msgstr ""
 "*** Érvénytelen XML karakterek - ld. az exportált XML fájlt a részletekért "
 "***"
 
-#: ../../../core/core_st.cpp:328
+#: ../../../core/core_st.cpp:344
 msgid "Internal error: Couldn't initialize config file XML structure"
 msgstr ""
 "Belső hiba: a konfigurációs fájl XML struktúrájának inicializálása sikertelen"
 
-#: ../../../core/core_st.cpp:329
+#: ../../../core/core_st.cpp:345
 msgid ""
 "A filter was active. Export of data was restricted to include only those "
 "displayed."
 msgstr "Egy szűrő aktív volt. Csak a megjelenített tételek lettek exportálva."
 
-#: ../../../core/core_st.cpp:330
+#: ../../../core/core_st.cpp:346
 msgid "Export of data was restricted to certain fields by the user."
 msgstr ""
 "Az adatok exportálása néhány mezőre lett korlátozva a felhasználó által."
 
-#: ../../../core/core_st.cpp:331
+#: ../../../core/core_st.cpp:347
 msgid ""
 "Note: These Password Policies will not replace existing policies with the "
 "same name in the current database."
@@ -6120,24 +6192,24 @@ msgstr ""
 "Megjegyzés: ezek a jelszószabályok nem fogják lecserélni az aktuális "
 "adatbázisban lévő azonos nevű jelszószabályokat."
 
-#: ../../../core/core_st.cpp:332
+#: ../../../core/core_st.cpp:348
 msgid ""
 "Note: These preferences are only used when importing into an empty database."
 msgstr ""
 "Megjegyzés: ezek a beállítások csak üres adatbázisba történő importálás "
 "esetén lesznek használva."
 
-#: ../../../core/core_st.cpp:333
+#: ../../../core/core_st.cpp:349
 #, fuzzy
 msgid "Subset of entries restricted by the following rule:"
 msgstr "\t%s korlátozva lett az alábbi mezőkre:"
 
-#: ../../../core/core_st.cpp:334
+#: ../../../core/core_st.cpp:350
 msgid ""
 "The user specified that the following fields be excluded from the export:"
 msgstr ""
 
-#: ../../../core/core_st.cpp:335
+#: ../../../core/core_st.cpp:351
 #, c-format
 msgid ""
 "Configuration file error:\n"
@@ -6150,16 +6222,16 @@ msgstr ""
 "%ls\n"
 "pozíció kb. itt: %d"
 
-#: ../../../core/core_st.cpp:336
+#: ../../../core/core_st.cpp:352
 msgid "import"
 msgstr "import"
 
-#: ../../../core/core_st.cpp:337
+#: ../../../core/core_st.cpp:353
 #, fuzzy
 msgid "Unable to load configuration file"
 msgstr "Konfigurációs fájl:"
 
-#: ../../../core/core_st.cpp:338
+#: ../../../core/core_st.cpp:354
 msgid ""
 "Failed to lock configuration file - opened by another instance of "
 "PasswordSafe?"
@@ -6167,113 +6239,58 @@ msgstr ""
 "A konfigurációs fájl zárolása sikertelen - talán a PasswordSafe alkalmazás "
 "egy másik példánya használja?"
 
-#: ../../../core/core_st.cpp:339
+#: ../../../core/core_st.cpp:355
 #, fuzzy
 msgid "Unable to save configuration file"
 msgstr "Konfigurációs fájl:"
 
-#: ../../../core/core_st.cpp:340
+#: ../../../core/core_st.cpp:356
 msgid "validation"
 msgstr "ellenőrzés"
 
-#: ../../../core/core_st.cpp:342
+#: ../../../core/core_st.cpp:358
 #, fuzzy
 msgid " (EasyVision Symbols)"
 msgstr "Igen - könnyen olvasható szimbólumok: %ls"
 
-#: ../../../core/core_st.cpp:343
+#: ../../../core/core_st.cpp:359
 #, c-format
 msgid "Yes (at least %d)"
 msgstr "Igen (legalább %d)"
 
-#: ../../../core/core_st.cpp:344
+#: ../../../core/core_st.cpp:360
 #, fuzzy
 msgid " (Pronounceable Symbols)"
 msgstr "Igen - könnyen kiejthető szimbólumok: %ls"
 
-#: ../../../core/core_st.cpp:345
+#: ../../../core/core_st.cpp:361
 #, fuzzy, c-format
 msgid "Yes - At least %d from %ls: %ls%ls"
 msgstr "Igen - Legalább %d ebből: %ls: %ls"
 
-#: ../../../core/core_st.cpp:346
 #, fuzzy, c-format
-msgid "\tGroup='%ls', Title='%ls', User='%ls'"
-msgstr "\tCsoport='%ls', Megnevezés='%ls', Felhasználó='%ls' %ls"
+#~ msgid "\tGroup='%ls', Title='%ls', User='%ls'"
+#~ msgstr "\tCsoport='%ls', Megnevezés='%ls', Felhasználó='%ls' %ls"
 
-#: ../../../core/core_st.cpp:347
-#, fuzzy, c-format
-msgid ""
-"Compare complete of current database:\n"
-"\t %ls\n"
-" and:\n"
-"\t %ls\n"
-msgstr ""
-"Összehasonlítás elkészült az aktuális adatbázisra: \n"
-"\t %s\n"
-" és:\n"
-"\t %s"
-
-#: ../../../core/core_st.cpp:348
-#, fuzzy, c-format
-msgid "\tNo entries were found containing search string '%ls' %ls"
-msgstr ""
-"\tNem található olyan bejegyzés, amely tartalmazza a keresett szöveget: '%s'"
-
-#: ../../../core/core_st.cpp:349
-#, fuzzy, c-format
-msgid "\tThe following entries contain search string '%ls' %ls"
-msgstr ""
-"\tNem található olyan bejegyzés, amely tartalmazza a keresett szöveget: '%s'"
-
-#: ../../../core/core_st.cpp:350
 #, fuzzy
-msgid "Export DB"
-msgstr "&Exportálás"
+#~ msgid "Import KeePassV1 CSV"
+#~ msgstr "KeePass V1 CSV importálása"
 
-#: ../../../core/core_st.cpp:351
 #, fuzzy
-msgid "Import KeePassV1 CSV"
-msgstr "KeePass V1 CSV importálása"
+#~ msgid "Import KeePassV1 TXT"
+#~ msgstr "KeePass V1 TXT importálása"
 
-#: ../../../core/core_st.cpp:352
 #, fuzzy
-msgid "Import KeePassV1 TXT"
-msgstr "KeePass V1 TXT importálása"
+#~ msgid "Import XML"
+#~ msgstr ""
+#~ "\n"
+#~ "XML Importálása"
 
-#: ../../../core/core_st.cpp:353
 #, fuzzy
-msgid "Import XML"
-msgstr ""
-"\n"
-"XML Importálása"
-
-#: ../../../core/core_st.cpp:354
-#, fuzzy
-msgid "Import Text"
-msgstr ""
-"\n"
-"Szöveg Importálása"
-
-#: ../../../core/core_st.cpp:355
-msgid "Merge"
-msgstr "Összefűzés"
-
-#: ../../../core/core_st.cpp:356
-msgid "Compare"
-msgstr "Összehasonlítás"
-
-#~ msgid "Import_Text"
-#~ msgstr "Import_Text"
-
-#~ msgid "Import_XML"
-#~ msgstr "Import_XML"
-
-#~ msgid "Import_KeePassV1_CSV"
-#~ msgstr "Import_KeePassV1_CSV"
-
-#~ msgid "Import_KeePassV1_TXT"
-#~ msgstr "Import_KeePassV1_TXT"
+#~ msgid "Import Text"
+#~ msgstr ""
+#~ "\n"
+#~ "Szöveg Importálása"
 
 #~ msgid "Advanced..."
 #~ msgstr "Speciális.."
@@ -7572,12 +7589,6 @@ msgstr "Összehasonlítás"
 #~ "A kimeneti fájl: '%s' már létezik.\n"
 #~ "Lecseréli?"
 
-#~ msgid "Export_Text"
-#~ msgstr "Export_Text"
-
-#~ msgid "Export_XML"
-#~ msgstr "Export_XML"
-
 #~ msgid "Exporting to file:"
 #~ msgstr "Exportálás ebbe a fájlba:"
 
@@ -8256,9 +8267,6 @@ msgstr "Összehasonlítás"
 
 #~ msgid "Redo the last change to password policies that was previously undone"
 #~ msgstr "A korábban visszavont jelszószabály-módosítások újbóli beállítása"
-
-#~ msgid "Relative"
-#~ msgstr "Relatív"
 
 #~ msgid "Remember this keyboard"
 #~ msgstr "E billentyűzet megjegyzése"
@@ -9001,9 +9009,6 @@ msgstr "Összehasonlítás"
 #~ msgstr ""
 #~ "\n"
 #~ "figyelmeztetésekkel "
-
-#~ msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-#~ msgstr "\tCsoport:'%s'; Megnevezés:'%s'; Felhasználó:'%s'"
 
 #~ msgid ""
 #~ "\tThe following restrictions were selected:\n"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_it.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PasswordSafe ITA v0.94\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-28 12:52+0100\n"
+"POT-Creation-Date: 2021-03-19 21:58+0100\n"
 "PO-Revision-Date: 2014-06-28 14:48+0200\n"
 "Last-Translator: Luca Mariot <rymoah@users.sourceforge.net>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -218,7 +218,7 @@ msgstr "Date e Scadenze"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:348
 #: ../../../ui/wxWidgets/HelpMap.h:41 ../../../ui/wxWidgets/HelpMap.h:49
-#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:141
+#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:143
 msgid "Password Policy"
 msgstr "Generazione Password"
 
@@ -232,7 +232,7 @@ msgid "Set Date/Time"
 msgstr "Imposta Data/Ora"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:370
-#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:137
+#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:139
 msgid "Password"
 msgstr "Password"
 
@@ -509,13 +509,13 @@ msgstr "Usa lettere MAIUSCOLE"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:747
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:281
-#: ../../../core/core_st.cpp:260
+#: ../../../core/core_st.cpp:262
 msgid "Use digits"
 msgstr "Usa numeri"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:771
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:305
-#: ../../../core/core_st.cpp:262
+#: ../../../core/core_st.cpp:264
 msgid "Use symbols"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr "Genera password pronunciabili"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:815
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:350
-#: ../../../core/core_st.cpp:253
+#: ../../../core/core_st.cpp:255
 msgid "Or"
 msgstr "Oppure"
 
@@ -596,7 +596,7 @@ msgstr "Proprietà"
 #: ../../../ui/wxWidgets/CreateShortcutDlg.cpp:219
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:269
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:274
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
 msgid "Text"
 msgstr "Testo"
 
@@ -649,7 +649,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:160
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:173
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:192
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:301
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:317
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -760,7 +760,7 @@ msgstr "[Note nascoste - cliccare qui per visualizzarle]"
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:1653
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2145
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2820
-#: ../../../core/core_st.cpp:74
+#: ../../../core/core_st.cpp:76
 msgid "Default Policy"
 msgstr "Metodo Predefinito"
 
@@ -781,7 +781,7 @@ msgstr "Impossibile generare la password - metodo non valido"
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:144
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:151
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:159
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:200
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:201
 #: ../../../ui/wxWidgets/PWSafeApp.cpp:367
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:737
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:756
@@ -805,7 +805,7 @@ msgstr "Impossibile generare la password - metodo non valido"
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:249
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:277
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:316
-#: ../../../core/core_st.cpp:274
+#: ../../../core/core_st.cpp:288
 msgid "Error"
 msgstr "Errore"
 
@@ -958,7 +958,7 @@ msgid "Synchronize this item..."
 msgstr "Sincronizza questo elemento..."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:482
-#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:357
+#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:286
 msgid "Synchronize"
 msgstr "Sincronizza"
 
@@ -1028,8 +1028,8 @@ msgid "Current safe was opened read-only"
 msgstr "Il database corrente è stato aperto in sola lettura"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:793
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:996
-#: ../../../ui/wxWidgets/SyncWizard.cpp:618
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
+#: ../../../ui/wxWidgets/SyncWizard.cpp:619
 #, fuzzy, c-format
 msgid ""
 "The database:\n"
@@ -1047,7 +1047,7 @@ msgstr ""
 "Correggere validando il database."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:794
-#: ../../../ui/wxWidgets/SyncWizard.cpp:617
+#: ../../../ui/wxWidgets/SyncWizard.cpp:618
 msgid "Synchronization failed"
 msgstr "Sincronizzazione fallita"
 
@@ -1406,7 +1406,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/GridCtrl.cpp:164
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:292
-#: ../../../core/core_st.cpp:147
+#: ../../../core/core_st.cpp:149
 msgid "Title"
 msgstr "Titolo"
 
@@ -1611,7 +1611,7 @@ msgid "Value"
 msgstr "Valore"
 
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:291
-#: ../../../core/core_st.cpp:133
+#: ../../../core/core_st.cpp:135
 msgid "Group"
 msgstr "Gruppo"
 
@@ -1694,23 +1694,23 @@ msgstr ""
 msgid "Error parsing Run Command"
 msgstr "Esegui Comando"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:56
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:57
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:355
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:362
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:166
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:623
 msgid "Write Error"
 msgstr "Errore di scrittura"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:61
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:62
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:165
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:622
 msgid "Could not open file for writing!"
 msgstr "Impossibile aprire il file in scrittura!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:64
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:65
 msgid ""
 "Write operation failed!\n"
 "File may have been corrupted.\n"
@@ -1720,56 +1720,56 @@ msgstr ""
 "Il file potrebbe risultare corrotto.\n"
 "Tentativo di salvataggio in un percorso differente"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:69
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:70
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "Unknown error"
 msgstr "Errore sconosciuto"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:90
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:91
 msgid "Do you want to save changes to the password database: "
 msgstr "Si desidera salvare le modifiche al database: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:145
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:146
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:557
 msgid "Please choose a name for the new database"
 msgstr "Scegliere un nome per il nuovo database"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:155
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:156
 msgid "psafe3 files (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 msgstr "File psafe3 (*.psafe3)|*.psafe3|Tutti i file(*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Lock is done by yourself"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Remove Lock?"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:194
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:195
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:602
 #, fuzzy
 msgid "Could not lock file.\n"
 msgstr "Impossibile aprire il file in lettura!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:196
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:197
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:452
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:604
 msgid "Locked by "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:236
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:237
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:515
 msgid "Please Choose a Database to Open:"
 msgstr "Selezionare un Database da Aprire:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:353
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
 msgid ""
 "Unable to create intermediate backup.  Save database elsewhere or with "
 "another name?\n"
@@ -1781,7 +1781,7 @@ msgstr ""
 "\n"
 "Cliccare 'No' per uscire senza salvare."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:360
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Do you wish to save changes to your "
@@ -1792,12 +1792,12 @@ msgstr ""
 "\n"
 "Cliccare 'No' per uscire senza salvare."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 msgid "Unable to create intermediate backup."
 msgstr "Impossibile creare il backup intermedio."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:386
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:387
 #, fuzzy, c-format
 msgid ""
 "The original database, \"%ls\", is in pre-3.0 format. It will be unchanged.\n"
@@ -1812,12 +1812,12 @@ msgstr ""
 "salvare i cambiamenti nel formato vecchio, utilizzare il comando \"File-"
 ">Esporta in-> Formato (v1.x oppure v2.x)\"."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:388
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:389
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:447
 msgid "File version warning"
 msgstr "Avviso di versione del file"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:445
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
 #, fuzzy, c-format
 msgid ""
 "The original database, '%ls', is in pre-3.0 format. The data will now be "
@@ -1830,15 +1830,15 @@ msgstr ""
 "versioni vecchie di PasswordSafe. Per salvare i dati nel formato vecchio, "
 "usare il comando 'File->Esporta in-> Formato (v1.x o v2.x)."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:458
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
 msgid "Please choose a name for the current (Untitled) database:"
 msgstr "Scegliere un nome per il database corrente (Senza Titolo):"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:460
 msgid "Please choose a new name for the current database:"
 msgstr "Scegliere un nuovo nome per il database corrente:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:467
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:468
 msgid ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|"
 "*.*;*"
@@ -1846,7 +1846,7 @@ msgstr ""
 "Database Password Safe (*.psafe3; *.dat)|*.psafe3;*.dat|Tutti i file (*.*; "
 "*)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:479
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -1857,126 +1857,126 @@ msgstr ""
 "\n"
 "Il file è attualmente bloccato da %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:481
 msgid "File lock error"
 msgstr "Errore di blocco del file"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:547
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
 #, fuzzy
 msgid "Do you wish to save this restored database as new database?"
 msgstr "Si desidera salvare le modifiche al database"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:549
 #, fuzzy
 msgid "Unsaved restored database"
 msgstr "Il database:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:580
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:581
 msgid "Do you want to save changes to the password database"
 msgstr "Si desidera salvare le modifiche al database"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:617
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:618
 msgid "Export Text"
 msgstr "Esportazione Testo"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:621
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:622
 msgid "Export Text failed"
 msgstr "Esportazione Testo fallita"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:623
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
 msgid "Please name the plaintext file"
 msgstr "Scegliere un nome per il file di testo"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1143
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:625
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1144
 msgid ""
 "Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
 msgstr ""
 "File di testo (*.txt)|*.txt|File CSV (*.csv)|*.csv|Tutti i file (*.*; *)|*.*;"
 "*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:634
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:635
 msgid "Advanced Text Export Options"
 msgstr "Opzioni Avanzate Esportazione Testo"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:654
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:697
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:655
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:698
 msgid "export"
 msgstr "esportazione"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:660
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:661
 msgid "Export XML"
 msgstr "Esportazione XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:664
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:665
 msgid "Export XML failed"
 msgstr "Esportazione XML fallita"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:666
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
 msgid "Please name the XML file"
 msgstr "Scegliere un nome per il file XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:668
 msgid "XML files (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 msgstr "File XML (*.xml)|*.xml|Tutti i file (*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:678
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:679
 msgid "Advanced XML Export Options"
 msgstr "Opzioni Avanzate Esportazione XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:712
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:716
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:713
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:717
 #, fuzzy
 msgid "Password Safe Databases (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 msgstr ""
 "Database Password Safe (*.psafe3; *.dat)|*.psafe3;*.dat|Tutti i file (*.*; "
 "*)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:720
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:721
 #, fuzzy
 msgid "Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 msgstr ""
 "Database Password Safe (*.psafe3; *.dat)|*.psafe3;*.dat|Tutti i file (*.*; "
 "*)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:731
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:732
 msgid "Please name the exported database"
 msgstr "Scegliere un nome per il database esportato"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:748
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:749
 msgid "Could not figure out why PasswordSafeFrame::OnExportVx was invoked"
 msgstr ""
 "Impossibile determinare per quale ragione PasswordSafeFrame::OnExportVx è "
 "stato invocato"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:782
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:783
 msgid "You must save this database before it can be exported."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid "Exporting database: "
 msgstr "Esportazione database: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid " to "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:841
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:842
 #, fuzzy
 msgid "Export complete.  Do you wish to see a detailed report?"
 msgstr "Si desidera visualizzare un report dettagliato?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:852
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:853
 msgid "No entries satisfied your selection criteria and so none were exported!"
 msgstr ""
 "Nessuna voce soddisfa i criteri di selezione impostati, e quindi nessuna "
 "voce è stata esportata!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:865
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:866
 msgid "Passkey incorrect"
 msgstr "Combinazione di Sicurezza errata"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:873
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
 msgid ""
 "The current database was opened in read-only mode.  You cannot import into "
 "it."
@@ -1984,113 +1984,113 @@ msgstr ""
 "Il database corrente è stato aperto in sola lettura. Impossibile importare "
 "elementi al suo interno."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:875
 msgid "Import text"
 msgstr "Importa testo"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:882
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
 msgid "The database:"
 msgstr "Il database:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
 msgid "has duplicate entries with the same group/title/user combination."
 msgstr ""
 "contiene voci duplicate con la stessa combinazione di gruppo/titolo/utente."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
 msgid "  Please fix by validating database."
 msgstr "  Correggere validando il database."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:931
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:886
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:932
 msgid "Import Text failed"
 msgstr "Importazione di testo fallita"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 #, fuzzy, c-format
 msgid "%ls file being imported: %ls"
 msgstr "%ls file da importare: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:921
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:926
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:223
-#: ../../../ui/wxWidgets/SyncWizard.cpp:572
+#: ../../../ui/wxWidgets/SyncWizard.cpp:573
 #: ../../../ui/wxWidgets/wxUtilities.cpp:59
 #: ../../../ui/wxWidgets/wxUtilities.cpp:64
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "File Read Error"
 msgstr "Errore di lettura del file"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:923
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:222
 #: ../../../ui/wxWidgets/wxUtilities.cpp:58
 msgid "Could not open file for reading!"
 msgstr "Impossibile aprire il file in lettura!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:928
 msgid "Invalid format"
 msgstr "Formato non valido"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 msgid "Updated "
 msgstr "Aggiornato "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 msgid "Imported "
 msgstr "Importato "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 msgid " entry"
 msgstr " voce"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 msgid " entries"
 msgstr " voci"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
 msgid "Skipped "
 msgstr "Saltato "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:957
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:958
 msgid "with Password History errors "
 msgstr "con errori nella Cronologia Password "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 msgid "Renamed "
 msgstr "Rinominato "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed successfully"
 msgstr "Completato con successo"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed but ...."
 msgstr "Completato, ma ..."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:981
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1127
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1197
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1218
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1279
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:982
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1128
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1219
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
 msgid "Do you wish to see a detailed report?"
 msgstr "Si desidera visualizzare un report dettagliato?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1045
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:998
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1046
 msgid "Import XML failed"
 msgstr "Importazione XML fallita"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1007
-#: ../../../core/core_st.cpp:238
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../core/core_st.cpp:240
 #, fuzzy, c-format
 msgid ""
 "Can't find XML Schema Definition file (%ls) in your PasswordSafe Application "
@@ -2101,19 +2101,19 @@ msgstr ""
 "cartella di PasswordSafe.\n"
 "Copiarlo dal file di installazione, oppure reinstallare PasswordSafe."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid "Missing XSD File - "
 msgstr "File XSD Mancante - "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid " Build"
 msgstr " Compilazione"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 msgid "XML"
 msgstr "XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1051
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1052
 #, fuzzy, c-format
 msgid ""
 "File: %ls failed validation against XML Schema:\n"
@@ -2124,7 +2124,7 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1057
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1058
 #, fuzzy, c-format
 msgid ""
 "File: %ls passed Validation but had the following errors during import:\n"
@@ -2136,25 +2136,25 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1078
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1079
 msgid "The following records were skipped:"
 msgstr "I record seguenti sono stati saltati:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1080
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1081
 #, c-format
 msgid " / skipped %d"
 msgstr " / saltati %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1085
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1086
 msgid "The following records had errors in their Password History:"
 msgstr "I record seguenti contenevano errori nella loro Cronologia Password:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1087
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1088
 #, c-format
 msgid " / with Password History errors %d"
 msgstr " / con errori nella Cronologia Password %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1092
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1093
 msgid ""
 "The following records were renamed as an entry already exists in your "
 "database or in the Import file:"
@@ -2162,12 +2162,12 @@ msgstr ""
 "I record seguenti sono stati rinominati poiché esiste già una voce nel "
 "database o nel file in cui importare:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1094
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1095
 #, c-format
 msgid " / renamed %d"
 msgstr " / rinominati %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1099
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1100
 #, fuzzy, c-format
 msgid ""
 "File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See "
@@ -2176,25 +2176,25 @@ msgstr ""
 "Il file: %ls è stato importato (voci validate %d / importate %d%ls%ls%ls). "
 "Si veda il report per altri dettagli."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:95
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:97
 msgid "entry"
 msgstr "voce"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:93
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:95
 msgid "entries"
 msgstr "voci"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1107
 #, fuzzy, c-format
 msgid ""
 "Validated %d %ls\n"
@@ -2205,26 +2205,26 @@ msgstr ""
 "\n"
 "Importate %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1114
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1115
 msgid "XML import not supported in this release"
 msgstr "Importazione XML non supportata in questa release"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1117
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1118
 #, c-format
 msgid "XML import: Unexpected return code(%d)"
 msgstr "Importazione XML: codice di return inatteso (%d)"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1141
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1142
 msgid "Please Choose a KeePass Text File to Import"
 msgstr "Selezionare un file di testo KeePass da importare"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1163
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1164
 #, fuzzy, c-format
 msgid "Text file being imported: %ls"
 msgstr "File di testo da importare: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1180
-#: ../../../ui/wxWidgets/SyncWizard.cpp:602
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/SyncWizard.cpp:603
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2235,11 +2235,11 @@ msgstr ""
 "\n"
 "Impossibile aprire il file in lettura!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1182
 msgid "File open error"
 msgstr "Errore durante l'apertura del file"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1195
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1196
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2250,20 +2250,20 @@ msgstr ""
 "\n"
 "Formato non valido"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1199
 msgid "Import failed"
 msgstr "Importazione fallita"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1214
 #, fuzzy, c-format
 msgid "Imported %d %ls"
 msgstr "Importato %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1265
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1266
 msgid "Merging database: "
 msgstr "Unione database: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1281
 msgid "Merge Complete"
 msgstr "Unione Completata"
 
@@ -2359,15 +2359,15 @@ msgid ""
 "Try exiting and restarting program."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid " file '"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid "' not readable"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #: ../../../ui/wxWidgets/ViewReportDlg.cpp:32
 msgid "View Report"
 msgstr "Visualizza Report"
@@ -2409,7 +2409,7 @@ msgid "Please select a valid file"
 msgstr "Selezionare un file valido"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:123
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:249
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:251
 msgid "None"
 msgstr "Nessuno"
 
@@ -2422,7 +2422,7 @@ msgid "Incremented Number [001-999]"
 msgstr "Numero Progressivo [001-999]"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:132
-#: ../../../core/core_st.cpp:66
+#: ../../../core/core_st.cpp:68
 #, fuzzy
 msgid "Copy password to clipboard"
 msgstr "Copia password negli appunti"
@@ -2433,37 +2433,37 @@ msgstr "Modifica/Visualizza voce selezionata"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:134
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:623
-#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:62
+#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:64
 msgid "Autotype"
 msgstr "Digitazione Automatica"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:135
-#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:63
+#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:65
 msgid "Browse to URL"
 msgstr "Visita URL"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:136
-#: ../../../core/core_st.cpp:65
+#: ../../../core/core_st.cpp:67
 msgid "Copy notes to clipboard"
 msgstr "Copia note negli appunti"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:137
-#: ../../../core/core_st.cpp:68
+#: ../../../core/core_st.cpp:70
 msgid "Copy username to clipboard"
 msgstr "Copia nome utente negli appunti"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:138
-#: ../../../core/core_st.cpp:67
+#: ../../../core/core_st.cpp:69
 msgid "Copy password to clipboard, minimize"
 msgstr "Copia password negli appunti e minimizza"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:139
-#: ../../../core/core_st.cpp:64
+#: ../../../core/core_st.cpp:66
 msgid "Browse to URL + Autotype"
 msgstr "Visita URL + Digitazione Automatica"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:140
-#: ../../../core/core_st.cpp:69 ../../../core/core_st.cpp:144
+#: ../../../core/core_st.cpp:71 ../../../core/core_st.cpp:146
 #, fuzzy
 msgid "Run Command"
 msgstr "Esegui Co&mando"
@@ -2882,23 +2882,23 @@ msgstr "Errore durante l'inizializzazione dell'aiuto"
 msgid "Don't show this warning again"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:849
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:854
 msgid "Missing help definition for page \""
 msgstr "Definizione d'aiuto mancante per la pagina \""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:850
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
 msgid "\" of \""
 msgstr "\" di \""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:860
 msgid "Missing help definition for window \""
 msgstr "Definizione d'aiuto mancante per la finestra \""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:866
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:871
 msgid "Please inform the developers."
 msgstr "Si prega di informare gli sviluppatori."
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:867
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:872
 msgid "Help Undefined"
 msgstr "Aiuto non definito"
 
@@ -3593,6 +3593,7 @@ msgid "search"
 msgstr "ricerca"
 
 #: ../../../ui/wxWidgets/PasswordSafeSearch.cpp:427
+#: ../../../core/core_st.cpp:280
 #, fuzzy
 msgid "Find"
 msgstr "&Trova"
@@ -3708,20 +3709,20 @@ msgstr "&Convalida"
 msgid " empty)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:306
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:322
 #, fuzzy, c-format
 msgid "%ls on %ls"
 msgstr "%ls su %ls"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:341
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:357
 msgid "Yes"
 msgstr "Sì"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:244
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:246
 msgid "No"
 msgstr "No"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:302
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:318
 #, fuzzy, c-format
 msgid "In Headers(%ls)/In Entries("
 msgstr "Nelle Intestazioni(%ls)/Nelle Voci("
@@ -3896,7 +3897,7 @@ msgstr "Impossibile aprire il file in lettura!"
 
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:457
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:269
-#: ../../../core/core_st.cpp:276
+#: ../../../core/core_st.cpp:290
 msgid "Warning"
 msgstr "Attenzione"
 
@@ -3968,11 +3969,11 @@ msgstr "Inserire la chiave e verificarla."
 msgid "Please try another"
 msgstr "Provarne un'altra"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:96
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:98
 msgid "equals"
 msgstr "è uguale"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:83
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:85
 msgid "does not equal"
 msgstr "non è uguale"
 
@@ -3980,23 +3981,23 @@ msgstr "non è uguale"
 msgid "begins with"
 msgstr "inizia con"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:78
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:80
 msgid "does not begin with"
 msgstr "non inizia con"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:90
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:92
 msgid "ends with"
 msgstr "termina con"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:82
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:84
 msgid "does not end with"
 msgstr "non termina con"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:56
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:58
 msgid "contains"
 msgstr "contiene"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:79
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:81
 msgid "does not contain"
 msgstr "non contiene"
 
@@ -4052,19 +4053,19 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:143
+#: ../../../ui/wxWidgets/SyncWizard.cpp:144
 msgid "synchronize"
 msgstr "sincronizzazione"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:220
+#: ../../../ui/wxWidgets/SyncWizard.cpp:221
 msgid "Synchronize another database with currently open database"
 msgstr "Sincronizza un altro database con il database attualmente aperto"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:349
+#: ../../../ui/wxWidgets/SyncWizard.cpp:350
 msgid "Introduction"
 msgstr "Introduzione"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:353
+#: ../../../ui/wxWidgets/SyncWizard.cpp:354
 msgid ""
 "Synchronizing with another database will update the entries in your\n"
 "database with matching entries from the other database."
@@ -4072,11 +4073,11 @@ msgstr ""
 "La sincronizzazione con un altro database aggiornerà le voci nel database\n"
 "corrente con le voci corrispondenti dell'altro database."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:356
+#: ../../../ui/wxWidgets/SyncWizard.cpp:357
 msgid "More Info"
 msgstr "Altre Informazioni"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:359
+#: ../../../ui/wxWidgets/SyncWizard.cpp:360
 msgid ""
 "1. Two entries from different databases match if their Group, Title\n"
 "and User fields match."
@@ -4084,7 +4085,7 @@ msgstr ""
 "1. Due voci provenienti da database differenti corrispondono se i loro\n"
 "campi Gruppo, Titolo e Nome Utente coincidono."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:360
+#: ../../../ui/wxWidgets/SyncWizard.cpp:361
 msgid ""
 "2. You can select the fields to update, as well as filter the entries\n"
 "for synchronization."
@@ -4092,7 +4093,7 @@ msgstr ""
 "2. È possibile selezionare i campi da aggiornare, così come è possibile\n"
 "filtrare le voci da sincronizzare."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:361
+#: ../../../ui/wxWidgets/SyncWizard.cpp:362
 msgid ""
 "3. Only existing entries in your database are updated.  No new entries are\n"
 "added or existing entries removed during this process."
@@ -4102,7 +4103,7 @@ msgstr ""
 "voce viene aggiunta e nessuna voce esistente viene rimossa durante questo "
 "processo."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:362
+#: ../../../ui/wxWidgets/SyncWizard.cpp:363
 msgid ""
 "4. You can undo the operation once it is complete, but won't be\n"
 "able to abort it mid-way."
@@ -4110,27 +4111,27 @@ msgstr ""
 "4. È possibile annullare l'operazione una volta completata, ma\n"
 "non è possibile interromperla durante la sua esecuzione."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:379
+#: ../../../ui/wxWidgets/SyncWizard.cpp:380
 msgid "Select another database"
 msgstr "Selezionare un altro database"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:381
+#: ../../../ui/wxWidgets/SyncWizard.cpp:382
 msgid "Choose Database to Synchronize with \""
 msgstr "Scegliere database da sincronizzare con \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:382
+#: ../../../ui/wxWidgets/SyncWizard.cpp:383
 msgid "Please Choose a Database to Synchronize with current database"
 msgstr "Scegliere un database da sincronizzare con il database corrente"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:405
+#: ../../../ui/wxWidgets/SyncWizard.cpp:406
 msgid "Synchronization options"
 msgstr "Opzioni di Sincronizzazione"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:429
+#: ../../../ui/wxWidgets/SyncWizard.cpp:430
 msgid "Options Summary"
 msgstr "Riepilogo Opzioni"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:454
+#: ../../../ui/wxWidgets/SyncWizard.cpp:455
 msgid ""
 "WARNING!!\n"
 "\n"
@@ -4142,53 +4143,53 @@ msgstr ""
 "Se si continua, i campi nel database corrente verranno aggiornati\n"
 "con quelli del database selezionato."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:471
+#: ../../../ui/wxWidgets/SyncWizard.cpp:472
 msgid " will be updated with corresponding entries from \""
 msgstr " verranno aggiornate con le voci corrispondenti in \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:478
+#: ../../../ui/wxWidgets/SyncWizard.cpp:479
 msgid "All fields in matching entries will be updated"
 msgstr "Tutti i campi verranno aggiornati"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:484
+#: ../../../ui/wxWidgets/SyncWizard.cpp:485
 msgid "Following fields in matching entries will be updated:"
 msgstr "I campi seguenti verranno aggiornati:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:488
+#: ../../../ui/wxWidgets/SyncWizard.cpp:489
 msgid "Following fields will not be updated:"
 msgstr "I campi seguenti non verranno aggiornati:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:507
+#: ../../../ui/wxWidgets/SyncWizard.cpp:508
 msgid "Synchronization status"
 msgstr "Stato sincronizzazione"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:525
+#: ../../../ui/wxWidgets/SyncWizard.cpp:526
 msgid "See a detailed report"
 msgstr "Visualizza un report dettagliato"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:561
+#: ../../../ui/wxWidgets/SyncWizard.cpp:562
 msgid "Your database is being synchronized with \""
 msgstr "Sincronizzazione in corso del database corrente con \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:571
+#: ../../../ui/wxWidgets/SyncWizard.cpp:572
 msgid "There was an error during synchronization"
 msgstr "Si è verificato un errore durante la sincronizzazione"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:585
+#: ../../../ui/wxWidgets/SyncWizard.cpp:586
 #, fuzzy, c-format
 msgid "Your database has been synchronized with \"%ls\""
 msgstr "Il database corrente è stato sincronizzato con \"%ls\""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:586
+#: ../../../ui/wxWidgets/SyncWizard.cpp:587
 #, fuzzy, c-format
 msgid "%ld %ls updated"
 msgstr "%d %ls aggiornato"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:589
 msgid "Synchronization completed successfully"
 msgstr "Sincronizzazione completata con successo"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:604
+#: ../../../ui/wxWidgets/SyncWizard.cpp:605
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4201,7 +4202,7 @@ msgstr ""
 "File corrotto o troncato!\n"
 "Alcuni dati potrebbero essere andati persi o modificati."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:606
+#: ../../../ui/wxWidgets/SyncWizard.cpp:607
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4212,24 +4213,24 @@ msgstr ""
 "\n"
 "Errore sconosciuto"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:640
+#: ../../../ui/wxWidgets/SyncWizard.cpp:641
 #, fuzzy, c-format
 msgid "Synchronizing from database: %ls\n"
 msgstr "Sincronizzando dal database: %ls\n"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:643
+#: ../../../ui/wxWidgets/SyncWizard.cpp:644
 msgid "synchronized"
 msgstr "sincronizzato"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:322
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:338
 msgid "was"
 msgstr "è stato aggiornato"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:323
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:339
 msgid "were"
 msgstr "sono stati aggiornati"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:298
+#: ../../../ui/wxWidgets/SyncWizard.cpp:733 ../../../core/core_st.cpp:314
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4238,7 +4239,7 @@ msgstr ""
 "\n"
 "Il/i seguente/i %ls %ls aggiornato/i:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:297
+#: ../../../ui/wxWidgets/SyncWizard.cpp:749 ../../../core/core_st.cpp:313
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4399,7 +4400,7 @@ msgstr ""
 msgid "This shortcut's target [%s:%s:%s] is not a normal entry."
 msgstr ""
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:94
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:96
 #, c-format
 msgid ""
 "The following entries had a policy name that already existed in this "
@@ -4497,13 +4498,13 @@ msgstr ""
 "Alcuni dati potrebbero essere andati persi o modificati.\n"
 "Continuare ugualmente?"
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:381
+#: ../../../ui/wxWidgets/wxUtilities.cpp:390
 msgid ""
 "An error occurred while trying to get the image data from database item.\n"
 "Therefore, the image cannot be displayed in the preview."
 msgstr ""
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:394
+#: ../../../ui/wxWidgets/wxUtilities.cpp:403
 msgid ""
 "An error occurred while trying to load the image data into the preview "
 "area.\n"
@@ -4625,7 +4626,7 @@ msgstr "Salva Database"
 msgid "Copy Password to Clipboard"
 msgstr "Copia Password negli Appunti"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:149
+#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:151
 #, fuzzy
 msgid "Username"
 msgstr "Nome utente:"
@@ -4634,7 +4635,7 @@ msgstr "Nome utente:"
 msgid "Copy Username to Clipboard"
 msgstr "Copia Nome Utente negli Appunti"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:136
+#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:138
 #, fuzzy
 msgid "Notes"
 msgstr "Note:"
@@ -4661,7 +4662,7 @@ msgstr "Esegui Digitazione Automatica"
 msgid "Browse URL"
 msgstr "Visita URL"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:70
+#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:72
 msgid "Send Email"
 msgstr "Invia Email"
 
@@ -4827,71 +4828,85 @@ msgid "(case sensitive)"
 msgstr "sensibile a maiuscole/minuscole"
 
 #: ../../../core/core_st.cpp:50
-msgid "C:F[R-O]"
+#, c-format
+msgid ""
+"Compare complete of current database:\n"
+"\t %ls\n"
+" and:\n"
+"\t %ls\n"
 msgstr ""
 
 #: ../../../core/core_st.cpp:51
-msgid "C:F[R/W]"
+#, c-format
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
 msgstr ""
 
 #: ../../../core/core_st.cpp:52
-#, fuzzy
-msgid "C:None  "
-msgstr "Nessuno"
+msgid "C:F[R-O]"
+msgstr ""
 
 #: ../../../core/core_st.cpp:53
-msgid "C:Reg   "
+msgid "C:F[R/W]"
 msgstr ""
 
 #: ../../../core/core_st.cpp:54
 #, fuzzy
-msgid "conflict"
-msgstr "Elementi in conflitto"
+msgid "C:None  "
+msgstr "Nessuno"
 
 #: ../../../core/core_st.cpp:55
+msgid "C:Reg   "
+msgstr ""
+
+#: ../../../core/core_st.cpp:56
 #, fuzzy
-msgid "conflicts"
+msgid "conflict"
 msgstr "Elementi in conflitto"
 
 #: ../../../core/core_st.cpp:57
 #, fuzzy
+msgid "conflicts"
+msgstr "Elementi in conflitto"
+
+#: ../../../core/core_st.cpp:59
+#, fuzzy
 msgid "contains all of"
 msgstr "contiene"
 
-#: ../../../core/core_st.cpp:58
+#: ../../../core/core_st.cpp:60
 #, fuzzy
 msgid "contains any of"
 msgstr "contiene"
 
-#: ../../../core/core_st.cpp:59
+#: ../../../core/core_st.cpp:61
 msgid "copied"
 msgstr ""
 
-#: ../../../core/core_st.cpp:60
+#: ../../../core/core_st.cpp:62
 #, fuzzy, c-format
 msgid "%ls - Copied %ls"
 msgstr "%ls - Unione %ls"
 
-#: ../../../core/core_st.cpp:61
+#: ../../../core/core_st.cpp:63
 #, c-format
 msgid " Current default (%ls)"
 msgstr ""
 
-#: ../../../core/core_st.cpp:71
+#: ../../../core/core_st.cpp:73
 #, fuzzy
 msgid "View/Edit selected entry"
 msgstr "Modifica/Visualizza voce selezionata"
 
-#: ../../../core/core_st.cpp:72
+#: ../../../core/core_st.cpp:74
 #, fuzzy
 msgid " (application default)"
 msgstr "Applicazione utilizzata:"
 
-#: ../../../core/core_st.cpp:73
+#: ../../../core/core_st.cpp:75
 msgid "default symbol set"
 msgstr ""
 
-#: ../../../core/core_st.cpp:75
+#: ../../../core/core_st.cpp:77
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -4900,12 +4915,12 @@ msgid ""
 "entry's password)?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:76
+#: ../../../core/core_st.cpp:78
 #, fuzzy
 msgid "Delete Base Entry Confirmation"
 msgstr "Conferma Cancellazione"
 
-#: ../../../core/core_st.cpp:77
+#: ../../../core/core_st.cpp:79
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -4913,154 +4928,154 @@ msgid ""
 "Please confirm to continue (All shortcuts to this entry will be deleted)?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:80
+#: ../../../core/core_st.cpp:82
 #, fuzzy
 msgid "does not contain all of"
 msgstr "non contiene"
 
-#: ../../../core/core_st.cpp:81
+#: ../../../core/core_st.cpp:83
 #, fuzzy
 msgid "does not contain any of"
 msgstr "non contiene"
 
-#: ../../../core/core_st.cpp:84
+#: ../../../core/core_st.cpp:86
 #, fuzzy, c-format
 msgid " Drag # %d"
 msgstr "&Duplica Voce"
 
-#: ../../../core/core_st.cpp:85
-#, c-format
-msgid "%s - Drag & Drop %s"
-msgstr ""
+#: ../../../core/core_st.cpp:87
+#, fuzzy, c-format
+msgid "%ls - Drag & Drop %ls"
+msgstr "%ls - Unione %ls"
 
-#: ../../../core/core_st.cpp:86
+#: ../../../core/core_st.cpp:88
 #, fuzzy, c-format
 msgid " Duplicate # %d"
 msgstr "&Duplica Voce"
 
-#: ../../../core/core_st.cpp:87
+#: ../../../core/core_st.cpp:89
 #, fuzzy
 msgid "empty group"
 msgstr "Importa nel gruppo"
 
-#: ../../../core/core_st.cpp:88
+#: ../../../core/core_st.cpp:90
 #, fuzzy
 msgid "empty groups"
 msgstr "Importa nel gruppo"
 
-#: ../../../core/core_st.cpp:89
+#: ../../../core/core_st.cpp:91
 #, c-format
 msgid ""
 "Trouble with a non-textual (e.g., time) field in record '%ls' - please check "
 "data carefully."
 msgstr ""
 
-#: ../../../core/core_st.cpp:91
+#: ../../../core/core_st.cpp:93
 #, fuzzy
 msgid "End Report"
 msgstr "Report"
 
-#: ../../../core/core_st.cpp:92
+#: ../../../core/core_st.cpp:94
 msgid "--------------------------------------------------------------------------------"
 msgstr ""
 
-#: ../../../core/core_st.cpp:97
+#: ../../../core/core_st.cpp:99
 msgid "has expired"
 msgstr ""
 
-#: ../../../core/core_st.cpp:98
+#: ../../../core/core_st.cpp:100
 msgid "Entries with a password expiry"
 msgstr ""
 
-#: ../../../core/core_st.cpp:99
+#: ../../../core/core_st.cpp:101
 #, c-format
 msgid "within %d day(s)"
 msgstr ""
 
-#: ../../../core/core_st.cpp:100
+#: ../../../core/core_st.cpp:102
 #, fuzzy, c-format
 msgid "DB Export from database: '%s'"
 msgstr "Esportazione database: "
 
-#: ../../../core/core_st.cpp:101
+#: ../../../core/core_st.cpp:103
 msgid "First character of variable name must be alphabetic"
 msgstr ""
 
-#: ../../../core/core_st.cpp:102
+#: ../../../core/core_st.cpp:104
 msgid "Index not numeric"
 msgstr ""
 
-#: ../../../core/core_st.cpp:103
+#: ../../../core/core_st.cpp:105
 msgid "Input string is empty"
 msgstr ""
 
-#: ../../../core/core_st.cpp:104
+#: ../../../core/core_st.cpp:106
 msgid "Characters present between end of index ']' and '}'"
 msgstr ""
 
-#: ../../../core/core_st.cpp:105
+#: ../../../core/core_st.cpp:107
 msgid "Index is invalid or missing"
 msgstr ""
 
-#: ../../../core/core_st.cpp:106
+#: ../../../core/core_st.cpp:108
 msgid "Missing ending curly bracket for variable name"
 msgstr ""
 
-#: ../../../core/core_st.cpp:107
+#: ../../../core/core_st.cpp:109
 msgid "Missing ending round bracket for Autotype value"
 msgstr ""
 
-#: ../../../core/core_st.cpp:108
+#: ../../../core/core_st.cpp:110
 msgid "Missing ending square bracket for index value"
 msgstr ""
 
-#: ../../../core/core_st.cpp:109
+#: ../../../core/core_st.cpp:111
 msgid "There are unmatched quotes in the run command"
 msgstr ""
 
-#: ../../../core/core_st.cpp:110
+#: ../../../core/core_st.cpp:112
 msgid "Variable name is empty"
 msgstr ""
 
-#: ../../../core/core_st.cpp:111
+#: ../../../core/core_st.cpp:113
 msgid "Variable name must be alphanumeric"
 msgstr ""
 
-#: ../../../core/core_st.cpp:112
+#: ../../../core/core_st.cpp:114
 #, fuzzy
 msgid "an alias entry"
 msgstr "Vai alla voce base"
 
-#: ../../../core/core_st.cpp:113
+#: ../../../core/core_st.cpp:115
 #, fuzzy
 msgid "a base entry of an alias"
 msgstr "non è una scorciatoia valida"
 
-#: ../../../core/core_st.cpp:114
+#: ../../../core/core_st.cpp:116
 #, fuzzy
 msgid "  Field is too long."
 msgstr "Cronologia Password"
 
-#: ../../../core/core_st.cpp:115
+#: ../../../core/core_st.cpp:117
 #, fuzzy
 msgid "  Field is too short."
 msgstr "Cronologia Password"
 
-#: ../../../core/core_st.cpp:116
+#: ../../../core/core_st.cpp:118
 msgid "Error: A file with this name already exists"
 msgstr ""
 
-#: ../../../core/core_st.cpp:117
+#: ../../../core/core_st.cpp:119
 #, fuzzy
 msgid "The file was not found."
 msgstr "File o percorso non trovato."
 
-#: ../../../core/core_st.cpp:118
+#: ../../../core/core_st.cpp:120
 #, fuzzy
 msgid "Error: File is read-only"
 msgstr "Apri in sola lettura"
 
-#: ../../../core/core_st.cpp:119
+#: ../../../core/core_st.cpp:121
 #, fuzzy
 msgid "Error while writing file! Try saving in a different location"
 msgstr ""
@@ -5068,198 +5083,198 @@ msgstr ""
 "Il file potrebbe risultare corrotto.\n"
 "Tentativo di salvataggio in un percorso differente"
 
-#: ../../../core/core_st.cpp:120
+#: ../../../core/core_st.cpp:122
 #, fuzzy
 msgid "File is too big."
 msgstr "Cronologia Password"
 
-#: ../../../core/core_st.cpp:121
+#: ../../../core/core_st.cpp:123
 #, fuzzy
 msgid "File is too short."
 msgstr "Cronologia Password"
 
-#: ../../../core/core_st.cpp:122
+#: ../../../core/core_st.cpp:124
 msgid "File is truncated or otherwise corrupt. Please use backup database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:123
+#: ../../../core/core_st.cpp:125
 msgid "Cannot read file. Please check file permissions."
 msgstr ""
 
-#: ../../../core/core_st.cpp:124
+#: ../../../core/core_st.cpp:126
 #, c-format
 msgid ""
 "Filter %ls already exists in the database, do you wish to replace it with "
 "this?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:125
+#: ../../../core/core_st.cpp:127
 #, fuzzy
 msgid "Current database filters have been exported to this database."
 msgstr "Confronta il database corrente con un altro database"
 
-#: ../../../core/core_st.cpp:126
-msgid "Stored filters will be unusable until the file's restored."
-msgstr ""
-
-#: ../../../core/core_st.cpp:127
-#, fuzzy
-msgid "Last Access Time"
-msgstr "Data ultimo accesso:"
-
 #: ../../../core/core_st.cpp:128
-msgid "Attachment Reference"
+msgid "Stored filters will be unusable until the file's restored."
 msgstr ""
 
 #: ../../../core/core_st.cpp:129
 #, fuzzy
+msgid "Last Access Time"
+msgstr "Data ultimo accesso:"
+
+#: ../../../core/core_st.cpp:130
+msgid "Attachment Reference"
+msgstr ""
+
+#: ../../../core/core_st.cpp:131
+#, fuzzy
 msgid "AutoType"
 msgstr "Digitazione Automatica"
 
-#: ../../../core/core_st.cpp:130
+#: ../../../core/core_st.cpp:132
 #, fuzzy
 msgid "Created Time"
 msgstr "Data creazione voce:"
 
-#: ../../../core/core_st.cpp:131
+#: ../../../core/core_st.cpp:133
 msgid "DCA"
 msgstr ""
 
-#: ../../../core/core_st.cpp:132
+#: ../../../core/core_st.cpp:134
 #, fuzzy
 msgid "e-mail"
 msgstr "email:"
 
-#: ../../../core/core_st.cpp:134
+#: ../../../core/core_st.cpp:136
 #, fuzzy
 msgid "Group/Title"
 msgstr "Gruppo"
 
-#: ../../../core/core_st.cpp:135
+#: ../../../core/core_st.cpp:137
 #, fuzzy
 msgid "Keyboard Shortcut"
 msgstr "Crea Scorciatoia"
 
-#: ../../../core/core_st.cpp:138
+#: ../../../core/core_st.cpp:140
 #, fuzzy
 msgid "Password Modified Time"
 msgstr "Password Safe"
 
-#: ../../../core/core_st.cpp:139
+#: ../../../core/core_st.cpp:141
 #, fuzzy
 msgid "Protected"
 msgstr "Cancella Voce"
 
-#: ../../../core/core_st.cpp:140
+#: ../../../core/core_st.cpp:142
 #, fuzzy
 msgid "History"
 msgstr "Cancella Cronologia"
 
-#: ../../../core/core_st.cpp:142
+#: ../../../core/core_st.cpp:144
 #, fuzzy
 msgid "Password Policy Name"
 msgstr "Generazione Password"
 
-#: ../../../core/core_st.cpp:143
+#: ../../../core/core_st.cpp:145
 #, fuzzy
 msgid "Record Modified Time"
 msgstr "Password Safe"
 
-#: ../../../core/core_st.cpp:145
+#: ../../../core/core_st.cpp:147
 msgid "Shift+DCA"
 msgstr ""
 
-#: ../../../core/core_st.cpp:146
+#: ../../../core/core_st.cpp:148
 msgid "Symbols"
 msgstr ""
 
-#: ../../../core/core_st.cpp:148
+#: ../../../core/core_st.cpp:150
 #, fuzzy
 msgid "URL"
 msgstr "URL:"
 
-#: ../../../core/core_st.cpp:150
+#: ../../../core/core_st.cpp:152
 msgid "UUID"
 msgstr ""
 
-#: ../../../core/core_st.cpp:151
+#: ../../../core/core_st.cpp:153
 #, fuzzy
 msgid "Password Expiry Date"
 msgstr "Scadenza Password"
 
-#: ../../../core/core_st.cpp:152
+#: ../../../core/core_st.cpp:154
 #, fuzzy
 msgid "Password Expiry Interval"
 msgstr "Scadenza Password"
 
-#: ../../../core/core_st.cpp:153
+#: ../../../core/core_st.cpp:155
 #, fuzzy
 msgid "a normal entry"
 msgstr "Vai alla voce base"
 
-#: ../../../core/core_st.cpp:154
+#: ../../../core/core_st.cpp:156
 #, fuzzy
 msgid "Last found entries"
 msgstr " voci"
 
-#: ../../../core/core_st.cpp:155
+#: ../../../core/core_st.cpp:157
 #, fuzzy
 msgid "added but not yet saved to database"
 msgstr "Il database:"
 
-#: ../../../core/core_st.cpp:156
+#: ../../../core/core_st.cpp:158
 #, fuzzy
 msgid "in the database"
 msgstr "Il database:"
 
-#: ../../../core/core_st.cpp:157
+#: ../../../core/core_st.cpp:159
 #, fuzzy
 msgid "a shortcut entry"
 msgstr "Scorciatoia non valida"
 
-#: ../../../core/core_st.cpp:158
+#: ../../../core/core_st.cpp:160
 #, fuzzy
 msgid "a base entry of a shortcut"
 msgstr "non è una scorciatoia valida"
 
-#: ../../../core/core_st.cpp:159
+#: ../../../core/core_st.cpp:161
 #, fuzzy
 msgid "changed but not yet saved to database"
 msgstr "Il database:"
 
-#: ../../../core/core_st.cpp:160
+#: ../../../core/core_st.cpp:162
 #, fuzzy
 msgid "greater than"
 msgstr "Data creazione voce:"
 
-#: ../../../core/core_st.cpp:161
+#: ../../../core/core_st.cpp:163
 #, fuzzy
 msgid "greater than or equal to"
 msgstr "non è uguale"
 
-#: ../../../core/core_st.cpp:162
+#: ../../../core/core_st.cpp:164
 #, c-format
 msgid ""
 "Invalid input on line %d.  Number of fields separated by '%c' is not as "
 "expected."
 msgstr ""
 
-#: ../../../core/core_st.cpp:163
+#: ../../../core/core_st.cpp:165
 #, c-format
 msgid "Line %d: "
 msgstr ""
 
-#: ../../../core/core_st.cpp:164
+#: ../../../core/core_st.cpp:166
 #, c-format
 msgid ""
 "File ends on line %d before ending double quote of last entry's note field."
 msgstr ""
 
-#: ../../../core/core_st.cpp:165
+#: ../../../core/core_st.cpp:167
 msgid "Import aborted. Please see report."
 msgstr ""
 
-#: ../../../core/core_st.cpp:166
+#: ../../../core/core_st.cpp:168
 msgid ""
 "The TXT or CSV file was not imported as required as entry records span "
 "multiple lines in the CSV file.\n"
@@ -5267,319 +5282,319 @@ msgid ""
 "Import aborted."
 msgstr ""
 
-#: ../../../core/core_st.cpp:167
+#: ../../../core/core_st.cpp:169
 #, c-format
 msgid ""
 "%ls, Title=\"%ls\", User=\"%ls\" already exists in your database or in the "
 "Import file. Added imported entry with title=\"%ls\".\n"
 msgstr ""
 
-#: ../../../core/core_st.cpp:168
+#: ../../../core/core_st.cpp:170
 #, c-format
 msgid "Entry on line %d with Group=\"%ls\""
 msgstr ""
 
-#: ../../../core/core_st.cpp:169
+#: ../../../core/core_st.cpp:171
 #, c-format
 msgid "Entry on line %d with no group"
 msgstr ""
 
-#: ../../../core/core_st.cpp:170
+#: ../../../core/core_st.cpp:172
 #, c-format
 msgid "Entry with Group=\"%ls\""
 msgstr ""
 
-#: ../../../core/core_st.cpp:171
+#: ../../../core/core_st.cpp:173
 msgid "Entry with no group"
 msgstr ""
 
-#: ../../../core/core_st.cpp:172
+#: ../../../core/core_st.cpp:174
 #, fuzzy
 msgid "imported"
 msgstr "Importato "
 
-#: ../../../core/core_st.cpp:173
+#: ../../../core/core_st.cpp:175
 #, fuzzy, c-format
 msgid "including %d empty group(s)."
 msgstr "Importa nel gruppo"
 
-#: ../../../core/core_st.cpp:174
+#: ../../../core/core_st.cpp:176
 #, c-format
 msgid "Empty line %d skipped"
 msgstr ""
 
-#: ../../../core/core_st.cpp:175
+#: ../../../core/core_st.cpp:177
 #, c-format
 msgid "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 msgstr ""
 
-#: ../../../core/core_st.cpp:176
-msgid "Internal error. Import failed. No records imported."
-msgstr ""
-
-#: ../../../core/core_st.cpp:177
-#, c-format
-msgid "Found %d known column headers:"
-msgstr ""
-
 #: ../../../core/core_st.cpp:178
-msgid "Invalid field delimiter: must be within ASCII range."
+msgid "Internal error. Import failed. No records imported."
 msgstr ""
 
 #: ../../../core/core_st.cpp:179
 #, c-format
-msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
+msgid "Found %d known column headers:"
 msgstr ""
 
 #: ../../../core/core_st.cpp:180
+msgid "Invalid field delimiter: must be within ASCII range."
+msgstr ""
+
+#: ../../../core/core_st.cpp:181
+#, c-format
+msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
+msgstr ""
+
+#: ../../../core/core_st.cpp:182
 #, fuzzy
 msgid "The following columns will be processed: "
 msgstr "I record seguenti sono stati saltati:"
 
-#: ../../../core/core_st.cpp:181
+#: ../../../core/core_st.cpp:183
 msgid ""
 "The following columns were recognised but only Group/Title, Username and "
 "Password will be processed:"
 msgstr ""
 
-#: ../../../core/core_st.cpp:182
+#: ../../../core/core_st.cpp:184
 #, c-format
 msgid ""
 "Line %d skipped - Only %d fields found, whereas parsing the Header says "
 "there should be %d."
 msgstr ""
 
-#: ../../../core/core_st.cpp:183
+#: ../../../core/core_st.cpp:185
 msgid ""
 "Either or both of the Group/Title and Password columns are missing. No "
 "records imported."
 msgstr ""
 
-#: ../../../core/core_st.cpp:184
+#: ../../../core/core_st.cpp:186
 msgid ""
 "Could not find the next entry's title field in the KeePass V1 TXT (should be "
 "within square brackets)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:185
+#: ../../../core/core_st.cpp:187
 msgid "Column header row not recognised as first record. No records imported."
 msgstr ""
 
-#: ../../../core/core_st.cpp:186
+#: ../../../core/core_st.cpp:188
 msgid "No records in import file!"
 msgstr ""
 
-#: ../../../core/core_st.cpp:187
+#: ../../../core/core_st.cpp:189
 #, c-format
 msgid "Line %d skipped: Empty mandatory Password field."
 msgstr ""
 
-#: ../../../core/core_st.cpp:188
+#: ../../../core/core_st.cpp:190
 #, c-format
 msgid "Line %d skipped: Empty mandatory Title field."
 msgstr ""
 
-#: ../../../core/core_st.cpp:189
+#: ../../../core/core_st.cpp:191
 #, fuzzy, c-format
 msgid " Import # %d"
 msgstr "Importato %d %s"
 
-#: ../../../core/core_st.cpp:190
+#: ../../../core/core_st.cpp:192
 #, fuzzy, c-format
 msgid "%ls - Imported %ls"
 msgstr "%ls - Importato %ls"
 
-#: ../../../core/core_st.cpp:191
+#: ../../../core/core_st.cpp:193
 msgid ""
 "To replace passwords of existing entries, all the following columns must be "
 "present: Group/Title, Username and Password.  One or more are missing and no "
 "entries have been updated."
 msgstr ""
 
-#: ../../../core/core_st.cpp:192
+#: ../../../core/core_st.cpp:194
 #, c-format
 msgid "%ls not found. Cannot update entry's password.\n"
 msgstr ""
 
-#: ../../../core/core_st.cpp:193
+#: ../../../core/core_st.cpp:195
 #, fuzzy, c-format
 msgid "%ls has an empty %ls.\n"
 msgstr "%ls - Importato %ls"
 
-#: ../../../core/core_st.cpp:194
+#: ../../../core/core_st.cpp:196
 #, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
 "the base entry is already an alias."
 msgstr ""
 
-#: ../../../core/core_st.cpp:195
+#: ../../../core/core_st.cpp:197
 msgid "\tThis entry has been made an alias of associated base entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:196
+#: ../../../core/core_st.cpp:198
 #, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
 "the base entry does not exist."
 msgstr ""
 
-#: ../../../core/core_st.cpp:197
+#: ../../../core/core_st.cpp:199
 msgid ""
 "\tThis entry remains a normal entry and the password has not been changed."
 msgstr ""
 
-#: ../../../core/core_st.cpp:198
+#: ../../../core/core_st.cpp:200
 #, c-format
 msgid ""
 "The %ls entry \"%ls, %ls, %ls\" doesn't point to a normal or existing %ls "
 "base entry. It cannot be imported."
 msgstr ""
 
-#: ../../../core/core_st.cpp:199
+#: ../../../core/core_st.cpp:201
 msgid "Entry import warnings"
 msgstr ""
 
-#: ../../../core/core_st.cpp:200
+#: ../../../core/core_st.cpp:202
 msgid "id="
 msgstr ""
 
-#: ../../../core/core_st.cpp:201
+#: ../../../core/core_st.cpp:203
 msgid "on line "
 msgstr ""
 
-#: ../../../core/core_st.cpp:202
+#: ../../../core/core_st.cpp:204
 msgid "Internal error: Invalid oflag or pmode argument"
 msgstr ""
 
-#: ../../../core/core_st.cpp:203
+#: ../../../core/core_st.cpp:205
 msgid "invalid!"
 msgstr ""
 
-#: ../../../core/core_st.cpp:204
+#: ../../../core/core_st.cpp:206
 msgid "  Invalid date/time value."
 msgstr ""
 
-#: ../../../core/core_st.cpp:205
+#: ../../../core/core_st.cpp:207
 #, fuzzy
 msgid "  Field length is incorrect."
 msgstr "Cronologia Password"
 
-#: ../../../core/core_st.cpp:206
+#: ../../../core/core_st.cpp:208
 msgid "Internal error: An invalid flag was specified"
 msgstr ""
 
-#: ../../../core/core_st.cpp:207
+#: ../../../core/core_st.cpp:209
 #, c-format
 msgid "  Invalid header: '%ls' (must be 5 hexadecimal characters)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:208
+#: ../../../core/core_st.cpp:210
 #, fuzzy, c-format
 msgid "Invalid lock file \"%ls\"."
 msgstr "Formato non valido"
 
-#: ../../../core/core_st.cpp:209
+#: ../../../core/core_st.cpp:211
 #, c-format
 msgid "  Invalid number of saved old passwords %d."
 msgstr ""
 
-#: ../../../core/core_st.cpp:210
+#: ../../../core/core_st.cpp:212
 #, c-format
 msgid "  Invalid status value: %d (must be either 0 or 1)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:211
+#: ../../../core/core_st.cpp:213
 msgid "  Invalid password length found (not a hexadecimal number)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:212
+#: ../../../core/core_st.cpp:214
 msgid ""
 "  Invalid password length found (differs from length of following password)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:213
+#: ../../../core/core_st.cpp:215
 msgid ""
 "  Invalid field separator character found - only a single blank is allowed "
 "between fields."
 msgstr ""
 
-#: ../../../core/core_st.cpp:214
+#: ../../../core/core_st.cpp:216
 #, fuzzy
 msgid "Invalid Filter schema."
 msgstr "Formato non valido"
 
-#: ../../../core/core_st.cpp:215
+#: ../../../core/core_st.cpp:217
 msgid "Schema does not have a version number."
 msgstr ""
 
-#: ../../../core/core_st.cpp:216
+#: ../../../core/core_st.cpp:218
 #, c-format
 msgid "The filter XML version (%d) is greater than the current schema (%d)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:217
+#: ../../../core/core_st.cpp:219
 #, c-format
 msgid ""
 "The filter XML version (%d) is greater than that supported by this instance "
 "of PasswordSafe (%d)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:218
+#: ../../../core/core_st.cpp:220
 #, fuzzy
 msgid "is"
 msgstr "Elenca"
 
-#: ../../../core/core_st.cpp:219
+#: ../../../core/core_st.cpp:221
 msgid "is active"
 msgstr ""
 
-#: ../../../core/core_st.cpp:220
+#: ../../../core/core_st.cpp:222
 msgid "is inactive"
 msgstr ""
 
-#: ../../../core/core_st.cpp:221
+#: ../../../core/core_st.cpp:223
 msgid "is not"
 msgstr ""
 
-#: ../../../core/core_st.cpp:222
+#: ../../../core/core_st.cpp:224
 msgid "is not present"
 msgstr ""
 
-#: ../../../core/core_st.cpp:223
+#: ../../../core/core_st.cpp:225
 msgid "is present"
 msgstr ""
 
-#: ../../../core/core_st.cpp:224
+#: ../../../core/core_st.cpp:226
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to entry %ls. It "
 "has been removed from the %ls entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:225
+#: ../../../core/core_st.cpp:227
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to the "
 "PasswordSafe application. It has been removed from the entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:226
+#: ../../../core/core_st.cpp:228
 #, fuzzy
 msgid "less than"
 msgstr "non è uguale"
 
-#: ../../../core/core_st.cpp:227
+#: ../../../core/core_st.cpp:229
 #, fuzzy
 msgid "less than or equal to"
 msgstr "non è uguale"
 
-#: ../../../core/core_st.cpp:228
+#: ../../../core/core_st.cpp:230
 #, fuzzy
 msgid "File or path not found"
 msgstr "File o percorso non trovato."
 
-#: ../../../core/core_st.cpp:229
+#: ../../../core/core_st.cpp:231
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5588,14 +5603,14 @@ msgstr ""
 "\n"
 "Il/i seguente/i %ls %ls aggiornato/i:"
 
-#: ../../../core/core_st.cpp:230
+#: ../../../core/core_st.cpp:232
 #, c-format
 msgid ""
 "\n"
 "Merge completed: %d %ls added (%d %ls, %d %ls, %d %ls, %d %ls)"
 msgstr ""
 
-#: ../../../core/core_st.cpp:231
+#: ../../../core/core_st.cpp:233
 #, c-format
 msgid ""
 "Conflicting entries for \"%ls\" \"%ls\" \"%ls\".\n"
@@ -5603,60 +5618,60 @@ msgid ""
 "    Differing field(s): %ls"
 msgstr ""
 
-#: ../../../core/core_st.cpp:232
+#: ../../../core/core_st.cpp:234
 #, fuzzy
 msgid "merged"
 msgstr "unione"
 
-#: ../../../core/core_st.cpp:233
+#: ../../../core/core_st.cpp:235
 #, fuzzy, c-format
 msgid "%ls - Merged %ls"
 msgstr "%ls - Unione %ls"
 
-#: ../../../core/core_st.cpp:234
+#: ../../../core/core_st.cpp:236
 msgid "MISSING PASSWORD"
 msgstr ""
 
-#: ../../../core/core_st.cpp:235
+#: ../../../core/core_st.cpp:237
 #, c-format
 msgid "\tPassword policy name '%ls' is not in the database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:236
+#: ../../../core/core_st.cpp:238
 msgid ""
 "\tOne or more Password Policy Names were not found in the database. The "
 "affected entries have been changed to use the database's default policy."
 msgstr ""
 
-#: ../../../core/core_st.cpp:237
+#: ../../../core/core_st.cpp:239
 #, c-format
 msgid "MISSING TITLE # %d"
 msgstr ""
 
-#: ../../../core/core_st.cpp:239
+#: ../../../core/core_st.cpp:241
 msgid "Can't obtain the schema version."
 msgstr ""
 
-#: ../../../core/core_st.cpp:240
-msgid "The filter XML version is missing."
-msgstr ""
-
-#: ../../../core/core_st.cpp:241
-#, c-format
-msgid "Create SchemaCache60 Error 0x%08X during %ls."
-msgstr ""
-
 #: ../../../core/core_st.cpp:242
-#, c-format
-msgid "SAX Parse60 Error 0x%08X during %ls."
+msgid "The filter XML version is missing."
 msgstr ""
 
 #: ../../../core/core_st.cpp:243
 #, c-format
-msgid "Error (%08X): line %d character %d %ls"
+msgid "Create SchemaCache60 Error 0x%08X during %ls."
+msgstr ""
+
+#: ../../../core/core_st.cpp:244
+#, c-format
+msgid "SAX Parse60 Error 0x%08X during %ls."
 msgstr ""
 
 #: ../../../core/core_st.cpp:245
+#, c-format
+msgid "Error (%08X): line %d character %d %ls"
+msgstr ""
+
+#: ../../../core/core_st.cpp:247
 #, fuzzy
 msgid ""
 "Unable to get configuration file lock.\n"
@@ -5664,29 +5679,29 @@ msgid ""
 "Will use registry."
 msgstr "Impossibile inviare l'email"
 
-#: ../../../core/core_st.cpp:246
+#: ../../../core/core_st.cpp:248
 msgid "Cannot create lock file - no permission in directory?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:247
+#: ../../../core/core_st.cpp:249
 msgid "Internal error: Out of file handles"
 msgstr ""
 
-#: ../../../core/core_st.cpp:248
+#: ../../../core/core_st.cpp:250
 msgid ""
 "Unable to use a MS XML reader on your system.  Neither MS XML V3, V4 or V6 "
 "seems available."
 msgstr ""
 
-#: ../../../core/core_st.cpp:250
+#: ../../../core/core_st.cpp:252
 msgid "Unsaved changes"
 msgstr ""
 
-#: ../../../core/core_st.cpp:251
+#: ../../../core/core_st.cpp:253
 msgid "is not set"
 msgstr ""
 
-#: ../../../core/core_st.cpp:252
+#: ../../../core/core_st.cpp:254
 #, c-format
 msgid ""
 "Number of entries processed: %d\n"
@@ -5708,361 +5723,417 @@ msgid ""
 "Recommend that the database is now saved."
 msgstr ""
 
-#: ../../../core/core_st.cpp:254
+#: ../../../core/core_st.cpp:256
 msgid ""
 "Password should be mixed case, with at least one digit or punctuation "
 "character"
 msgstr ""
 
-#: ../../../core/core_st.cpp:255
+#: ../../../core/core_st.cpp:257
 #, fuzzy
 msgid "Password is too short"
 msgstr "Cronologia Password"
 
-#: ../../../core/core_st.cpp:256
+#: ../../../core/core_st.cpp:258
 #, fuzzy
 msgid "Easyvision characters"
 msgstr "Usa lettere minuscole"
 
-#: ../../../core/core_st.cpp:257
+#: ../../../core/core_st.cpp:259
 #, fuzzy
 msgid "Hexadecimal characters"
 msgstr "Usa lettere minuscole"
 
-#: ../../../core/core_st.cpp:258
+#: ../../../core/core_st.cpp:260
 #, fuzzy
 msgid "Password length"
 msgstr "Lunghezza password:"
 
-#: ../../../core/core_st.cpp:259
+#: ../../../core/core_st.cpp:261
 #, fuzzy
 msgid "Pronounceable passwords"
 msgstr "Genera password pronunciabili"
 
-#: ../../../core/core_st.cpp:261
+#: ../../../core/core_st.cpp:263
 #, fuzzy
 msgid "Use lowercase characters"
 msgstr "Usa lettere minuscole"
 
-#: ../../../core/core_st.cpp:263
+#: ../../../core/core_st.cpp:265
 #, fuzzy
 msgid "Use uppercase characters"
 msgstr "Usa lettere minuscole"
 
-#: ../../../core/core_st.cpp:264
+#: ../../../core/core_st.cpp:266
 #, fuzzy, c-format
 msgid "Error in a Password History %ls:"
 msgstr "con errori nella Cronologia Password "
 
-#: ../../../core/core_st.cpp:265
+#: ../../../core/core_st.cpp:267
 #, c-format
 msgid "sub-field starting at position %d (within the History field): "
 msgstr ""
 
-#: ../../../core/core_st.cpp:266
+#: ../../../core/core_st.cpp:268
 #, fuzzy
 msgid "  All Password History ignored."
 msgstr " / con errori nella Cronologia Password %d"
 
-#: ../../../core/core_st.cpp:267
+#: ../../../core/core_st.cpp:269
 #, fuzzy
 msgid "Read Error"
 msgstr "Errore di lettura del file"
 
-#: ../../../core/core_st.cpp:268
+#: ../../../core/core_st.cpp:270
+msgid "Relative"
+msgstr ""
+
+#: ../../../core/core_st.cpp:271
 #, c-format
 msgid ""
 "\tOne or more entry keyboard shortcuts were already assigned to entries in "
 "this database. They have been removed from the %ls entries."
 msgstr ""
 
-#: ../../../core/core_st.cpp:269
+#: ../../../core/core_st.cpp:272
 msgid ""
 "\tOne or more Password Policy Names were already in this database but had "
 "different settings. They have been renamed."
 msgstr ""
 
-#: ../../../core/core_st.cpp:270
+#: ../../../core/core_st.cpp:273
 #, c-format
 msgid "%ls%ls%ls_Report.txt"
 msgstr ""
 
-#: ../../../core/core_st.cpp:271
+#: ../../../core/core_st.cpp:274
 #, c-format
 msgid "Report of %ls function started at %ls"
 msgstr ""
 
-#: ../../../core/core_st.cpp:272
+#: ../../../core/core_st.cpp:275
 #, fuzzy, c-format
 msgid "on database %ls"
 msgstr "database %ls"
 
-#: ../../../core/core_st.cpp:273
+#: ../../../core/core_st.cpp:276
+#, fuzzy
+msgid "Compare"
+msgstr "&Confronta"
+
+#: ../../../core/core_st.cpp:277
+#, fuzzy
+msgid "Export_DB"
+msgstr "esportazione"
+
+#: ../../../core/core_st.cpp:278
+#, fuzzy
+msgid "Export_Text"
+msgstr "Esportazione Testo"
+
+#: ../../../core/core_st.cpp:279
+#, fuzzy
+msgid "Export_XML"
+msgstr "Esportazione XML"
+
+#: ../../../core/core_st.cpp:281
+#, fuzzy
+msgid "Import_KeePassV1_CSV"
+msgstr "Importa_KeePassV1_CSV"
+
+#: ../../../core/core_st.cpp:282
+#, fuzzy
+msgid "Import_KeePassV1_TXT"
+msgstr "Importa_KeePassV1_TXT"
+
+#: ../../../core/core_st.cpp:283
+msgid "Import_Text"
+msgstr "Importa_Testo"
+
+#: ../../../core/core_st.cpp:284
+msgid "Import_XML"
+msgstr "Importa_XML"
+
+#: ../../../core/core_st.cpp:285
+msgid "Merge"
+msgstr "Unisci"
+
+#: ../../../core/core_st.cpp:287
 #, fuzzy
 msgid "Validate"
 msgstr "&Convalida"
 
-#: ../../../core/core_st.cpp:275
+#: ../../../core/core_st.cpp:289
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Errore di scrittura"
 
-#: ../../../core/core_st.cpp:277
+#: ../../../core/core_st.cpp:291
 #, fuzzy, c-format
 msgid ""
 "\n"
 "Error in Password History for entry: \"%ls\"%ls\"%ls\": "
 msgstr "con errori nella Cronologia Password "
 
-#: ../../../core/core_st.cpp:278
+#: ../../../core/core_st.cpp:292
+#, c-format
+msgid "\tNo entries were found containing search string '%ls' %ls"
+msgstr ""
+
+#: ../../../core/core_st.cpp:293
+#, c-format
+msgid "\tThe following entries contain search string '%ls' %ls"
+msgstr ""
+
+#: ../../../core/core_st.cpp:294
 msgid "See Attachment filters"
 msgstr ""
 
-#: ../../../core/core_st.cpp:279
+#: ../../../core/core_st.cpp:295
 #, fuzzy
 msgid "See Password History filters"
 msgstr "con errori nella Cronologia Password "
 
-#: ../../../core/core_st.cpp:280
+#: ../../../core/core_st.cpp:296
 #, fuzzy
 msgid "See Password Policy filters"
 msgstr "Gestione Metodi Generazione Password"
 
-#: ../../../core/core_st.cpp:281
+#: ../../../core/core_st.cpp:297
 msgid "is set"
 msgstr ""
 
-#: ../../../core/core_st.cpp:282
+#: ../../../core/core_st.cpp:298
 #, fuzzy
 msgid "shortcut"
 msgstr "Scorciatoie"
 
-#: ../../../core/core_st.cpp:283
+#: ../../../core/core_st.cpp:299
 #, fuzzy
 msgid "shortcuts"
 msgstr "Scorciatoie"
 
-#: ../../../core/core_st.cpp:284
+#: ../../../core/core_st.cpp:300
 msgid "policy specific symbols"
 msgstr ""
 
-#: ../../../core/core_st.cpp:285
+#: ../../../core/core_st.cpp:301
 #, fuzzy
 msgid "Start Report"
 msgstr "Report"
 
-#: ../../../core/core_st.cpp:286
+#: ../../../core/core_st.cpp:302
 #, fuzzy
 msgid "Double-Click on entry to Autotype"
 msgstr "Visita URL + Digitazione Automatica"
 
-#: ../../../core/core_st.cpp:287
+#: ../../../core/core_st.cpp:303
 #, fuzzy
 msgid "Double-Click on entry to Browse to URL"
 msgstr "Visita URL + Digitazione Automatica"
 
-#: ../../../core/core_st.cpp:288
+#: ../../../core/core_st.cpp:304
 #, fuzzy
 msgid "Double-Click on entry to Browse to URL + Autotype"
 msgstr "Visita URL + Digitazione Automatica"
 
-#: ../../../core/core_st.cpp:289
+#: ../../../core/core_st.cpp:305
 #, fuzzy
 msgid "https://pwsafe.org/"
 msgstr "https://pwsafe.org/latest.xml"
 
-#: ../../../core/core_st.cpp:290
+#: ../../../core/core_st.cpp:306
 #, fuzzy
 msgid "Double-Click on entry to Copy Notes"
 msgstr "Copia Password + Minimizza"
 
-#: ../../../core/core_st.cpp:291
+#: ../../../core/core_st.cpp:307
 #, fuzzy
 msgid "Double-Click on entry to Copy Password"
 msgstr "Copia Password + Minimizza"
 
-#: ../../../core/core_st.cpp:292
+#: ../../../core/core_st.cpp:308
 #, fuzzy
 msgid "Double-Click on entry to Copy Password and Minimize"
 msgstr "Copia Password + Minimizza"
 
-#: ../../../core/core_st.cpp:293
+#: ../../../core/core_st.cpp:309
 #, fuzzy
 msgid "Double-Click on entry to Copy Username"
 msgstr "Copia Password + Minimizza"
 
-#: ../../../core/core_st.cpp:294
+#: ../../../core/core_st.cpp:310
 #, fuzzy
 msgid "Double-Click on entry to Run Command"
 msgstr "Copia Password + Minimizza"
 
-#: ../../../core/core_st.cpp:295
+#: ../../../core/core_st.cpp:311
 #, fuzzy
 msgid "Double-Click on entry to Send Email"
 msgstr "Copia Password + Minimizza"
 
-#: ../../../core/core_st.cpp:296
+#: ../../../core/core_st.cpp:312
 #, fuzzy
 msgid "Double-Click on entry to View/Edit it"
 msgstr "Visita URL + Digitazione Automatica"
 
-#: ../../../core/core_st.cpp:299
+#: ../../../core/core_st.cpp:315
 #, fuzzy, c-format
 msgid "%ls - Sync'd %ls"
 msgstr "%ls su %ls"
 
-#: ../../../core/core_st.cpp:300
+#: ../../../core/core_st.cpp:316
 msgid "System error: No more file handles available"
 msgstr ""
 
-#: ../../../core/core_st.cpp:303
+#: ../../../core/core_st.cpp:319
 #, fuzzy
 msgid "Unknown function"
 msgstr "Campi sconosciuti:"
 
-#: ../../../core/core_st.cpp:304
+#: ../../../core/core_st.cpp:320
 #, fuzzy
 msgid "Unknown object"
 msgstr "Codice sconosciuto: %d"
 
-#: ../../../core/core_st.cpp:305
+#: ../../../core/core_st.cpp:321
 msgid "Internal error: Unexpected error number"
 msgstr ""
 
-#: ../../../core/core_st.cpp:307
+#: ../../../core/core_st.cpp:323
 #, c-format
 msgid "\tName: %s; Filename: %s"
 msgstr ""
 
-#: ../../../core/core_st.cpp:308
+#: ../../../core/core_st.cpp:324
 msgid ""
 "The following entries had an invalid UUID field.  This has been corrected."
 msgstr ""
 
-#: ../../../core/core_st.cpp:309
+#: ../../../core/core_st.cpp:325
 #, c-format
 msgid ""
 "The following entries have passwords in the correct form for %ls, but the "
 "base entry does not exist."
 msgstr ""
 
-#: ../../../core/core_st.cpp:310
+#: ../../../core/core_st.cpp:326
 msgid "The following entries were duplicates of an existing entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:311
+#: ../../../core/core_st.cpp:327
 msgid ""
 "The following entries had a duplicate UUID field.  This has been corrected."
 msgstr ""
 
-#: ../../../core/core_st.cpp:312
+#: ../../../core/core_st.cpp:328
 #, c-format
 msgid ""
 "The following entries had an empty Password field, which is not permitted. "
 "The password has been set to '%ls'"
 msgstr ""
 
-#: ../../../core/core_st.cpp:313
+#: ../../../core/core_st.cpp:329
 msgid "The following entries had an empty Title field, which is not permitted."
 msgstr ""
 
-#: ../../../core/core_st.cpp:314
+#: ../../../core/core_st.cpp:330
 #, c-format
 msgid "\tGroup='%ls', Title='%ls', User='%ls' %ls"
 msgstr ""
 
-#: ../../../core/core_st.cpp:315
+#: ../../../core/core_st.cpp:331
 #, c-format
 msgid "- Its title has been changed to:'%ls'"
 msgstr ""
 
-#: ../../../core/core_st.cpp:316
+#: ../../../core/core_st.cpp:332
 msgid "The following ERRORS were detected and were FIXED."
 msgstr ""
 
-#: ../../../core/core_st.cpp:317
+#: ../../../core/core_st.cpp:333
 msgid "The following entries refer to missing attachments."
 msgstr ""
 
-#: ../../../core/core_st.cpp:318
+#: ../../../core/core_st.cpp:334
 msgid "The following attachments are not referred to by any entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:319
+#: ../../../core/core_st.cpp:335
 msgid ""
 "The following entries had an invalid Password History.  This has been "
 "rebuilt with available data.  There may be some loss of history."
 msgstr ""
 
-#: ../../../core/core_st.cpp:320
+#: ../../../core/core_st.cpp:336
 #, c-format
 msgid ""
 "The following entries have one or more text fields too long to display or "
 "edit (over %d characters).  The largest entry size found was ~%d %ls."
 msgstr ""
 
-#: ../../../core/core_st.cpp:321
+#: ../../../core/core_st.cpp:337
 msgid ""
 "The following WARNINGS were detected - you should review and fix them "
 "manually."
 msgstr ""
 
-#: ../../../core/core_st.cpp:324
+#: ../../../core/core_st.cpp:340
 msgid "will expire"
 msgstr ""
 
-#: ../../../core/core_st.cpp:325
+#: ../../../core/core_st.cpp:341
 #, c-format
 msgid ""
 "SAX Parse Error during %ls\n"
 "%ls."
 msgstr ""
 
-#: ../../../core/core_st.cpp:326
+#: ../../../core/core_st.cpp:342
 #, c-format
 msgid "XML %ls: line %d character %d: %ls"
 msgstr ""
 
-#: ../../../core/core_st.cpp:327
+#: ../../../core/core_st.cpp:343
 msgid ""
 "*** Invalid XML characters found - see exported XML file for more details ***"
 msgstr ""
 
-#: ../../../core/core_st.cpp:328
+#: ../../../core/core_st.cpp:344
 msgid "Internal error: Couldn't initialize config file XML structure"
 msgstr ""
 
-#: ../../../core/core_st.cpp:329
+#: ../../../core/core_st.cpp:345
 msgid ""
 "A filter was active. Export of data was restricted to include only those "
 "displayed."
 msgstr ""
 
-#: ../../../core/core_st.cpp:330
+#: ../../../core/core_st.cpp:346
 msgid "Export of data was restricted to certain fields by the user."
 msgstr ""
 
-#: ../../../core/core_st.cpp:331
+#: ../../../core/core_st.cpp:347
 msgid ""
 "Note: These Password Policies will not replace existing policies with the "
 "same name in the current database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:332
+#: ../../../core/core_st.cpp:348
 msgid ""
 "Note: These preferences are only used when importing into an empty database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:333
+#: ../../../core/core_st.cpp:349
 msgid "Subset of entries restricted by the following rule:"
 msgstr ""
 
-#: ../../../core/core_st.cpp:334
+#: ../../../core/core_st.cpp:350
 msgid ""
 "The user specified that the following fields be excluded from the export:"
 msgstr ""
 
-#: ../../../core/core_st.cpp:335
+#: ../../../core/core_st.cpp:351
 #, c-format
 msgid ""
 "Configuration file error:\n"
@@ -6071,114 +6142,58 @@ msgid ""
 "offset approximately at %d"
 msgstr ""
 
-#: ../../../core/core_st.cpp:336
+#: ../../../core/core_st.cpp:352
 #, fuzzy
 msgid "import"
 msgstr "Importato "
 
-#: ../../../core/core_st.cpp:337
+#: ../../../core/core_st.cpp:353
 #, fuzzy
 msgid "Unable to load configuration file"
 msgstr "Impossibile inviare l'email"
 
-#: ../../../core/core_st.cpp:338
+#: ../../../core/core_st.cpp:354
 msgid ""
 "Failed to lock configuration file - opened by another instance of "
 "PasswordSafe?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:339
+#: ../../../core/core_st.cpp:355
 #, fuzzy
 msgid "Unable to save configuration file"
 msgstr "Impossibile inviare l'email"
 
-#: ../../../core/core_st.cpp:340
+#: ../../../core/core_st.cpp:356
 #, fuzzy
 msgid "validation"
 msgstr "&Convalida"
 
-#: ../../../core/core_st.cpp:342
+#: ../../../core/core_st.cpp:358
 msgid " (EasyVision Symbols)"
 msgstr ""
 
-#: ../../../core/core_st.cpp:343
+#: ../../../core/core_st.cpp:359
 #, fuzzy, c-format
 msgid "Yes (at least %d)"
 msgstr "(Almeno "
 
-#: ../../../core/core_st.cpp:344
+#: ../../../core/core_st.cpp:360
 #, fuzzy
 msgid " (Pronounceable Symbols)"
 msgstr "Genera password pronunciabili"
 
-#: ../../../core/core_st.cpp:345
+#: ../../../core/core_st.cpp:361
 #, c-format
 msgid "Yes - At least %d from %ls: %ls%ls"
 msgstr ""
 
-#: ../../../core/core_st.cpp:346
-#, c-format
-msgid "\tGroup='%ls', Title='%ls', User='%ls'"
-msgstr ""
-
-#: ../../../core/core_st.cpp:347
-#, c-format
-msgid ""
-"Compare complete of current database:\n"
-"\t %ls\n"
-" and:\n"
-"\t %ls\n"
-msgstr ""
-
-#: ../../../core/core_st.cpp:348
-#, c-format
-msgid "\tNo entries were found containing search string '%ls' %ls"
-msgstr ""
-
-#: ../../../core/core_st.cpp:349
-#, c-format
-msgid "\tThe following entries contain search string '%ls' %ls"
-msgstr ""
-
-#: ../../../core/core_st.cpp:350
 #, fuzzy
-msgid "Export DB"
-msgstr "esportazione"
+#~ msgid "Import XML"
+#~ msgstr "Importa &XML"
 
-#: ../../../core/core_st.cpp:351
 #, fuzzy
-msgid "Import KeePassV1 CSV"
-msgstr "Importa_KeePassV1_CSV"
-
-#: ../../../core/core_st.cpp:352
-#, fuzzy
-msgid "Import KeePassV1 TXT"
-msgstr "Importa_KeePassV1_TXT"
-
-#: ../../../core/core_st.cpp:353
-#, fuzzy
-msgid "Import XML"
-msgstr "Importa &XML"
-
-#: ../../../core/core_st.cpp:354
-#, fuzzy
-msgid "Import Text"
-msgstr "Importa T&esto"
-
-#: ../../../core/core_st.cpp:355
-msgid "Merge"
-msgstr "Unisci"
-
-#: ../../../core/core_st.cpp:356
-#, fuzzy
-msgid "Compare"
-msgstr "&Confronta"
-
-#~ msgid "Import_Text"
-#~ msgstr "Importa_Testo"
-
-#~ msgid "Import_XML"
-#~ msgstr "Importa_XML"
+#~ msgid "Import Text"
+#~ msgstr "Importa T&esto"
 
 #~ msgid "Advanced..."
 #~ msgstr "Avanzate..."

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ko.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-28 12:52+0100\n"
+"POT-Creation-Date: 2021-03-19 21:58+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -236,7 +236,7 @@ msgstr "요일 및 시간"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:348
 #: ../../../ui/wxWidgets/HelpMap.h:41 ../../../ui/wxWidgets/HelpMap.h:49
-#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:141
+#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:143
 msgid "Password Policy"
 msgstr "비밀번호 정책"
 
@@ -250,7 +250,7 @@ msgid "Set Date/Time"
 msgstr "날짜/시간 설정"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:370
-#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:137
+#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:139
 msgid "Password"
 msgstr "비밀번호"
 
@@ -534,14 +534,14 @@ msgstr "대문자 사용"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:747
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:281
-#: ../../../core/core_st.cpp:260
+#: ../../../core/core_st.cpp:262
 #, fuzzy
 msgid "Use digits"
 msgstr "숫자 사용(&D)"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:771
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:305
-#: ../../../core/core_st.cpp:262
+#: ../../../core/core_st.cpp:264
 #, fuzzy
 msgid "Use symbols"
 msgstr "기본 사용자 이름"
@@ -576,7 +576,7 @@ msgstr "발음 가능한 비밀번호 생성(&P)"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:815
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:350
-#: ../../../core/core_st.cpp:253
+#: ../../../core/core_st.cpp:255
 msgid "Or"
 msgstr "또는"
 
@@ -624,7 +624,7 @@ msgstr "속성"
 #: ../../../ui/wxWidgets/CreateShortcutDlg.cpp:219
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:269
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:274
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
 msgid "Text"
 msgstr "텍스트"
 
@@ -680,7 +680,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:160
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:173
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:192
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:301
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:317
 msgid "Unknown"
 msgstr "알 수 없는"
 
@@ -795,7 +795,7 @@ msgstr "[노트가 숨겨져있음 - 표시하려면 이곳을 클릭하세요]"
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:1653
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2145
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2820
-#: ../../../core/core_st.cpp:74
+#: ../../../core/core_st.cpp:76
 msgid "Default Policy"
 msgstr ""
 
@@ -816,7 +816,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:144
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:151
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:159
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:200
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:201
 #: ../../../ui/wxWidgets/PWSafeApp.cpp:367
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:737
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:756
@@ -840,7 +840,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:249
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:277
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:316
-#: ../../../core/core_st.cpp:274
+#: ../../../core/core_st.cpp:288
 msgid "Error"
 msgstr "오류"
 
@@ -1018,7 +1018,7 @@ msgid "Synchronize this item..."
 msgstr "동기화(&Y)..."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:482
-#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:357
+#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:286
 msgid "Synchronize"
 msgstr "동기화"
 
@@ -1100,8 +1100,8 @@ msgid "Current safe was opened read-only"
 msgstr "읽기 전용 모드로 열기"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:793
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:996
-#: ../../../ui/wxWidgets/SyncWizard.cpp:618
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
+#: ../../../ui/wxWidgets/SyncWizard.cpp:619
 #, fuzzy, c-format
 msgid ""
 "The database:\n"
@@ -1119,7 +1119,7 @@ msgstr ""
 "사를 통해 수정해 주십시오."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:794
-#: ../../../ui/wxWidgets/SyncWizard.cpp:617
+#: ../../../ui/wxWidgets/SyncWizard.cpp:618
 msgid "Synchronization failed"
 msgstr "동기화 실패"
 
@@ -1486,7 +1486,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/GridCtrl.cpp:164
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:292
-#: ../../../core/core_st.cpp:147
+#: ../../../core/core_st.cpp:149
 msgid "Title"
 msgstr "주제"
 
@@ -1709,7 +1709,7 @@ msgid "Value"
 msgstr "값:"
 
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:291
-#: ../../../core/core_st.cpp:133
+#: ../../../core/core_st.cpp:135
 msgid "Group"
 msgstr "그룹"
 
@@ -1794,17 +1794,17 @@ msgstr ""
 msgid "Error parsing Run Command"
 msgstr "실행 명령 분석 실패"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:56
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:57
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:355
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:362
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:166
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:623
 msgid "Write Error"
 msgstr "쓰기 오류"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:61
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:62
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:165
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:622
 #, fuzzy
@@ -1814,7 +1814,7 @@ msgstr ""
 "\n"
 "파일을 쓸 수 없었습니다!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:64
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:65
 msgid ""
 "Write operation failed!\n"
 "File may have been corrupted.\n"
@@ -1824,7 +1824,7 @@ msgstr ""
 "파일이 손상된 것 같습니다.\n"
 "다른 곳에 저장해 보십시오"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:69
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:70
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 #, fuzzy
 msgid "Unknown error"
@@ -1833,36 +1833,36 @@ msgstr ""
 "\n"
 "알 수 없는 오류"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:90
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:91
 #, fuzzy
 msgid "Do you want to save changes to the password database: "
 msgstr "비밀번호 데이터베이스 %s에 변경 사항을 저장하시겠습니까?:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:145
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:146
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:557
 msgid "Please choose a name for the new database"
 msgstr "새 데이터베이스에 사용할 이름을 지정해 주십시오"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:155
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:156
 #, fuzzy
 msgid "psafe3 files (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 msgstr "Password Safe 데이터베이스 (*.psafe3)|*.psafe3|모든 파일 (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Lock is done by yourself"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Remove Lock?"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:194
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:195
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:602
 #, fuzzy
 msgid "Could not lock file.\n"
@@ -1871,18 +1871,18 @@ msgstr ""
 "\n"
 "파일을 읽을 수 없었습니다!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:196
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:197
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:452
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:604
 msgid "Locked by "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:236
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:237
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:515
 msgid "Please Choose a Database to Open:"
 msgstr "불러올 데이터베이스를 선택하세요:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:353
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Save database elsewhere or with "
@@ -1892,7 +1892,7 @@ msgid ""
 msgstr ""
 "%s. 데이터베이스를 다른 이름으로 저장하거나, 저장하지 말고 종료해주십시오."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:360
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Do you wish to save changes to your "
@@ -1900,12 +1900,12 @@ msgid ""
 msgstr ""
 "%s. 데이터베이스를 다른 이름으로 저장하거나, 저장하지 말고 종료해주십시오."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 msgid "Unable to create intermediate backup."
 msgstr "임시 백업본을 생성하는 데 실패했습니다."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:386
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:387
 #, c-format
 msgid ""
 "The original database, \"%ls\", is in pre-3.0 format. It will be unchanged.\n"
@@ -1914,12 +1914,12 @@ msgid ""
 "the \"File->Export To-> Old (1.x or 2) format\" command."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:388
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:389
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:447
 msgid "File version warning"
 msgstr "파일 버전 경고"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:445
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
 #, c-format
 msgid ""
 "The original database, '%ls', is in pre-3.0 format. The data will now be "
@@ -1928,15 +1928,15 @@ msgid ""
 "Old (1.x or 2) format' command."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:458
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
 msgid "Please choose a name for the current (Untitled) database:"
 msgstr "현재 (제목없는) 데이터베이스에 사용할 이름을 지정해 주십시오:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:460
 msgid "Please choose a new name for the current database:"
 msgstr "현재 데이터베이스의 새 이름을 지정해 주십시오:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:467
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:468
 #, fuzzy
 msgid ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|"
@@ -1945,7 +1945,7 @@ msgstr ""
 "Password Safe 데이터베이스 (*.psafe3; *.dat)|*.psafe3; *.dat|모든 파일 (*.*)|"
 "*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:479
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -1956,143 +1956,143 @@ msgstr ""
 "\n"
 "파일이 현재 %ls에 의해 잠겨져 있습니다"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:481
 msgid "File lock error"
 msgstr "파일 잠금 오류"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:547
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
 #, fuzzy
 msgid "Do you wish to save this restored database as new database?"
 msgstr "비밀번호 데이터베이스 %s에 변경 사항을 저장하시겠습니까?:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:549
 #, fuzzy
 msgid "Unsaved restored database"
 msgstr "in the database"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:580
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:581
 #, fuzzy
 msgid "Do you want to save changes to the password database"
 msgstr "비밀번호 데이터베이스 %s에 변경 사항을 저장하시겠습니까?:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:617
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:618
 msgid "Export Text"
 msgstr "텍스트 보내기"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:621
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:622
 #, fuzzy
 msgid "Export Text failed"
 msgstr "텍스트 불러오기 실패"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:623
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
 msgid "Please name the plaintext file"
 msgstr "텍스트 파일의 이름을 지정해 주십시오"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1143
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:625
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1144
 #, fuzzy
 msgid ""
 "Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
 msgstr "텍스트 파일 (*.txt)|*.txt|CSV 파일 (*.csv)|*.csv|모든 파일 (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:634
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:635
 msgid "Advanced Text Export Options"
 msgstr "고급 텍스트 보내기 옵션"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:654
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:697
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:655
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:698
 #, fuzzy
 msgid "export"
 msgstr "exported"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:660
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:661
 msgid "Export XML"
 msgstr "XML 보내기"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:664
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:665
 #, fuzzy
 msgid "Export XML failed"
 msgstr "XML 설정 불러오기 실패"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:666
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
 msgid "Please name the XML file"
 msgstr "XML 파일의 이름을 지정해주세요"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:668
 #, fuzzy
 msgid "XML files (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 msgstr "XML 파일 (*.xml)|*.xml|모든 파일 (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:678
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:679
 msgid "Advanced XML Export Options"
 msgstr "고급 XML 보내기 옵션"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:712
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:716
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:713
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:717
 #, fuzzy
 msgid "Password Safe Databases (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 msgstr ""
 "Password Safe 데이터베이스 (*.psafe3; *.dat)|*.psafe3; *.dat|모든 파일 (*.*)|"
 "*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:720
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:721
 #, fuzzy
 msgid "Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 msgstr ""
 "Password Safe 데이터베이스 (*.psafe3; *.dat)|*.psafe3; *.dat|모든 파일 (*.*)|"
 "*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:731
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:732
 msgid "Please name the exported database"
 msgstr "내보낼 데이터베이스의 이름을 지정해 주십시오"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:748
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:749
 msgid "Could not figure out why PasswordSafeFrame::OnExportVx was invoked"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:782
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:783
 msgid "You must save this database before it can be exported."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 #, fuzzy
 msgid "Exporting database: "
 msgstr "데이터베이스 병합: %s\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid " to "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:841
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:842
 #, fuzzy
 msgid "Export complete.  Do you wish to see a detailed report?"
 msgstr "정말 이것을 교체하시겠습니까?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:852
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:853
 msgid "No entries satisfied your selection criteria and so none were exported!"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:865
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:866
 msgid "Passkey incorrect"
 msgstr "비밀번호 불일치"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:873
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
 msgid ""
 "The current database was opened in read-only mode.  You cannot import into "
 "it."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:875
 #, fuzzy
 msgid "Import text"
 msgstr "텍스트 불러오기(&T)"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:882
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
 #, fuzzy
 msgid "The database:"
 msgstr "in the database"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
 #, fuzzy
 msgid "has duplicate entries with the same group/title/user combination."
 msgstr ""
@@ -2103,33 +2103,33 @@ msgstr ""
 "가 같은 그룹/제목/사용자 모음의 항목들을 복제했습니다. 데이터베이스 유효성 검"
 "사를 통해 수정해 주십시오."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
 msgid "  Please fix by validating database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:931
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:886
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:932
 #, fuzzy
 msgid "Import Text failed"
 msgstr "텍스트 불러오기 실패"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 #, fuzzy, c-format
 msgid "%ls file being imported: %ls"
 msgstr "%ls 파일을 불러왔습니다: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:921
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:926
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:223
-#: ../../../ui/wxWidgets/SyncWizard.cpp:572
+#: ../../../ui/wxWidgets/SyncWizard.cpp:573
 #: ../../../ui/wxWidgets/wxUtilities.cpp:59
 #: ../../../ui/wxWidgets/wxUtilities.cpp:64
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "File Read Error"
 msgstr "파일 읽기 오류"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:923
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:222
 #: ../../../ui/wxWidgets/wxUtilities.cpp:58
 #, fuzzy
@@ -2139,7 +2139,7 @@ msgstr ""
 "\n"
 "파일을 읽을 수 없었습니다!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:928
 #, fuzzy
 msgid "Invalid format"
 msgstr ""
@@ -2147,77 +2147,77 @@ msgstr ""
 "\n"
 "잘못된 형식"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Updated "
 msgstr "%d %s 갱신함"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Imported "
 msgstr "불러옴"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entry"
 msgstr "항목"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entries"
 msgstr "항목들"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
 #, fuzzy
 msgid "Skipped "
 msgstr ""
 "\n"
 "%d %s 생략됨"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:957
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:958
 #, fuzzy
 msgid "with Password History errors "
 msgstr ""
 "\n"
 "와 %d 비밀번호 내역 오류"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid "Renamed "
 msgstr "이름 변경"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed successfully"
 msgstr "성공적으로 완료했습니다"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed but ...."
 msgstr "완료하였습니다만..."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:981
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1127
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1197
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1218
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1279
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:982
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1128
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1219
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
 #, fuzzy
 msgid "Do you wish to see a detailed report?"
 msgstr "정말 이것을 교체하시겠습니까?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1045
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:998
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1046
 msgid "Import XML failed"
 msgstr "XML 설정 불러오기 실패"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1007
-#: ../../../core/core_st.cpp:238
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../core/core_st.cpp:240
 #, fuzzy, c-format
 msgid ""
 "Can't find XML Schema Definition file (%ls) in your PasswordSafe Application "
@@ -2227,20 +2227,20 @@ msgstr ""
 "Password Safe 실행 폴더에서 XML 스키마 정의 파일 (%ls) 을 찾을 수 없습니다.\n"
 "설치 파일에서 복사하시거나, Password Safe를 재설치 해 주십시오."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 #, fuzzy
 msgid "Missing XSD File - "
 msgstr "xsd 파일 없음"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid " Build"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 msgid "XML"
 msgstr "XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1051
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1052
 #, fuzzy, c-format
 msgid ""
 "File: %ls failed validation against XML Schema:\n"
@@ -2251,7 +2251,7 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1057
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1058
 #, fuzzy, c-format
 msgid ""
 "File: %ls passed Validation but had the following errors during import:\n"
@@ -2263,25 +2263,25 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1078
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1079
 msgid "The following records were skipped:"
 msgstr "다음 레코드가 무시되었습니다:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1080
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1081
 #, c-format
 msgid " / skipped %d"
 msgstr " / %d 생략됨"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1085
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1086
 msgid "The following records had errors in their Password History:"
 msgstr "다음 항목들이 비밀번호 내역에서 오류를 가지고 있습니다:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1087
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1088
 #, c-format
 msgid " / with Password History errors %d"
 msgstr "/ %d 비밀번호 과거 오류"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1092
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1093
 msgid ""
 "The following records were renamed as an entry already exists in your "
 "database or in the Import file:"
@@ -2289,12 +2289,12 @@ msgstr ""
 "다음 레코드는 이미 당신의 데이터베이스에 존재하거나 불러온 파일으로써 이름이 "
 "변경되었습니다:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1094
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1095
 #, c-format
 msgid " / renamed %d"
 msgstr " / %d 이름이 변경됨"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1099
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1100
 #, fuzzy, c-format
 msgid ""
 "File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See "
@@ -2303,25 +2303,25 @@ msgstr ""
 "파일: %ls 을 불러왔습니다 (유효한 항목 %d / %d%ls%ls%ls 불러옴). 자세한 내용"
 "은 보고서를 참조하십시오."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:95
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:97
 msgid "entry"
 msgstr "항목"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:93
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:95
 msgid "entries"
 msgstr "항목들"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1107
 #, fuzzy, c-format
 msgid ""
 "Validated %d %ls\n"
@@ -2332,26 +2332,26 @@ msgstr ""
 "\n"
 "%d %ls 불러옴"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1114
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1115
 msgid "XML import not supported in this release"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1117
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1118
 #, c-format
 msgid "XML import: Unexpected return code(%d)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1141
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1142
 msgid "Please Choose a KeePass Text File to Import"
 msgstr "불러올 KeePass 텍스트 파일을 선택해 주십시오"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1163
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1164
 #, fuzzy, c-format
 msgid "Text file being imported: %ls"
 msgstr "파일을 불러왔습니다: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1180
-#: ../../../ui/wxWidgets/SyncWizard.cpp:602
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/SyncWizard.cpp:603
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2362,11 +2362,11 @@ msgstr ""
 "\n"
 "파일을 읽을 수 없었습니다!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1182
 msgid "File open error"
 msgstr "파일 열기 오류"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1195
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1196
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2377,21 +2377,21 @@ msgstr ""
 "\n"
 "잘못된 형식"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1199
 msgid "Import failed"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1214
 #, fuzzy, c-format
 msgid "Imported %d %ls"
 msgstr "%d %ls 불러옴"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1265
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1266
 #, fuzzy
 msgid "Merging database: "
 msgstr "데이터베이스 병합: %s\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1281
 #, fuzzy
 msgid "Merge Complete"
 msgstr "비교 완료"
@@ -2487,16 +2487,16 @@ msgid ""
 "Try exiting and restarting program."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #, fuzzy
 msgid " file '"
 msgstr "필터 관리"
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid "' not readable"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #: ../../../ui/wxWidgets/ViewReportDlg.cpp:32
 msgid "View Report"
 msgstr "보고서 보기"
@@ -2546,7 +2546,7 @@ msgid "Please select a valid file"
 msgstr "열람할 리포트를 선택해 주십시오."
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:123
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:249
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:251
 msgid "None"
 msgstr "None"
 
@@ -2560,7 +2560,7 @@ msgid "Incremented Number [001-999]"
 msgstr "증가수 [001-999]"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:132
-#: ../../../core/core_st.cpp:66
+#: ../../../core/core_st.cpp:68
 #, fuzzy
 msgid "Copy password to clipboard"
 msgstr "비밀번호를 클립보드에 복사(&C)"
@@ -2572,37 +2572,37 @@ msgstr "선택한 항목을 편집"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:134
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:623
-#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:62
+#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:64
 msgid "Autotype"
 msgstr "자동 입력"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:135
-#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:63
+#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:65
 msgid "Browse to URL"
 msgstr "URL으로 탐색"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:136
-#: ../../../core/core_st.cpp:65
+#: ../../../core/core_st.cpp:67
 msgid "Copy notes to clipboard"
 msgstr "노트를 클립보드에 복사"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:137
-#: ../../../core/core_st.cpp:68
+#: ../../../core/core_st.cpp:70
 msgid "Copy username to clipboard"
 msgstr "사용자 이름을 클립보드에 복사"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:138
-#: ../../../core/core_st.cpp:67
+#: ../../../core/core_st.cpp:69
 msgid "Copy password to clipboard, minimize"
 msgstr "비밀번호를 클립보드에 복사하고 창 최소화"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:139
-#: ../../../core/core_st.cpp:64
+#: ../../../core/core_st.cpp:66
 msgid "Browse to URL + Autotype"
 msgstr "URL으로 탐색하고 자동입력"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:140
-#: ../../../core/core_st.cpp:69 ../../../core/core_st.cpp:144
+#: ../../../core/core_st.cpp:71 ../../../core/core_st.cpp:146
 msgid "Run Command"
 msgstr "명령 실행"
 
@@ -3027,24 +3027,24 @@ msgstr ""
 msgid "Don't show this warning again"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:849
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:854
 msgid "Missing help definition for page \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:850
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
 msgid "\" of \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:860
 msgid "Missing help definition for window \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:866
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:871
 #, fuzzy
 msgid "Please inform the developers."
 msgstr "이 필터의 이름을 지정해 주십시오"
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:867
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:872
 msgid "Help Undefined"
 msgstr ""
 
@@ -3779,6 +3779,7 @@ msgid "search"
 msgstr "검색(&S)"
 
 #: ../../../ui/wxWidgets/PasswordSafeSearch.cpp:427
+#: ../../../core/core_st.cpp:280
 msgid "Find"
 msgstr "찾기"
 
@@ -3899,20 +3900,20 @@ msgstr "validation"
 msgid " empty)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:306
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:322
 #, fuzzy, c-format
 msgid "%ls on %ls"
 msgstr "%ls - %ls중에서"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:341
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:357
 msgid "Yes"
 msgstr "Yes"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:244
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:246
 msgid "No"
 msgstr "아니오"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:302
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:318
 #, fuzzy, c-format
 msgid "In Headers(%ls)/In Entries("
 msgstr "In Headers(%ls)/In Entries("
@@ -4101,7 +4102,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:457
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:269
-#: ../../../core/core_st.cpp:276
+#: ../../../core/core_st.cpp:290
 msgid "Warning"
 msgstr "경고"
 
@@ -4176,11 +4177,11 @@ msgstr ""
 "\n"
 "다른 "
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:96
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:98
 msgid "equals"
 msgstr "equals"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:83
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:85
 msgid "does not equal"
 msgstr "does not equal"
 
@@ -4188,23 +4189,23 @@ msgstr "does not equal"
 msgid "begins with"
 msgstr "begins with"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:78
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:80
 msgid "does not begin with"
 msgstr "does not begin with"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:90
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:92
 msgid "ends with"
 msgstr "ends with"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:82
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:84
 msgid "does not end with"
 msgstr "does not end with"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:56
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:58
 msgid "contains"
 msgstr "contains"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:79
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:81
 msgid "does not contain"
 msgstr "does not contain"
 
@@ -4263,79 +4264,79 @@ msgstr "확인"
 msgid "Cancel"
 msgstr "취소"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:143
+#: ../../../ui/wxWidgets/SyncWizard.cpp:144
 #, fuzzy
 msgid "synchronize"
 msgstr "동기화됨"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:220
+#: ../../../ui/wxWidgets/SyncWizard.cpp:221
 #, fuzzy
 msgid "Synchronize another database with currently open database"
 msgstr "이 데이터베이스와 통합할 대상 데이터베이스:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:349
+#: ../../../ui/wxWidgets/SyncWizard.cpp:350
 msgid "Introduction"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:353
+#: ../../../ui/wxWidgets/SyncWizard.cpp:354
 msgid ""
 "Synchronizing with another database will update the entries in your\n"
 "database with matching entries from the other database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:356
+#: ../../../ui/wxWidgets/SyncWizard.cpp:357
 msgid "More Info"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:359
+#: ../../../ui/wxWidgets/SyncWizard.cpp:360
 msgid ""
 "1. Two entries from different databases match if their Group, Title\n"
 "and User fields match."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:360
+#: ../../../ui/wxWidgets/SyncWizard.cpp:361
 msgid ""
 "2. You can select the fields to update, as well as filter the entries\n"
 "for synchronization."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:361
+#: ../../../ui/wxWidgets/SyncWizard.cpp:362
 msgid ""
 "3. Only existing entries in your database are updated.  No new entries are\n"
 "added or existing entries removed during this process."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:362
+#: ../../../ui/wxWidgets/SyncWizard.cpp:363
 msgid ""
 "4. You can undo the operation once it is complete, but won't be\n"
 "able to abort it mid-way."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:379
+#: ../../../ui/wxWidgets/SyncWizard.cpp:380
 #, fuzzy
 msgid "Select another database"
 msgstr "데이터베이스 선택"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:381
+#: ../../../ui/wxWidgets/SyncWizard.cpp:382
 msgid "Choose Database to Synchronize with \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:382
+#: ../../../ui/wxWidgets/SyncWizard.cpp:383
 #, fuzzy
 msgid "Please Choose a Database to Synchronize with current database"
 msgstr "현재 열려있는 데이터베이스와 비교할 데이터베이스를 선택해 주십시오"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:405
+#: ../../../ui/wxWidgets/SyncWizard.cpp:406
 #, fuzzy
 msgid "Synchronization options"
 msgstr "동기화 실패"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:429
+#: ../../../ui/wxWidgets/SyncWizard.cpp:430
 #, fuzzy
 msgid "Options Summary"
 msgstr "옵션"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:454
+#: ../../../ui/wxWidgets/SyncWizard.cpp:455
 #, fuzzy
 msgid ""
 "WARNING!!\n"
@@ -4346,58 +4347,58 @@ msgstr ""
 "경고: 계속 진행하시면, 현재 존재하는 데이터베이스 내의 항목의 필드가 선택하"
 "신 입력 데이터베이스의 내용으로 교체됩니다."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:471
+#: ../../../ui/wxWidgets/SyncWizard.cpp:472
 msgid " will be updated with corresponding entries from \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:478
+#: ../../../ui/wxWidgets/SyncWizard.cpp:479
 msgid "All fields in matching entries will be updated"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:484
+#: ../../../ui/wxWidgets/SyncWizard.cpp:485
 msgid "Following fields in matching entries will be updated:"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:488
+#: ../../../ui/wxWidgets/SyncWizard.cpp:489
 #, fuzzy
 msgid "Following fields will not be updated:"
 msgstr "다음 항목이 처리될 것입니다:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:507
+#: ../../../ui/wxWidgets/SyncWizard.cpp:508
 #, fuzzy
 msgid "Synchronization status"
 msgstr "동기화 실패"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:525
+#: ../../../ui/wxWidgets/SyncWizard.cpp:526
 msgid "See a detailed report"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:561
+#: ../../../ui/wxWidgets/SyncWizard.cpp:562
 msgid "Your database is being synchronized with \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:571
+#: ../../../ui/wxWidgets/SyncWizard.cpp:572
 msgid "There was an error during synchronization"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:585
+#: ../../../ui/wxWidgets/SyncWizard.cpp:586
 #, c-format
 msgid "Your database has been synchronized with \"%ls\""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:586
+#: ../../../ui/wxWidgets/SyncWizard.cpp:587
 #, fuzzy, c-format
 msgid "%ld %ls updated"
 msgstr ""
 "\n"
 "다음 %ls %ls 가 갱신됨:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:589
 #, fuzzy
 msgid "Synchronization completed successfully"
 msgstr "성공적으로 완료했습니다"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:604
+#: ../../../ui/wxWidgets/SyncWizard.cpp:605
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4411,7 +4412,7 @@ msgstr ""
 "데이터가 사라지거나 변경될 수 있습니다.\n"
 "이대로 진행하시겠습니까?"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:606
+#: ../../../ui/wxWidgets/SyncWizard.cpp:607
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4422,24 +4423,24 @@ msgstr ""
 "\n"
 "알 수 없는 오류"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:640
+#: ../../../ui/wxWidgets/SyncWizard.cpp:641
 #, fuzzy, c-format
 msgid "Synchronizing from database: %ls\n"
 msgstr "데이터베이스로부터 동기화 중: %ls\n"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:643
+#: ../../../ui/wxWidgets/SyncWizard.cpp:644
 msgid "synchronized"
 msgstr "동기화됨"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:322
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:338
 msgid "was"
 msgstr "was"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:323
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:339
 msgid "were"
 msgstr "were"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:298
+#: ../../../ui/wxWidgets/SyncWizard.cpp:733 ../../../core/core_st.cpp:314
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4448,7 +4449,7 @@ msgstr ""
 "\n"
 "다음 %ls %ls 가 갱신됨:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:297
+#: ../../../ui/wxWidgets/SyncWizard.cpp:749 ../../../core/core_st.cpp:313
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4620,7 +4621,7 @@ msgstr ""
 "이 바로가기 항목 [%s:%s:%s] 의 상대가 일반 항목이 아니거나 이미 바로가기 항목"
 "입니다."
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:94
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:96
 #, c-format
 msgid ""
 "The following entries had a policy name that already existed in this "
@@ -4725,13 +4726,13 @@ msgstr ""
 "데이터가 사라지거나 변경될 수 있습니다.\n"
 "이대로 진행하시겠습니까?"
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:381
+#: ../../../ui/wxWidgets/wxUtilities.cpp:390
 msgid ""
 "An error occurred while trying to get the image data from database item.\n"
 "Therefore, the image cannot be displayed in the preview."
 msgstr ""
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:394
+#: ../../../ui/wxWidgets/wxUtilities.cpp:403
 msgid ""
 "An error occurred while trying to load the image data into the preview "
 "area.\n"
@@ -4873,7 +4874,7 @@ msgstr ""
 "\n"
 "클립보드에 비밀번호 복사"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:149
+#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:151
 msgid "Username"
 msgstr "사용자 이름"
 
@@ -4884,7 +4885,7 @@ msgstr ""
 "\n"
 "클립보드에 사용자 이름 복사"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:136
+#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:138
 #, fuzzy
 msgid "Notes"
 msgstr "메모(&N):"
@@ -4920,7 +4921,7 @@ msgstr ""
 msgid "Browse URL"
 msgstr "URL으로 탐색"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:70
+#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:72
 #, fuzzy
 msgid "Send Email"
 msgstr "전자우편 보내기"
@@ -5118,69 +5119,87 @@ msgid "(case sensitive)"
 msgstr "(대소문자 구별)"
 
 #: ../../../core/core_st.cpp:50
+#, fuzzy, c-format
+msgid ""
+"Compare complete of current database:\n"
+"\t %ls\n"
+" and:\n"
+"\t %ls\n"
+msgstr ""
+"현재 데이터베이스의 비교 완료\n"
+"\t %s\n"
+" 그리고:\n"
+"\t %s"
+
+#: ../../../core/core_st.cpp:51
+#, fuzzy, c-format
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\t그룹:'%s'; 제목:'%s'; 사용자 이름:'%s'"
+
+#: ../../../core/core_st.cpp:52
 msgid "C:F[R-O]"
 msgstr "C:F[R-O]"
 
-#: ../../../core/core_st.cpp:51
+#: ../../../core/core_st.cpp:53
 msgid "C:F[R/W]"
 msgstr "C:F[R/W]"
 
-#: ../../../core/core_st.cpp:52
+#: ../../../core/core_st.cpp:54
 msgid "C:None  "
 msgstr "C:None  "
 
-#: ../../../core/core_st.cpp:53
+#: ../../../core/core_st.cpp:55
 msgid "C:Reg   "
 msgstr "C:Reg   "
 
-#: ../../../core/core_st.cpp:54
+#: ../../../core/core_st.cpp:56
 msgid "conflict"
 msgstr "conflict"
 
-#: ../../../core/core_st.cpp:55
+#: ../../../core/core_st.cpp:57
 msgid "conflicts"
 msgstr "conflicts"
 
-#: ../../../core/core_st.cpp:57
+#: ../../../core/core_st.cpp:59
 #, fuzzy
 msgid "contains all of"
 msgstr "contains"
 
-#: ../../../core/core_st.cpp:58
+#: ../../../core/core_st.cpp:60
 #, fuzzy
 msgid "contains any of"
 msgstr "contains"
 
-#: ../../../core/core_st.cpp:59
+#: ../../../core/core_st.cpp:61
 #, fuzzy
 msgid "copied"
 msgstr "URL 복사됨"
 
-#: ../../../core/core_st.cpp:60
+#: ../../../core/core_st.cpp:62
 #, fuzzy, c-format
 msgid "%ls - Copied %ls"
 msgstr "%ls - 복사됨 %ls"
 
-#: ../../../core/core_st.cpp:61
+#: ../../../core/core_st.cpp:63
 #, fuzzy, c-format
 msgid " Current default (%ls)"
 msgstr "현재 기본값 (%ls)"
 
-#: ../../../core/core_st.cpp:71
+#: ../../../core/core_st.cpp:73
 msgid "View/Edit selected entry"
 msgstr "선택한 항목을 편집"
 
-#: ../../../core/core_st.cpp:72
+#: ../../../core/core_st.cpp:74
 #, fuzzy
 msgid " (application default)"
 msgstr "사용된 프로그램:"
 
-#: ../../../core/core_st.cpp:73
+#: ../../../core/core_st.cpp:75
 #, fuzzy
 msgid "default symbol set"
 msgstr "기본 사용자 이름"
 
-#: ../../../core/core_st.cpp:75
+#: ../../../core/core_st.cpp:77
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5189,12 +5208,12 @@ msgid ""
 "entry's password)?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:76
+#: ../../../core/core_st.cpp:78
 #, fuzzy
 msgid "Delete Base Entry Confirmation"
 msgstr "기본 항목 삭제 확인"
 
-#: ../../../core/core_st.cpp:77
+#: ../../../core/core_st.cpp:79
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5202,42 +5221,42 @@ msgid ""
 "Please confirm to continue (All shortcuts to this entry will be deleted)?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:80
+#: ../../../core/core_st.cpp:82
 #, fuzzy
 msgid "does not contain all of"
 msgstr "does not contain"
 
-#: ../../../core/core_st.cpp:81
+#: ../../../core/core_st.cpp:83
 #, fuzzy
 msgid "does not contain any of"
 msgstr "does not contain"
 
-#: ../../../core/core_st.cpp:84
+#: ../../../core/core_st.cpp:86
 #, c-format
 msgid " Drag # %d"
 msgstr "# %d 을(를) 드래그"
 
-#: ../../../core/core_st.cpp:85
-#, c-format
-msgid "%s - Drag & Drop %s"
-msgstr ""
+#: ../../../core/core_st.cpp:87
+#, fuzzy, c-format
+msgid "%ls - Drag & Drop %ls"
+msgstr "%ls - 복사됨 %ls"
 
-#: ../../../core/core_st.cpp:86
+#: ../../../core/core_st.cpp:88
 #, c-format
 msgid " Duplicate # %d"
 msgstr "# %d 을(를) 복제"
 
-#: ../../../core/core_st.cpp:87
+#: ../../../core/core_st.cpp:89
 #, fuzzy
 msgid "empty group"
 msgstr "아래 그룹을 불러오시겠습니까?"
 
-#: ../../../core/core_st.cpp:88
+#: ../../../core/core_st.cpp:90
 #, fuzzy
 msgid "empty groups"
 msgstr "#groups"
 
-#: ../../../core/core_st.cpp:89
+#: ../../../core/core_st.cpp:91
 #, fuzzy, c-format
 msgid ""
 "Trouble with a non-textual (e.g., time) field in record '%ls' - please check "
@@ -5246,127 +5265,127 @@ msgstr ""
 "'%ls' 레코드에서 텍스트가 아닌 필드에 오류가 발생 - 데이터를 꼼꼼히 살펴 주십"
 "시오."
 
-#: ../../../core/core_st.cpp:91
+#: ../../../core/core_st.cpp:93
 msgid "End Report"
 msgstr "보고 중지"
 
-#: ../../../core/core_st.cpp:92
+#: ../../../core/core_st.cpp:94
 msgid "--------------------------------------------------------------------------------"
 msgstr "--------------------------------------------------------------------------------"
 
-#: ../../../core/core_st.cpp:97
+#: ../../../core/core_st.cpp:99
 msgid "has expired"
 msgstr "has expired"
 
-#: ../../../core/core_st.cpp:98
+#: ../../../core/core_st.cpp:100
 msgid "Entries with a password expiry"
 msgstr "비밀번호 만료 일자와 항목"
 
-#: ../../../core/core_st.cpp:99
+#: ../../../core/core_st.cpp:101
 #, c-format
 msgid "within %d day(s)"
 msgstr "within %d day(s)"
 
-#: ../../../core/core_st.cpp:100
+#: ../../../core/core_st.cpp:102
 #, fuzzy, c-format
 msgid "DB Export from database: '%s'"
 msgstr "데이터베이스 병합: %s\n"
 
-#: ../../../core/core_st.cpp:101
+#: ../../../core/core_st.cpp:103
 msgid "First character of variable name must be alphabetic"
 msgstr "변수 이름의 첫 글자는 반드시 알파벳이 와야 합니다"
 
-#: ../../../core/core_st.cpp:102
+#: ../../../core/core_st.cpp:104
 msgid "Index not numeric"
 msgstr "색인이 숫자가 아님"
 
-#: ../../../core/core_st.cpp:103
+#: ../../../core/core_st.cpp:105
 msgid "Input string is empty"
 msgstr "입력란이 비어있습니다"
 
-#: ../../../core/core_st.cpp:104
+#: ../../../core/core_st.cpp:106
 msgid "Characters present between end of index ']' and '}'"
 msgstr "인덱서 ']' 와 '}' 의 끝이 나타나기 전에 문자열이 존재합니다."
 
-#: ../../../core/core_st.cpp:105
+#: ../../../core/core_st.cpp:107
 msgid "Index is invalid or missing"
 msgstr "색인이 올바르지 않거나 손상되었습니다"
 
-#: ../../../core/core_st.cpp:106
+#: ../../../core/core_st.cpp:108
 msgid "Missing ending curly bracket for variable name"
 msgstr "변수 이름의 폐행문자가 없음"
 
-#: ../../../core/core_st.cpp:107
+#: ../../../core/core_st.cpp:109
 msgid "Missing ending round bracket for Autotype value"
 msgstr "자동 입력 값의 폐행문자가 없음"
 
-#: ../../../core/core_st.cpp:108
+#: ../../../core/core_st.cpp:110
 msgid "Missing ending square bracket for index value"
 msgstr "목차값의 폐행문자가 없음"
 
-#: ../../../core/core_st.cpp:109
+#: ../../../core/core_st.cpp:111
 msgid "There are unmatched quotes in the run command"
 msgstr "실행 명령에 짝이 맞지 않는 쌍따옴표가 있습니다"
 
-#: ../../../core/core_st.cpp:110
+#: ../../../core/core_st.cpp:112
 msgid "Variable name is empty"
 msgstr "변수 이름이 비어있습니다"
 
-#: ../../../core/core_st.cpp:111
+#: ../../../core/core_st.cpp:113
 msgid "Variable name must be alphanumeric"
 msgstr "변수 이름은 반드시 알파벳과 숫자로 구성되어야 합니다"
 
-#: ../../../core/core_st.cpp:112
+#: ../../../core/core_st.cpp:114
 msgid "an alias entry"
 msgstr "보조 항목"
 
-#: ../../../core/core_st.cpp:113
+#: ../../../core/core_st.cpp:115
 msgid "a base entry of an alias"
 msgstr "보조 항목의 기본 항목"
 
-#: ../../../core/core_st.cpp:114
+#: ../../../core/core_st.cpp:116
 msgid "  Field is too long."
 msgstr "필드 값이 너무 깁니다."
 
-#: ../../../core/core_st.cpp:115
+#: ../../../core/core_st.cpp:117
 msgid "  Field is too short."
 msgstr "필드 값이 너무 짧습니다."
 
-#: ../../../core/core_st.cpp:116
+#: ../../../core/core_st.cpp:118
 msgid "Error: A file with this name already exists"
 msgstr "오류: 같은 이름의 파일이 이미 존재합니다"
 
-#: ../../../core/core_st.cpp:117
+#: ../../../core/core_st.cpp:119
 msgid "The file was not found."
 msgstr "파일을 찾을 수 없습니다."
 
-#: ../../../core/core_st.cpp:118
+#: ../../../core/core_st.cpp:120
 msgid "Error: File is read-only"
 msgstr "오류: 파일이 읽기전용 입니다."
 
-#: ../../../core/core_st.cpp:119
+#: ../../../core/core_st.cpp:121
 msgid "Error while writing file! Try saving in a different location"
 msgstr "파일 작성 중 오류가 발생했습니다! 다른 곳에 저장해 보십시오"
 
-#: ../../../core/core_st.cpp:120
+#: ../../../core/core_st.cpp:122
 #, fuzzy
 msgid "File is too big."
 msgstr "필드 값이 너무 깁니다."
 
-#: ../../../core/core_st.cpp:121
+#: ../../../core/core_st.cpp:123
 #, fuzzy
 msgid "File is too short."
 msgstr "필드 값이 너무 짧습니다."
 
-#: ../../../core/core_st.cpp:122
+#: ../../../core/core_st.cpp:124
 msgid "File is truncated or otherwise corrupt. Please use backup database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:123
+#: ../../../core/core_st.cpp:125
 msgid "Cannot read file. Please check file permissions."
 msgstr "파일을 읽을 수 없습니다. 파일 권한을 점검해 보십시오."
 
-#: ../../../core/core_st.cpp:124
+#: ../../../core/core_st.cpp:126
 #, fuzzy, c-format
 msgid ""
 "Filter %ls already exists in the database, do you wish to replace it with "
@@ -5374,134 +5393,134 @@ msgid ""
 msgstr ""
 "%ls 필터가 이미 데이터베이스에 존재합니다만, 이 것으로 교체하시겠습니까?"
 
-#: ../../../core/core_st.cpp:125
+#: ../../../core/core_st.cpp:127
 #, fuzzy
 msgid "Current database filters have been exported to this database."
 msgstr "현재 데이터베이스와 비교할 대상: %s"
 
-#: ../../../core/core_st.cpp:126
+#: ../../../core/core_st.cpp:128
 msgid "Stored filters will be unusable until the file's restored."
 msgstr "파일을 다시 불러오기 전 까지 저장된 필터는 사용할 수 없습니다."
 
-#: ../../../core/core_st.cpp:127
+#: ../../../core/core_st.cpp:129
 msgid "Last Access Time"
 msgstr "최종 접근 시간:"
 
-#: ../../../core/core_st.cpp:128
+#: ../../../core/core_st.cpp:130
 msgid "Attachment Reference"
 msgstr ""
 
-#: ../../../core/core_st.cpp:129
+#: ../../../core/core_st.cpp:131
 msgid "AutoType"
 msgstr "자동입력"
 
-#: ../../../core/core_st.cpp:130
+#: ../../../core/core_st.cpp:132
 msgid "Created Time"
 msgstr "생성 시간"
 
-#: ../../../core/core_st.cpp:131
+#: ../../../core/core_st.cpp:133
 msgid "DCA"
 msgstr "DCA"
 
-#: ../../../core/core_st.cpp:132
+#: ../../../core/core_st.cpp:134
 msgid "e-mail"
 msgstr "전자우편"
 
-#: ../../../core/core_st.cpp:134
+#: ../../../core/core_st.cpp:136
 msgid "Group/Title"
 msgstr "그룹/주제"
 
-#: ../../../core/core_st.cpp:135
+#: ../../../core/core_st.cpp:137
 #, fuzzy
 msgid "Keyboard Shortcut"
 msgstr "바로가기 만들기"
 
-#: ../../../core/core_st.cpp:138
+#: ../../../core/core_st.cpp:140
 msgid "Password Modified Time"
 msgstr "비밀번호 수정 시간"
 
-#: ../../../core/core_st.cpp:139
+#: ../../../core/core_st.cpp:141
 msgid "Protected"
 msgstr "보호됨"
 
-#: ../../../core/core_st.cpp:140
+#: ../../../core/core_st.cpp:142
 msgid "History"
 msgstr "내역"
 
-#: ../../../core/core_st.cpp:142
+#: ../../../core/core_st.cpp:144
 #, fuzzy
 msgid "Password Policy Name"
 msgstr "비밀번호 정책"
 
-#: ../../../core/core_st.cpp:143
+#: ../../../core/core_st.cpp:145
 msgid "Record Modified Time"
 msgstr "기록이 수정된 시간"
 
-#: ../../../core/core_st.cpp:145
+#: ../../../core/core_st.cpp:147
 #, fuzzy
 msgid "Shift+DCA"
 msgstr "Shift+"
 
-#: ../../../core/core_st.cpp:146
+#: ../../../core/core_st.cpp:148
 #, fuzzy
 msgid "Symbols"
 msgstr "기본 사용자 이름"
 
-#: ../../../core/core_st.cpp:148
+#: ../../../core/core_st.cpp:150
 msgid "URL"
 msgstr "URL"
 
-#: ../../../core/core_st.cpp:150
+#: ../../../core/core_st.cpp:152
 msgid "UUID"
 msgstr "UUID"
 
-#: ../../../core/core_st.cpp:151
+#: ../../../core/core_st.cpp:153
 msgid "Password Expiry Date"
 msgstr "비밀번호 만료일"
 
-#: ../../../core/core_st.cpp:152
+#: ../../../core/core_st.cpp:154
 msgid "Password Expiry Interval"
 msgstr "비밀번호 만료 간격"
 
-#: ../../../core/core_st.cpp:153
+#: ../../../core/core_st.cpp:155
 msgid "a normal entry"
 msgstr "일반 항목"
 
-#: ../../../core/core_st.cpp:154
+#: ../../../core/core_st.cpp:156
 #, fuzzy
 msgid "Last found entries"
 msgstr "항목들"
 
-#: ../../../core/core_st.cpp:155
+#: ../../../core/core_st.cpp:157
 msgid "added but not yet saved to database"
 msgstr "추가되었지만 데이터베이스에 저장되지 않음"
 
-#: ../../../core/core_st.cpp:156
+#: ../../../core/core_st.cpp:158
 #, fuzzy
 msgid "in the database"
 msgstr "in the database"
 
-#: ../../../core/core_st.cpp:157
+#: ../../../core/core_st.cpp:159
 msgid "a shortcut entry"
 msgstr "바로가기 항목"
 
-#: ../../../core/core_st.cpp:158
+#: ../../../core/core_st.cpp:160
 msgid "a base entry of a shortcut"
 msgstr "바로가기의 기본 항목"
 
-#: ../../../core/core_st.cpp:159
+#: ../../../core/core_st.cpp:161
 msgid "changed but not yet saved to database"
 msgstr "변경되었지만 데이터베이스에 저장되지 않음"
 
-#: ../../../core/core_st.cpp:160
+#: ../../../core/core_st.cpp:162
 msgid "greater than"
 msgstr "greater than"
 
-#: ../../../core/core_st.cpp:161
+#: ../../../core/core_st.cpp:163
 msgid "greater than or equal to"
 msgstr "greater than or equal to"
 
-#: ../../../core/core_st.cpp:162
+#: ../../../core/core_st.cpp:164
 #, c-format
 msgid ""
 "Invalid input on line %d.  Number of fields separated by '%c' is not as "
@@ -5510,12 +5529,12 @@ msgstr ""
 "%d 행에서 잘못된 입력값이 있습니다..  Number of fields separated by '%c' is "
 "not as expected."
 
-#: ../../../core/core_st.cpp:163
+#: ../../../core/core_st.cpp:165
 #, c-format
 msgid "Line %d: "
 msgstr "%d 행:"
 
-#: ../../../core/core_st.cpp:164
+#: ../../../core/core_st.cpp:166
 #, c-format
 msgid ""
 "File ends on line %d before ending double quote of last entry's note field."
@@ -5523,11 +5542,11 @@ msgstr ""
 "파일의 %d번째 줄에서 마지막 항목의 메모 노트에 포함된 쌍따옴표가 나타나기 전"
 "에 파일의 끝에 도착했습니다."
 
-#: ../../../core/core_st.cpp:165
+#: ../../../core/core_st.cpp:167
 msgid "Import aborted. Please see report."
 msgstr ""
 
-#: ../../../core/core_st.cpp:166
+#: ../../../core/core_st.cpp:168
 msgid ""
 "The TXT or CSV file was not imported as required as entry records span "
 "multiple lines in the CSV file.\n"
@@ -5535,7 +5554,7 @@ msgid ""
 "Import aborted."
 msgstr ""
 
-#: ../../../core/core_st.cpp:167
+#: ../../../core/core_st.cpp:169
 #, fuzzy, c-format
 msgid ""
 "%ls, Title=\"%ls\", User=\"%ls\" already exists in your database or in the "
@@ -5544,77 +5563,77 @@ msgstr ""
 "%ls, 주제=\"%ls\", 사용자=\"%ls\" 가 이미 데이터베이스 혹은 불러온 파일에 존"
 "재합니다. 불러온 항목에 다음과 같이 주제를 추가했습니다=\"%ls\".\n"
 
-#: ../../../core/core_st.cpp:168
+#: ../../../core/core_st.cpp:170
 #, fuzzy, c-format
 msgid "Entry on line %d with Group=\"%ls\""
 msgstr "Entry on line %d with Group=\"%ls\""
 
-#: ../../../core/core_st.cpp:169
+#: ../../../core/core_st.cpp:171
 #, c-format
 msgid "Entry on line %d with no group"
 msgstr "%d 행의 그룹이 없는 항목"
 
-#: ../../../core/core_st.cpp:170
+#: ../../../core/core_st.cpp:172
 #, fuzzy, c-format
 msgid "Entry with Group=\"%ls\""
 msgstr "\"%ls\" 그룹의 항목"
 
-#: ../../../core/core_st.cpp:171
+#: ../../../core/core_st.cpp:173
 msgid "Entry with no group"
 msgstr "그룹이 없는 항목"
 
-#: ../../../core/core_st.cpp:172
+#: ../../../core/core_st.cpp:174
 #, fuzzy
 msgid "imported"
 msgstr "import"
 
-#: ../../../core/core_st.cpp:173
+#: ../../../core/core_st.cpp:175
 #, fuzzy, c-format
 msgid "including %d empty group(s)."
 msgstr "#groups"
 
-#: ../../../core/core_st.cpp:174
+#: ../../../core/core_st.cpp:176
 #, c-format
 msgid "Empty line %d skipped"
 msgstr "비어있는 %d째 줄이 생략됨"
 
-#: ../../../core/core_st.cpp:175
+#: ../../../core/core_st.cpp:177
 #, fuzzy, c-format
 msgid "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 msgstr "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 
-#: ../../../core/core_st.cpp:176
+#: ../../../core/core_st.cpp:178
 msgid "Internal error. Import failed. No records imported."
 msgstr "내부 오류: 불러오기 실패. 아무 레코드도 불러오지 않았습니다."
 
-#: ../../../core/core_st.cpp:177
+#: ../../../core/core_st.cpp:179
 #, c-format
 msgid "Found %d known column headers:"
 msgstr "컬럼 헤더에서 알려진 %d개 발견:"
 
-#: ../../../core/core_st.cpp:178
+#: ../../../core/core_st.cpp:180
 msgid "Invalid field delimiter: must be within ASCII range."
 msgstr ""
 
-#: ../../../core/core_st.cpp:179
+#: ../../../core/core_st.cpp:181
 #, fuzzy, c-format
 msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
 msgstr ""
 "%d 행에 있는 항목이 잘못된 \"%ls\" 필드값을 가지고 잇습니다. 이 항목은 무시"
 "될 것입니다."
 
-#: ../../../core/core_st.cpp:180
+#: ../../../core/core_st.cpp:182
 msgid "The following columns will be processed: "
 msgstr "다음 항목이 처리될 것입니다:"
 
-#: ../../../core/core_st.cpp:181
+#: ../../../core/core_st.cpp:183
 msgid ""
 "The following columns were recognised but only Group/Title, Username and "
 "Password will be processed:"
 msgstr ""
 "다음 항목들이 인식되었으나 그룹/제목,  사용자 이름과 비밀번호만 처리됩니다:"
 
-#: ../../../core/core_st.cpp:182
+#: ../../../core/core_st.cpp:184
 #, c-format
 msgid ""
 "Line %d skipped - Only %d fields found, whereas parsing the Header says "
@@ -5623,7 +5642,7 @@ msgstr ""
 "%d 행 생략됨: 헤더에는 %d개의 필드가 있다고 분석되었지만 불과 %d개만 검색되었"
 "습니다"
 
-#: ../../../core/core_st.cpp:183
+#: ../../../core/core_st.cpp:185
 msgid ""
 "Either or both of the Group/Title and Password columns are missing. No "
 "records imported."
@@ -5631,43 +5650,43 @@ msgstr ""
 "그룹/제목 항목과 비밀번호 항목 중 적어도 하나 이상이 손상되었습니다. 아무 항"
 "목도 불러오지 않았습니다."
 
-#: ../../../core/core_st.cpp:184
+#: ../../../core/core_st.cpp:186
 msgid ""
 "Could not find the next entry's title field in the KeePass V1 TXT (should be "
 "within square brackets)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:185
+#: ../../../core/core_st.cpp:187
 msgid "Column header row not recognised as first record. No records imported."
 msgstr ""
 "첫번째 항목으로 컬럼 헤더의 행이 인식되지 않았습니다. 아무 항목도 불러오지 않"
 "았습니다."
 
-#: ../../../core/core_st.cpp:186
+#: ../../../core/core_st.cpp:188
 msgid "No records in import file!"
 msgstr "불러온 파일에 레코드가 없습니다!"
 
-#: ../../../core/core_st.cpp:187
+#: ../../../core/core_st.cpp:189
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Password field."
 msgstr "%d 행 생략됨: 비밀번호 항목이 비어 있습니다."
 
-#: ../../../core/core_st.cpp:188
+#: ../../../core/core_st.cpp:190
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Title field."
 msgstr "%d 행 생략됨: 제목 항목이 비어 있습니다"
 
-#: ../../../core/core_st.cpp:189
+#: ../../../core/core_st.cpp:191
 #, c-format
 msgid " Import # %d"
 msgstr "# %d 을(를) 불러오기"
 
-#: ../../../core/core_st.cpp:190
+#: ../../../core/core_st.cpp:192
 #, fuzzy, c-format
 msgid "%ls - Imported %ls"
 msgstr "%ls - 복사됨 %ls"
 
-#: ../../../core/core_st.cpp:191
+#: ../../../core/core_st.cpp:193
 msgid ""
 "To replace passwords of existing entries, all the following columns must be "
 "present: Group/Title, Username and Password.  One or more are missing and no "
@@ -5677,17 +5696,17 @@ msgstr ""
 "니다: 그룹/제목, 사용자 이름 그리고 비밀번호. 하나라도 빠트리면 아무 항목도 "
 "갱신되지 않을 것입니다."
 
-#: ../../../core/core_st.cpp:192
+#: ../../../core/core_st.cpp:194
 #, fuzzy, c-format
 msgid "%ls not found. Cannot update entry's password.\n"
 msgstr "%ls 가 발견되지 않았습니다. 항목의 비밀번호를 갱신할 수 없습니다.\n"
 
-#: ../../../core/core_st.cpp:193
+#: ../../../core/core_st.cpp:195
 #, fuzzy, c-format
 msgid "%ls has an empty %ls.\n"
 msgstr "%ls 항목이 비었습니다 %ls.\n"
 
-#: ../../../core/core_st.cpp:194
+#: ../../../core/core_st.cpp:196
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5696,11 +5715,11 @@ msgstr ""
 "Entry \"%ls, %ls, %ls\" 가 보조 항목에 대한 올바른 비밀번호를 가지고 있으나, "
 "기본 항목이 이미 보조 항목에 속해 있습니다."
 
-#: ../../../core/core_st.cpp:195
+#: ../../../core/core_st.cpp:197
 msgid "\tThis entry has been made an alias of associated base entry."
 msgstr "\t이 항목은 연관된 기본 항목의 보조 항목으로 만들어졌습니다."
 
-#: ../../../core/core_st.cpp:196
+#: ../../../core/core_st.cpp:198
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5709,12 +5728,12 @@ msgstr ""
 "Entry \"%ls, %ls, %ls\" 가 보조 항목에 대한 올바른 비밀번호를 가지고 있으나, "
 "기본 항목이 존재하지 않습니다."
 
-#: ../../../core/core_st.cpp:197
+#: ../../../core/core_st.cpp:199
 msgid ""
 "\tThis entry remains a normal entry and the password has not been changed."
 msgstr "\t이 항목은 일반 항목으로 남아 있고 비밀번호는 변경되지 않았습니다."
 
-#: ../../../core/core_st.cpp:198
+#: ../../../core/core_st.cpp:200
 #, fuzzy, c-format
 msgid ""
 "The %ls entry \"%ls, %ls, %ls\" doesn't point to a normal or existing %ls "
@@ -5723,69 +5742,69 @@ msgstr ""
 "%ls \"%ls, %ls, %ls\" 항목이 일반항목 혹은 존재하는 기본항목 %ls 을 향하지 않"
 "습니다. 이 항목을 불러올 수 없습니다."
 
-#: ../../../core/core_st.cpp:199
+#: ../../../core/core_st.cpp:201
 msgid "Entry import warnings"
 msgstr "항목 불러오기 경고"
 
-#: ../../../core/core_st.cpp:200
+#: ../../../core/core_st.cpp:202
 msgid "id="
 msgstr "id="
 
-#: ../../../core/core_st.cpp:201
+#: ../../../core/core_st.cpp:203
 msgid "on line "
 msgstr "on line "
 
-#: ../../../core/core_st.cpp:202
+#: ../../../core/core_st.cpp:204
 msgid "Internal error: Invalid oflag or pmode argument"
 msgstr "내부 오류: 잘못된 플래그 혹은 모드 변수"
 
-#: ../../../core/core_st.cpp:203
+#: ../../../core/core_st.cpp:205
 msgid "invalid!"
 msgstr "invalid!"
 
-#: ../../../core/core_st.cpp:204
+#: ../../../core/core_st.cpp:206
 msgid "  Invalid date/time value."
 msgstr "잘못된 날짜/시간 값입니다."
 
-#: ../../../core/core_st.cpp:205
+#: ../../../core/core_st.cpp:207
 #, fuzzy
 msgid "  Field length is incorrect."
 msgstr "필드 값이 너무 짧습니다."
 
-#: ../../../core/core_st.cpp:206
+#: ../../../core/core_st.cpp:208
 msgid "Internal error: An invalid flag was specified"
 msgstr "내부 오류: 잘못된 플래그가 지정되었습니다"
 
-#: ../../../core/core_st.cpp:207
+#: ../../../core/core_st.cpp:209
 #, c-format
 msgid "  Invalid header: '%ls' (must be 5 hexadecimal characters)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:208
+#: ../../../core/core_st.cpp:210
 #, fuzzy, c-format
 msgid "Invalid lock file \"%ls\"."
 msgstr "잘못된 필터 스키마"
 
-#: ../../../core/core_st.cpp:209
+#: ../../../core/core_st.cpp:211
 #, c-format
 msgid "  Invalid number of saved old passwords %d."
 msgstr "저장된 과거 비밀번호의 수 %d가 잘못되었습니다."
 
-#: ../../../core/core_st.cpp:210
+#: ../../../core/core_st.cpp:212
 #, c-format
 msgid "  Invalid status value: %d (must be either 0 or 1)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:211
+#: ../../../core/core_st.cpp:213
 msgid "  Invalid password length found (not a hexadecimal number)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:212
+#: ../../../core/core_st.cpp:214
 msgid ""
 "  Invalid password length found (differs from length of following password)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:213
+#: ../../../core/core_st.cpp:215
 msgid ""
 "  Invalid field separator character found - only a single blank is allowed "
 "between fields."
@@ -5793,20 +5812,20 @@ msgstr ""
 "잘못된 필드 구분자가 발견되었습니다 - 필드 사이에는 반드시 하나의 공백만 가능"
 "합니다."
 
-#: ../../../core/core_st.cpp:214
+#: ../../../core/core_st.cpp:216
 msgid "Invalid Filter schema."
 msgstr "잘못된 필터 스키마"
 
-#: ../../../core/core_st.cpp:215
+#: ../../../core/core_st.cpp:217
 msgid "Schema does not have a version number."
 msgstr "스키마가 버전 정보를 가지고 있지 않습니다."
 
-#: ../../../core/core_st.cpp:216
+#: ../../../core/core_st.cpp:218
 #, c-format
 msgid "The filter XML version (%d) is greater than the current schema (%d)."
 msgstr "필터의 XML 버전 (%d) 이 현재 스키마 (%d) 보다 높습니다."
 
-#: ../../../core/core_st.cpp:217
+#: ../../../core/core_st.cpp:219
 #, c-format
 msgid ""
 "The filter XML version (%d) is greater than that supported by this instance "
@@ -5815,57 +5834,57 @@ msgstr ""
 "필터의 XML 버전 (%d) 이 그것을 지원하는 Password Safe의 버전 (%d) 보다 높습니"
 "다."
 
-#: ../../../core/core_st.cpp:218
+#: ../../../core/core_st.cpp:220
 msgid "is"
 msgstr "is"
 
-#: ../../../core/core_st.cpp:219
+#: ../../../core/core_st.cpp:221
 msgid "is active"
 msgstr "is active"
 
-#: ../../../core/core_st.cpp:220
+#: ../../../core/core_st.cpp:222
 msgid "is inactive"
 msgstr "is inactive"
 
-#: ../../../core/core_st.cpp:221
+#: ../../../core/core_st.cpp:223
 msgid "is not"
 msgstr "is not"
 
-#: ../../../core/core_st.cpp:222
+#: ../../../core/core_st.cpp:224
 msgid "is not present"
 msgstr "is not present"
 
-#: ../../../core/core_st.cpp:223
+#: ../../../core/core_st.cpp:225
 msgid "is present"
 msgstr "is present"
 
-#: ../../../core/core_st.cpp:224
+#: ../../../core/core_st.cpp:226
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to entry %ls. It "
 "has been removed from the %ls entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:225
+#: ../../../core/core_st.cpp:227
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to the "
 "PasswordSafe application. It has been removed from the entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:226
+#: ../../../core/core_st.cpp:228
 msgid "less than"
 msgstr "less than"
 
-#: ../../../core/core_st.cpp:227
+#: ../../../core/core_st.cpp:229
 msgid "less than or equal to"
 msgstr "less than or equal to"
 
-#: ../../../core/core_st.cpp:228
+#: ../../../core/core_st.cpp:230
 msgid "File or path not found"
 msgstr "파일 또는 경로를 찾을 수 없습니다"
 
-#: ../../../core/core_st.cpp:229
+#: ../../../core/core_st.cpp:231
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5874,7 +5893,7 @@ msgstr ""
 "\n"
 "다음 새 데이터베이스 %ls %ls 가 이 데이터베이스로 병합됩니다:"
 
-#: ../../../core/core_st.cpp:230
+#: ../../../core/core_st.cpp:232
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5883,7 +5902,7 @@ msgstr ""
 "\n"
 "병합 완료: %d %ls 추가됨 (%d %ls, %d %ls, %d %ls)"
 
-#: ../../../core/core_st.cpp:231
+#: ../../../core/core_st.cpp:233
 #, fuzzy, c-format
 msgid ""
 "Conflicting entries for \"%ls\" \"%ls\" \"%ls\".\n"
@@ -5894,60 +5913,60 @@ msgstr ""
 "  «%ls» «%ls» «%ls» 항목으로 병합함.\n"
 "    차이점: %ls"
 
-#: ../../../core/core_st.cpp:232
+#: ../../../core/core_st.cpp:234
 #, fuzzy
 msgid "merged"
 msgstr "병합"
 
-#: ../../../core/core_st.cpp:233
+#: ../../../core/core_st.cpp:235
 #, fuzzy, c-format
 msgid "%ls - Merged %ls"
 msgstr "%ls - 복사됨 %ls"
 
-#: ../../../core/core_st.cpp:234
+#: ../../../core/core_st.cpp:236
 msgid "MISSING PASSWORD"
 msgstr ""
 
-#: ../../../core/core_st.cpp:235
+#: ../../../core/core_st.cpp:237
 #, c-format
 msgid "\tPassword policy name '%ls' is not in the database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:236
+#: ../../../core/core_st.cpp:238
 msgid ""
 "\tOne or more Password Policy Names were not found in the database. The "
 "affected entries have been changed to use the database's default policy."
 msgstr ""
 
-#: ../../../core/core_st.cpp:237
+#: ../../../core/core_st.cpp:239
 #, c-format
 msgid "MISSING TITLE # %d"
 msgstr ""
 
-#: ../../../core/core_st.cpp:239
+#: ../../../core/core_st.cpp:241
 msgid "Can't obtain the schema version."
 msgstr "스키마 버전을 획득할 수 없습니다."
 
-#: ../../../core/core_st.cpp:240
+#: ../../../core/core_st.cpp:242
 msgid "The filter XML version is missing."
 msgstr "필터의 XML 버전이 없습니다."
 
-#: ../../../core/core_st.cpp:241
+#: ../../../core/core_st.cpp:243
 #, fuzzy, c-format
 msgid "Create SchemaCache60 Error 0x%08X during %ls."
 msgstr "Create SchemaCache%2d Error 0x%08X during %ls."
 
-#: ../../../core/core_st.cpp:242
+#: ../../../core/core_st.cpp:244
 #, fuzzy, c-format
 msgid "SAX Parse60 Error 0x%08X during %ls."
 msgstr "SAX Parse%2d Error 0x%08X during %ls."
 
-#: ../../../core/core_st.cpp:243
+#: ../../../core/core_st.cpp:245
 #, fuzzy, c-format
 msgid "Error (%08X): line %d character %d %ls"
 msgstr "오류 (%08X): %d 행 %d 열 %ls"
 
-#: ../../../core/core_st.cpp:245
+#: ../../../core/core_st.cpp:247
 msgid ""
 "Unable to get configuration file lock.\n"
 "\n"
@@ -5957,15 +5976,15 @@ msgstr ""
 "\n"
 "레지스트리를 대신 사용합니다."
 
-#: ../../../core/core_st.cpp:246
+#: ../../../core/core_st.cpp:248
 msgid "Cannot create lock file - no permission in directory?"
 msgstr "잠금 파일을 만들 수 없습니다 - 디렉터리 권한이 없습니까?"
 
-#: ../../../core/core_st.cpp:247
+#: ../../../core/core_st.cpp:249
 msgid "Internal error: Out of file handles"
 msgstr "내부 오류: 파일 핸들 오류"
 
-#: ../../../core/core_st.cpp:248
+#: ../../../core/core_st.cpp:250
 msgid ""
 "Unable to use a MS XML reader on your system.  Neither MS XML V3, V4 or V6 "
 "seems available."
@@ -5973,16 +5992,16 @@ msgstr ""
 "이 시스템에서 MS XML 리더를 사용할 수 없습니다. MS XML의 버전이 V3, V4 혹은 "
 "V6 을  사용할 수 없는 것 같습니다."
 
-#: ../../../core/core_st.cpp:250
+#: ../../../core/core_st.cpp:252
 #, fuzzy
 msgid "Unsaved changes"
 msgstr "저장되지 않은 변경사항 보이기(&U)"
 
-#: ../../../core/core_st.cpp:251
+#: ../../../core/core_st.cpp:253
 msgid "is not set"
 msgstr "is not set"
 
-#: ../../../core/core_st.cpp:252
+#: ../../../core/core_st.cpp:254
 #, fuzzy, c-format
 msgid ""
 "Number of entries processed: %d\n"
@@ -6017,7 +6036,7 @@ msgstr ""
 "\n"
 "전부 표시할 수 없는 항목: %d"
 
-#: ../../../core/core_st.cpp:254
+#: ../../../core/core_st.cpp:256
 msgid ""
 "Password should be mixed case, with at least one digit or punctuation "
 "character"
@@ -6025,94 +6044,137 @@ msgstr ""
 "비밀번호가 반드시 대소문자를 혼합하고, 최소한 1개의 숫자 혹은 알파벳 문자를 "
 "입력해야 합니다"
 
-#: ../../../core/core_st.cpp:255
+#: ../../../core/core_st.cpp:257
 msgid "Password is too short"
 msgstr "비밀번호가 너무 짧습니다"
 
-#: ../../../core/core_st.cpp:256
+#: ../../../core/core_st.cpp:258
 msgid "Easyvision characters"
 msgstr "읽기 쉬운 문자들"
 
-#: ../../../core/core_st.cpp:257
+#: ../../../core/core_st.cpp:259
 msgid "Hexadecimal characters"
 msgstr "16진수 문자"
 
-#: ../../../core/core_st.cpp:258
+#: ../../../core/core_st.cpp:260
 #, fuzzy
 msgid "Password length"
 msgstr "비밀번호 길이:"
 
-#: ../../../core/core_st.cpp:259
+#: ../../../core/core_st.cpp:261
 msgid "Pronounceable passwords"
 msgstr "발음할 수 있는 비밀번호"
 
-#: ../../../core/core_st.cpp:261
+#: ../../../core/core_st.cpp:263
 #, fuzzy
 msgid "Use lowercase characters"
 msgstr "최소 대문자 개수"
 
-#: ../../../core/core_st.cpp:263
+#: ../../../core/core_st.cpp:265
 #, fuzzy
 msgid "Use uppercase characters"
 msgstr "최소 대문자 개수"
 
-#: ../../../core/core_st.cpp:264
+#: ../../../core/core_st.cpp:266
 #, fuzzy, c-format
 msgid "Error in a Password History %ls:"
 msgstr ""
 "\n"
 "비밀번호 내역의 다음 항목에서 에러가 발생했습니다: »%ls»%ls»%ls»: "
 
-#: ../../../core/core_st.cpp:265
+#: ../../../core/core_st.cpp:267
 #, c-format
 msgid "sub-field starting at position %d (within the History field): "
 msgstr ""
 
-#: ../../../core/core_st.cpp:266
+#: ../../../core/core_st.cpp:268
 msgid "  All Password History ignored."
 msgstr "모든 비밀번호 내역이 무시되었습니다."
 
-#: ../../../core/core_st.cpp:267
+#: ../../../core/core_st.cpp:269
 msgid "Read Error"
 msgstr "읽기 오류"
 
-#: ../../../core/core_st.cpp:268
+#: ../../../core/core_st.cpp:270
+msgid "Relative"
+msgstr "연관"
+
+#: ../../../core/core_st.cpp:271
 #, c-format
 msgid ""
 "\tOne or more entry keyboard shortcuts were already assigned to entries in "
 "this database. They have been removed from the %ls entries."
 msgstr ""
 
-#: ../../../core/core_st.cpp:269
+#: ../../../core/core_st.cpp:272
 msgid ""
 "\tOne or more Password Policy Names were already in this database but had "
 "different settings. They have been renamed."
 msgstr ""
 
-#: ../../../core/core_st.cpp:270
+#: ../../../core/core_st.cpp:273
 #, fuzzy, c-format
 msgid "%ls%ls%ls_Report.txt"
 msgstr "%ls%ls%ls_보고서.txt"
 
-#: ../../../core/core_st.cpp:271
+#: ../../../core/core_st.cpp:274
 #, fuzzy, c-format
 msgid "Report of %ls function started at %ls"
 msgstr "%ls 의 보고서 기능이 %ls에 시작했습니다."
 
-#: ../../../core/core_st.cpp:272
+#: ../../../core/core_st.cpp:275
 #, fuzzy, c-format
 msgid "on database %ls"
 msgstr "on database %ls"
 
-#: ../../../core/core_st.cpp:273
+#: ../../../core/core_st.cpp:276
+msgid "Compare"
+msgstr "비교"
+
+#: ../../../core/core_st.cpp:277
+#, fuzzy
+msgid "Export_DB"
+msgstr "내보내기(&E)"
+
+#: ../../../core/core_st.cpp:278
+msgid "Export_Text"
+msgstr "텍스트 내보내기"
+
+#: ../../../core/core_st.cpp:279
+msgid "Export_XML"
+msgstr "XML로 내보내기"
+
+#: ../../../core/core_st.cpp:281
+#, fuzzy
+msgid "Import_KeePassV1_CSV"
+msgstr "텍스트 불러오기(&T)"
+
+#: ../../../core/core_st.cpp:282
+#, fuzzy
+msgid "Import_KeePassV1_TXT"
+msgstr "텍스트 불러오기(&T)"
+
+#: ../../../core/core_st.cpp:283
+msgid "Import_Text"
+msgstr "텍스트 불러오기"
+
+#: ../../../core/core_st.cpp:284
+msgid "Import_XML"
+msgstr "XML 불러오기"
+
+#: ../../../core/core_st.cpp:285
+msgid "Merge"
+msgstr "병합"
+
+#: ../../../core/core_st.cpp:287
 msgid "Validate"
 msgstr "유효화"
 
-#: ../../../core/core_st.cpp:275
+#: ../../../core/core_st.cpp:289
 msgid "Fatal Error"
 msgstr "치명적 오류"
 
-#: ../../../core/core_st.cpp:277
+#: ../../../core/core_st.cpp:291
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -6121,118 +6183,130 @@ msgstr ""
 "\n"
 "비밀번호 내역의 다음 항목에서 에러가 발생했습니다: »%ls»%ls»%ls»: "
 
-#: ../../../core/core_st.cpp:278
+#: ../../../core/core_st.cpp:292
+#, c-format
+msgid "\tNo entries were found containing search string '%ls' %ls"
+msgstr ""
+
+#: ../../../core/core_st.cpp:293
+#, fuzzy, c-format
+msgid "\tThe following entries contain search string '%ls' %ls"
+msgstr ""
+"\t다음 제약조건이 선택되었습니다:\n"
+"\t\t %s"
+
+#: ../../../core/core_st.cpp:294
 msgid "See Attachment filters"
 msgstr ""
 
-#: ../../../core/core_st.cpp:279
+#: ../../../core/core_st.cpp:295
 msgid "See Password History filters"
 msgstr "비밀번호 내역 필터 보기"
 
-#: ../../../core/core_st.cpp:280
+#: ../../../core/core_st.cpp:296
 msgid "See Password Policy filters"
 msgstr "비밀번호 정책 필터 보기"
 
-#: ../../../core/core_st.cpp:281
+#: ../../../core/core_st.cpp:297
 msgid "is set"
 msgstr "is set"
 
-#: ../../../core/core_st.cpp:282
+#: ../../../core/core_st.cpp:298
 msgid "shortcut"
 msgstr "바로가기"
 
-#: ../../../core/core_st.cpp:283
+#: ../../../core/core_st.cpp:299
 msgid "shortcuts"
 msgstr "shortcuts"
 
-#: ../../../core/core_st.cpp:284
+#: ../../../core/core_st.cpp:300
 msgid "policy specific symbols"
 msgstr ""
 
-#: ../../../core/core_st.cpp:285
+#: ../../../core/core_st.cpp:301
 msgid "Start Report"
 msgstr "보고서 시작"
 
-#: ../../../core/core_st.cpp:286
+#: ../../../core/core_st.cpp:302
 msgid "Double-Click on entry to Autotype"
 msgstr "항목을 더블클릭하여 자동입력"
 
-#: ../../../core/core_st.cpp:287
+#: ../../../core/core_st.cpp:303
 msgid "Double-Click on entry to Browse to URL"
 msgstr "항목을 더블클릭하여 URL 탐색"
 
-#: ../../../core/core_st.cpp:288
+#: ../../../core/core_st.cpp:304
 msgid "Double-Click on entry to Browse to URL + Autotype"
 msgstr "항목을 더블클릭하여 URL 탐색하고 자동입력"
 
-#: ../../../core/core_st.cpp:289
+#: ../../../core/core_st.cpp:305
 #, fuzzy
 msgid "https://pwsafe.org/"
 msgstr "https://pwsafe.org/"
 
-#: ../../../core/core_st.cpp:290
+#: ../../../core/core_st.cpp:306
 msgid "Double-Click on entry to Copy Notes"
 msgstr "항목을 더블클릭하여 노트를 복사"
 
-#: ../../../core/core_st.cpp:291
+#: ../../../core/core_st.cpp:307
 msgid "Double-Click on entry to Copy Password"
 msgstr "항목을 더블클릭하여 비밀번호를 복사"
 
-#: ../../../core/core_st.cpp:292
+#: ../../../core/core_st.cpp:308
 msgid "Double-Click on entry to Copy Password and Minimize"
 msgstr "항목을 더블클릭하여 비밀번호를 복사하고 창을 최소화"
 
-#: ../../../core/core_st.cpp:293
+#: ../../../core/core_st.cpp:309
 msgid "Double-Click on entry to Copy Username"
 msgstr "항목을 더블클릭하여 사용자 이름 복사"
 
-#: ../../../core/core_st.cpp:294
+#: ../../../core/core_st.cpp:310
 msgid "Double-Click on entry to Run Command"
 msgstr "항목을 더블클릭하여 명령 실행"
 
-#: ../../../core/core_st.cpp:295
+#: ../../../core/core_st.cpp:311
 #, fuzzy
 msgid "Double-Click on entry to Send Email"
 msgstr "항목을 더블클릭하여 전자우편 보내기"
 
-#: ../../../core/core_st.cpp:296
+#: ../../../core/core_st.cpp:312
 msgid "Double-Click on entry to View/Edit it"
 msgstr "항목을 더블클릭하여 편집하기"
 
-#: ../../../core/core_st.cpp:299
+#: ../../../core/core_st.cpp:315
 #, fuzzy, c-format
 msgid "%ls - Sync'd %ls"
 msgstr "%ls - %ls중에서"
 
-#: ../../../core/core_st.cpp:300
+#: ../../../core/core_st.cpp:316
 msgid "System error: No more file handles available"
 msgstr "시스템 오류: 더 이상 사용 가능한 파일 핸들이 없습니다"
 
-#: ../../../core/core_st.cpp:303
+#: ../../../core/core_st.cpp:319
 msgid "Unknown function"
 msgstr "알 수 없는 기능"
 
-#: ../../../core/core_st.cpp:304
+#: ../../../core/core_st.cpp:320
 msgid "Unknown object"
 msgstr "알 수 없는 객체"
 
-#: ../../../core/core_st.cpp:305
+#: ../../../core/core_st.cpp:321
 msgid "Internal error: Unexpected error number"
 msgstr "내부 오류: 예기치 못한 오류"
 
-#: ../../../core/core_st.cpp:307
+#: ../../../core/core_st.cpp:323
 #, c-format
 msgid "\tName: %s; Filename: %s"
 msgstr ""
 
-#: ../../../core/core_st.cpp:308
+#: ../../../core/core_st.cpp:324
 msgid ""
 "The following entries had an invalid UUID field.  This has been corrected."
 msgstr ""
 "다음 항목이 잘못된 UUID 항목 값을 가지고 있습니다. 이 항목은 다시 교정되었습"
 "니다."
 
-#: ../../../core/core_st.cpp:309
+#: ../../../core/core_st.cpp:325
 #, fuzzy, c-format
 msgid ""
 "The following entries have passwords in the correct form for %ls, but the "
@@ -6241,11 +6315,11 @@ msgstr ""
 "Entry \"%ls, %ls, %ls\" 가 보조 항목에 대한 올바른 비밀번호를 가지고 있으나, "
 "기본 항목이 존재하지 않습니다."
 
-#: ../../../core/core_st.cpp:310
+#: ../../../core/core_st.cpp:326
 msgid "The following entries were duplicates of an existing entry."
 msgstr "다음 항목은 같은 항목의 복제본입니다."
 
-#: ../../../core/core_st.cpp:311
+#: ../../../core/core_st.cpp:327
 #, fuzzy
 msgid ""
 "The following entries had a duplicate UUID field.  This has been corrected."
@@ -6253,7 +6327,7 @@ msgstr ""
 "다음 항목이 잘못된 UUID 항목 값을 가지고 있습니다. 이 항목은 다시 교정되었습"
 "니다."
 
-#: ../../../core/core_st.cpp:312
+#: ../../../core/core_st.cpp:328
 #, fuzzy, c-format
 msgid ""
 "The following entries had an empty Password field, which is not permitted. "
@@ -6262,38 +6336,38 @@ msgstr ""
 "다음 항목이 잘못된 UUID 항목 값을 가지고 있습니다. 이 항목은 다시 교정되었습"
 "니다."
 
-#: ../../../core/core_st.cpp:313
+#: ../../../core/core_st.cpp:329
 #, fuzzy
 msgid "The following entries had an empty Title field, which is not permitted."
 msgstr ""
 "다음 항목이 잘못된 UUID 항목 값을 가지고 있습니다. 이 항목은 다시 교정되었습"
 "니다."
 
-#: ../../../core/core_st.cpp:314
+#: ../../../core/core_st.cpp:330
 #, fuzzy, c-format
 msgid "\tGroup='%ls', Title='%ls', User='%ls' %ls"
 msgstr "\t그룹:'%ls'; 제목:'%ls'; 사용자 이름:'%ls' %ls"
 
-#: ../../../core/core_st.cpp:315
+#: ../../../core/core_st.cpp:331
 #, fuzzy, c-format
 msgid "- Its title has been changed to:'%ls'"
 msgstr "- 주제가 다음과 같이 변경되었습니다:'%ls'"
 
-#: ../../../core/core_st.cpp:316
+#: ../../../core/core_st.cpp:332
 msgid "The following ERRORS were detected and were FIXED."
 msgstr ""
 
-#: ../../../core/core_st.cpp:317
+#: ../../../core/core_st.cpp:333
 #, fuzzy
 msgid "The following entries refer to missing attachments."
 msgstr "다음 항목은 같은 항목의 복제본입니다."
 
-#: ../../../core/core_st.cpp:318
+#: ../../../core/core_st.cpp:334
 #, fuzzy
 msgid "The following attachments are not referred to by any entry."
 msgstr "다음 항목은 같은 항목의 복제본입니다."
 
-#: ../../../core/core_st.cpp:319
+#: ../../../core/core_st.cpp:335
 msgid ""
 "The following entries had an invalid Password History.  This has been "
 "rebuilt with available data.  There may be some loss of history."
@@ -6301,24 +6375,24 @@ msgstr ""
 "다음 항목이 잘못된 비밀번호 내역을 가지고 있습니다. 곧 사용가능한 데이터로 재"
 "생성 될 것입니다. 이전 기록의 손실이 발생할 수 있습니다."
 
-#: ../../../core/core_st.cpp:320
+#: ../../../core/core_st.cpp:336
 #, c-format
 msgid ""
 "The following entries have one or more text fields too long to display or "
 "edit (over %d characters).  The largest entry size found was ~%d %ls."
 msgstr ""
 
-#: ../../../core/core_st.cpp:321
+#: ../../../core/core_st.cpp:337
 msgid ""
 "The following WARNINGS were detected - you should review and fix them "
 "manually."
 msgstr ""
 
-#: ../../../core/core_st.cpp:324
+#: ../../../core/core_st.cpp:340
 msgid "will expire"
 msgstr "will expire"
 
-#: ../../../core/core_st.cpp:325
+#: ../../../core/core_st.cpp:341
 #, fuzzy, c-format
 msgid ""
 "SAX Parse Error during %ls\n"
@@ -6327,51 +6401,51 @@ msgstr ""
 "%ls 도중 SAX 분석 오류가 발생했습니다.\n"
 "%ls."
 
-#: ../../../core/core_st.cpp:326
+#: ../../../core/core_st.cpp:342
 #, fuzzy, c-format
 msgid "XML %ls: line %d character %d: %ls"
 msgstr "XML %ls: line %d character %d: %ls"
 
-#: ../../../core/core_st.cpp:327
+#: ../../../core/core_st.cpp:343
 msgid ""
 "*** Invalid XML characters found - see exported XML file for more details ***"
 msgstr ""
 
-#: ../../../core/core_st.cpp:328
+#: ../../../core/core_st.cpp:344
 msgid "Internal error: Couldn't initialize config file XML structure"
 msgstr "내부 오류: 설정 XML 파일을 초기화 할 수 없었습니다"
 
-#: ../../../core/core_st.cpp:329
+#: ../../../core/core_st.cpp:345
 msgid ""
 "A filter was active. Export of data was restricted to include only those "
 "displayed."
 msgstr "필터가 활성화되었습니다. 현재 표시된 데이터만 내보낼 수 있습니다."
 
-#: ../../../core/core_st.cpp:330
+#: ../../../core/core_st.cpp:346
 msgid "Export of data was restricted to certain fields by the user."
 msgstr "사용자에 의해 특정 필드값의 데이터가 제한되어 내보내졌습니다."
 
-#: ../../../core/core_st.cpp:331
+#: ../../../core/core_st.cpp:347
 msgid ""
 "Note: These Password Policies will not replace existing policies with the "
 "same name in the current database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:332
+#: ../../../core/core_st.cpp:348
 msgid ""
 "Note: These preferences are only used when importing into an empty database."
 msgstr "주의: 이 설정들은 다른 빈 데이터베이스를 불러올 때에만 사용됩니다."
 
-#: ../../../core/core_st.cpp:333
+#: ../../../core/core_st.cpp:349
 msgid "Subset of entries restricted by the following rule:"
 msgstr "다음 규칙에 따라 제한된 항목들:"
 
-#: ../../../core/core_st.cpp:334
+#: ../../../core/core_st.cpp:350
 msgid ""
 "The user specified that the following fields be excluded from the export:"
 msgstr "사용자가 입력한 다음 필드는 내보내기 중에 제외됩니다:"
 
-#: ../../../core/core_st.cpp:335
+#: ../../../core/core_st.cpp:351
 #, fuzzy, c-format
 msgid ""
 "Configuration file error:\n"
@@ -6384,119 +6458,64 @@ msgstr ""
 "%ls\n"
 "%d 행 %d 열"
 
-#: ../../../core/core_st.cpp:336
+#: ../../../core/core_st.cpp:352
 msgid "import"
 msgstr "import"
 
-#: ../../../core/core_st.cpp:337
+#: ../../../core/core_st.cpp:353
 msgid "Unable to load configuration file"
 msgstr "설정 파일을 불러올 수 없었습니다"
 
-#: ../../../core/core_st.cpp:338
+#: ../../../core/core_st.cpp:354
 msgid ""
 "Failed to lock configuration file - opened by another instance of "
 "PasswordSafe?"
 msgstr ""
 "설정파일을 잠그는 데 실패했습니다 - 다른 Password Safe에 의해 열려있습니까?"
 
-#: ../../../core/core_st.cpp:339
+#: ../../../core/core_st.cpp:355
 msgid "Unable to save configuration file"
 msgstr "설정 파일을 저장할 수 없었습니다"
 
-#: ../../../core/core_st.cpp:340
+#: ../../../core/core_st.cpp:356
 #, fuzzy
 msgid "validation"
 msgstr "validation"
 
-#: ../../../core/core_st.cpp:342
+#: ../../../core/core_st.cpp:358
 msgid " (EasyVision Symbols)"
 msgstr ""
 
-#: ../../../core/core_st.cpp:343
+#: ../../../core/core_st.cpp:359
 #, fuzzy, c-format
 msgid "Yes (at least %d)"
 msgstr "최소 %d 이상이어야 합니다"
 
-#: ../../../core/core_st.cpp:344
+#: ../../../core/core_st.cpp:360
 #, fuzzy
 msgid " (Pronounceable Symbols)"
 msgstr "발음할 수 있는 비밀번호"
 
-#: ../../../core/core_st.cpp:345
+#: ../../../core/core_st.cpp:361
 #, c-format
 msgid "Yes - At least %d from %ls: %ls%ls"
 msgstr ""
 
-#: ../../../core/core_st.cpp:346
 #, fuzzy, c-format
-msgid "\tGroup='%ls', Title='%ls', User='%ls'"
-msgstr "\t그룹:'%ls'; 제목:'%ls'; 사용자 이름:'%ls' %ls"
+#~ msgid "\tGroup='%ls', Title='%ls', User='%ls'"
+#~ msgstr "\t그룹:'%ls'; 제목:'%ls'; 사용자 이름:'%ls' %ls"
 
-#: ../../../core/core_st.cpp:347
-#, fuzzy, c-format
-msgid ""
-"Compare complete of current database:\n"
-"\t %ls\n"
-" and:\n"
-"\t %ls\n"
-msgstr ""
-"현재 데이터베이스의 비교 완료\n"
-"\t %s\n"
-" 그리고:\n"
-"\t %s"
-
-#: ../../../core/core_st.cpp:348
-#, c-format
-msgid "\tNo entries were found containing search string '%ls' %ls"
-msgstr ""
-
-#: ../../../core/core_st.cpp:349
-#, fuzzy, c-format
-msgid "\tThe following entries contain search string '%ls' %ls"
-msgstr ""
-"\t다음 제약조건이 선택되었습니다:\n"
-"\t\t %s"
-
-#: ../../../core/core_st.cpp:350
 #, fuzzy
-msgid "Export DB"
-msgstr "내보내기(&E)"
+#~ msgid "Import XML"
+#~ msgstr ""
+#~ "\n"
+#~ "XML 파일 불러오기"
 
-#: ../../../core/core_st.cpp:351
-msgid "Import KeePassV1 CSV"
-msgstr ""
-
-#: ../../../core/core_st.cpp:352
-msgid "Import KeePassV1 TXT"
-msgstr ""
-
-#: ../../../core/core_st.cpp:353
 #, fuzzy
-msgid "Import XML"
-msgstr ""
-"\n"
-"XML 파일 불러오기"
-
-#: ../../../core/core_st.cpp:354
-#, fuzzy
-msgid "Import Text"
-msgstr ""
-"\n"
-"텍스트 파일 불러오기"
-
-#: ../../../core/core_st.cpp:355
-msgid "Merge"
-msgstr "병합"
-
-#: ../../../core/core_st.cpp:356
-msgid "Compare"
-msgstr "비교"
-
-#~ msgid "Import_Text"
-#~ msgstr "텍스트 불러오기"
-
-#~ msgid "Import_XML"
-#~ msgstr "XML 불러오기"
+#~ msgid "Import Text"
+#~ msgstr ""
+#~ "\n"
+#~ "텍스트 파일 불러오기"
 
 #, fuzzy
 #~ msgid "Advanced..."
@@ -7850,12 +7869,6 @@ msgstr "비교"
 #~ msgid "Export file:"
 #~ msgstr "파일로 내보내기:"
 
-#~ msgid "Export_Text"
-#~ msgstr "텍스트 내보내기"
-
-#~ msgid "Export_XML"
-#~ msgstr "XML로 내보내기"
-
 #~ msgid "Exporting to file:"
 #~ msgstr "파일로 내보내는 중:"
 
@@ -8569,9 +8582,6 @@ msgstr "비교"
 #~ msgstr ""
 #~ "자동 저장된 문서 복구\n"
 #~ "바로 이전에 저장한 파일 대신 자동 저장된 파일을 열어 주십시오"
-
-#~ msgid "Relative"
-#~ msgstr "연관"
 
 #~ msgid ""
 #~ "Relative dates are in days relative to today e.g. '-1' is yesterday and "
@@ -9798,9 +9808,6 @@ msgstr "비교"
 #~ msgstr ""
 #~ "\t그룹:\"%s\"; 제목:\"%s\"; 사용자 이름:\"%s\"를 포함한 항목이\n"
 #~ "\t\t다음과 같은 차이점을 가진 필드를 가지고 있습니다:"
-
-#~ msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-#~ msgstr "\t그룹:'%s'; 제목:'%s'; 사용자 이름:'%s'"
 
 #~ msgid "an unnamed file"
 #~ msgstr "이름없는 파일"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-28 12:52+0100\n"
+"POT-Creation-Date: 2021-03-19 21:58+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -238,7 +238,7 @@ msgstr "Data en Tijden"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:348
 #: ../../../ui/wxWidgets/HelpMap.h:41 ../../../ui/wxWidgets/HelpMap.h:49
-#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:141
+#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:143
 msgid "Password Policy"
 msgstr "Wachtwoord regels"
 
@@ -252,7 +252,7 @@ msgid "Set Date/Time"
 msgstr "Zetten Datum/Tijd"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:370
-#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:137
+#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:139
 msgid "Password"
 msgstr "Wachtwoord"
 
@@ -537,14 +537,14 @@ msgstr "Gebruik &HOOFDletters"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:747
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:281
-#: ../../../core/core_st.cpp:260
+#: ../../../core/core_st.cpp:262
 #, fuzzy
 msgid "Use digits"
 msgstr "Gebruik &Cijfers"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:771
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:305
-#: ../../../core/core_st.cpp:262
+#: ../../../core/core_st.cpp:264
 #, fuzzy
 msgid "Use symbols"
 msgstr "symbolen"
@@ -579,7 +579,7 @@ msgstr "Produceer wachtwoorden die &uit te spreken zijn"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:815
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:350
-#: ../../../core/core_st.cpp:253
+#: ../../../core/core_st.cpp:255
 msgid "Or"
 msgstr "Of"
 
@@ -627,7 +627,7 @@ msgstr "Eigenschappen"
 #: ../../../ui/wxWidgets/CreateShortcutDlg.cpp:219
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:269
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:274
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
 msgid "Text"
 msgstr "Tekst"
 
@@ -683,7 +683,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:160
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:173
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:192
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:301
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:317
 msgid "Unknown"
 msgstr "Onbekend"
 
@@ -798,7 +798,7 @@ msgstr "[Notities verborgen - hier klikken om zichtbaar te maken]"
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:1653
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2145
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2820
-#: ../../../core/core_st.cpp:74
+#: ../../../core/core_st.cpp:76
 #, fuzzy
 msgid "Default Policy"
 msgstr "Standaard set"
@@ -820,7 +820,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:144
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:151
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:159
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:200
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:201
 #: ../../../ui/wxWidgets/PWSafeApp.cpp:367
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:737
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:756
@@ -844,7 +844,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:249
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:277
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:316
-#: ../../../core/core_st.cpp:274
+#: ../../../core/core_st.cpp:288
 msgid "Error"
 msgstr "Fout"
 
@@ -1023,7 +1023,7 @@ msgid "Synchronize this item..."
 msgstr "S&ynchronizeren..."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:482
-#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:357
+#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:286
 msgid "Synchronize"
 msgstr "Synchroniseren"
 
@@ -1105,8 +1105,8 @@ msgid "Current safe was opened read-only"
 msgstr "Open in alleen-lezen modus"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:793
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:996
-#: ../../../ui/wxWidgets/SyncWizard.cpp:618
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
+#: ../../../ui/wxWidgets/SyncWizard.cpp:619
 #, fuzzy, c-format
 msgid ""
 "The database:\n"
@@ -1124,7 +1124,7 @@ msgstr ""
 "SVP dit oplossen door de database te valideren."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:794
-#: ../../../ui/wxWidgets/SyncWizard.cpp:617
+#: ../../../ui/wxWidgets/SyncWizard.cpp:618
 msgid "Synchronization failed"
 msgstr "Synchronisatie mislukt"
 
@@ -1493,7 +1493,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/GridCtrl.cpp:164
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:292
-#: ../../../core/core_st.cpp:147
+#: ../../../core/core_st.cpp:149
 msgid "Title"
 msgstr "Titel"
 
@@ -1718,7 +1718,7 @@ msgid "Value"
 msgstr "Waarde:"
 
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:291
-#: ../../../core/core_st.cpp:133
+#: ../../../core/core_st.cpp:135
 msgid "Group"
 msgstr "Groep"
 
@@ -1803,17 +1803,17 @@ msgstr ""
 msgid "Error parsing Run Command"
 msgstr "Fout bij het analyzeren van het commando uitvoeren"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:56
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:57
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:355
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:362
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:166
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:623
 msgid "Write Error"
 msgstr "Schrijf Fout"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:61
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:62
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:165
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:622
 #, fuzzy
@@ -1823,7 +1823,7 @@ msgstr ""
 "\n"
 "Kon bestand niet openen voor schrijven!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:64
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:65
 msgid ""
 "Write operation failed!\n"
 "File may have been corrupted.\n"
@@ -1833,7 +1833,7 @@ msgstr ""
 "Bestand kan beschadigt zijn\n"
 "Probeer op te slaan in een andere folder"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:69
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:70
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 #, fuzzy
 msgid "Unknown error"
@@ -1842,36 +1842,36 @@ msgstr ""
 "\n"
 "Onbekende fout"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:90
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:91
 #, fuzzy
 msgid "Do you want to save changes to the password database: "
 msgstr "Wilt u de wijzigingen bewaren van de wachtwoord database: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:145
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:146
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:557
 msgid "Please choose a name for the new database"
 msgstr "Kies alstublieft een naam voor de nieuwe database"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:155
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:156
 #, fuzzy
 msgid "psafe3 files (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 msgstr "Password Safe Databases (*.psafe3)|*.psafe3|Alle bestanden (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Lock is done by yourself"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Remove Lock?"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:194
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:195
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:602
 #, fuzzy
 msgid "Could not lock file.\n"
@@ -1880,18 +1880,18 @@ msgstr ""
 "\n"
 "Kon bestand niet openen voor lezen!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:196
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:197
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:452
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:604
 msgid "Locked by "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:236
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:237
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:515
 msgid "Please Choose a Database to Open:"
 msgstr "Kies alstublieft een database om te openen:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:353
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Save database elsewhere or with "
@@ -1902,7 +1902,7 @@ msgstr ""
 "%s. Probeer het bestand met een andere naam op te slaan of beeindig sonder "
 "op te slaan."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:360
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Do you wish to save changes to your "
@@ -1911,12 +1911,12 @@ msgstr ""
 "%s. Probeer het bestand met een andere naam op te slaan of beeindig sonder "
 "op te slaan."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 msgid "Unable to create intermediate backup."
 msgstr "Niet mogelijk om tussentijdse backup te creëeren"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:386
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:387
 #, fuzzy, c-format
 msgid ""
 "The original database, \"%ls\", is in pre-3.0 format. It will be unchanged.\n"
@@ -1931,12 +1931,12 @@ msgstr ""
 "formaat te bewaren, gebruikt u het \"Bestand->Exporteren naar->Oud (1.x of "
 "2) formaat\" commando."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:388
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:389
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:447
 msgid "File version warning"
 msgstr "Bestand versie waarschuwing"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:445
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
 #, fuzzy, c-format
 msgid ""
 "The original database, '%ls', is in pre-3.0 format. The data will now be "
@@ -1949,15 +1949,15 @@ msgstr ""
 "PasswordSafe. Om uw wijzigingen in het oude formaat te bewaren, gebruikt u "
 "het \"Bestand->Exporteren naar->Oud (1.x of 2) formaat\" commando."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:458
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
 msgid "Please choose a name for the current (Untitled) database:"
 msgstr "Kies alstublieft een naam voor de actieve (Titelloze) database:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:460
 msgid "Please choose a new name for the current database:"
 msgstr "Kies alstublieft een nieuwe naam voor de actieve database:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:467
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:468
 #, fuzzy
 msgid ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|"
@@ -1966,7 +1966,7 @@ msgstr ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3; *.dat|Alle bestanden (*."
 "*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:479
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -1977,40 +1977,40 @@ msgstr ""
 "\n"
 "Bestand is momenteel in gebruik door %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:481
 msgid "File lock error"
 msgstr "Fout bij het vergrendelen van het bestand"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:547
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
 #, fuzzy
 msgid "Do you wish to save this restored database as new database?"
 msgstr "Wilt u de wijzigingen bewaren van de wachtwoord database: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:549
 #, fuzzy
 msgid "Unsaved restored database"
 msgstr "in de database"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:580
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:581
 #, fuzzy
 msgid "Do you want to save changes to the password database"
 msgstr "Wilt u de wijzigingen bewaren van de wachtwoord database: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:617
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:618
 msgid "Export Text"
 msgstr "Export van tekst"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:621
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:622
 #, fuzzy
 msgid "Export Text failed"
 msgstr "Importeren tekst mislukt"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:623
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
 msgid "Please name the plaintext file"
 msgstr "SVP dit text bestand een naam geven"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1143
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:625
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1144
 #, fuzzy
 msgid ""
 "Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
@@ -2018,107 +2018,107 @@ msgstr ""
 "Tekst bestanden (*.txt)|*.txt|CSV bestanden (*.csv)|*.csv|Alle bestanden (*."
 "*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:634
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:635
 msgid "Advanced Text Export Options"
 msgstr "Geavanceerde Opties voor Tekst Exporteren"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:654
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:697
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:655
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:698
 #, fuzzy
 msgid "export"
 msgstr "geëxporteerd"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:660
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:661
 msgid "Export XML"
 msgstr "Export XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:664
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:665
 #, fuzzy
 msgid "Export XML failed"
 msgstr "Importeren XML mislukt"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:666
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
 msgid "Please name the XML file"
 msgstr "SVP het XML bestand een naam geven"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:668
 #, fuzzy
 msgid "XML files (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 msgstr "XML bestanden (*.xml)|*.xml|Alle bestanden (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:678
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:679
 msgid "Advanced XML Export Options"
 msgstr "Geavanceerde Opties voor XML Exporteren"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:712
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:716
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:713
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:717
 #, fuzzy
 msgid "Password Safe Databases (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 msgstr ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3; *.dat|Alle bestanden (*."
 "*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:720
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:721
 #, fuzzy
 msgid "Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 msgstr ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3; *.dat|Alle bestanden (*."
 "*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:731
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:732
 msgid "Please name the exported database"
 msgstr "SVP de geÃƒÂ«xporteerde database een naam geven"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:748
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:749
 msgid "Could not figure out why PasswordSafeFrame::OnExportVx was invoked"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:782
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:783
 msgid "You must save this database before it can be exported."
 msgstr "U moet de database opslaan voordat het geëxporteerd kan worden."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 #, fuzzy
 msgid "Exporting database: "
 msgstr "Samenvoegen van database: %s\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid " to "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:841
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:842
 #, fuzzy
 msgid "Export complete.  Do you wish to see a detailed report?"
 msgstr "Wilt u het vervangen?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:852
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:853
 #, fuzzy
 msgid "No entries satisfied your selection criteria and so none were exported!"
 msgstr ""
 "Geen enkele vermelding voldoet aan uw selectie kriteria, dus geen enkele kan "
 "worden %s!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:865
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:866
 msgid "Passkey incorrect"
 msgstr "Wachtwoordsleutel is onjuist"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:873
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
 msgid ""
 "The current database was opened in read-only mode.  You cannot import into "
 "it."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:875
 #, fuzzy
 msgid "Import text"
 msgstr "Importeren &tekst"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:882
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
 #, fuzzy
 msgid "The database:"
 msgstr "in de database"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
 #, fuzzy
 msgid "has duplicate entries with the same group/title/user combination."
 msgstr ""
@@ -2129,33 +2129,33 @@ msgstr ""
 "heeft dubbelele vermeldingen met dezelfde groep/titel/gebruiker combinatie. "
 "SVP dit oplossen door de database te valideren."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
 msgid "  Please fix by validating database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:931
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:886
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:932
 #, fuzzy
 msgid "Import Text failed"
 msgstr "Importeren tekst mislukt"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 #, fuzzy, c-format
 msgid "%ls file being imported: %ls"
 msgstr "%ls bestand wordt geïmporteerd: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:921
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:926
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:223
-#: ../../../ui/wxWidgets/SyncWizard.cpp:572
+#: ../../../ui/wxWidgets/SyncWizard.cpp:573
 #: ../../../ui/wxWidgets/wxUtilities.cpp:59
 #: ../../../ui/wxWidgets/wxUtilities.cpp:64
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "File Read Error"
 msgstr "Leesfout in bestand"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:923
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:222
 #: ../../../ui/wxWidgets/wxUtilities.cpp:58
 #, fuzzy
@@ -2165,7 +2165,7 @@ msgstr ""
 "\n"
 "Kon bestand niet openen voor lezen!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:928
 #, fuzzy
 msgid "Invalid format"
 msgstr ""
@@ -2173,77 +2173,77 @@ msgstr ""
 "\n"
 "Onjuist formaat"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Updated "
 msgstr "Bijgewerkt %d %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Imported "
 msgstr "Geïmporteerd"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entry"
 msgstr "vermelding"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entries"
 msgstr "vermeldingen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
 #, fuzzy
 msgid "Skipped "
 msgstr ""
 "\n"
 "Overgeslagen %d %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:957
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:958
 #, fuzzy
 msgid "with Password History errors "
 msgstr ""
 "\n"
 "met Wachtwoord Geschiedenis fouten %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid "Renamed "
 msgstr "Naam wijzigen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed successfully"
 msgstr "Met succes uitgevoerd"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed but ...."
 msgstr "Volledig maar ..."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:981
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1127
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1197
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1218
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1279
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:982
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1128
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1219
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
 #, fuzzy
 msgid "Do you wish to see a detailed report?"
 msgstr "Wilt u het vervangen?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1045
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:998
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1046
 msgid "Import XML failed"
 msgstr "Importeren XML mislukt"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1007
-#: ../../../core/core_st.cpp:238
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../core/core_st.cpp:240
 #, fuzzy, c-format
 msgid ""
 "Can't find XML Schema Definition file (%ls) in your PasswordSafe Application "
@@ -2254,20 +2254,20 @@ msgstr ""
 "programma folder.\n"
 "SVP kopieer het van uw installatie folder of herinstalleer PasswordSafe."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 #, fuzzy
 msgid "Missing XSD File - "
 msgstr "Ontbrekend XSD bestand"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid " Build"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 msgid "XML"
 msgstr "XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1051
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1052
 #, fuzzy, c-format
 msgid ""
 "File: %ls failed validation against XML Schema:\n"
@@ -2278,7 +2278,7 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1057
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1058
 #, fuzzy, c-format
 msgid ""
 "File: %ls passed Validation but had the following errors during import:\n"
@@ -2290,25 +2290,25 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1078
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1079
 msgid "The following records were skipped:"
 msgstr "De volgende records zijn overgeslagen:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1080
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1081
 #, c-format
 msgid " / skipped %d"
 msgstr "/ overgeslagen %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1085
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1086
 msgid "The following records had errors in their Password History:"
 msgstr "De volgende records hadden fouten in hun Wachtwoord Geschiedenis"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1087
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1088
 #, c-format
 msgid " / with Password History errors %d"
 msgstr "/ met fouten in Wachtwoord Geschiedenis %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1092
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1093
 msgid ""
 "The following records were renamed as an entry already exists in your "
 "database or in the Import file:"
@@ -2316,12 +2316,12 @@ msgstr ""
 "De volgende records hebben een andere naam gekregen. De vermelding bestaat "
 "al in uw database of in het import bestand:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1094
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1095
 #, c-format
 msgid " / renamed %d"
 msgstr "/ naam gewijzigd %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1099
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1100
 #, fuzzy, c-format
 msgid ""
 "File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See "
@@ -2330,25 +2330,25 @@ msgstr ""
 "Bestand: %ls is geïmporteerd (%d Elementen gevalideerd / ingelezen %d%ls%ls"
 "%ls). Zie rapportage voor details."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:95
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:97
 msgid "entry"
 msgstr "vermelding"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:93
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:95
 msgid "entries"
 msgstr "vermeldingen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1107
 #, fuzzy, c-format
 msgid ""
 "Validated %d %ls\n"
@@ -2359,26 +2359,26 @@ msgstr ""
 "\n"
 "Geïmporteerd %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1114
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1115
 msgid "XML import not supported in this release"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1117
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1118
 #, c-format
 msgid "XML import: Unexpected return code(%d)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1141
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1142
 msgid "Please Choose a KeePass Text File to Import"
 msgstr "Kies alstublieft een KeePass tekst bestand om te importeren"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1163
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1164
 #, fuzzy, c-format
 msgid "Text file being imported: %ls"
 msgstr "Text bestand wordt geïmporteerd: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1180
-#: ../../../ui/wxWidgets/SyncWizard.cpp:602
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/SyncWizard.cpp:603
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2389,11 +2389,11 @@ msgstr ""
 "\n"
 "Kon bestand niet openen voor lezen!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1182
 msgid "File open error"
 msgstr "Fout bij het openen van het bestand"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1195
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1196
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2404,21 +2404,21 @@ msgstr ""
 "\n"
 "Onjuist formaat"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1199
 msgid "Import failed"
 msgstr "Importeren mislukt"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1214
 #, fuzzy, c-format
 msgid "Imported %d %ls"
 msgstr "Geïmporteerd %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1265
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1266
 #, fuzzy
 msgid "Merging database: "
 msgstr "Samenvoegen van database: %s\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1281
 #, fuzzy
 msgid "Merge Complete"
 msgstr "Vergelijk Volledig"
@@ -2527,16 +2527,16 @@ msgstr ""
 "vergrendeling van de database kon niet verwijderd worden.\n"
 "Probeer het programma af te sluiten en opnieuw te starten. "
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #, fuzzy
 msgid " file '"
 msgstr "Beheren van Filters"
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid "' not readable"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #: ../../../ui/wxWidgets/ViewReportDlg.cpp:32
 msgid "View Report"
 msgstr "Bekijk Rapport"
@@ -2587,7 +2587,7 @@ msgid "Please select a valid file"
 msgstr "SVP kies het rapport om te zien"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:123
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:249
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:251
 msgid "None"
 msgstr "Geen"
 
@@ -2601,7 +2601,7 @@ msgid "Incremented Number [001-999]"
 msgstr "Opgehoogd getal [001-999]"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:132
-#: ../../../core/core_st.cpp:66
+#: ../../../core/core_st.cpp:68
 #, fuzzy
 msgid "Copy password to clipboard"
 msgstr "&Kopieer Wachtwoord naar klembord"
@@ -2613,37 +2613,37 @@ msgstr "Bekijk/Bewerk geselecteerd vermelding"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:134
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:623
-#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:62
+#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:64
 msgid "Autotype"
 msgstr "Automatische invoer"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:135
-#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:63
+#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:65
 msgid "Browse to URL"
 msgstr "Brows naar URL"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:136
-#: ../../../core/core_st.cpp:65
+#: ../../../core/core_st.cpp:67
 msgid "Copy notes to clipboard"
 msgstr "Kopieer notities naar klembord"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:137
-#: ../../../core/core_st.cpp:68
+#: ../../../core/core_st.cpp:70
 msgid "Copy username to clipboard"
 msgstr "Kopieer gebruikersnaam naar klembord"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:138
-#: ../../../core/core_st.cpp:67
+#: ../../../core/core_st.cpp:69
 msgid "Copy password to clipboard, minimize"
 msgstr "Kopieer wachtwoord naar klembord, minimaliseer"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:139
-#: ../../../core/core_st.cpp:64
+#: ../../../core/core_st.cpp:66
 msgid "Browse to URL + Autotype"
 msgstr "Brows naar URL + Automatisch invoer"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:140
-#: ../../../core/core_st.cpp:69 ../../../core/core_st.cpp:144
+#: ../../../core/core_st.cpp:71 ../../../core/core_st.cpp:146
 msgid "Run Command"
 msgstr "Uitvoeren commando"
 
@@ -3076,24 +3076,24 @@ msgstr ""
 msgid "Don't show this warning again"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:849
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:854
 msgid "Missing help definition for page \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:850
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
 msgid "\" of \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:860
 msgid "Missing help definition for window \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:866
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:871
 #, fuzzy
 msgid "Please inform the developers."
 msgstr "SVP deze filter een naam geven"
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:867
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:872
 msgid "Help Undefined"
 msgstr ""
 
@@ -3831,6 +3831,7 @@ msgid "search"
 msgstr "&Zoeken"
 
 #: ../../../ui/wxWidgets/PasswordSafeSearch.cpp:427
+#: ../../../core/core_st.cpp:280
 msgid "Find"
 msgstr "Zoeken"
 
@@ -3952,20 +3953,20 @@ msgstr "valideren"
 msgid " empty)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:306
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:322
 #, fuzzy, c-format
 msgid "%ls on %ls"
 msgstr "%ls op %ls"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:341
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:357
 msgid "Yes"
 msgstr "Ja"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:244
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:246
 msgid "No"
 msgstr "Nee"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:302
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:318
 #, fuzzy, c-format
 msgid "In Headers(%ls)/In Entries("
 msgstr "In Titels (%ls)/In Elementen("
@@ -4154,7 +4155,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:457
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:269
-#: ../../../core/core_st.cpp:276
+#: ../../../core/core_st.cpp:290
 msgid "Warning"
 msgstr "Waarschuwing"
 
@@ -4230,11 +4231,11 @@ msgstr ""
 "\n"
 "SVP een andere proberen"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:96
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:98
 msgid "equals"
 msgstr "is gelijk aan"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:83
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:85
 msgid "does not equal"
 msgstr "is niet gelijk"
 
@@ -4242,23 +4243,23 @@ msgstr "is niet gelijk"
 msgid "begins with"
 msgstr "begint met"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:78
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:80
 msgid "does not begin with"
 msgstr "begint niet met"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:90
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:92
 msgid "ends with"
 msgstr "eindigt met"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:82
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:84
 msgid "does not end with"
 msgstr "eindigt niet met"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:56
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:58
 msgid "contains"
 msgstr "bevat"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:79
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:81
 msgid "does not contain"
 msgstr "bevat geen"
 
@@ -4317,82 +4318,82 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Annuleer"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:143
+#: ../../../ui/wxWidgets/SyncWizard.cpp:144
 #, fuzzy
 msgid "synchronize"
 msgstr "gesynchroniseerd"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:220
+#: ../../../ui/wxWidgets/SyncWizard.cpp:221
 #, fuzzy
 msgid "Synchronize another database with currently open database"
 msgstr "Samenvoegen van deze database met de actieve database"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:349
+#: ../../../ui/wxWidgets/SyncWizard.cpp:350
 msgid "Introduction"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:353
+#: ../../../ui/wxWidgets/SyncWizard.cpp:354
 msgid ""
 "Synchronizing with another database will update the entries in your\n"
 "database with matching entries from the other database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:356
+#: ../../../ui/wxWidgets/SyncWizard.cpp:357
 msgid "More Info"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:359
+#: ../../../ui/wxWidgets/SyncWizard.cpp:360
 msgid ""
 "1. Two entries from different databases match if their Group, Title\n"
 "and User fields match."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:360
+#: ../../../ui/wxWidgets/SyncWizard.cpp:361
 msgid ""
 "2. You can select the fields to update, as well as filter the entries\n"
 "for synchronization."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:361
+#: ../../../ui/wxWidgets/SyncWizard.cpp:362
 msgid ""
 "3. Only existing entries in your database are updated.  No new entries are\n"
 "added or existing entries removed during this process."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:362
+#: ../../../ui/wxWidgets/SyncWizard.cpp:363
 msgid ""
 "4. You can undo the operation once it is complete, but won't be\n"
 "able to abort it mid-way."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:379
+#: ../../../ui/wxWidgets/SyncWizard.cpp:380
 #, fuzzy
 msgid "Select another database"
 msgstr "Selecteer database"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:381
+#: ../../../ui/wxWidgets/SyncWizard.cpp:382
 #, fuzzy
 msgid "Choose Database to Synchronize with \""
 msgstr ""
 "Kies alstublieft een database om met de huidige database te synchroniseren"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:382
+#: ../../../ui/wxWidgets/SyncWizard.cpp:383
 #, fuzzy
 msgid "Please Choose a Database to Synchronize with current database"
 msgstr ""
 "Kies alstublieft een database om met de huidige database te synchroniseren"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:405
+#: ../../../ui/wxWidgets/SyncWizard.cpp:406
 #, fuzzy
 msgid "Synchronization options"
 msgstr "Synchronisatie mislukt"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:429
+#: ../../../ui/wxWidgets/SyncWizard.cpp:430
 #, fuzzy
 msgid "Options Summary"
 msgstr "Opties"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:454
+#: ../../../ui/wxWidgets/SyncWizard.cpp:455
 #, fuzzy
 msgid ""
 "WARNING!!\n"
@@ -4403,58 +4404,58 @@ msgstr ""
 "WAARSCHUWING: Als u doorgaat zullen vermeldingen in uw bestaande database "
 "worden gewijzigd door uw geselecteerde bron database."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:471
+#: ../../../ui/wxWidgets/SyncWizard.cpp:472
 msgid " will be updated with corresponding entries from \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:478
+#: ../../../ui/wxWidgets/SyncWizard.cpp:479
 msgid "All fields in matching entries will be updated"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:484
+#: ../../../ui/wxWidgets/SyncWizard.cpp:485
 msgid "Following fields in matching entries will be updated:"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:488
+#: ../../../ui/wxWidgets/SyncWizard.cpp:489
 #, fuzzy
 msgid "Following fields will not be updated:"
 msgstr "De volgende kolommen worden bewerkt:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:507
+#: ../../../ui/wxWidgets/SyncWizard.cpp:508
 #, fuzzy
 msgid "Synchronization status"
 msgstr "Synchronisatie mislukt"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:525
+#: ../../../ui/wxWidgets/SyncWizard.cpp:526
 msgid "See a detailed report"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:561
+#: ../../../ui/wxWidgets/SyncWizard.cpp:562
 msgid "Your database is being synchronized with \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:571
+#: ../../../ui/wxWidgets/SyncWizard.cpp:572
 msgid "There was an error during synchronization"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:585
+#: ../../../ui/wxWidgets/SyncWizard.cpp:586
 #, c-format
 msgid "Your database has been synchronized with \"%ls\""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:586
+#: ../../../ui/wxWidgets/SyncWizard.cpp:587
 #, fuzzy, c-format
 msgid "%ld %ls updated"
 msgstr ""
 "\n"
 "De volgende %ls %ls bijgewerkt:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:589
 #, fuzzy
 msgid "Synchronization completed successfully"
 msgstr "Met succes uitgevoerd"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:604
+#: ../../../ui/wxWidgets/SyncWizard.cpp:605
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4468,7 +4469,7 @@ msgstr ""
 "Gegevens kunnen verloren of gewijzigd zijn.\n"
 "Toch doorgaan?"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:606
+#: ../../../ui/wxWidgets/SyncWizard.cpp:607
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4479,24 +4480,24 @@ msgstr ""
 "\n"
 "Onbekende fout"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:640
+#: ../../../ui/wxWidgets/SyncWizard.cpp:641
 #, fuzzy, c-format
 msgid "Synchronizing from database: %ls\n"
 msgstr "Synchroniseren vanaf database: %ls\n"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:643
+#: ../../../ui/wxWidgets/SyncWizard.cpp:644
 msgid "synchronized"
 msgstr "gesynchroniseerd"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:322
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:338
 msgid "was"
 msgstr "was"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:323
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:339
 msgid "were"
 msgstr "waar"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:298
+#: ../../../ui/wxWidgets/SyncWizard.cpp:733 ../../../core/core_st.cpp:314
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4505,7 +4506,7 @@ msgstr ""
 "\n"
 "De volgende %ls %ls bijgewerkt:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:297
+#: ../../../ui/wxWidgets/SyncWizard.cpp:749 ../../../core/core_st.cpp:313
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4678,7 +4679,7 @@ msgstr ""
 "Het doel van deze snelkoppeling [%s:%s:%s] is geen normale vermelding of is "
 "al het doel van een snelkoppeling"
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:94
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:96
 #, c-format
 msgid ""
 "The following entries had a policy name that already existed in this "
@@ -4783,13 +4784,13 @@ msgstr ""
 "Gegevens kunnen verloren of gewijzigd zijn.\n"
 "Toch doorgaan?"
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:381
+#: ../../../ui/wxWidgets/wxUtilities.cpp:390
 msgid ""
 "An error occurred while trying to get the image data from database item.\n"
 "Therefore, the image cannot be displayed in the preview."
 msgstr ""
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:394
+#: ../../../ui/wxWidgets/wxUtilities.cpp:403
 msgid ""
 "An error occurred while trying to load the image data into the preview "
 "area.\n"
@@ -4931,7 +4932,7 @@ msgstr ""
 "\n"
 "Kopieer Wachtwoord naar klembord"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:149
+#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:151
 msgid "Username"
 msgstr "Gebruikersnaam"
 
@@ -4942,7 +4943,7 @@ msgstr ""
 "\n"
 "Kopieer Gebruikersnaam naar klembord"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:136
+#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:138
 #, fuzzy
 msgid "Notes"
 msgstr "&Notities:"
@@ -4978,7 +4979,7 @@ msgstr ""
 msgid "Browse URL"
 msgstr "Brows naar URL"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:70
+#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:72
 #, fuzzy
 msgid "Send Email"
 msgstr "Verzenden e-mail"
@@ -5179,67 +5180,85 @@ msgid "(case sensitive)"
 msgstr "(hoofdlettergevoelig)"
 
 #: ../../../core/core_st.cpp:50
+#, fuzzy, c-format
+msgid ""
+"Compare complete of current database:\n"
+"\t %ls\n"
+" and:\n"
+"\t %ls\n"
+msgstr ""
+"Vergelijk volledig van huidige database:\n"
+"\t %s\n"
+" en:\n"
+"\t %s"
+
+#: ../../../core/core_st.cpp:51
+#, fuzzy, c-format
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGroep:'%s'; Titel:'%s'; Gebruiker:'%s'"
+
+#: ../../../core/core_st.cpp:52
 msgid "C:F[R-O]"
 msgstr "C:F[R-O]"
 
-#: ../../../core/core_st.cpp:51
+#: ../../../core/core_st.cpp:53
 msgid "C:F[R/W]"
 msgstr "C:F[R/W]"
 
-#: ../../../core/core_st.cpp:52
+#: ../../../core/core_st.cpp:54
 msgid "C:None  "
 msgstr "C:Geen"
 
-#: ../../../core/core_st.cpp:53
+#: ../../../core/core_st.cpp:55
 msgid "C:Reg   "
 msgstr "C:Reg   "
 
-#: ../../../core/core_st.cpp:54
+#: ../../../core/core_st.cpp:56
 msgid "conflict"
 msgstr "conflict"
 
-#: ../../../core/core_st.cpp:55
+#: ../../../core/core_st.cpp:57
 msgid "conflicts"
 msgstr "conflicten"
 
-#: ../../../core/core_st.cpp:57
+#: ../../../core/core_st.cpp:59
 msgid "contains all of"
 msgstr "bevat alle"
 
-#: ../../../core/core_st.cpp:58
+#: ../../../core/core_st.cpp:60
 msgid "contains any of"
 msgstr "bevat een van"
 
-#: ../../../core/core_st.cpp:59
+#: ../../../core/core_st.cpp:61
 #, fuzzy
 msgid "copied"
 msgstr "URL gecopieerd"
 
-#: ../../../core/core_st.cpp:60
+#: ../../../core/core_st.cpp:62
 #, fuzzy, c-format
 msgid "%ls - Copied %ls"
 msgstr "%ls - Gecopieerd %ls"
 
-#: ../../../core/core_st.cpp:61
+#: ../../../core/core_st.cpp:63
 #, fuzzy, c-format
 msgid " Current default (%ls)"
 msgstr "Huidige standaard (%ls)"
 
-#: ../../../core/core_st.cpp:71
+#: ../../../core/core_st.cpp:73
 msgid "View/Edit selected entry"
 msgstr "Bekijk/Bewerk geselecteerd vermelding"
 
-#: ../../../core/core_st.cpp:72
+#: ../../../core/core_st.cpp:74
 #, fuzzy
 msgid " (application default)"
 msgstr "Met gebruik van applicatie"
 
-#: ../../../core/core_st.cpp:73
+#: ../../../core/core_st.cpp:75
 #, fuzzy
 msgid "default symbol set"
 msgstr "Standaard set"
 
-#: ../../../core/core_st.cpp:75
+#: ../../../core/core_st.cpp:77
 #, fuzzy, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5252,12 +5271,12 @@ msgstr ""
 "Svp bevestigen om door te gaan (wachwoorden alias vermeldingen worden "
 "vervangen door het wachtwoord van deze vermelding)?"
 
-#: ../../../core/core_st.cpp:76
+#: ../../../core/core_st.cpp:78
 #, fuzzy
 msgid "Delete Base Entry Confirmation"
 msgstr "Verwijder een Basis Vermelding Bevestiging?"
 
-#: ../../../core/core_st.cpp:77
+#: ../../../core/core_st.cpp:79
 #, fuzzy, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5269,40 +5288,40 @@ msgstr ""
 "Svp bevestigen om door te gaan (Alle verwijzingen naar deze vermeldingen "
 "worden verwijderd)?"
 
-#: ../../../core/core_st.cpp:80
+#: ../../../core/core_st.cpp:82
 msgid "does not contain all of"
 msgstr "bevat niet alle"
 
-#: ../../../core/core_st.cpp:81
+#: ../../../core/core_st.cpp:83
 msgid "does not contain any of"
 msgstr "bevat geen enkele van"
 
-#: ../../../core/core_st.cpp:84
+#: ../../../core/core_st.cpp:86
 #, c-format
 msgid " Drag # %d"
 msgstr "Sleep # %d"
 
-#: ../../../core/core_st.cpp:85
-#, c-format
-msgid "%s - Drag & Drop %s"
-msgstr ""
+#: ../../../core/core_st.cpp:87
+#, fuzzy, c-format
+msgid "%ls - Drag & Drop %ls"
+msgstr "%ls - Gecopieerd %ls"
 
-#: ../../../core/core_st.cpp:86
+#: ../../../core/core_st.cpp:88
 #, c-format
 msgid " Duplicate # %d"
 msgstr "Dubbele # %d"
 
-#: ../../../core/core_st.cpp:87
+#: ../../../core/core_st.cpp:89
 #, fuzzy
 msgid "empty group"
 msgstr "Importeren in Groep?"
 
-#: ../../../core/core_st.cpp:88
+#: ../../../core/core_st.cpp:90
 #, fuzzy
 msgid "empty groups"
 msgstr "#groepen"
 
-#: ../../../core/core_st.cpp:89
+#: ../../../core/core_st.cpp:91
 #, fuzzy, c-format
 msgid ""
 "Trouble with a non-textual (e.g., time) field in record '%ls' - please check "
@@ -5311,264 +5330,264 @@ msgstr ""
 "Probleem met een niet-tekst veld (bv tijd) in record '%ls' - svp gegevens "
 "goed controleren"
 
-#: ../../../core/core_st.cpp:91
+#: ../../../core/core_st.cpp:93
 msgid "End Report"
 msgstr "Eind rapport"
 
-#: ../../../core/core_st.cpp:92
+#: ../../../core/core_st.cpp:94
 msgid "--------------------------------------------------------------------------------"
 msgstr "--------------------------------------------------------------------------------"
 
-#: ../../../core/core_st.cpp:97
+#: ../../../core/core_st.cpp:99
 msgid "has expired"
 msgstr "is verlopen"
 
-#: ../../../core/core_st.cpp:98
+#: ../../../core/core_st.cpp:100
 msgid "Entries with a password expiry"
 msgstr "Vermeldingen met verloopdatum voor het wachtwoord"
 
-#: ../../../core/core_st.cpp:99
+#: ../../../core/core_st.cpp:101
 #, c-format
 msgid "within %d day(s)"
 msgstr "binnen %d dag(en)"
 
-#: ../../../core/core_st.cpp:100
+#: ../../../core/core_st.cpp:102
 #, fuzzy, c-format
 msgid "DB Export from database: '%s'"
 msgstr "Samenvoegen van database: %s\n"
 
-#: ../../../core/core_st.cpp:101
+#: ../../../core/core_st.cpp:103
 msgid "First character of variable name must be alphabetic"
 msgstr "De eerste positie van een variabele naam moet een letter zijn"
 
-#: ../../../core/core_st.cpp:102
+#: ../../../core/core_st.cpp:104
 msgid "Index not numeric"
 msgstr "Index is geen getal"
 
-#: ../../../core/core_st.cpp:103
+#: ../../../core/core_st.cpp:105
 msgid "Input string is empty"
 msgstr "De aangeboden tekenreeks is leeg"
 
-#: ../../../core/core_st.cpp:104
+#: ../../../core/core_st.cpp:106
 msgid "Characters present between end of index ']' and '}'"
 msgstr "Tekens aanwezig tussen het einde van index ']' en '}' "
 
-#: ../../../core/core_st.cpp:105
+#: ../../../core/core_st.cpp:107
 msgid "Index is invalid or missing"
 msgstr "Index is ongeldig of ontbreekt"
 
-#: ../../../core/core_st.cpp:106
+#: ../../../core/core_st.cpp:108
 msgid "Missing ending curly bracket for variable name"
 msgstr "Ontbrekende sluit accolade voor een variabele naam"
 
-#: ../../../core/core_st.cpp:107
+#: ../../../core/core_st.cpp:109
 msgid "Missing ending round bracket for Autotype value"
 msgstr "Ontbrekend sluit haakje voor een Automatische Invoer waarde"
 
-#: ../../../core/core_st.cpp:108
+#: ../../../core/core_st.cpp:110
 msgid "Missing ending square bracket for index value"
 msgstr "Ontbrekende afsluitende vierkante haak voor een index waarde"
 
-#: ../../../core/core_st.cpp:109
+#: ../../../core/core_st.cpp:111
 msgid "There are unmatched quotes in the run command"
 msgstr "Oneven aantal aanhalingstekings in het uitvoer commando"
 
-#: ../../../core/core_st.cpp:110
+#: ../../../core/core_st.cpp:112
 msgid "Variable name is empty"
 msgstr "De variabele naam is leeg"
 
-#: ../../../core/core_st.cpp:111
+#: ../../../core/core_st.cpp:113
 msgid "Variable name must be alphanumeric"
 msgstr "De variabele naam is alfanumeriek"
 
-#: ../../../core/core_st.cpp:112
+#: ../../../core/core_st.cpp:114
 msgid "an alias entry"
 msgstr "een alias vermelding"
 
-#: ../../../core/core_st.cpp:113
+#: ../../../core/core_st.cpp:115
 msgid "a base entry of an alias"
 msgstr "een basis vermelding van een alias"
 
-#: ../../../core/core_st.cpp:114
+#: ../../../core/core_st.cpp:116
 msgid "  Field is too long."
 msgstr "Veld is te lang."
 
-#: ../../../core/core_st.cpp:115
+#: ../../../core/core_st.cpp:117
 msgid "  Field is too short."
 msgstr "Veld is te kort."
 
-#: ../../../core/core_st.cpp:116
+#: ../../../core/core_st.cpp:118
 msgid "Error: A file with this name already exists"
 msgstr "Fout: Een bestand met deze naam bestaat al"
 
-#: ../../../core/core_st.cpp:117
+#: ../../../core/core_st.cpp:119
 msgid "The file was not found."
 msgstr "Het bestand is niet gevonden."
 
-#: ../../../core/core_st.cpp:118
+#: ../../../core/core_st.cpp:120
 msgid "Error: File is read-only"
 msgstr "Fout: Het bestand is in alleen lezen modus"
 
-#: ../../../core/core_st.cpp:119
+#: ../../../core/core_st.cpp:121
 msgid "Error while writing file! Try saving in a different location"
 msgstr ""
 "Fout bij het schrijven van het bestand! Probeer om deze op een ander plaats "
 "op te slaan"
 
-#: ../../../core/core_st.cpp:120
+#: ../../../core/core_st.cpp:122
 #, fuzzy
 msgid "File is too big."
 msgstr "Veld is te lang."
 
-#: ../../../core/core_st.cpp:121
+#: ../../../core/core_st.cpp:123
 #, fuzzy
 msgid "File is too short."
 msgstr "Veld is te kort."
 
-#: ../../../core/core_st.cpp:122
+#: ../../../core/core_st.cpp:124
 msgid "File is truncated or otherwise corrupt. Please use backup database."
 msgstr ""
 "Bestand is afgekort of op andere wijze beschadigd. SVP een backup database "
 "gebruiken."
 
-#: ../../../core/core_st.cpp:123
+#: ../../../core/core_st.cpp:125
 msgid "Cannot read file. Please check file permissions."
 msgstr "Kan bestand niet lezen. Controleer bestandspermissies"
 
-#: ../../../core/core_st.cpp:124
+#: ../../../core/core_st.cpp:126
 #, fuzzy, c-format
 msgid ""
 "Filter %ls already exists in the database, do you wish to replace it with "
 "this?"
 msgstr "Filter %ls bestaat al in de database, wilt U het vervangen met deze?"
 
-#: ../../../core/core_st.cpp:125
+#: ../../../core/core_st.cpp:127
 #, fuzzy
 msgid "Current database filters have been exported to this database."
 msgstr "Vergelijk active database met: %s"
 
-#: ../../../core/core_st.cpp:126
+#: ../../../core/core_st.cpp:128
 msgid "Stored filters will be unusable until the file's restored."
 msgstr "Opgeslagen filters zijn onbruikbaar totdat het bestand hersteld is."
 
-#: ../../../core/core_st.cpp:127
+#: ../../../core/core_st.cpp:129
 msgid "Last Access Time"
 msgstr "Tijdstip laatste opening"
 
-#: ../../../core/core_st.cpp:128
+#: ../../../core/core_st.cpp:130
 msgid "Attachment Reference"
 msgstr ""
 
-#: ../../../core/core_st.cpp:129
+#: ../../../core/core_st.cpp:131
 msgid "AutoType"
 msgstr "Automatische Invoer"
 
-#: ../../../core/core_st.cpp:130
+#: ../../../core/core_st.cpp:132
 msgid "Created Time"
 msgstr "Tijdstip waarop gemaakt:"
 
-#: ../../../core/core_st.cpp:131
+#: ../../../core/core_st.cpp:133
 msgid "DCA"
 msgstr "DCA"
 
-#: ../../../core/core_st.cpp:132
+#: ../../../core/core_st.cpp:134
 msgid "e-mail"
 msgstr "e-mail"
 
-#: ../../../core/core_st.cpp:134
+#: ../../../core/core_st.cpp:136
 msgid "Group/Title"
 msgstr "Groep/Titel"
 
-#: ../../../core/core_st.cpp:135
+#: ../../../core/core_st.cpp:137
 #, fuzzy
 msgid "Keyboard Shortcut"
 msgstr "Maak Snelkoppeling"
 
-#: ../../../core/core_st.cpp:138
+#: ../../../core/core_st.cpp:140
 msgid "Password Modified Time"
 msgstr "Tijd waarop wachtwoord gewijzigd is"
 
-#: ../../../core/core_st.cpp:139
+#: ../../../core/core_st.cpp:141
 msgid "Protected"
 msgstr "Beschermd"
 
-#: ../../../core/core_st.cpp:140
+#: ../../../core/core_st.cpp:142
 msgid "History"
 msgstr "Geschiedenis"
 
-#: ../../../core/core_st.cpp:142
+#: ../../../core/core_st.cpp:144
 #, fuzzy
 msgid "Password Policy Name"
 msgstr "Wachtwoord regels"
 
-#: ../../../core/core_st.cpp:143
+#: ../../../core/core_st.cpp:145
 msgid "Record Modified Time"
 msgstr "Wijzigings tijdstip opslaan"
 
-#: ../../../core/core_st.cpp:145
+#: ../../../core/core_st.cpp:147
 #, fuzzy
 msgid "Shift+DCA"
 msgstr "Shift+"
 
-#: ../../../core/core_st.cpp:146
+#: ../../../core/core_st.cpp:148
 msgid "Symbols"
 msgstr "Symbolen"
 
-#: ../../../core/core_st.cpp:148
+#: ../../../core/core_st.cpp:150
 msgid "URL"
 msgstr "URL"
 
-#: ../../../core/core_st.cpp:150
+#: ../../../core/core_st.cpp:152
 msgid "UUID"
 msgstr "UUID"
 
-#: ../../../core/core_st.cpp:151
+#: ../../../core/core_st.cpp:153
 msgid "Password Expiry Date"
 msgstr "Datum waarop wachtwoord verloopt"
 
-#: ../../../core/core_st.cpp:152
+#: ../../../core/core_st.cpp:154
 msgid "Password Expiry Interval"
 msgstr "Interval van wachtwoord verloop"
 
-#: ../../../core/core_st.cpp:153
+#: ../../../core/core_st.cpp:155
 msgid "a normal entry"
 msgstr "een normale vermelding"
 
-#: ../../../core/core_st.cpp:154
+#: ../../../core/core_st.cpp:156
 #, fuzzy
 msgid "Last found entries"
 msgstr "vermeldingen"
 
-#: ../../../core/core_st.cpp:155
+#: ../../../core/core_st.cpp:157
 msgid "added but not yet saved to database"
 msgstr "toegevoegd maar nog niet opgeslagen in de database"
 
-#: ../../../core/core_st.cpp:156
+#: ../../../core/core_st.cpp:158
 #, fuzzy
 msgid "in the database"
 msgstr "in de database"
 
-#: ../../../core/core_st.cpp:157
+#: ../../../core/core_st.cpp:159
 msgid "a shortcut entry"
 msgstr "een snelkoppeling vermelding"
 
-#: ../../../core/core_st.cpp:158
+#: ../../../core/core_st.cpp:160
 msgid "a base entry of a shortcut"
 msgstr "een basis vermelding van een snelkoppeling"
 
-#: ../../../core/core_st.cpp:159
+#: ../../../core/core_st.cpp:161
 msgid "changed but not yet saved to database"
 msgstr "gewijzigd maar nog niet opgeslagen in database"
 
-#: ../../../core/core_st.cpp:160
+#: ../../../core/core_st.cpp:162
 msgid "greater than"
 msgstr "groter dan"
 
-#: ../../../core/core_st.cpp:161
+#: ../../../core/core_st.cpp:163
 msgid "greater than or equal to"
 msgstr "groter dan of gelijk aan"
 
-#: ../../../core/core_st.cpp:162
+#: ../../../core/core_st.cpp:164
 #, c-format
 msgid ""
 "Invalid input on line %d.  Number of fields separated by '%c' is not as "
@@ -5577,12 +5596,12 @@ msgstr ""
 "Ongeldig invoer op regel %d. Het aantal velden, gescheiden door '%c', is "
 "niet volgens verwachting."
 
-#: ../../../core/core_st.cpp:163
+#: ../../../core/core_st.cpp:165
 #, c-format
 msgid "Line %d: "
 msgstr "Regel %d:"
 
-#: ../../../core/core_st.cpp:164
+#: ../../../core/core_st.cpp:166
 #, c-format
 msgid ""
 "File ends on line %d before ending double quote of last entry's note field."
@@ -5590,11 +5609,11 @@ msgstr ""
 "Bestand eindigt op regel %d voor een afsluitend aanhalingsteken van het "
 "opmerking veld van de vermelding ."
 
-#: ../../../core/core_st.cpp:165
+#: ../../../core/core_st.cpp:167
 msgid "Import aborted. Please see report."
 msgstr "Importeren afgebroken. Lees de rapportage."
 
-#: ../../../core/core_st.cpp:166
+#: ../../../core/core_st.cpp:168
 msgid ""
 "The TXT or CSV file was not imported as required as entry records span "
 "multiple lines in the CSV file.\n"
@@ -5602,7 +5621,7 @@ msgid ""
 "Import aborted."
 msgstr ""
 
-#: ../../../core/core_st.cpp:167
+#: ../../../core/core_st.cpp:169
 #, fuzzy, c-format
 msgid ""
 "%ls, Title=\"%ls\", User=\"%ls\" already exists in your database or in the "
@@ -5612,69 +5631,69 @@ msgstr ""
 "Importeer bestand. Vermelding geimporteerd met titel=\"%ls\".\n"
 
 # egin vertaling fred
-#: ../../../core/core_st.cpp:168
+#: ../../../core/core_st.cpp:170
 #, fuzzy, c-format
 msgid "Entry on line %d with Group=\"%ls\""
 msgstr "Vermelding op regel %d met Groep=\"%ls\""
 
-#: ../../../core/core_st.cpp:169
+#: ../../../core/core_st.cpp:171
 #, c-format
 msgid "Entry on line %d with no group"
 msgstr "Vermelding op regel %d zonder groep"
 
-#: ../../../core/core_st.cpp:170
+#: ../../../core/core_st.cpp:172
 #, fuzzy, c-format
 msgid "Entry with Group=\"%ls\""
 msgstr "Vermelding met groep=\"%ls\""
 
-#: ../../../core/core_st.cpp:171
+#: ../../../core/core_st.cpp:173
 msgid "Entry with no group"
 msgstr "Vermelding zonder groep"
 
-#: ../../../core/core_st.cpp:172
+#: ../../../core/core_st.cpp:174
 #, fuzzy
 msgid "imported"
 msgstr "importeer"
 
-#: ../../../core/core_st.cpp:173
+#: ../../../core/core_st.cpp:175
 #, fuzzy, c-format
 msgid "including %d empty group(s)."
 msgstr "#groepen"
 
-#: ../../../core/core_st.cpp:174
+#: ../../../core/core_st.cpp:176
 #, c-format
 msgid "Empty line %d skipped"
 msgstr "Lege regel %d overgeslagen"
 
-#: ../../../core/core_st.cpp:175
+#: ../../../core/core_st.cpp:177
 #, fuzzy, c-format
 msgid "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 msgstr "Vermelding %ls%d met Groep=\"%ls\", Titel=\"%ls\", Gebruiker=\"%ls\""
 
-#: ../../../core/core_st.cpp:176
+#: ../../../core/core_st.cpp:178
 msgid "Internal error. Import failed. No records imported."
 msgstr "Interne programma fout. Inlezen mislukt. Geen Elementen ingelezen."
 
-#: ../../../core/core_st.cpp:177
+#: ../../../core/core_st.cpp:179
 #, c-format
 msgid "Found %d known column headers:"
 msgstr "%d bekende kolom namen gevonden:"
 
-#: ../../../core/core_st.cpp:178
+#: ../../../core/core_st.cpp:180
 msgid "Invalid field delimiter: must be within ASCII range."
 msgstr ""
 
-#: ../../../core/core_st.cpp:179
+#: ../../../core/core_st.cpp:181
 #, fuzzy, c-format
 msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
 msgstr ""
 "Vermelding op regel %d heeft een ongeldig \"%ls\" veld. Het is overgeslagen."
 
-#: ../../../core/core_st.cpp:180
+#: ../../../core/core_st.cpp:182
 msgid "The following columns will be processed: "
 msgstr "De volgende kolommen worden bewerkt:"
 
-#: ../../../core/core_st.cpp:181
+#: ../../../core/core_st.cpp:183
 msgid ""
 "The following columns were recognised but only Group/Title, Username and "
 "Password will be processed:"
@@ -5682,7 +5701,7 @@ msgstr ""
 "De volgende kolommen waren herkend maar alleen Groep/Titel, Gebruikersnaam "
 "en Wachtwoord worden bewerkt:"
 
-#: ../../../core/core_st.cpp:182
+#: ../../../core/core_st.cpp:184
 #, c-format
 msgid ""
 "Line %d skipped - Only %d fields found, whereas parsing the Header says "
@@ -5691,14 +5710,14 @@ msgstr ""
 "Regel %d overgeslagen - Slechts %d velden gevonden, terwijl analyze van de "
 "kop zegt dat er %d zouden moeten zijn."
 
-#: ../../../core/core_st.cpp:183
+#: ../../../core/core_st.cpp:185
 msgid ""
 "Either or both of the Group/Title and Password columns are missing. No "
 "records imported."
 msgstr ""
 "Groep/Titel en/of Wachtwoord kolommen ontbreken. Geen regels geïmporteerd"
 
-#: ../../../core/core_st.cpp:184
+#: ../../../core/core_st.cpp:186
 msgid ""
 "Could not find the next entry's title field in the KeePass V1 TXT (should be "
 "within square brackets)."
@@ -5706,36 +5725,36 @@ msgstr ""
 "Kan van de volgende vermelding het titel veld niet vinden in de Keepass V1 "
 "TXT (moet tussen vierkante haakjes staan)"
 
-#: ../../../core/core_st.cpp:185
+#: ../../../core/core_st.cpp:187
 msgid "Column header row not recognised as first record. No records imported."
 msgstr ""
 "Regel met Kolom titels niet herkend als eerste rij. Geen rijen geïmporteerd"
 
-#: ../../../core/core_st.cpp:186
+#: ../../../core/core_st.cpp:188
 msgid "No records in import file!"
 msgstr "Geen regels in het import bestand!"
 
-#: ../../../core/core_st.cpp:187
+#: ../../../core/core_st.cpp:189
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Password field."
 msgstr "Regel %d overgeslagen. Het verplichte Wachtwoord veld is leeg."
 
-#: ../../../core/core_st.cpp:188
+#: ../../../core/core_st.cpp:190
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Title field."
 msgstr "Regel %d overgeslagen. Het verplichte Titel veld is leeg"
 
-#: ../../../core/core_st.cpp:189
+#: ../../../core/core_st.cpp:191
 #, c-format
 msgid " Import # %d"
 msgstr "Importeer # %d"
 
-#: ../../../core/core_st.cpp:190
+#: ../../../core/core_st.cpp:192
 #, fuzzy, c-format
 msgid "%ls - Imported %ls"
 msgstr "%ls - Geïmporteerd %ls"
 
-#: ../../../core/core_st.cpp:191
+#: ../../../core/core_st.cpp:193
 msgid ""
 "To replace passwords of existing entries, all the following columns must be "
 "present: Group/Title, Username and Password.  One or more are missing and no "
@@ -5745,17 +5764,17 @@ msgstr ""
 "kolommen zichtbaar zijn: Groep/Titel, Gebruikersnaam en Wachtwoord. Een of "
 "meer ontbreken en geen enkel vermelding is aangepast."
 
-#: ../../../core/core_st.cpp:192
+#: ../../../core/core_st.cpp:194
 #, fuzzy, c-format
 msgid "%ls not found. Cannot update entry's password.\n"
 msgstr "%ls niet gevonden. Kan wachtwoord van vermelding niet wijzigen.\n"
 
-#: ../../../core/core_st.cpp:193
+#: ../../../core/core_st.cpp:195
 #, fuzzy, c-format
 msgid "%ls has an empty %ls.\n"
 msgstr "%ls heeft een lege %ls.\n"
 
-#: ../../../core/core_st.cpp:194
+#: ../../../core/core_st.cpp:196
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5764,12 +5783,12 @@ msgstr ""
 "Vermelding \"%ls, %ls, %ls\" heeft een wachtwoord met de correcte opmaak "
 "voor een alias, maar de basis vermelding is al een alias."
 
-#: ../../../core/core_st.cpp:195
+#: ../../../core/core_st.cpp:197
 msgid "\tThis entry has been made an alias of associated base entry."
 msgstr ""
 "\tDeze vermelding is een alias gemaakt van het geassocieerde basis vermelding"
 
-#: ../../../core/core_st.cpp:196
+#: ../../../core/core_st.cpp:198
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5778,14 +5797,14 @@ msgstr ""
 "Vermelding \"%ls, %ls, %ls\" heeft een wachtwoord met de correcte opmaak "
 "voor een alias, maar de basis vermelding bestaat niet."
 
-#: ../../../core/core_st.cpp:197
+#: ../../../core/core_st.cpp:199
 msgid ""
 "\tThis entry remains a normal entry and the password has not been changed."
 msgstr ""
 "\tDeze vermelding blijft een gewone vermelding en het wachtwoord is niet "
 "gewijzigd"
 
-#: ../../../core/core_st.cpp:198
+#: ../../../core/core_st.cpp:200
 #, fuzzy, c-format
 msgid ""
 "The %ls entry \"%ls, %ls, %ls\" doesn't point to a normal or existing %ls "
@@ -5794,71 +5813,71 @@ msgstr ""
 "De %ls vermelding \"%ls, %ls, %ls\" wijst niet naar een gewone of bestaande "
 "%ls basis vermelding. Het kan niet geïmporteerd worden."
 
-#: ../../../core/core_st.cpp:199
+#: ../../../core/core_st.cpp:201
 msgid "Entry import warnings"
 msgstr "Vermeldings importeringswaarschuwingen "
 
-#: ../../../core/core_st.cpp:200
+#: ../../../core/core_st.cpp:202
 msgid "id="
 msgstr "id="
 
-#: ../../../core/core_st.cpp:201
+#: ../../../core/core_st.cpp:203
 msgid "on line "
 msgstr "on-line"
 
-#: ../../../core/core_st.cpp:202
+#: ../../../core/core_st.cpp:204
 msgid "Internal error: Invalid oflag or pmode argument"
 msgstr "Interne programma fout: Ongeldige 'oflag' of 'pmode' argument"
 
-#: ../../../core/core_st.cpp:203
+#: ../../../core/core_st.cpp:205
 msgid "invalid!"
 msgstr "ongeldig!"
 
-#: ../../../core/core_st.cpp:204
+#: ../../../core/core_st.cpp:206
 msgid "  Invalid date/time value."
 msgstr "Ongeldige datum/tijd."
 
-#: ../../../core/core_st.cpp:205
+#: ../../../core/core_st.cpp:207
 msgid "  Field length is incorrect."
 msgstr "Veld lengte is fout."
 
-#: ../../../core/core_st.cpp:206
+#: ../../../core/core_st.cpp:208
 msgid "Internal error: An invalid flag was specified"
 msgstr "Interne programma fout: Er werd een ongeldige vlag opgegeven."
 
-#: ../../../core/core_st.cpp:207
+#: ../../../core/core_st.cpp:209
 #, fuzzy, c-format
 msgid "  Invalid header: '%ls' (must be 5 hexadecimal characters)."
 msgstr "Ongeldige titel: '%ls' (moet 5 hexadecimale tekens zijn)."
 
-#: ../../../core/core_st.cpp:208
+#: ../../../core/core_st.cpp:210
 #, fuzzy, c-format
 msgid "Invalid lock file \"%ls\"."
 msgstr "Ongeldig filter ontwerp."
 
-#: ../../../core/core_st.cpp:209
+#: ../../../core/core_st.cpp:211
 #, c-format
 msgid "  Invalid number of saved old passwords %d."
 msgstr "Ongeldig aantal opgeslagen oude wachtwoorden %d."
 
-#: ../../../core/core_st.cpp:210
+#: ../../../core/core_st.cpp:212
 #, c-format
 msgid "  Invalid status value: %d (must be either 0 or 1)."
 msgstr "Ongeldige status waarde: %d (moet 0 of 1 zijn)."
 
-#: ../../../core/core_st.cpp:211
+#: ../../../core/core_st.cpp:213
 msgid "  Invalid password length found (not a hexadecimal number)."
 msgstr ""
 "Wachtwoord met ongeldige lengte gevonden (niet een hexadecimale getal)."
 
-#: ../../../core/core_st.cpp:212
+#: ../../../core/core_st.cpp:214
 msgid ""
 "  Invalid password length found (differs from length of following password)."
 msgstr ""
 "Wachtwoord met ongeldige lengte gevonden (verschilt van lengte met volgende "
 "wachtwoord)."
 
-#: ../../../core/core_st.cpp:213
+#: ../../../core/core_st.cpp:215
 msgid ""
 "  Invalid field separator character found - only a single blank is allowed "
 "between fields."
@@ -5866,20 +5885,20 @@ msgstr ""
 "Ongeldig teken voor veldscheiding gevonden -  alleen een enkele spatie is "
 "toegestaan tussen velden"
 
-#: ../../../core/core_st.cpp:214
+#: ../../../core/core_st.cpp:216
 msgid "Invalid Filter schema."
 msgstr "Ongeldig filter ontwerp."
 
-#: ../../../core/core_st.cpp:215
+#: ../../../core/core_st.cpp:217
 msgid "Schema does not have a version number."
 msgstr "Schema heeft geen versie nummer."
 
-#: ../../../core/core_st.cpp:216
+#: ../../../core/core_st.cpp:218
 #, c-format
 msgid "The filter XML version (%d) is greater than the current schema (%d)."
 msgstr "Het filter XML versie (%d) is groter dan het huidige schema (%d)"
 
-#: ../../../core/core_st.cpp:217
+#: ../../../core/core_st.cpp:219
 #, c-format
 msgid ""
 "The filter XML version (%d) is greater than that supported by this instance "
@@ -5888,57 +5907,57 @@ msgstr ""
 "Het filter XML versie (%d) is groter dan ondersteund wordt door deze versie "
 "van PasswordSafe (%d)."
 
-#: ../../../core/core_st.cpp:218
+#: ../../../core/core_st.cpp:220
 msgid "is"
 msgstr "is"
 
-#: ../../../core/core_st.cpp:219
+#: ../../../core/core_st.cpp:221
 msgid "is active"
 msgstr "is actief"
 
-#: ../../../core/core_st.cpp:220
+#: ../../../core/core_st.cpp:222
 msgid "is inactive"
 msgstr "is niet actief"
 
-#: ../../../core/core_st.cpp:221
+#: ../../../core/core_st.cpp:223
 msgid "is not"
 msgstr "is niet"
 
-#: ../../../core/core_st.cpp:222
+#: ../../../core/core_st.cpp:224
 msgid "is not present"
 msgstr "is niet aanwezig"
 
-#: ../../../core/core_st.cpp:223
+#: ../../../core/core_st.cpp:225
 msgid "is present"
 msgstr "is aanwezig"
 
-#: ../../../core/core_st.cpp:224
+#: ../../../core/core_st.cpp:226
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to entry %ls. It "
 "has been removed from the %ls entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:225
+#: ../../../core/core_st.cpp:227
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to the "
 "PasswordSafe application. It has been removed from the entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:226
+#: ../../../core/core_st.cpp:228
 msgid "less than"
 msgstr "minder dan"
 
-#: ../../../core/core_st.cpp:227
+#: ../../../core/core_st.cpp:229
 msgid "less than or equal to"
 msgstr "minder dan of gelijk aan"
 
-#: ../../../core/core_st.cpp:228
+#: ../../../core/core_st.cpp:230
 msgid "File or path not found"
 msgstr "Bestand of bestandspad niet gevonden"
 
-#: ../../../core/core_st.cpp:229
+#: ../../../core/core_st.cpp:231
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5947,7 +5966,7 @@ msgstr ""
 "\n"
 "De volgende nieuwe %ls %ls samengevoegd in deze database:"
 
-#: ../../../core/core_st.cpp:230
+#: ../../../core/core_st.cpp:232
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5956,7 +5975,7 @@ msgstr ""
 "\n"
 "Samenvoegen afgerond: %d %ls toegevoegd (%d %ls, %d %ls, %d %ls)"
 
-#: ../../../core/core_st.cpp:231
+#: ../../../core/core_st.cpp:233
 #, fuzzy, c-format
 msgid ""
 "Conflicting entries for \"%ls\" \"%ls\" \"%ls\".\n"
@@ -5967,60 +5986,60 @@ msgstr ""
 " Samengevoegde vermelding toegevoegd als  «%ls» «%ls» «%ls».\n"
 "  Veld(en) welke verschillen: %ls"
 
-#: ../../../core/core_st.cpp:232
+#: ../../../core/core_st.cpp:234
 #, fuzzy
 msgid "merged"
 msgstr "Samenvoegen"
 
-#: ../../../core/core_st.cpp:233
+#: ../../../core/core_st.cpp:235
 #, fuzzy, c-format
 msgid "%ls - Merged %ls"
 msgstr "%ls - Samenvoegen %ls"
 
-#: ../../../core/core_st.cpp:234
+#: ../../../core/core_st.cpp:236
 msgid "MISSING PASSWORD"
 msgstr ""
 
-#: ../../../core/core_st.cpp:235
+#: ../../../core/core_st.cpp:237
 #, c-format
 msgid "\tPassword policy name '%ls' is not in the database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:236
+#: ../../../core/core_st.cpp:238
 msgid ""
 "\tOne or more Password Policy Names were not found in the database. The "
 "affected entries have been changed to use the database's default policy."
 msgstr ""
 
-#: ../../../core/core_st.cpp:237
+#: ../../../core/core_st.cpp:239
 #, c-format
 msgid "MISSING TITLE # %d"
 msgstr ""
 
-#: ../../../core/core_st.cpp:239
+#: ../../../core/core_st.cpp:241
 msgid "Can't obtain the schema version."
 msgstr "Kan schema versie niet verkrijgen."
 
-#: ../../../core/core_st.cpp:240
+#: ../../../core/core_st.cpp:242
 msgid "The filter XML version is missing."
 msgstr "De versie van de XML filter ontbreekt."
 
-#: ../../../core/core_st.cpp:241
+#: ../../../core/core_st.cpp:243
 #, fuzzy, c-format
 msgid "Create SchemaCache60 Error 0x%08X during %ls."
 msgstr "Maak SchemaCache%2d Fout 0x%08X tijdens %ls."
 
-#: ../../../core/core_st.cpp:242
+#: ../../../core/core_st.cpp:244
 #, fuzzy, c-format
 msgid "SAX Parse60 Error 0x%08X during %ls."
 msgstr "SAX ontleed %2d fout 0x%08X tijdens %ls."
 
-#: ../../../core/core_st.cpp:243
+#: ../../../core/core_st.cpp:245
 #, fuzzy, c-format
 msgid "Error (%08X): line %d character %d %ls"
 msgstr "Fout code (%08X): regel %d positie %d %ls"
 
-#: ../../../core/core_st.cpp:245
+#: ../../../core/core_st.cpp:247
 msgid ""
 "Unable to get configuration file lock.\n"
 "\n"
@@ -6030,15 +6049,15 @@ msgstr ""
 "\n"
 "Zal register gebruiken."
 
-#: ../../../core/core_st.cpp:246
+#: ../../../core/core_st.cpp:248
 msgid "Cannot create lock file - no permission in directory?"
 msgstr "Kan vergrendel bestand niet maken -  geen toestemming in folder?"
 
-#: ../../../core/core_st.cpp:247
+#: ../../../core/core_st.cpp:249
 msgid "Internal error: Out of file handles"
 msgstr "Interne programma fout: Er zijn geen bestands adressen meer"
 
-#: ../../../core/core_st.cpp:248
+#: ../../../core/core_st.cpp:250
 msgid ""
 "Unable to use a MS XML reader on your system.  Neither MS XML V3, V4 or V6 "
 "seems available."
@@ -6046,15 +6065,15 @@ msgstr ""
 "Niet mogelijk om een MS XML lezer op uw computer te gebruiken. MS XML V3, "
 "V4,  of V6 lijkt niet aanwezig te zijn."
 
-#: ../../../core/core_st.cpp:250
+#: ../../../core/core_st.cpp:252
 msgid "Unsaved changes"
 msgstr "Niet opgeslagen veranderingen"
 
-#: ../../../core/core_st.cpp:251
+#: ../../../core/core_st.cpp:253
 msgid "is not set"
 msgstr "is niet gezet"
 
-#: ../../../core/core_st.cpp:252
+#: ../../../core/core_st.cpp:254
 #, fuzzy, c-format
 msgid ""
 "Number of entries processed: %d\n"
@@ -6089,7 +6108,7 @@ msgstr ""
 "\n"
 "Aantal elementen met velden die niet volledig getoond kunne worden: %d"
 
-#: ../../../core/core_st.cpp:254
+#: ../../../core/core_st.cpp:256
 msgid ""
 "Password should be mixed case, with at least one digit or punctuation "
 "character"
@@ -6097,92 +6116,133 @@ msgstr ""
 "Wachtwoord moet hoofdletters en kleine letters bevatten, met tenminste een "
 "cijfer of leesteken"
 
-#: ../../../core/core_st.cpp:255
+#: ../../../core/core_st.cpp:257
 msgid "Password is too short"
 msgstr "Wachtwoord is te kort"
 
-#: ../../../core/core_st.cpp:256
+#: ../../../core/core_st.cpp:258
 msgid "Easyvision characters"
 msgstr "Easyvision tekens"
 
-#: ../../../core/core_st.cpp:257
+#: ../../../core/core_st.cpp:259
 msgid "Hexadecimal characters"
 msgstr "Hexadecimale letters"
 
-#: ../../../core/core_st.cpp:258
+#: ../../../core/core_st.cpp:260
 #, fuzzy
 msgid "Password length"
 msgstr "Wachtwoord lengte:"
 
-#: ../../../core/core_st.cpp:259
+#: ../../../core/core_st.cpp:261
 msgid "Pronounceable passwords"
 msgstr "Wachtwoorden die uit te spreken zijn"
 
-#: ../../../core/core_st.cpp:261
+#: ../../../core/core_st.cpp:263
 #, fuzzy
 msgid "Use lowercase characters"
 msgstr "Minimum aantal hoofdletters"
 
-#: ../../../core/core_st.cpp:263
+#: ../../../core/core_st.cpp:265
 #, fuzzy
 msgid "Use uppercase characters"
 msgstr "Minimum aantal hoofdletters"
 
-#: ../../../core/core_st.cpp:264
+#: ../../../core/core_st.cpp:266
 #, fuzzy, c-format
 msgid "Error in a Password History %ls:"
 msgstr "Fout in Wachtwoord Geschiedenis %ls:"
 
-#: ../../../core/core_st.cpp:265
+#: ../../../core/core_st.cpp:267
 #, c-format
 msgid "sub-field starting at position %d (within the History field): "
 msgstr "neven-veld beginnend op positie %d(in het Geschiedenis veld):"
 
-#: ../../../core/core_st.cpp:266
+#: ../../../core/core_st.cpp:268
 msgid "  All Password History ignored."
 msgstr "Alle Wachtwoord Geschiedenis genegeerd."
 
-#: ../../../core/core_st.cpp:267
+#: ../../../core/core_st.cpp:269
 msgid "Read Error"
 msgstr "Lees fout"
 
-#: ../../../core/core_st.cpp:268
+#: ../../../core/core_st.cpp:270
+msgid "Relative"
+msgstr "Relatief"
+
+#: ../../../core/core_st.cpp:271
 #, c-format
 msgid ""
 "\tOne or more entry keyboard shortcuts were already assigned to entries in "
 "this database. They have been removed from the %ls entries."
 msgstr ""
 
-#: ../../../core/core_st.cpp:269
+#: ../../../core/core_st.cpp:272
 msgid ""
 "\tOne or more Password Policy Names were already in this database but had "
 "different settings. They have been renamed."
 msgstr ""
 
-#: ../../../core/core_st.cpp:270
+#: ../../../core/core_st.cpp:273
 #, fuzzy, c-format
 msgid "%ls%ls%ls_Report.txt"
 msgstr "%ls%ls%ls_Rapport.txt"
 
-#: ../../../core/core_st.cpp:271
+#: ../../../core/core_st.cpp:274
 #, fuzzy, c-format
 msgid "Report of %ls function started at %ls"
 msgstr "Rapport van %ls funktie gestart als %ls"
 
-#: ../../../core/core_st.cpp:272
+#: ../../../core/core_st.cpp:275
 #, fuzzy, c-format
 msgid "on database %ls"
 msgstr "in database %ls"
 
-#: ../../../core/core_st.cpp:273
+#: ../../../core/core_st.cpp:276
+msgid "Compare"
+msgstr "Vergelijk"
+
+#: ../../../core/core_st.cpp:277
+#, fuzzy
+msgid "Export_DB"
+msgstr "&Exporteer"
+
+#: ../../../core/core_st.cpp:278
+msgid "Export_Text"
+msgstr "Exporteer_Tekst"
+
+#: ../../../core/core_st.cpp:279
+msgid "Export_XML"
+msgstr "Exporteer_XML"
+
+#: ../../../core/core_st.cpp:281
+msgid "Import_KeePassV1_CSV"
+msgstr "Importeer_KeePassV1_CSV"
+
+#: ../../../core/core_st.cpp:282
+msgid "Import_KeePassV1_TXT"
+msgstr "Importeer_KeePassV1_TXT"
+
+#: ../../../core/core_st.cpp:283
+msgid "Import_Text"
+msgstr "Importeren_Tekst"
+
+#: ../../../core/core_st.cpp:284
+msgid "Import_XML"
+msgstr "Importeren_XML"
+
+#: ../../../core/core_st.cpp:285
+msgid "Merge"
+msgstr "Samenvoegen"
+
+#: ../../../core/core_st.cpp:287
 msgid "Validate"
 msgstr "Valideren"
 
-#: ../../../core/core_st.cpp:275
+#: ../../../core/core_st.cpp:289
 msgid "Fatal Error"
 msgstr "Fatale fout"
 
-#: ../../../core/core_st.cpp:277
+#: ../../../core/core_st.cpp:291
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -6191,119 +6251,129 @@ msgstr ""
 "\n"
 "Fout in Wachtwoord Geschiedenis voor vermelding: »%ls»%ls»%ls»: "
 
-#: ../../../core/core_st.cpp:278
+#: ../../../core/core_st.cpp:292
+#, fuzzy, c-format
+msgid "\tNo entries were found containing search string '%ls' %ls"
+msgstr "\tGeen vermdelingen zijn gevonden die de zoek tekst '%s' bevattan"
+
+#: ../../../core/core_st.cpp:293
+#, fuzzy, c-format
+msgid "\tThe following entries contain search string '%ls' %ls"
+msgstr "\tDe volgende vermeldingen bevatten de zoek tekst '%s'"
+
+#: ../../../core/core_st.cpp:294
 msgid "See Attachment filters"
 msgstr ""
 
-#: ../../../core/core_st.cpp:279
+#: ../../../core/core_st.cpp:295
 msgid "See Password History filters"
 msgstr "Zie wachtwoord geschiedenis filters"
 
-#: ../../../core/core_st.cpp:280
+#: ../../../core/core_st.cpp:296
 msgid "See Password Policy filters"
 msgstr "Zie wachtwoord beleids filters"
 
-#: ../../../core/core_st.cpp:281
+#: ../../../core/core_st.cpp:297
 msgid "is set"
 msgstr "is gezet"
 
-#: ../../../core/core_st.cpp:282
+#: ../../../core/core_st.cpp:298
 msgid "shortcut"
 msgstr "Snelkoppeling"
 
-#: ../../../core/core_st.cpp:283
+#: ../../../core/core_st.cpp:299
 msgid "shortcuts"
 msgstr "Snelkoppelingen"
 
-#: ../../../core/core_st.cpp:284
+#: ../../../core/core_st.cpp:300
 msgid "policy specific symbols"
 msgstr ""
 
-#: ../../../core/core_st.cpp:285
+#: ../../../core/core_st.cpp:301
 msgid "Start Report"
 msgstr "Begin Rapport"
 
-#: ../../../core/core_st.cpp:286
+#: ../../../core/core_st.cpp:302
 msgid "Double-Click on entry to Autotype"
 msgstr "Dubbel klik de vermelding voor automatische invoer"
 
-#: ../../../core/core_st.cpp:287
+#: ../../../core/core_st.cpp:303
 msgid "Double-Click on entry to Browse to URL"
 msgstr "Dubbel klik de vermelding om de URL in de browser te openen"
 
-#: ../../../core/core_st.cpp:288
+#: ../../../core/core_st.cpp:304
 msgid "Double-Click on entry to Browse to URL + Autotype"
 msgstr ""
 "Dubbel klik de vermelding om de URL in de browser te openen en automatische "
 "invoer te gebruiken"
 
-#: ../../../core/core_st.cpp:289
+#: ../../../core/core_st.cpp:305
 #, fuzzy
 msgid "https://pwsafe.org/"
 msgstr "https://pwsafe.org/"
 
-#: ../../../core/core_st.cpp:290
+#: ../../../core/core_st.cpp:306
 msgid "Double-Click on entry to Copy Notes"
 msgstr "Dubbel klik de vermelding om notities te kopiëreen"
 
-#: ../../../core/core_st.cpp:291
+#: ../../../core/core_st.cpp:307
 msgid "Double-Click on entry to Copy Password"
 msgstr "Dubbel klik de vermelding om wachtwoord te kopiëren"
 
-#: ../../../core/core_st.cpp:292
+#: ../../../core/core_st.cpp:308
 msgid "Double-Click on entry to Copy Password and Minimize"
 msgstr "Dubbel klik de vermelding om wachtwoord te kopiëren en minimaliseren"
 
-#: ../../../core/core_st.cpp:293
+#: ../../../core/core_st.cpp:309
 msgid "Double-Click on entry to Copy Username"
 msgstr "Dubbel klik de vermelding om gebruikersnaam te kopiëren"
 
-#: ../../../core/core_st.cpp:294
+#: ../../../core/core_st.cpp:310
 msgid "Double-Click on entry to Run Command"
 msgstr "Dubbel klik de vermelding om Opdracht Uit te voeren"
 
-#: ../../../core/core_st.cpp:295
+#: ../../../core/core_st.cpp:311
 #, fuzzy
 msgid "Double-Click on entry to Send Email"
 msgstr "Dubbel klik de vermelding om e-mail te versturen"
 
-#: ../../../core/core_st.cpp:296
+#: ../../../core/core_st.cpp:312
 msgid "Double-Click on entry to View/Edit it"
 msgstr "Dubbel klik de vermelding om het te bekijken/bewerken"
 
-#: ../../../core/core_st.cpp:299
+#: ../../../core/core_st.cpp:315
 #, fuzzy, c-format
 msgid "%ls - Sync'd %ls"
 msgstr "%ls op %ls"
 
-#: ../../../core/core_st.cpp:300
+#: ../../../core/core_st.cpp:316
 msgid "System error: No more file handles available"
 msgstr "Systeem fout: Geen bestands verwijzing beschikbaar"
 
-#: ../../../core/core_st.cpp:303
+#: ../../../core/core_st.cpp:319
 msgid "Unknown function"
 msgstr "Onbekende functie"
 
-#: ../../../core/core_st.cpp:304
+#: ../../../core/core_st.cpp:320
 msgid "Unknown object"
 msgstr "Onbekend object"
 
-#: ../../../core/core_st.cpp:305
+#: ../../../core/core_st.cpp:321
 msgid "Internal error: Unexpected error number"
 msgstr "Interne programma fout: Onbekend fout nummer"
 
-#: ../../../core/core_st.cpp:307
+#: ../../../core/core_st.cpp:323
 #, c-format
 msgid "\tName: %s; Filename: %s"
 msgstr ""
 
-#: ../../../core/core_st.cpp:308
+#: ../../../core/core_st.cpp:324
 msgid ""
 "The following entries had an invalid UUID field.  This has been corrected."
 msgstr ""
 "De volgende vermeldingen hadden een ongeldige UUID waarde. Dit is aangepast."
 
-#: ../../../core/core_st.cpp:309
+#: ../../../core/core_st.cpp:325
 #, fuzzy, c-format
 msgid ""
 "The following entries have passwords in the correct form for %ls, but the "
@@ -6312,18 +6382,18 @@ msgstr ""
 "Vermelding \"%ls, %ls, %ls\" heeft een wachtwoord met de correcte opmaak "
 "voor een alias, maar de basis vermelding bestaat niet."
 
-#: ../../../core/core_st.cpp:310
+#: ../../../core/core_st.cpp:326
 msgid "The following entries were duplicates of an existing entry."
 msgstr "De volgende vermeldingen zijn een kopie van een bestaande vermelding."
 
-#: ../../../core/core_st.cpp:311
+#: ../../../core/core_st.cpp:327
 #, fuzzy
 msgid ""
 "The following entries had a duplicate UUID field.  This has been corrected."
 msgstr ""
 "De volgende vermeldingen hadden een ongeldige UUID waarde. Dit is aangepast."
 
-#: ../../../core/core_st.cpp:312
+#: ../../../core/core_st.cpp:328
 #, fuzzy, c-format
 msgid ""
 "The following entries had an empty Password field, which is not permitted. "
@@ -6331,37 +6401,37 @@ msgid ""
 msgstr ""
 "De volgende vermeldingen hadden een ongeldige UUID waarde. Dit is aangepast."
 
-#: ../../../core/core_st.cpp:313
+#: ../../../core/core_st.cpp:329
 #, fuzzy
 msgid "The following entries had an empty Title field, which is not permitted."
 msgstr ""
 "De volgende vermeldingen hadden een ongeldige UUID waarde. Dit is aangepast."
 
-#: ../../../core/core_st.cpp:314
+#: ../../../core/core_st.cpp:330
 #, fuzzy, c-format
 msgid "\tGroup='%ls', Title='%ls', User='%ls' %ls"
 msgstr "\tGroep='%ls', Titel='%ls', Gebruiker='%ls' %ls"
 
-#: ../../../core/core_st.cpp:315
+#: ../../../core/core_st.cpp:331
 #, fuzzy, c-format
 msgid "- Its title has been changed to:'%ls'"
 msgstr "-De titel hiervan is veranderd in:'%ls'"
 
-#: ../../../core/core_st.cpp:316
+#: ../../../core/core_st.cpp:332
 msgid "The following ERRORS were detected and were FIXED."
 msgstr ""
 
-#: ../../../core/core_st.cpp:317
+#: ../../../core/core_st.cpp:333
 #, fuzzy
 msgid "The following entries refer to missing attachments."
 msgstr "De volgende vermeldingen zijn een kopie van een bestaande vermelding."
 
-#: ../../../core/core_st.cpp:318
+#: ../../../core/core_st.cpp:334
 #, fuzzy
 msgid "The following attachments are not referred to by any entry."
 msgstr "De volgende vermeldingen zijn een kopie van een bestaande vermelding."
 
-#: ../../../core/core_st.cpp:319
+#: ../../../core/core_st.cpp:335
 msgid ""
 "The following entries had an invalid Password History.  This has been "
 "rebuilt with available data.  There may be some loss of history."
@@ -6370,24 +6440,24 @@ msgstr ""
 "hersteld met beschikbare gegevens. Een deel van de geschiedenis kan hierdoor "
 "verloren zijn."
 
-#: ../../../core/core_st.cpp:320
+#: ../../../core/core_st.cpp:336
 #, c-format
 msgid ""
 "The following entries have one or more text fields too long to display or "
 "edit (over %d characters).  The largest entry size found was ~%d %ls."
 msgstr ""
 
-#: ../../../core/core_st.cpp:321
+#: ../../../core/core_st.cpp:337
 msgid ""
 "The following WARNINGS were detected - you should review and fix them "
 "manually."
 msgstr ""
 
-#: ../../../core/core_st.cpp:324
+#: ../../../core/core_st.cpp:340
 msgid "will expire"
 msgstr "zal verlopen"
 
-#: ../../../core/core_st.cpp:325
+#: ../../../core/core_st.cpp:341
 #, fuzzy, c-format
 msgid ""
 "SAX Parse Error during %ls\n"
@@ -6396,23 +6466,23 @@ msgstr ""
 "SAX ontleed fout tijdens %ls\n"
 "%ls."
 
-#: ../../../core/core_st.cpp:326
+#: ../../../core/core_st.cpp:342
 #, fuzzy, c-format
 msgid "XML %ls: line %d character %d: %ls"
 msgstr "XML %ls: regel %d teken %d: %ls"
 
-#: ../../../core/core_st.cpp:327
+#: ../../../core/core_st.cpp:343
 msgid ""
 "*** Invalid XML characters found - see exported XML file for more details ***"
 msgstr ""
 
-#: ../../../core/core_st.cpp:328
+#: ../../../core/core_st.cpp:344
 msgid "Internal error: Couldn't initialize config file XML structure"
 msgstr ""
 "Interne programma fout: De configuratiebestand XML-structuur kan niet worden "
 "geÃ¯nitialiseerd"
 
-#: ../../../core/core_st.cpp:329
+#: ../../../core/core_st.cpp:345
 msgid ""
 "A filter was active. Export of data was restricted to include only those "
 "displayed."
@@ -6420,36 +6490,36 @@ msgstr ""
 "Een filter was actief. De geëxporteerde data was beperkt tot alleen de "
 "getoonde data."
 
-#: ../../../core/core_st.cpp:330
+#: ../../../core/core_st.cpp:346
 msgid "Export of data was restricted to certain fields by the user."
 msgstr ""
 "Exporteren van gegevens was door de gebruiker beperkt tot bepaalde velden"
 
-#: ../../../core/core_st.cpp:331
+#: ../../../core/core_st.cpp:347
 msgid ""
 "Note: These Password Policies will not replace existing policies with the "
 "same name in the current database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:332
+#: ../../../core/core_st.cpp:348
 msgid ""
 "Note: These preferences are only used when importing into an empty database."
 msgstr ""
 "Opmerking: Deze voorkeuren worden alleen gebruikt bij het importeren in een "
 "lege database."
 
-#: ../../../core/core_st.cpp:333
+#: ../../../core/core_st.cpp:349
 msgid "Subset of entries restricted by the following rule:"
 msgstr "Deel van de vermeldingen beperkt door de volgende regel:"
 
-#: ../../../core/core_st.cpp:334
+#: ../../../core/core_st.cpp:350
 msgid ""
 "The user specified that the following fields be excluded from the export:"
 msgstr ""
 "De gebruiker gaf op dat de volgende velden uitgesloten moeten worden van de "
 "export:"
 
-#: ../../../core/core_st.cpp:335
+#: ../../../core/core_st.cpp:351
 #, fuzzy, c-format
 msgid ""
 "Configuration file error:\n"
@@ -6462,15 +6532,15 @@ msgstr ""
 "%ls\n"
 "regel %d kolom %d"
 
-#: ../../../core/core_st.cpp:336
+#: ../../../core/core_st.cpp:352
 msgid "import"
 msgstr "importeer"
 
-#: ../../../core/core_st.cpp:337
+#: ../../../core/core_st.cpp:353
 msgid "Unable to load configuration file"
 msgstr "Niet mogelijk om configuratie bestand te laden."
 
-#: ../../../core/core_st.cpp:338
+#: ../../../core/core_st.cpp:354
 msgid ""
 "Failed to lock configuration file - opened by another instance of "
 "PasswordSafe?"
@@ -6478,110 +6548,57 @@ msgstr ""
 "Het vergrendelen van het configuratie bestand is mislukt - geopend door een "
 "andere instantie van PasswordSafe?"
 
-#: ../../../core/core_st.cpp:339
+#: ../../../core/core_st.cpp:355
 msgid "Unable to save configuration file"
 msgstr "Niet mogelijk om configuratie bestand op te slaan"
 
-#: ../../../core/core_st.cpp:340
+#: ../../../core/core_st.cpp:356
 #, fuzzy
 msgid "validation"
 msgstr "valideren"
 
-#: ../../../core/core_st.cpp:342
+#: ../../../core/core_st.cpp:358
 msgid " (EasyVision Symbols)"
 msgstr ""
 
-#: ../../../core/core_st.cpp:343
+#: ../../../core/core_st.cpp:359
 #, fuzzy, c-format
 msgid "Yes (at least %d)"
 msgstr "Moet tenmiste %d zijn."
 
-#: ../../../core/core_st.cpp:344
+#: ../../../core/core_st.cpp:360
 #, fuzzy
 msgid " (Pronounceable Symbols)"
 msgstr "Wachtwoorden die uit te spreken zijn"
 
-#: ../../../core/core_st.cpp:345
+#: ../../../core/core_st.cpp:361
 #, c-format
 msgid "Yes - At least %d from %ls: %ls%ls"
 msgstr ""
 
-#: ../../../core/core_st.cpp:346
 #, fuzzy, c-format
-msgid "\tGroup='%ls', Title='%ls', User='%ls'"
-msgstr "\tGroep='%ls', Titel='%ls', Gebruiker='%ls' %ls"
+#~ msgid "\tGroup='%ls', Title='%ls', User='%ls'"
+#~ msgstr "\tGroep='%ls', Titel='%ls', Gebruiker='%ls' %ls"
 
-#: ../../../core/core_st.cpp:347
-#, fuzzy, c-format
-msgid ""
-"Compare complete of current database:\n"
-"\t %ls\n"
-" and:\n"
-"\t %ls\n"
-msgstr ""
-"Vergelijk volledig van huidige database:\n"
-"\t %s\n"
-" en:\n"
-"\t %s"
-
-#: ../../../core/core_st.cpp:348
-#, fuzzy, c-format
-msgid "\tNo entries were found containing search string '%ls' %ls"
-msgstr "\tGeen vermdelingen zijn gevonden die de zoek tekst '%s' bevattan"
-
-#: ../../../core/core_st.cpp:349
-#, fuzzy, c-format
-msgid "\tThe following entries contain search string '%ls' %ls"
-msgstr "\tDe volgende vermeldingen bevatten de zoek tekst '%s'"
-
-#: ../../../core/core_st.cpp:350
 #, fuzzy
-msgid "Export DB"
-msgstr "&Exporteer"
+#~ msgid "Import KeePassV1 CSV"
+#~ msgstr "Importeer KeePass V1 CSV"
 
-#: ../../../core/core_st.cpp:351
 #, fuzzy
-msgid "Import KeePassV1 CSV"
-msgstr "Importeer KeePass V1 CSV"
+#~ msgid "Import KeePassV1 TXT"
+#~ msgstr "Importeer KeePass V1 TXT"
 
-#: ../../../core/core_st.cpp:352
 #, fuzzy
-msgid "Import KeePassV1 TXT"
-msgstr "Importeer KeePass V1 TXT"
+#~ msgid "Import XML"
+#~ msgstr ""
+#~ "\n"
+#~ "Importeer XML"
 
-#: ../../../core/core_st.cpp:353
 #, fuzzy
-msgid "Import XML"
-msgstr ""
-"\n"
-"Importeer XML"
-
-#: ../../../core/core_st.cpp:354
-#, fuzzy
-msgid "Import Text"
-msgstr ""
-"\n"
-"Importeer Tekst"
-
-#: ../../../core/core_st.cpp:355
-msgid "Merge"
-msgstr "Samenvoegen"
-
-#: ../../../core/core_st.cpp:356
-msgid "Compare"
-msgstr "Vergelijk"
-
-#~ msgid "Import_Text"
-#~ msgstr "Importeren_Tekst"
-
-#~ msgid "Import_XML"
-#~ msgstr "Importeren_XML"
-
-#~ msgid "Import_KeePassV1_CSV"
-#~ msgstr "Importeer_KeePassV1_CSV"
-
-#~ msgid "Import_KeePassV1_TXT"
-#~ msgstr "Importeer_KeePassV1_TXT"
+#~ msgid "Import Text"
+#~ msgstr ""
+#~ "\n"
+#~ "Importeer Tekst"
 
 #, fuzzy
 #~ msgid "Advanced..."
@@ -8044,12 +8061,6 @@ msgstr "Vergelijk"
 #~ "Het te exporteren bestand: '%s' bestaat al.\n"
 #~ "Wilt u het overschrijven?"
 
-#~ msgid "Export_Text"
-#~ msgstr "Exporteer_Tekst"
-
-#~ msgid "Export_XML"
-#~ msgstr "Exporteer_XML"
-
 #~ msgid "Exporting to file:"
 #~ msgstr "Exporteer naar bestand:"
 
@@ -8815,9 +8826,6 @@ msgstr "Vergelijk"
 #~ "Herstel de automatisch bewaarde documenten\n"
 #~ "Open de automatisch bewaarde versies in plaats van de expliciet bewaarde "
 #~ "versies"
-
-#~ msgid "Relative"
-#~ msgstr "Relatief"
 
 #~ msgid ""
 #~ "Relative dates are in days relative to today e.g. '-1' is yesterday and "
@@ -10123,9 +10131,6 @@ msgstr "Vergelijk"
 #~ msgstr ""
 #~ "\t Vermelding-Groep:\"%s\";Titel:\"%s\";Gebruiker:\"%s\"\n"
 #~ "\t\t heeft verschillen in de volgende velden:"
-
-#~ msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-#~ msgstr "\tGroep:'%s'; Titel:'%s'; Gebruiker:'%s'"
 
 #~ msgid ""
 #~ "\tThe following restrictions were selected:\n"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-28 12:52+0100\n"
+"POT-Creation-Date: 2021-03-19 21:58+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -240,7 +240,7 @@ msgstr "Daty i czas"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:348
 #: ../../../ui/wxWidgets/HelpMap.h:41 ../../../ui/wxWidgets/HelpMap.h:49
-#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:141
+#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:143
 msgid "Password Policy"
 msgstr "Właściwości Haseł"
 
@@ -254,7 +254,7 @@ msgid "Set Date/Time"
 msgstr "Ustaw Datę/Czas"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:370
-#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:137
+#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:139
 msgid "Password"
 msgstr "Hasło"
 
@@ -544,14 +544,14 @@ msgstr "Użyj DUŻYCH liter"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:747
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:281
-#: ../../../core/core_st.cpp:260
+#: ../../../core/core_st.cpp:262
 #, fuzzy
 msgid "Use digits"
 msgstr "Użyj cyfr"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:771
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:305
-#: ../../../core/core_st.cpp:262
+#: ../../../core/core_st.cpp:264
 #, fuzzy
 msgid "Use symbols"
 msgstr "Użyć symboli"
@@ -586,7 +586,7 @@ msgstr "Generuj hasło wymawialne"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:815
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:350
-#: ../../../core/core_st.cpp:253
+#: ../../../core/core_st.cpp:255
 msgid "Or"
 msgstr "Lub"
 
@@ -634,7 +634,7 @@ msgstr "Właściwości"
 #: ../../../ui/wxWidgets/CreateShortcutDlg.cpp:219
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:269
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:274
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
 msgid "Text"
 msgstr "Tekst"
 
@@ -690,7 +690,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:160
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:173
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:192
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:301
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:317
 msgid "Unknown"
 msgstr "Nieznany"
 
@@ -805,7 +805,7 @@ msgstr "[Notatki są ukryte - kliknij tutaj żeby je zobaczyć]"
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:1653
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2145
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2820
-#: ../../../core/core_st.cpp:74
+#: ../../../core/core_st.cpp:76
 #, fuzzy
 msgid "Default Policy"
 msgstr "Domyślna polityka"
@@ -827,7 +827,7 @@ msgstr "Nie można stworzyc hasła - nieprawidłowa polityka haseł"
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:144
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:151
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:159
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:200
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:201
 #: ../../../ui/wxWidgets/PWSafeApp.cpp:367
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:737
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:756
@@ -851,7 +851,7 @@ msgstr "Nie można stworzyc hasła - nieprawidłowa polityka haseł"
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:249
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:277
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:316
-#: ../../../core/core_st.cpp:274
+#: ../../../core/core_st.cpp:288
 msgid "Error"
 msgstr "Błąd"
 
@@ -1025,7 +1025,7 @@ msgid "Synchronize this item..."
 msgstr "Synchronizuj ten wpis..."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:482
-#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:357
+#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:286
 msgid "Synchronize"
 msgstr "Synchronizuj"
 
@@ -1104,8 +1104,8 @@ msgid "Current safe was opened read-only"
 msgstr "Bieżący sejf został otwarty tylko do odczytu"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:793
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:996
-#: ../../../ui/wxWidgets/SyncWizard.cpp:618
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
+#: ../../../ui/wxWidgets/SyncWizard.cpp:619
 #, fuzzy, c-format
 msgid ""
 "The database:\n"
@@ -1123,7 +1123,7 @@ msgstr ""
 "Proszę to naprawić przez walidację bazy danych."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:794
-#: ../../../ui/wxWidgets/SyncWizard.cpp:617
+#: ../../../ui/wxWidgets/SyncWizard.cpp:618
 msgid "Synchronization failed"
 msgstr "Synchronizacja sie nie powiodła"
 
@@ -1492,7 +1492,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/GridCtrl.cpp:164
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:292
-#: ../../../core/core_st.cpp:147
+#: ../../../core/core_st.cpp:149
 #, fuzzy
 msgid "Title"
 msgstr "Tytuł"
@@ -1706,7 +1706,7 @@ msgid "Value"
 msgstr "Wartość"
 
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:291
-#: ../../../core/core_st.cpp:133
+#: ../../../core/core_st.cpp:135
 msgid "Group"
 msgstr "Grupa"
 
@@ -1792,24 +1792,24 @@ msgstr ""
 msgid "Error parsing Run Command"
 msgstr "Błąd parsowania komendy Run"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:56
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:57
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:355
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:362
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:166
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:623
 msgid "Write Error"
 msgstr "Błąd zapisu"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:61
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:62
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:165
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:622
 #, fuzzy
 msgid "Could not open file for writing!"
 msgstr "Nie można otworzyć pliku do zapisu!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:64
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:65
 msgid ""
 "Write operation failed!\n"
 "File may have been corrupted.\n"
@@ -1819,56 +1819,56 @@ msgstr ""
 "Plik może byc uszkodzony.\n"
 "Spróbuj go zachować w innym miejscu"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:69
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:70
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "Unknown error"
 msgstr "Nieznany błąd"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:90
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:91
 msgid "Do you want to save changes to the password database: "
 msgstr "Czy chcesz zapisać zmiany w bazie haseł: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:145
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:146
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:557
 msgid "Please choose a name for the new database"
 msgstr "Wybierz nazwę dla nowej bazy danych"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:155
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:156
 msgid "psafe3 files (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 msgstr "Pliki psafe3 (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Lock is done by yourself"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Remove Lock?"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:194
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:195
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:602
 #, fuzzy
 msgid "Could not lock file.\n"
 msgstr "Nie można otworzyć pliku do odczytu!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:196
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:197
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:452
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:604
 msgid "Locked by "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:236
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:237
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:515
 msgid "Please Choose a Database to Open:"
 msgstr "Wybierz bazę danych do otwarcia:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:353
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
 msgid ""
 "Unable to create intermediate backup.  Save database elsewhere or with "
 "another name?\n"
@@ -1880,7 +1880,7 @@ msgstr ""
 "\n"
 "Wybierz 'Nie' by wyjść bez zapisu."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:360
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Do you wish to save changes to your "
@@ -1891,12 +1891,12 @@ msgstr ""
 "\n"
 "Wybierz 'Nie' by wyjść bez zapisu."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 msgid "Unable to create intermediate backup."
 msgstr "Nie udało się utworzyć tymczasowej kopii zapasowej."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:386
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:387
 #, fuzzy, c-format
 msgid ""
 "The original database, \"%ls\", is in pre-3.0 format. It will be unchanged.\n"
@@ -1910,12 +1910,12 @@ msgstr ""
 "być użyty przez starsze wersje PasswordSafe. By zapisać zmiany w starym "
 "formacie użyj komendy \"Plik->Eksportuj do -> Stary formatd (1.x lub 2)\"."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:388
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:389
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:447
 msgid "File version warning"
 msgstr "Ostrzeżenie o wersji pliku"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:445
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
 #, fuzzy, c-format
 msgid ""
 "The original database, '%ls', is in pre-3.0 format. The data will now be "
@@ -1928,15 +1928,15 @@ msgstr ""
 "PasswordSafe. By zapisać dane w starym formacie użyj komendy 'Plik->Eksport "
 "do-> Stary format (1.x lub 2)'."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:458
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
 msgid "Please choose a name for the current (Untitled) database:"
 msgstr "Wybierz nazwę dla bieżącej (bez nazwy) bazy danych:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:460
 msgid "Please choose a new name for the current database:"
 msgstr "Wybierz nową nazwę dla bieżącej bazy danych:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:467
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:468
 msgid ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|"
 "*.*;*"
@@ -1944,7 +1944,7 @@ msgstr ""
 "Bazy danych Password Safe (*.psafe3; *.dat)|*.psafe3;*.dat|Wszystkie pliki "
 "(*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:479
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -1955,126 +1955,126 @@ msgstr ""
 "\n"
 "Plik jest obecnie używany przez %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:481
 msgid "File lock error"
 msgstr "Błąd blokowania pliku"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:547
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
 #, fuzzy
 msgid "Do you wish to save this restored database as new database?"
 msgstr "Czy chcesz zachować zmiany w bazie haseł"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:549
 #, fuzzy
 msgid "Unsaved restored database"
 msgstr "w bazie danych"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:580
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:581
 msgid "Do you want to save changes to the password database"
 msgstr "Czy chcesz zachować zmiany w bazie haseł"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:617
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:618
 msgid "Export Text"
 msgstr "Eksportuj Tekst"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:621
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:622
 msgid "Export Text failed"
 msgstr "Problem z eksportem tekstowym"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:623
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
 msgid "Please name the plaintext file"
 msgstr "Nazwij plik tekstowy"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1143
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:625
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1144
 msgid ""
 "Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
 msgstr ""
 "Pliki tekstowe (*.txt)|*.txt|Pliki CSV (*.csv)|*.csv|Wszystkie pliki (*.*; "
 "*)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:634
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:635
 msgid "Advanced Text Export Options"
 msgstr "Zaawansowane opcje eksportu tekstu"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:654
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:697
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:655
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:698
 msgid "export"
 msgstr "eksport"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:660
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:661
 msgid "Export XML"
 msgstr "Eksportuj XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:664
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:665
 msgid "Export XML failed"
 msgstr "Problem w czasie eskportu XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:666
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
 #, fuzzy
 msgid "Please name the XML file"
 msgstr "Podaj nazwę pliku XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:668
 msgid "XML files (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 msgstr "Pliki XML (*.xml)|*.xml|Wszystkie pliki (*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:678
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:679
 msgid "Advanced XML Export Options"
 msgstr "Zaawansowane opcje eksportu XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:712
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:716
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:713
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:717
 #, fuzzy
 msgid "Password Safe Databases (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 msgstr ""
 "Bazy danych Password Safe (*.psafe3; *.dat)|*.psafe3;*.dat|Wszystkie pliki "
 "(*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:720
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:721
 #, fuzzy
 msgid "Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 msgstr ""
 "Bazy danych Password Safe (*.psafe3; *.dat)|*.psafe3;*.dat|Wszystkie pliki "
 "(*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:731
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:732
 msgid "Please name the exported database"
 msgstr "Podaj nazwę eksportowanej bazy danych"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:748
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:749
 msgid "Could not figure out why PasswordSafeFrame::OnExportVx was invoked"
 msgstr "Nie można określić dlaczego wywołano PasswordSafeFrame::OnExportVx"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:782
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:783
 msgid "You must save this database before it can be exported."
 msgstr "Musisz zachować tę bazę danych przed jej wyeksportowanie,."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid "Exporting database: "
 msgstr "Eksport bazy danych: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid " to "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:841
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:842
 #, fuzzy
 msgid "Export complete.  Do you wish to see a detailed report?"
 msgstr "Czy chcesz zobaczyć dokładny raport?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:852
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:853
 msgid "No entries satisfied your selection criteria and so none were exported!"
 msgstr ""
 "Nie ma wpisów pasujących do podanych kryteriów i nic nie zostało "
 "wyeksportowane!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:865
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:866
 #, fuzzy
 msgid "Passkey incorrect"
 msgstr "Nieprawidłowy Passkey"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:873
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
 msgid ""
 "The current database was opened in read-only mode.  You cannot import into "
 "it."
@@ -2082,114 +2082,114 @@ msgstr ""
 "Aktualna baza danych została otwarta tylko do odczytu.  Nie można do niej "
 "importować."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:875
 msgid "Import text"
 msgstr "Import tekstu"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:882
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
 msgid "The database:"
 msgstr "Baza danych:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
 msgid "has duplicate entries with the same group/title/user combination."
 msgstr "ma duplikat wpisu w tej samej kombinacji grupa/tytuł/użytkownik."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
 msgid "  Please fix by validating database."
 msgstr "  Proszę naprawić przez sprawdzenie bazy danych."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:931
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:886
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:932
 #, fuzzy
 msgid "Import Text failed"
 msgstr "Import Text nie powiódł się"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 #, fuzzy, c-format
 msgid "%ls file being imported: %ls"
 msgstr "%ls plik importowany: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:921
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:926
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:223
-#: ../../../ui/wxWidgets/SyncWizard.cpp:572
+#: ../../../ui/wxWidgets/SyncWizard.cpp:573
 #: ../../../ui/wxWidgets/wxUtilities.cpp:59
 #: ../../../ui/wxWidgets/wxUtilities.cpp:64
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "File Read Error"
 msgstr "Błąd odczytu pliku"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:923
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:222
 #: ../../../ui/wxWidgets/wxUtilities.cpp:58
 #, fuzzy
 msgid "Could not open file for reading!"
 msgstr "Nie można otworzyć pliku do odczytu!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:928
 msgid "Invalid format"
 msgstr "Zły format"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 msgid "Updated "
 msgstr "Zaktualizowano "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 msgid "Imported "
 msgstr "Zaimportowano "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 msgid " entry"
 msgstr " wpis"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 msgid " entries"
 msgstr " wpisy"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
 msgid "Skipped "
 msgstr "Ominięto "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:957
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:958
 msgid "with Password History errors "
 msgstr "z błędami historii hasła "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 msgid "Renamed "
 msgstr "Zmieniono nazwę "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed successfully"
 msgstr "Zakończono z sukcesem"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed but ...."
 msgstr "Zakończono, lecz ...."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:981
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1127
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1197
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1218
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1279
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:982
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1128
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1219
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
 msgid "Do you wish to see a detailed report?"
 msgstr "Czy chcesz zobaczyć dokładny raport?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1045
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:998
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1046
 msgid "Import XML failed"
 msgstr "Import XML nie powiódł się"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1007
-#: ../../../core/core_st.cpp:238
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../core/core_st.cpp:240
 #, fuzzy, c-format
 msgid ""
 "Can't find XML Schema Definition file (%ls) in your PasswordSafe Application "
@@ -2200,19 +2200,19 @@ msgstr ""
 "PasswordSafe.\n"
 "Skopiuj go z pliku instalacyjnego lub przeinstaluj PasswordSafe. ."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid "Missing XSD File - "
 msgstr "Brak pliku XSD - "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid " Build"
 msgstr " Zbudowany"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 msgid "XML"
 msgstr "XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1051
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1052
 #, fuzzy, c-format
 msgid ""
 "File: %ls failed validation against XML Schema:\n"
@@ -2223,7 +2223,7 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1057
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1058
 #, fuzzy, c-format
 msgid ""
 "File: %ls passed Validation but had the following errors during import:\n"
@@ -2235,25 +2235,25 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1078
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1079
 msgid "The following records were skipped:"
 msgstr "Następujące rekordy zostały ominięte:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1080
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1081
 #, c-format
 msgid " / skipped %d"
 msgstr " / ominięto %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1085
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1086
 msgid "The following records had errors in their Password History:"
 msgstr "Nastepujące rekordy miały błędy w historii haseł:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1087
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1088
 #, c-format
 msgid " / with Password History errors %d"
 msgstr " / z błędami historii haseł %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1092
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1093
 msgid ""
 "The following records were renamed as an entry already exists in your "
 "database or in the Import file:"
@@ -2261,12 +2261,12 @@ msgstr ""
 "Następującym rekordom zostały zmienione nazwy ponieważ wpisy już istniały w "
 "Twojej bazie lub pliku importowanym:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1094
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1095
 #, c-format
 msgid " / renamed %d"
 msgstr " / zmieniono nazwę %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1099
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1100
 #, fuzzy, c-format
 msgid ""
 "File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See "
@@ -2275,25 +2275,25 @@ msgstr ""
 "Plik: %ls został zaimportowany (wpisy sprawdzone %d / zaimportowano %d%ls%ls"
 "%ls). Zobacz raport szczegółowy."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:95
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:97
 msgid "entry"
 msgstr "wpis"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:93
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:95
 msgid "entries"
 msgstr "wpisy"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1107
 #, fuzzy, c-format
 msgid ""
 "Validated %d %ls\n"
@@ -2304,26 +2304,26 @@ msgstr ""
 "\n"
 "Zaimportowane %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1114
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1115
 msgid "XML import not supported in this release"
 msgstr "Import XML nie jest dostępny w tej wersji"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1117
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1118
 #, c-format
 msgid "XML import: Unexpected return code(%d)"
 msgstr "Import XML: niespodziewany kod powrotu(%d)"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1141
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1142
 msgid "Please Choose a KeePass Text File to Import"
 msgstr "Wybierz plik tekstowy KeePass do zaimportowania"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1163
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1164
 #, fuzzy, c-format
 msgid "Text file being imported: %ls"
 msgstr "Plik tekstowy do zaimportowania: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1180
-#: ../../../ui/wxWidgets/SyncWizard.cpp:602
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/SyncWizard.cpp:603
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2334,12 +2334,12 @@ msgstr ""
 "\n"
 "Nie można otworzyć pliku do odczytu!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1182
 #, fuzzy
 msgid "File open error"
 msgstr "Błąd przy otwieraniu pliku"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1195
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1196
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2350,21 +2350,21 @@ msgstr ""
 "\n"
 "Nieprawidłowy format"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1199
 msgid "Import failed"
 msgstr "Import się nie powiódł"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1214
 #, fuzzy, c-format
 msgid "Imported %d %ls"
 msgstr "Zaimportowano %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1265
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1266
 #, fuzzy
 msgid "Merging database: "
 msgstr "Scalanie bazy danych: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1281
 msgid "Merge Complete"
 msgstr "Scalanie zakończone"
 
@@ -2470,16 +2470,16 @@ msgstr ""
 "Zawiodła zmiana z R/W na R-O: Nie można zwolnić blokady bazy danych.\n"
 "Spróbuj wyjść i zrestartować program."
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #, fuzzy
 msgid " file '"
 msgstr "Zarządzaj Filtrami"
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid "' not readable"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #: ../../../ui/wxWidgets/ViewReportDlg.cpp:32
 msgid "View Report"
 msgstr "Pokaż raport"
@@ -2529,7 +2529,7 @@ msgid "Please select a valid file"
 msgstr "Proszę wybrac prawidłowy plik"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:123
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:249
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:251
 #, fuzzy
 msgid "None"
 msgstr "Żaden"
@@ -2544,7 +2544,7 @@ msgid "Incremented Number [001-999]"
 msgstr "Liczba Przyrostowa [001-999]"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:132
-#: ../../../core/core_st.cpp:66
+#: ../../../core/core_st.cpp:68
 #, fuzzy
 msgid "Copy password to clipboard"
 msgstr "Kopiuj hasło do schowka"
@@ -2556,37 +2556,37 @@ msgstr "Pokaż/Edytuj wybrany wpis"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:134
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:623
-#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:62
+#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:64
 msgid "Autotype"
 msgstr "Autouzupełnianie"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:135
-#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:63
+#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:65
 msgid "Browse to URL"
 msgstr "Przejdź do adresu URL"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:136
-#: ../../../core/core_st.cpp:65
+#: ../../../core/core_st.cpp:67
 msgid "Copy notes to clipboard"
 msgstr "Kopiuj notatki do schowka"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:137
-#: ../../../core/core_st.cpp:68
+#: ../../../core/core_st.cpp:70
 msgid "Copy username to clipboard"
 msgstr "Kopiuj nazwę użytkownika do schowka"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:138
-#: ../../../core/core_st.cpp:67
+#: ../../../core/core_st.cpp:69
 msgid "Copy password to clipboard, minimize"
 msgstr "Kopiuj hasło do schowka i zminimalizuj"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:139
-#: ../../../core/core_st.cpp:64
+#: ../../../core/core_st.cpp:66
 msgid "Browse to URL + Autotype"
 msgstr "Idź do URL + Autouzupełnianie"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:140
-#: ../../../core/core_st.cpp:69 ../../../core/core_st.cpp:144
+#: ../../../core/core_st.cpp:71 ../../../core/core_st.cpp:146
 msgid "Run Command"
 msgstr "Komenda Run"
 
@@ -3028,23 +3028,23 @@ msgstr "Błąd w czasie inicjalizowania pomocy"
 msgid "Don't show this warning again"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:849
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:854
 msgid "Missing help definition for page \""
 msgstr "Brakuje definicji pomocy dla strony \""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:850
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
 msgid "\" of \""
 msgstr "\" z \""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:860
 msgid "Missing help definition for window \""
 msgstr "Brakuje definicji pomocy dla okna \""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:866
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:871
 msgid "Please inform the developers."
 msgstr "Proszę poinformować programistów."
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:867
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:872
 msgid "Help Undefined"
 msgstr "Pomoc nie jest zdefiniowana"
 
@@ -3754,6 +3754,7 @@ msgid "search"
 msgstr "szukaj"
 
 #: ../../../ui/wxWidgets/PasswordSafeSearch.cpp:427
+#: ../../../core/core_st.cpp:280
 msgid "Find"
 msgstr "Szukaj"
 
@@ -3871,20 +3872,20 @@ msgstr "sprawdzenie"
 msgid " empty)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:306
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:322
 #, fuzzy, c-format
 msgid "%ls on %ls"
 msgstr "%ls na %ls"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:341
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:357
 msgid "Yes"
 msgstr "Tak"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:244
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:246
 msgid "No"
 msgstr "Nie"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:302
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:318
 #, fuzzy, c-format
 msgid "In Headers(%ls)/In Entries("
 msgstr "W nagłówkach(%ls)/We wpisach("
@@ -4058,7 +4059,7 @@ msgstr "Nie można otworzyć pliku do odczytu!"
 
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:457
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:269
-#: ../../../core/core_st.cpp:276
+#: ../../../core/core_st.cpp:290
 msgid "Warning"
 msgstr "Ostrzeżenie"
 
@@ -4129,11 +4130,11 @@ msgstr "Wprowadź klucz i go zweryfikuj."
 msgid "Please try another"
 msgstr "Proszę spróbować innego"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:96
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:98
 msgid "equals"
 msgstr "jest równy"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:83
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:85
 msgid "does not equal"
 msgstr "nie jest równe"
 
@@ -4141,23 +4142,23 @@ msgstr "nie jest równe"
 msgid "begins with"
 msgstr "zaczyna się na"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:78
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:80
 msgid "does not begin with"
 msgstr "nie zaczyna się na"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:90
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:92
 msgid "ends with"
 msgstr "kończy się na"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:82
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:84
 msgid "does not end with"
 msgstr "nie kończy się na"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:56
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:58
 msgid "contains"
 msgstr "zawiera"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:79
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:81
 msgid "does not contain"
 msgstr "nie zawiera"
 
@@ -4213,19 +4214,19 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:143
+#: ../../../ui/wxWidgets/SyncWizard.cpp:144
 msgid "synchronize"
 msgstr "synchronizuj"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:220
+#: ../../../ui/wxWidgets/SyncWizard.cpp:221
 msgid "Synchronize another database with currently open database"
 msgstr "Synchronizuj inną bazę z aktualnie otwartą bazą"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:349
+#: ../../../ui/wxWidgets/SyncWizard.cpp:350
 msgid "Introduction"
 msgstr "Wstęp"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:353
+#: ../../../ui/wxWidgets/SyncWizard.cpp:354
 msgid ""
 "Synchronizing with another database will update the entries in your\n"
 "database with matching entries from the other database."
@@ -4233,11 +4234,11 @@ msgstr ""
 "Synchronizacja z inna bazą danych zmieni wpisy w Twojej\n"
 "bazie danych na podstawie odpowadnich wpisów z innej bazy."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:356
+#: ../../../ui/wxWidgets/SyncWizard.cpp:357
 msgid "More Info"
 msgstr "Więcej informacji"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:359
+#: ../../../ui/wxWidgets/SyncWizard.cpp:360
 msgid ""
 "1. Two entries from different databases match if their Group, Title\n"
 "and User fields match."
@@ -4245,7 +4246,7 @@ msgstr ""
 "1. Dwa wpisy z różnych baz danych pasują jeśli ich pola Grupa, Tytuł\n"
 "i Użytkownik są zgodne."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:360
+#: ../../../ui/wxWidgets/SyncWizard.cpp:361
 msgid ""
 "2. You can select the fields to update, as well as filter the entries\n"
 "for synchronization."
@@ -4253,7 +4254,7 @@ msgstr ""
 "2. Możesz wybrać pola do aktualizacji oraz odfiltrować wpisy\n"
 "do synchronizacji."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:361
+#: ../../../ui/wxWidgets/SyncWizard.cpp:362
 msgid ""
 "3. Only existing entries in your database are updated.  No new entries are\n"
 "added or existing entries removed during this process."
@@ -4262,7 +4263,7 @@ msgstr ""
 "operacji nie zostaną\n"
 "dodane żadne nowe ani nie zostaną usuniętw wpisy istniejące."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:362
+#: ../../../ui/wxWidgets/SyncWizard.cpp:363
 msgid ""
 "4. You can undo the operation once it is complete, but won't be\n"
 "able to abort it mid-way."
@@ -4270,27 +4271,27 @@ msgstr ""
 "4. Możesz cofnąć operację zaraz po jej zakończeniu,\n"
 "ale nie możesz jej przerwać."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:379
+#: ../../../ui/wxWidgets/SyncWizard.cpp:380
 msgid "Select another database"
 msgstr "Wybierz inną bazę danych"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:381
+#: ../../../ui/wxWidgets/SyncWizard.cpp:382
 msgid "Choose Database to Synchronize with \""
 msgstr "Wybierz bazę danych by zsynchronizować z \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:382
+#: ../../../ui/wxWidgets/SyncWizard.cpp:383
 msgid "Please Choose a Database to Synchronize with current database"
 msgstr "Proszę wybrać bazę do synchronizacji z aktualną bazą"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:405
+#: ../../../ui/wxWidgets/SyncWizard.cpp:406
 msgid "Synchronization options"
 msgstr "Opcje synchronizacji"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:429
+#: ../../../ui/wxWidgets/SyncWizard.cpp:430
 msgid "Options Summary"
 msgstr "Podumowanie opcji"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:454
+#: ../../../ui/wxWidgets/SyncWizard.cpp:455
 msgid ""
 "WARNING!!\n"
 "\n"
@@ -4302,53 +4303,53 @@ msgstr ""
 "Jeśli będziesz kontynuował, wpisy w instniejącej bazie danych\n"
 "zostaną zaktualizowane wpisami z wybranej bazy danych"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:471
+#: ../../../ui/wxWidgets/SyncWizard.cpp:472
 msgid " will be updated with corresponding entries from \""
 msgstr " będzie zaktualizowana odpowiednimi wpsami z \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:478
+#: ../../../ui/wxWidgets/SyncWizard.cpp:479
 msgid "All fields in matching entries will be updated"
 msgstr "Wszystkie pola pasujących wpisów będą zaktualizowane"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:484
+#: ../../../ui/wxWidgets/SyncWizard.cpp:485
 msgid "Following fields in matching entries will be updated:"
 msgstr "Następujące pola pasujących wpisów będą zaktualizowane:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:488
+#: ../../../ui/wxWidgets/SyncWizard.cpp:489
 msgid "Following fields will not be updated:"
 msgstr "Następujące pola nie będą aktualizowane:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:507
+#: ../../../ui/wxWidgets/SyncWizard.cpp:508
 msgid "Synchronization status"
 msgstr "Status synchronizacji"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:525
+#: ../../../ui/wxWidgets/SyncWizard.cpp:526
 msgid "See a detailed report"
 msgstr "Zobac raport szczegółowy"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:561
+#: ../../../ui/wxWidgets/SyncWizard.cpp:562
 msgid "Your database is being synchronized with \""
 msgstr "Twoja baza jest synchronizowana z \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:571
+#: ../../../ui/wxWidgets/SyncWizard.cpp:572
 msgid "There was an error during synchronization"
 msgstr "Podczas sychronizacji wystąpił błąd"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:585
+#: ../../../ui/wxWidgets/SyncWizard.cpp:586
 #, fuzzy, c-format
 msgid "Your database has been synchronized with \"%ls\""
 msgstr "Twoja baza danych została zsynchronizowana z \"%ls\""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:586
+#: ../../../ui/wxWidgets/SyncWizard.cpp:587
 #, fuzzy, c-format
 msgid "%ld %ls updated"
 msgstr "%d %ls zaktulizowano"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:589
 msgid "Synchronization completed successfully"
 msgstr "Synchronizacja zakończona pomyślnie"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:604
+#: ../../../ui/wxWidgets/SyncWizard.cpp:605
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4361,7 +4362,7 @@ msgstr ""
 "Plik popsuty lub przycięty!\n"
 "Dane mogły zostać stracone lub zmienione."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:606
+#: ../../../ui/wxWidgets/SyncWizard.cpp:607
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4372,24 +4373,24 @@ msgstr ""
 "\n"
 "Nieznany błąd"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:640
+#: ../../../ui/wxWidgets/SyncWizard.cpp:641
 #, fuzzy, c-format
 msgid "Synchronizing from database: %ls\n"
 msgstr "Synchronizacja aktualnej bazy: %ls\n"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:643
+#: ../../../ui/wxWidgets/SyncWizard.cpp:644
 msgid "synchronized"
 msgstr "zszynchronizowany"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:322
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:338
 msgid "was"
 msgstr "był"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:323
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:339
 msgid "were"
 msgstr "był"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:298
+#: ../../../ui/wxWidgets/SyncWizard.cpp:733 ../../../core/core_st.cpp:314
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4398,7 +4399,7 @@ msgstr ""
 "\n"
 "Następujące %ls %ls zostały uaktualnione:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:297
+#: ../../../ui/wxWidgets/SyncWizard.cpp:749 ../../../core/core_st.cpp:313
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4566,7 +4567,7 @@ msgid "This shortcut's target [%s:%s:%s] is not a normal entry."
 msgstr ""
 "Element docelowy skrótu [%s:%s:%s] jest normalnym wpisem lub bazą skrótu."
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:94
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:96
 #, fuzzy, c-format
 msgid ""
 "The following entries had a policy name that already existed in this "
@@ -4670,13 +4671,13 @@ msgstr ""
 "Dane mogą być stracone lub zmodyfikowane.\n"
 "Kontynuować?"
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:381
+#: ../../../ui/wxWidgets/wxUtilities.cpp:390
 msgid ""
 "An error occurred while trying to get the image data from database item.\n"
 "Therefore, the image cannot be displayed in the preview."
 msgstr ""
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:394
+#: ../../../ui/wxWidgets/wxUtilities.cpp:403
 msgid ""
 "An error occurred while trying to load the image data into the preview "
 "area.\n"
@@ -4818,7 +4819,7 @@ msgstr ""
 msgid "Copy Password to Clipboard"
 msgstr "Kopiuj hasło do s&chowka"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:149
+#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:151
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
@@ -4829,7 +4830,7 @@ msgstr ""
 "\n"
 "Kopiuj nazwę użytkownika do schowka"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:136
+#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:138
 #, fuzzy
 msgid "Notes"
 msgstr "Notes:"
@@ -4865,7 +4866,7 @@ msgstr ""
 msgid "Browse URL"
 msgstr "Przejdź do adresu URL"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:70
+#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:72
 #, fuzzy
 msgid "Send Email"
 msgstr "Wyślij email"
@@ -5064,70 +5065,88 @@ msgid "(case sensitive)"
 msgstr "(uwzględniaj wielkość liter)"
 
 #: ../../../core/core_st.cpp:50
+#, fuzzy, c-format
+msgid ""
+"Compare complete of current database:\n"
+"\t %ls\n"
+" and:\n"
+"\t %ls\n"
+msgstr ""
+"Zakończono porównanie bieżącej bazy danych:\n"
+"\t %s\n"
+" i:\n"
+"\t %s"
+
+#: ../../../core/core_st.cpp:51
+#, fuzzy, c-format
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGrupa:'%s'; Nazwa:'%s'; Użytkownik:'%s'"
+
+#: ../../../core/core_st.cpp:52
 msgid "C:F[R-O]"
 msgstr "C:F[R-O]"
 
-#: ../../../core/core_st.cpp:51
+#: ../../../core/core_st.cpp:53
 msgid "C:F[R/W]"
 msgstr "C:F[R/W]"
 
-#: ../../../core/core_st.cpp:52
+#: ../../../core/core_st.cpp:54
 #, fuzzy
 msgid "C:None  "
 msgstr "C:None  "
 
-#: ../../../core/core_st.cpp:53
+#: ../../../core/core_st.cpp:55
 msgid "C:Reg   "
 msgstr "C:Reg   "
 
-#: ../../../core/core_st.cpp:54
+#: ../../../core/core_st.cpp:56
 #, fuzzy
 msgid "conflict"
 msgstr "sprzeczność"
 
-#: ../../../core/core_st.cpp:55
+#: ../../../core/core_st.cpp:57
 #, fuzzy
 msgid "conflicts"
 msgstr "koliduje z"
 
-#: ../../../core/core_st.cpp:57
+#: ../../../core/core_st.cpp:59
 msgid "contains all of"
 msgstr "zawierający wszystko z"
 
-#: ../../../core/core_st.cpp:58
+#: ../../../core/core_st.cpp:60
 msgid "contains any of"
 msgstr "zawierający dowolny z"
 
-#: ../../../core/core_st.cpp:59
+#: ../../../core/core_st.cpp:61
 #, fuzzy
 msgid "copied"
 msgstr "skopiowano"
 
-#: ../../../core/core_st.cpp:60
+#: ../../../core/core_st.cpp:62
 #, fuzzy, c-format
 msgid "%ls - Copied %ls"
 msgstr "%ls - Skopiowano %ls"
 
-#: ../../../core/core_st.cpp:61
+#: ../../../core/core_st.cpp:63
 #, fuzzy, c-format
 msgid " Current default (%ls)"
 msgstr " Aktualna wartość domyślna (%ls)"
 
-#: ../../../core/core_st.cpp:71
+#: ../../../core/core_st.cpp:73
 msgid "View/Edit selected entry"
 msgstr "Pokaż/Edytuj wybrany wpis"
 
-#: ../../../core/core_st.cpp:72
+#: ../../../core/core_st.cpp:74
 #, fuzzy
 msgid " (application default)"
 msgstr "Wersja programu:"
 
-#: ../../../core/core_st.cpp:73
+#: ../../../core/core_st.cpp:75
 #, fuzzy
 msgid "default symbol set"
 msgstr "domyślny zestaw symboli"
 
-#: ../../../core/core_st.cpp:75
+#: ../../../core/core_st.cpp:77
 #, fuzzy, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5140,12 +5159,12 @@ msgstr ""
 "Proszę potwiedzić by kontunuować (hasła do aliasu zostaną zamienione przez "
 "hasło tego wpisu)?"
 
-#: ../../../core/core_st.cpp:76
+#: ../../../core/core_st.cpp:78
 #, fuzzy
 msgid "Delete Base Entry Confirmation"
 msgstr "Potwierdź kasowanie wpisu z bazy"
 
-#: ../../../core/core_st.cpp:77
+#: ../../../core/core_st.cpp:79
 #, fuzzy, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5157,40 +5176,40 @@ msgstr ""
 "Proszę potwiedzić by kontunuować (wszystkie skróty do tego wpisu będą "
 "usunięte)?"
 
-#: ../../../core/core_st.cpp:80
+#: ../../../core/core_st.cpp:82
 msgid "does not contain all of"
 msgstr "nie zawiera żadnego z"
 
-#: ../../../core/core_st.cpp:81
+#: ../../../core/core_st.cpp:83
 msgid "does not contain any of"
 msgstr "nie zawiera dowolnego z"
 
-#: ../../../core/core_st.cpp:84
+#: ../../../core/core_st.cpp:86
 #, c-format
 msgid " Drag # %d"
 msgstr " Przeciągnij # %d"
 
-#: ../../../core/core_st.cpp:85
-#, c-format
-msgid "%s - Drag & Drop %s"
-msgstr ""
+#: ../../../core/core_st.cpp:87
+#, fuzzy, c-format
+msgid "%ls - Drag & Drop %ls"
+msgstr "%ls - Skopiowano %ls"
 
-#: ../../../core/core_st.cpp:86
+#: ../../../core/core_st.cpp:88
 #, c-format
 msgid " Duplicate # %d"
 msgstr " Duplikat # %d"
 
-#: ../../../core/core_st.cpp:87
+#: ../../../core/core_st.cpp:89
 #, fuzzy
 msgid "empty group"
 msgstr "Importuj do grupy"
 
-#: ../../../core/core_st.cpp:88
+#: ../../../core/core_st.cpp:90
 #, fuzzy
 msgid "empty groups"
 msgstr "#grupy"
 
-#: ../../../core/core_st.cpp:89
+#: ../../../core/core_st.cpp:91
 #, fuzzy, c-format
 msgid ""
 "Trouble with a non-textual (e.g., time) field in record '%ls' - please check "
@@ -5199,264 +5218,264 @@ msgstr ""
 "Problem z nietekstowym (np. czas) polem w rekordzie '%ls - sprawdź dokładnie "
 "dane."
 
-#: ../../../core/core_st.cpp:91
+#: ../../../core/core_st.cpp:93
 msgid "End Report"
 msgstr "Koniec Raportu"
 
-#: ../../../core/core_st.cpp:92
+#: ../../../core/core_st.cpp:94
 msgid "--------------------------------------------------------------------------------"
 msgstr "--------------------------------------------------------------------------------"
 
-#: ../../../core/core_st.cpp:97
+#: ../../../core/core_st.cpp:99
 #, fuzzy
 msgid "has expired"
 msgstr "wygasło"
 
-#: ../../../core/core_st.cpp:98
+#: ../../../core/core_st.cpp:100
 msgid "Entries with a password expiry"
 msgstr "Wpisy z wygasaniem hasła"
 
-#: ../../../core/core_st.cpp:99
+#: ../../../core/core_st.cpp:101
 #, fuzzy, c-format
 msgid "within %d day(s)"
 msgstr "w przeciągu %d dni(a)"
 
-#: ../../../core/core_st.cpp:100
+#: ../../../core/core_st.cpp:102
 #, fuzzy, c-format
 msgid "DB Export from database: '%s'"
 msgstr "Eksport bazy danych: "
 
-#: ../../../core/core_st.cpp:101
+#: ../../../core/core_st.cpp:103
 msgid "First character of variable name must be alphabetic"
 msgstr "Pierwszy znak zmiennej musi być alfanumeryczny"
 
-#: ../../../core/core_st.cpp:102
+#: ../../../core/core_st.cpp:104
 msgid "Index not numeric"
 msgstr "Indeks nie jest numeryczny"
 
-#: ../../../core/core_st.cpp:103
+#: ../../../core/core_st.cpp:105
 msgid "Input string is empty"
 msgstr "Napis wejściowy jest pusty"
 
-#: ../../../core/core_st.cpp:104
+#: ../../../core/core_st.cpp:106
 msgid "Characters present between end of index ']' and '}'"
 msgstr "Znaki pomiędzy końcem indeksu ']' i '}'"
 
-#: ../../../core/core_st.cpp:105
+#: ../../../core/core_st.cpp:107
 msgid "Index is invalid or missing"
 msgstr "Indeks jest nieprawidłowy"
 
-#: ../../../core/core_st.cpp:106
+#: ../../../core/core_st.cpp:108
 msgid "Missing ending curly bracket for variable name"
 msgstr "W nazwie zmiennej brakuje zamykającego nawiasu okrągłego"
 
-#: ../../../core/core_st.cpp:107
+#: ../../../core/core_st.cpp:109
 msgid "Missing ending round bracket for Autotype value"
 msgstr "Brakujący okrągły nawias zamykający dla wartości autouzupełniania"
 
-#: ../../../core/core_st.cpp:108
+#: ../../../core/core_st.cpp:110
 msgid "Missing ending square bracket for index value"
 msgstr "Brakujący okrągły nawias kwadratowy dla wartości indeksu"
 
-#: ../../../core/core_st.cpp:109
+#: ../../../core/core_st.cpp:111
 msgid "There are unmatched quotes in the run command"
 msgstr "W komendzie Run są niedopasowane cudzysłowa"
 
-#: ../../../core/core_st.cpp:110
+#: ../../../core/core_st.cpp:112
 msgid "Variable name is empty"
 msgstr "Nazwa zmiennej jest pusta"
 
-#: ../../../core/core_st.cpp:111
+#: ../../../core/core_st.cpp:113
 msgid "Variable name must be alphanumeric"
 msgstr "Nazwa zmiennej musi być alfanumeryczna"
 
-#: ../../../core/core_st.cpp:112
+#: ../../../core/core_st.cpp:114
 msgid "an alias entry"
 msgstr "alias"
 
-#: ../../../core/core_st.cpp:113
+#: ../../../core/core_st.cpp:115
 msgid "a base entry of an alias"
 msgstr "bazowy wpis aliasu"
 
-#: ../../../core/core_st.cpp:114
+#: ../../../core/core_st.cpp:116
 msgid "  Field is too long."
 msgstr "  Pole jest zbyt długie."
 
-#: ../../../core/core_st.cpp:115
+#: ../../../core/core_st.cpp:117
 msgid "  Field is too short."
 msgstr "  Pole jest zbyt krótkie."
 
-#: ../../../core/core_st.cpp:116
+#: ../../../core/core_st.cpp:118
 msgid "Error: A file with this name already exists"
 msgstr "Błąd: Plik o tej samej nazwie już istnieje"
 
-#: ../../../core/core_st.cpp:117
+#: ../../../core/core_st.cpp:119
 msgid "The file was not found."
 msgstr "Nie znaleziono pliku."
 
-#: ../../../core/core_st.cpp:118
+#: ../../../core/core_st.cpp:120
 msgid "Error: File is read-only"
 msgstr "Błąd: Plik tylko do odczytu"
 
-#: ../../../core/core_st.cpp:119
+#: ../../../core/core_st.cpp:121
 msgid "Error while writing file! Try saving in a different location"
 msgstr "Błąd podczas zapisu pliku! Spróbuj zachować w innym miejscu"
 
-#: ../../../core/core_st.cpp:120
+#: ../../../core/core_st.cpp:122
 #, fuzzy
 msgid "File is too big."
 msgstr "Plik jest zbyt duży."
 
-#: ../../../core/core_st.cpp:121
+#: ../../../core/core_st.cpp:123
 #, fuzzy
 msgid "File is too short."
 msgstr "Plik jest zbyt mały."
 
-#: ../../../core/core_st.cpp:122
+#: ../../../core/core_st.cpp:124
 msgid "File is truncated or otherwise corrupt. Please use backup database."
 msgstr ""
 "Plik został obcięty lub uszkodzony w inny sposób. Proszę użyć kopii "
 "zapasowej."
 
-#: ../../../core/core_st.cpp:123
+#: ../../../core/core_st.cpp:125
 msgid "Cannot read file. Please check file permissions."
 msgstr "Nie można odczytać pliku. Proszę sprawdzić uprawnienia pliku."
 
-#: ../../../core/core_st.cpp:124
+#: ../../../core/core_st.cpp:126
 #, fuzzy, c-format
 msgid ""
 "Filter %ls already exists in the database, do you wish to replace it with "
 "this?"
 msgstr "Filtr %ls już istnieje w bazie danych, zastąpić?"
 
-#: ../../../core/core_st.cpp:125
+#: ../../../core/core_st.cpp:127
 #, fuzzy
 msgid "Current database filters have been exported to this database."
 msgstr "Porównaj aktualną bazę danychz inną bazą"
 
-#: ../../../core/core_st.cpp:126
+#: ../../../core/core_st.cpp:128
 msgid "Stored filters will be unusable until the file's restored."
 msgstr "Zapisane filtry będą niedostępne aż do odzyskania pliku."
 
-#: ../../../core/core_st.cpp:127
+#: ../../../core/core_st.cpp:129
 msgid "Last Access Time"
 msgstr "Czas ostatniego dostępu"
 
-#: ../../../core/core_st.cpp:128
+#: ../../../core/core_st.cpp:130
 msgid "Attachment Reference"
 msgstr ""
 
-#: ../../../core/core_st.cpp:129
+#: ../../../core/core_st.cpp:131
 msgid "AutoType"
 msgstr "Autouzupełnianie"
 
-#: ../../../core/core_st.cpp:130
+#: ../../../core/core_st.cpp:132
 msgid "Created Time"
 msgstr "Czas utworzenia"
 
-#: ../../../core/core_st.cpp:131
+#: ../../../core/core_st.cpp:133
 msgid "DCA"
 msgstr "DCA"
 
-#: ../../../core/core_st.cpp:132
+#: ../../../core/core_st.cpp:134
 msgid "e-mail"
 msgstr "e-mail"
 
-#: ../../../core/core_st.cpp:134
+#: ../../../core/core_st.cpp:136
 msgid "Group/Title"
 msgstr "Grupa/Nazwa"
 
-#: ../../../core/core_st.cpp:135
+#: ../../../core/core_st.cpp:137
 #, fuzzy
 msgid "Keyboard Shortcut"
 msgstr "Skrót klawiszowy"
 
-#: ../../../core/core_st.cpp:138
+#: ../../../core/core_st.cpp:140
 msgid "Password Modified Time"
 msgstr "Czas modyfikacji hasła"
 
-#: ../../../core/core_st.cpp:139
+#: ../../../core/core_st.cpp:141
 msgid "Protected"
 msgstr "Chroniony"
 
-#: ../../../core/core_st.cpp:140
+#: ../../../core/core_st.cpp:142
 msgid "History"
 msgstr "Historia"
 
-#: ../../../core/core_st.cpp:142
+#: ../../../core/core_st.cpp:144
 #, fuzzy
 msgid "Password Policy Name"
 msgstr "Nazwa polityki haseł"
 
-#: ../../../core/core_st.cpp:143
+#: ../../../core/core_st.cpp:145
 msgid "Record Modified Time"
 msgstr "Czas modyfikacji rekordu"
 
-#: ../../../core/core_st.cpp:145
+#: ../../../core/core_st.cpp:147
 msgid "Shift+DCA"
 msgstr "Shift+DCA"
 
-#: ../../../core/core_st.cpp:146
+#: ../../../core/core_st.cpp:148
 msgid "Symbols"
 msgstr "Symbole"
 
-#: ../../../core/core_st.cpp:148
+#: ../../../core/core_st.cpp:150
 msgid "URL"
 msgstr "URL"
 
-#: ../../../core/core_st.cpp:150
+#: ../../../core/core_st.cpp:152
 msgid "UUID"
 msgstr "UUID"
 
-#: ../../../core/core_st.cpp:151
+#: ../../../core/core_st.cpp:153
 msgid "Password Expiry Date"
 msgstr "Data wygaśnięcia hasła"
 
-#: ../../../core/core_st.cpp:152
+#: ../../../core/core_st.cpp:154
 msgid "Password Expiry Interval"
 msgstr "Przedział wygasania Haseł"
 
-#: ../../../core/core_st.cpp:153
+#: ../../../core/core_st.cpp:155
 msgid "a normal entry"
 msgstr "normalny wpis"
 
-#: ../../../core/core_st.cpp:154
+#: ../../../core/core_st.cpp:156
 #, fuzzy
 msgid "Last found entries"
 msgstr " wpisy"
 
-#: ../../../core/core_st.cpp:155
+#: ../../../core/core_st.cpp:157
 msgid "added but not yet saved to database"
 msgstr "dodany, ale jeszcze nie zapisany w bazie"
 
-#: ../../../core/core_st.cpp:156
+#: ../../../core/core_st.cpp:158
 #, fuzzy
 msgid "in the database"
 msgstr "Baza danych:"
 
-#: ../../../core/core_st.cpp:157
+#: ../../../core/core_st.cpp:159
 #, fuzzy
 msgid "a shortcut entry"
 msgstr "skrót"
 
-#: ../../../core/core_st.cpp:158
+#: ../../../core/core_st.cpp:160
 msgid "a base entry of a shortcut"
 msgstr "bazowy wpis skrótu"
 
-#: ../../../core/core_st.cpp:159
+#: ../../../core/core_st.cpp:161
 msgid "changed but not yet saved to database"
 msgstr "zmieniony, ale jeszcze nie zapisany w bazie danych"
 
-#: ../../../core/core_st.cpp:160
+#: ../../../core/core_st.cpp:162
 #, fuzzy
 msgid "greater than"
 msgstr "większy niż"
 
-#: ../../../core/core_st.cpp:161
+#: ../../../core/core_st.cpp:163
 msgid "greater than or equal to"
 msgstr "większy lub równy"
 
-#: ../../../core/core_st.cpp:162
+#: ../../../core/core_st.cpp:164
 #, c-format
 msgid ""
 "Invalid input on line %d.  Number of fields separated by '%c' is not as "
@@ -5465,12 +5484,12 @@ msgstr ""
 "Nieprawidłowe dane wejściowe na linii %d.  Liczba pól rozdzielonych '%c' nie "
 "jest taka jak oczekiwana."
 
-#: ../../../core/core_st.cpp:163
+#: ../../../core/core_st.cpp:165
 #, c-format
 msgid "Line %d: "
 msgstr "Linia %d: "
 
-#: ../../../core/core_st.cpp:164
+#: ../../../core/core_st.cpp:166
 #, c-format
 msgid ""
 "File ends on line %d before ending double quote of last entry's note field."
@@ -5478,11 +5497,11 @@ msgstr ""
 "Plik kończy się na linii %d przed zakończeniem podwójnego cudzysłowia pola "
 "notatek ostatniego wpisu."
 
-#: ../../../core/core_st.cpp:165
+#: ../../../core/core_st.cpp:167
 msgid "Import aborted. Please see report."
 msgstr "Import przerwany. Proszę zobaczyć raport."
 
-#: ../../../core/core_st.cpp:166
+#: ../../../core/core_st.cpp:168
 #, fuzzy
 msgid ""
 "The TXT or CSV file was not imported as required as entry records span "
@@ -5495,7 +5514,7 @@ msgstr ""
 "\n"
 "Import przerwany."
 
-#: ../../../core/core_st.cpp:167
+#: ../../../core/core_st.cpp:169
 #, fuzzy, c-format
 msgid ""
 "%ls, Title=\"%ls\", User=\"%ls\" already exists in your database or in the "
@@ -5504,68 +5523,68 @@ msgstr ""
 "%ls, nazwa=\"%ls\", użytkownik=\"%ls\" już jest w Twojej bazie danych lub w "
 "pliku importu. Dodano zaimportowany wpis z tytułem=\"%ls\".\n"
 
-#: ../../../core/core_st.cpp:168
+#: ../../../core/core_st.cpp:170
 #, fuzzy, c-format
 msgid "Entry on line %d with Group=\"%ls\""
 msgstr "Wpis w linii %d z grupą=\"%ls\""
 
-#: ../../../core/core_st.cpp:169
+#: ../../../core/core_st.cpp:171
 #, c-format
 msgid "Entry on line %d with no group"
 msgstr "Wpis w linii %d bez grupy"
 
-#: ../../../core/core_st.cpp:170
+#: ../../../core/core_st.cpp:172
 #, fuzzy, c-format
 msgid "Entry with Group=\"%ls\""
 msgstr "Wpis z grupą==\"%ls\""
 
-#: ../../../core/core_st.cpp:171
+#: ../../../core/core_st.cpp:173
 msgid "Entry with no group"
 msgstr "Wpis bez grupy"
 
-#: ../../../core/core_st.cpp:172
+#: ../../../core/core_st.cpp:174
 #, fuzzy
 msgid "imported"
 msgstr "zaimportowano"
 
-#: ../../../core/core_st.cpp:173
+#: ../../../core/core_st.cpp:175
 #, fuzzy, c-format
 msgid "including %d empty group(s)."
 msgstr "#grupy"
 
-#: ../../../core/core_st.cpp:174
+#: ../../../core/core_st.cpp:176
 #, c-format
 msgid "Empty line %d skipped"
 msgstr "Opuszczono pustą linię %d"
 
-#: ../../../core/core_st.cpp:175
+#: ../../../core/core_st.cpp:177
 #, fuzzy, c-format
 msgid "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 msgstr "Wpis %ls%d z grupą=\"%ls\", nazwą=\"%ls\", użytkownikiem=\"%ls\""
 
-#: ../../../core/core_st.cpp:176
+#: ../../../core/core_st.cpp:178
 msgid "Internal error. Import failed. No records imported."
 msgstr "Wewnętrzny błąd. Żadne dane nie zostały zaimportowane."
 
-#: ../../../core/core_st.cpp:177
+#: ../../../core/core_st.cpp:179
 #, c-format
 msgid "Found %d known column headers:"
 msgstr "Znaleziono %d znanych nagłówków kolumn:"
 
-#: ../../../core/core_st.cpp:178
+#: ../../../core/core_st.cpp:180
 msgid "Invalid field delimiter: must be within ASCII range."
 msgstr ""
 
-#: ../../../core/core_st.cpp:179
+#: ../../../core/core_st.cpp:181
 #, fuzzy, c-format
 msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
 msgstr "Wpis linii %d ma nieprawidłowe \"%ls\" pole. Został zignorowany."
 
-#: ../../../core/core_st.cpp:180
+#: ../../../core/core_st.cpp:182
 msgid "The following columns will be processed: "
 msgstr "Następujące kolumny zostaną przetworzone: "
 
-#: ../../../core/core_st.cpp:181
+#: ../../../core/core_st.cpp:183
 msgid ""
 "The following columns were recognised but only Group/Title, Username and "
 "Password will be processed:"
@@ -5573,7 +5592,7 @@ msgstr ""
 "Następujące kolumny zostały rozpoznane, ale tylgo Grupa/Tytuł, nazwa "
 "użytkownika i hasło będą przetwarzane:"
 
-#: ../../../core/core_st.cpp:182
+#: ../../../core/core_st.cpp:184
 #, c-format
 msgid ""
 "Line %d skipped - Only %d fields found, whereas parsing the Header says "
@@ -5582,7 +5601,7 @@ msgstr ""
 "Linia %d ominęta - znaleziono tylko %d pól, podczas gdy parsowanie nagłówka "
 "wykazało, że powinno ich być %d."
 
-#: ../../../core/core_st.cpp:183
+#: ../../../core/core_st.cpp:185
 msgid ""
 "Either or both of the Group/Title and Password columns are missing. No "
 "records imported."
@@ -5590,7 +5609,7 @@ msgstr ""
 "Brak obydwu lub jednej z kolumn grupa/nazwa i hasło. Nie zaimportowano "
 "żadnych rekordów."
 
-#: ../../../core/core_st.cpp:184
+#: ../../../core/core_st.cpp:186
 msgid ""
 "Could not find the next entry's title field in the KeePass V1 TXT (should be "
 "within square brackets)."
@@ -5598,37 +5617,37 @@ msgstr ""
 "Nie można znaleźć tytułu następnego pola w KeePass V1 TXT (powinien być w "
 "nawiasach kwadratowych)."
 
-#: ../../../core/core_st.cpp:185
+#: ../../../core/core_st.cpp:187
 msgid "Column header row not recognised as first record. No records imported."
 msgstr ""
 "Wiersz nagłówka kolumny nie rozpoznany jako pierwszy rekord. Nie importowano "
 "żadnych rekordów."
 
-#: ../../../core/core_st.cpp:186
+#: ../../../core/core_st.cpp:188
 msgid "No records in import file!"
 msgstr "Brak wpisów w importowanym pliku!"
 
-#: ../../../core/core_st.cpp:187
+#: ../../../core/core_st.cpp:189
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Password field."
 msgstr "Linia %d pominięta: pusta wymagana linia z hasłem."
 
-#: ../../../core/core_st.cpp:188
+#: ../../../core/core_st.cpp:190
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Title field."
 msgstr "Linia %d pominięta: pusta wymagana linia z tytułem."
 
-#: ../../../core/core_st.cpp:189
+#: ../../../core/core_st.cpp:191
 #, c-format
 msgid " Import # %d"
 msgstr " Importuj # %d"
 
-#: ../../../core/core_st.cpp:190
+#: ../../../core/core_st.cpp:192
 #, fuzzy, c-format
 msgid "%ls - Imported %ls"
 msgstr "%ls  - Zaimportowano %ls"
 
-#: ../../../core/core_st.cpp:191
+#: ../../../core/core_st.cpp:193
 msgid ""
 "To replace passwords of existing entries, all the following columns must be "
 "present: Group/Title, Username and Password.  One or more are missing and no "
@@ -5638,17 +5657,17 @@ msgstr ""
 "obecne: Grypa/Tytuł, nazwa użytkownika i hasło.  Brakuje tych danych i żaden "
 "wpis nie został zaktualizowany."
 
-#: ../../../core/core_st.cpp:192
+#: ../../../core/core_st.cpp:194
 #, fuzzy, c-format
 msgid "%ls not found. Cannot update entry's password.\n"
 msgstr "%ls nie znaleziony. Nie można uaktualnić hasła.\n"
 
-#: ../../../core/core_st.cpp:193
+#: ../../../core/core_st.cpp:195
 #, fuzzy, c-format
 msgid "%ls has an empty %ls.\n"
 msgstr "%ls ma pusty %ls.\n"
 
-#: ../../../core/core_st.cpp:194
+#: ../../../core/core_st.cpp:196
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5657,11 +5676,11 @@ msgstr ""
 "Wpis \"%ls, %ls, %ls\" ma hasło w poprawnej formie dla aliasu, ale wpis "
 "bazowy jest już aliasem."
 
-#: ../../../core/core_st.cpp:195
+#: ../../../core/core_st.cpp:197
 msgid "\tThis entry has been made an alias of associated base entry."
 msgstr "\tWpis jest aliasem powiązanego wpisu bazowego."
 
-#: ../../../core/core_st.cpp:196
+#: ../../../core/core_st.cpp:198
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5670,12 +5689,12 @@ msgstr ""
 "Wpis \"%ls, %ls, %ls\" ma hasło w poprawnej formie dla aliasu, ale wpis "
 "bazowy nie istnieje."
 
-#: ../../../core/core_st.cpp:197
+#: ../../../core/core_st.cpp:199
 msgid ""
 "\tThis entry remains a normal entry and the password has not been changed."
 msgstr "\tTen wpis zostanie zwykłym wpisem i hasło nie zostało zmienione."
 
-#: ../../../core/core_st.cpp:198
+#: ../../../core/core_st.cpp:200
 #, fuzzy, c-format
 msgid ""
 "The %ls entry \"%ls, %ls, %ls\" doesn't point to a normal or existing %ls "
@@ -5684,70 +5703,70 @@ msgstr ""
 "Wpis %ls \"%ls, %ls, %ls\" nie wskazuje na normalny lub istniejący wpis "
 "bazowy %ls. Nie może zostać zaimportowany."
 
-#: ../../../core/core_st.cpp:199
+#: ../../../core/core_st.cpp:201
 msgid "Entry import warnings"
 msgstr "Ostrzeżenia przy importowaniu wpisu"
 
-#: ../../../core/core_st.cpp:200
+#: ../../../core/core_st.cpp:202
 msgid "id="
 msgstr "id="
 
-#: ../../../core/core_st.cpp:201
+#: ../../../core/core_st.cpp:203
 msgid "on line "
 msgstr "w linii "
 
-#: ../../../core/core_st.cpp:202
+#: ../../../core/core_st.cpp:204
 msgid "Internal error: Invalid oflag or pmode argument"
 msgstr "Internal error: Invalid oflag or pmode argument"
 
-#: ../../../core/core_st.cpp:203
+#: ../../../core/core_st.cpp:205
 #, fuzzy
 msgid "invalid!"
 msgstr "nieprawidłowe!"
 
-#: ../../../core/core_st.cpp:204
+#: ../../../core/core_st.cpp:206
 msgid "  Invalid date/time value."
 msgstr "  Nieprawidłowa wartość daty/czasu."
 
-#: ../../../core/core_st.cpp:205
+#: ../../../core/core_st.cpp:207
 msgid "  Field length is incorrect."
 msgstr "  Długość pola nie jest prawidłowa."
 
-#: ../../../core/core_st.cpp:206
+#: ../../../core/core_st.cpp:208
 msgid "Internal error: An invalid flag was specified"
 msgstr "Błąd wewnętrzny: Wybrano nieprawidłową flagę"
 
-#: ../../../core/core_st.cpp:207
+#: ../../../core/core_st.cpp:209
 #, fuzzy, c-format
 msgid "  Invalid header: '%ls' (must be 5 hexadecimal characters)."
 msgstr "  Nieprawidłowy nagłówek: '%ls' (powinno być 5 znaków szesnastkowych)."
 
-#: ../../../core/core_st.cpp:208
+#: ../../../core/core_st.cpp:210
 #, fuzzy, c-format
 msgid "Invalid lock file \"%ls\"."
 msgstr "Nieprawidłowy schemat Filtra."
 
-#: ../../../core/core_st.cpp:209
+#: ../../../core/core_st.cpp:211
 #, fuzzy, c-format
 msgid "  Invalid number of saved old passwords %d."
 msgstr "  Nieprawidłowa liczba zapisanych starych haseł %d."
 
-#: ../../../core/core_st.cpp:210
+#: ../../../core/core_st.cpp:212
 #, c-format
 msgid "  Invalid status value: %d (must be either 0 or 1)."
 msgstr "  Nieprawidłowy status: %d (musi to być 0 lub 1)."
 
-#: ../../../core/core_st.cpp:211
+#: ../../../core/core_st.cpp:213
 msgid "  Invalid password length found (not a hexadecimal number)."
 msgstr "  Nieprawidłowa długość hasła (nie jest liczbą szesnastkową)."
 
-#: ../../../core/core_st.cpp:212
+#: ../../../core/core_st.cpp:214
 msgid ""
 "  Invalid password length found (differs from length of following password)."
 msgstr ""
 "  Nieprawidłowa długość hasła (różni się od długości następnego hasła)."
 
-#: ../../../core/core_st.cpp:213
+#: ../../../core/core_st.cpp:215
 msgid ""
 "  Invalid field separator character found - only a single blank is allowed "
 "between fields."
@@ -5755,20 +5774,20 @@ msgstr ""
 "  Wykryto nieprawidłowy znak separatora - między polami może występować "
 "tylko pojedyncza luka."
 
-#: ../../../core/core_st.cpp:214
+#: ../../../core/core_st.cpp:216
 msgid "Invalid Filter schema."
 msgstr "Nieprawidłowy schemat Filtra."
 
-#: ../../../core/core_st.cpp:215
+#: ../../../core/core_st.cpp:217
 msgid "Schema does not have a version number."
 msgstr "Schemat nie ma numeru wersji."
 
-#: ../../../core/core_st.cpp:216
+#: ../../../core/core_st.cpp:218
 #, c-format
 msgid "The filter XML version (%d) is greater than the current schema (%d)."
 msgstr "Wersja XML filtra (%d) jest wyższa niż bieżący schemat (%d)."
 
-#: ../../../core/core_st.cpp:217
+#: ../../../core/core_st.cpp:219
 #, c-format
 msgid ""
 "The filter XML version (%d) is greater than that supported by this instance "
@@ -5777,32 +5796,32 @@ msgstr ""
 "Wersja XML filtra (%d) jest wyższa niż ta wspierana przez tę wersję "
 "PasswordSafe (%d)."
 
-#: ../../../core/core_st.cpp:218
+#: ../../../core/core_st.cpp:220
 msgid "is"
 msgstr "jest"
 
-#: ../../../core/core_st.cpp:219
+#: ../../../core/core_st.cpp:221
 #, fuzzy
 msgid "is active"
 msgstr "jest aktywny"
 
-#: ../../../core/core_st.cpp:220
+#: ../../../core/core_st.cpp:222
 msgid "is inactive"
 msgstr "jest nieaktywny"
 
-#: ../../../core/core_st.cpp:221
+#: ../../../core/core_st.cpp:223
 msgid "is not"
 msgstr "nie jest"
 
-#: ../../../core/core_st.cpp:222
+#: ../../../core/core_st.cpp:224
 msgid "is not present"
 msgstr "nie jest obecny"
 
-#: ../../../core/core_st.cpp:223
+#: ../../../core/core_st.cpp:225
 msgid "is present"
 msgstr "jest obecny"
 
-#: ../../../core/core_st.cpp:224
+#: ../../../core/core_st.cpp:226
 #, fuzzy, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to entry %ls. It "
@@ -5811,7 +5830,7 @@ msgstr ""
 "Skrót klawiszowy %ls wpisu %ls jest już przydzielowny do wpisu %ls. Został "
 "on usunięty z wpisu %ls."
 
-#: ../../../core/core_st.cpp:225
+#: ../../../core/core_st.cpp:227
 #, fuzzy, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to the "
@@ -5820,20 +5839,20 @@ msgstr ""
 "Skrót klawiszowy %ls wpisu %ls jest już przydzielowny do wpisu %ls. Został "
 "on usunięty z wpisu %ls."
 
-#: ../../../core/core_st.cpp:226
+#: ../../../core/core_st.cpp:228
 msgid "less than"
 msgstr "mniejsze niż"
 
-#: ../../../core/core_st.cpp:227
+#: ../../../core/core_st.cpp:229
 #, fuzzy
 msgid "less than or equal to"
 msgstr "mniejszy lub równy"
 
-#: ../../../core/core_st.cpp:228
+#: ../../../core/core_st.cpp:230
 msgid "File or path not found"
 msgstr "Nie znaleziono pliku lub ścieżki"
 
-#: ../../../core/core_st.cpp:229
+#: ../../../core/core_st.cpp:231
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5842,7 +5861,7 @@ msgstr ""
 "\n"
 "Następujące nowe %ls %ls scalone z tą bazą danych:"
 
-#: ../../../core/core_st.cpp:230
+#: ../../../core/core_st.cpp:232
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5851,7 +5870,7 @@ msgstr ""
 "\n"
 "Scalanie zakończone: %d %ls dodano (%d %ls, %d %ls, %d %ls)"
 
-#: ../../../core/core_st.cpp:231
+#: ../../../core/core_st.cpp:233
 #, fuzzy, c-format
 msgid ""
 "Conflicting entries for \"%ls\" \"%ls\" \"%ls\".\n"
@@ -5862,26 +5881,26 @@ msgstr ""
 "  Dodano scalone wpisy jako \"%ls\" \"%ls\" \"%ls\".\n"
 "    Pola które sie różniły: %ls"
 
-#: ../../../core/core_st.cpp:232
+#: ../../../core/core_st.cpp:234
 #, fuzzy
 msgid "merged"
 msgstr "połączono"
 
-#: ../../../core/core_st.cpp:233
+#: ../../../core/core_st.cpp:235
 #, fuzzy, c-format
 msgid "%ls - Merged %ls"
 msgstr "%ls - Połączony %ls"
 
-#: ../../../core/core_st.cpp:234
+#: ../../../core/core_st.cpp:236
 msgid "MISSING PASSWORD"
 msgstr "BRAKUJĄCE HASŁO"
 
-#: ../../../core/core_st.cpp:235
+#: ../../../core/core_st.cpp:237
 #, fuzzy, c-format
 msgid "\tPassword policy name '%ls' is not in the database."
 msgstr "\tNazwy polityki haseł '%ls' nie ma w bazie danych."
 
-#: ../../../core/core_st.cpp:236
+#: ../../../core/core_st.cpp:238
 msgid ""
 "\tOne or more Password Policy Names were not found in the database. The "
 "affected entries have been changed to use the database's default policy."
@@ -5889,35 +5908,35 @@ msgstr ""
 "\tJedna lub więcej z nazw polityk haseł nie została znaleziona w bazie "
 "danych. Wpisom któych to dotyczyło zmieniono politykę na domyślną."
 
-#: ../../../core/core_st.cpp:237
+#: ../../../core/core_st.cpp:239
 #, c-format
 msgid "MISSING TITLE # %d"
 msgstr "BRAKUJĄCY TYTUŁ # %d"
 
-#: ../../../core/core_st.cpp:239
+#: ../../../core/core_st.cpp:241
 msgid "Can't obtain the schema version."
 msgstr "Niwe udało się uzyskać wersji schematu."
 
-#: ../../../core/core_st.cpp:240
+#: ../../../core/core_st.cpp:242
 msgid "The filter XML version is missing."
 msgstr "Brak wersji XML filtra."
 
-#: ../../../core/core_st.cpp:241
+#: ../../../core/core_st.cpp:243
 #, fuzzy, c-format
 msgid "Create SchemaCache60 Error 0x%08X during %ls."
 msgstr "Błąd twozenia SchemaCache60 0x%08X podczas %ls."
 
-#: ../../../core/core_st.cpp:242
+#: ../../../core/core_st.cpp:244
 #, fuzzy, c-format
 msgid "SAX Parse60 Error 0x%08X during %ls."
 msgstr "Błąd SAX Parse60 0x%08X podczas %ls."
 
-#: ../../../core/core_st.cpp:243
+#: ../../../core/core_st.cpp:245
 #, fuzzy, c-format
 msgid "Error (%08X): line %d character %d %ls"
 msgstr "Błąd (%08X): linia %d znak %d %ls"
 
-#: ../../../core/core_st.cpp:245
+#: ../../../core/core_st.cpp:247
 msgid ""
 "Unable to get configuration file lock.\n"
 "\n"
@@ -5927,16 +5946,16 @@ msgstr ""
 "\n"
 "Wykorzystany zostanie rejestr."
 
-#: ../../../core/core_st.cpp:246
+#: ../../../core/core_st.cpp:248
 #, fuzzy
 msgid "Cannot create lock file - no permission in directory?"
 msgstr "Nie można utworzyć blokady pliku - brak uprawnień w katalogu?"
 
-#: ../../../core/core_st.cpp:247
+#: ../../../core/core_st.cpp:249
 msgid "Internal error: Out of file handles"
 msgstr "Błąd wewnętrzny: Brak deskryptorów plików"
 
-#: ../../../core/core_st.cpp:248
+#: ../../../core/core_st.cpp:250
 msgid ""
 "Unable to use a MS XML reader on your system.  Neither MS XML V3, V4 or V6 "
 "seems available."
@@ -5944,15 +5963,15 @@ msgstr ""
 "Niemożliwe wykorzystaine systemowego czytnika MS XML.  Nie wykryto MS XML "
 "V3, V4 lub V6."
 
-#: ../../../core/core_st.cpp:250
+#: ../../../core/core_st.cpp:252
 msgid "Unsaved changes"
 msgstr "Niezachowane zmiany"
 
-#: ../../../core/core_st.cpp:251
+#: ../../../core/core_st.cpp:253
 msgid "is not set"
 msgstr "nie jest ustawiony"
 
-#: ../../../core/core_st.cpp:252
+#: ../../../core/core_st.cpp:254
 #, fuzzy, c-format
 msgid ""
 "Number of entries processed: %d\n"
@@ -5991,7 +6010,7 @@ msgstr ""
 "\n"
 "Rekomendacja, by zachować bazę danych."
 
-#: ../../../core/core_st.cpp:254
+#: ../../../core/core_st.cpp:256
 msgid ""
 "Password should be mixed case, with at least one digit or punctuation "
 "character"
@@ -5999,56 +6018,60 @@ msgstr ""
 "W haśle powinny występować wielki i małe litery, przynajmnej jedna cyfra i "
 "znak interpunkcyjny"
 
-#: ../../../core/core_st.cpp:255
+#: ../../../core/core_st.cpp:257
 msgid "Password is too short"
 msgstr "Hasło jest zbyt krótkie"
 
-#: ../../../core/core_st.cpp:256
+#: ../../../core/core_st.cpp:258
 msgid "Easyvision characters"
 msgstr "Znaki łatwo wyróżnialne"
 
-#: ../../../core/core_st.cpp:257
+#: ../../../core/core_st.cpp:259
 msgid "Hexadecimal characters"
 msgstr "Znaki szesnastkowe"
 
-#: ../../../core/core_st.cpp:258
+#: ../../../core/core_st.cpp:260
 #, fuzzy
 msgid "Password length"
 msgstr "Długość hasła"
 
-#: ../../../core/core_st.cpp:259
+#: ../../../core/core_st.cpp:261
 msgid "Pronounceable passwords"
 msgstr "Hasła łatwe do wymówienia"
 
-#: ../../../core/core_st.cpp:261
+#: ../../../core/core_st.cpp:263
 #, fuzzy
 msgid "Use lowercase characters"
 msgstr "Użyć dużych liter"
 
-#: ../../../core/core_st.cpp:263
+#: ../../../core/core_st.cpp:265
 #, fuzzy
 msgid "Use uppercase characters"
 msgstr "Użyć dużych liter"
 
-#: ../../../core/core_st.cpp:264
+#: ../../../core/core_st.cpp:266
 #, fuzzy, c-format
 msgid "Error in a Password History %ls:"
 msgstr "Błąd w historii hasła %ls:"
 
-#: ../../../core/core_st.cpp:265
+#: ../../../core/core_st.cpp:267
 #, c-format
 msgid "sub-field starting at position %d (within the History field): "
 msgstr "podpole zaczynające się na pozycji %d (w historio pola): "
 
-#: ../../../core/core_st.cpp:266
+#: ../../../core/core_st.cpp:268
 msgid "  All Password History ignored."
 msgstr "  Ignoruj historię wprowadzonych haseł."
 
-#: ../../../core/core_st.cpp:267
+#: ../../../core/core_st.cpp:269
 msgid "Read Error"
 msgstr "Błąd odczytu"
 
-#: ../../../core/core_st.cpp:268
+#: ../../../core/core_st.cpp:270
+msgid "Relative"
+msgstr "Względny"
+
+#: ../../../core/core_st.cpp:271
 #, fuzzy, c-format
 msgid ""
 "\tOne or more entry keyboard shortcuts were already assigned to entries in "
@@ -6057,7 +6080,7 @@ msgstr ""
 "\tJeden lub więcej skrótów klawiszowych były już przydzielone do wpisów w "
 "tej bazie danych. Zostały one usunięte z %ls wpisów."
 
-#: ../../../core/core_st.cpp:269
+#: ../../../core/core_st.cpp:272
 msgid ""
 "\tOne or more Password Policy Names were already in this database but had "
 "different settings. They have been renamed."
@@ -6065,146 +6088,194 @@ msgstr ""
 "\tJedna lub więcej z nazw polityk haseł już była w bazie danych, ale miała "
 "inne ustawienia. Zmieniono ich nazwę."
 
-#: ../../../core/core_st.cpp:270
+#: ../../../core/core_st.cpp:273
 #, fuzzy, c-format
 msgid "%ls%ls%ls_Report.txt"
 msgstr "%ls%ls%ls_Report.txt"
 
-#: ../../../core/core_st.cpp:271
+#: ../../../core/core_st.cpp:274
 #, fuzzy, c-format
 msgid "Report of %ls function started at %ls"
 msgstr "Raport z wywołania funkcji %ls rozpoczętej %ls"
 
-#: ../../../core/core_st.cpp:272
+#: ../../../core/core_st.cpp:275
 #, fuzzy, c-format
 msgid "on database %ls"
 msgstr "na bazie danych %ls"
 
-#: ../../../core/core_st.cpp:273
+#: ../../../core/core_st.cpp:276
+msgid "Compare"
+msgstr "Porównaj"
+
+#: ../../../core/core_st.cpp:277
+#, fuzzy
+msgid "Export_DB"
+msgstr "&Eksportuj"
+
+#: ../../../core/core_st.cpp:278
+msgid "Export_Text"
+msgstr "Export_Text"
+
+#: ../../../core/core_st.cpp:279
+msgid "Export_XML"
+msgstr "Export_XML"
+
+#: ../../../core/core_st.cpp:281
+msgid "Import_KeePassV1_CSV"
+msgstr "Import_KeePassV1_CSV"
+
+#: ../../../core/core_st.cpp:282
+msgid "Import_KeePassV1_TXT"
+msgstr "Import_KeePassV1_TXT"
+
+#: ../../../core/core_st.cpp:283
+msgid "Import_Text"
+msgstr "Import_Text"
+
+#: ../../../core/core_st.cpp:284
+msgid "Import_XML"
+msgstr "Import_XML"
+
+#: ../../../core/core_st.cpp:285
+#, fuzzy
+msgid "Merge"
+msgstr "Scal"
+
+#: ../../../core/core_st.cpp:287
 msgid "Validate"
 msgstr "Potwierdź"
 
-#: ../../../core/core_st.cpp:275
+#: ../../../core/core_st.cpp:289
 msgid "Fatal Error"
 msgstr "Błąd krytyczny"
 
-#: ../../../core/core_st.cpp:277
+#: ../../../core/core_st.cpp:291
 #, fuzzy, c-format
 msgid ""
 "\n"
 "Error in Password History for entry: \"%ls\"%ls\"%ls\": "
 msgstr "Błąd w historii hasła %ls:"
 
-#: ../../../core/core_st.cpp:278
+#: ../../../core/core_st.cpp:292
+#, fuzzy, c-format
+msgid "\tNo entries were found containing search string '%ls' %ls"
+msgstr "\tNie znaleziono żadnego wpisu zawierającego szukany ciąg '%s'"
+
+#: ../../../core/core_st.cpp:293
+#, fuzzy, c-format
+msgid "\tThe following entries contain search string '%ls' %ls"
+msgstr "\tNastępujące wpisy zawierają szukany ciąg '%s'"
+
+#: ../../../core/core_st.cpp:294
 msgid "See Attachment filters"
 msgstr ""
 
-#: ../../../core/core_st.cpp:279
+#: ../../../core/core_st.cpp:295
 msgid "See Password History filters"
 msgstr "Zobacz Filtry Historii Haseł"
 
-#: ../../../core/core_st.cpp:280
+#: ../../../core/core_st.cpp:296
 msgid "See Password Policy filters"
 msgstr "Zobacz Filtry Ustawień Haseł"
 
-#: ../../../core/core_st.cpp:281
+#: ../../../core/core_st.cpp:297
 msgid "is set"
 msgstr "jest ustawiony"
 
-#: ../../../core/core_st.cpp:282
+#: ../../../core/core_st.cpp:298
 msgid "shortcut"
 msgstr "skrót"
 
-#: ../../../core/core_st.cpp:283
+#: ../../../core/core_st.cpp:299
 msgid "shortcuts"
 msgstr "skróty"
 
-#: ../../../core/core_st.cpp:284
+#: ../../../core/core_st.cpp:300
 msgid "policy specific symbols"
 msgstr "symbole specyficzne dla polityki"
 
-#: ../../../core/core_st.cpp:285
+#: ../../../core/core_st.cpp:301
 msgid "Start Report"
 msgstr "Początek Raportu"
 
-#: ../../../core/core_st.cpp:286
+#: ../../../core/core_st.cpp:302
 msgid "Double-Click on entry to Autotype"
 msgstr "Kliknij dwa razy na wpisie żeby autouzupełnić"
 
-#: ../../../core/core_st.cpp:287
+#: ../../../core/core_st.cpp:303
 msgid "Double-Click on entry to Browse to URL"
 msgstr "Kliknij dwa razy na wpisie by przejść do adresu URL"
 
-#: ../../../core/core_st.cpp:288
+#: ../../../core/core_st.cpp:304
 msgid "Double-Click on entry to Browse to URL + Autotype"
 msgstr "Kliknij podwójnie na wpisie by iść do URL z autouzpełnianiem"
 
-#: ../../../core/core_st.cpp:289
+#: ../../../core/core_st.cpp:305
 #, fuzzy
 msgid "https://pwsafe.org/"
 msgstr "https://pwsafe.org/latest.xml"
 
-#: ../../../core/core_st.cpp:290
+#: ../../../core/core_st.cpp:306
 msgid "Double-Click on entry to Copy Notes"
 msgstr "Kliknij dwa razy na wpisie żeby skopiować notatki"
 
-#: ../../../core/core_st.cpp:291
+#: ../../../core/core_st.cpp:307
 msgid "Double-Click on entry to Copy Password"
 msgstr "Kliknij dwa razy na wpisie żeby skopiować hasło"
 
-#: ../../../core/core_st.cpp:292
+#: ../../../core/core_st.cpp:308
 msgid "Double-Click on entry to Copy Password and Minimize"
 msgstr "Kliknij dwa razy na wpisie żeby skopiować hasło i zminimalizować okno"
 
-#: ../../../core/core_st.cpp:293
+#: ../../../core/core_st.cpp:309
 msgid "Double-Click on entry to Copy Username"
 msgstr "Kliknij dwa razy na wpisie żeby skopiować nazwę użytkownika"
 
-#: ../../../core/core_st.cpp:294
+#: ../../../core/core_st.cpp:310
 msgid "Double-Click on entry to Run Command"
 msgstr "Kliknij dwa razy na wpisie by wykonać komendę Run"
 
-#: ../../../core/core_st.cpp:295
+#: ../../../core/core_st.cpp:311
 #, fuzzy
 msgid "Double-Click on entry to Send Email"
 msgstr "Kliknij dwa razy na wpisie by wysłać email"
 
-#: ../../../core/core_st.cpp:296
+#: ../../../core/core_st.cpp:312
 msgid "Double-Click on entry to View/Edit it"
 msgstr "Kliknij dwa razy na wpisie żeby go zobaczyć/edytować"
 
-#: ../../../core/core_st.cpp:299
+#: ../../../core/core_st.cpp:315
 #, fuzzy, c-format
 msgid "%ls - Sync'd %ls"
 msgstr "%ls - Zsynchronizowano %ls"
 
-#: ../../../core/core_st.cpp:300
+#: ../../../core/core_st.cpp:316
 msgid "System error: No more file handles available"
 msgstr "Błąd systemowy: Brak dostępnych deskryptorów pliku."
 
-#: ../../../core/core_st.cpp:303
+#: ../../../core/core_st.cpp:319
 msgid "Unknown function"
 msgstr "Nieznana funkcja"
 
-#: ../../../core/core_st.cpp:304
+#: ../../../core/core_st.cpp:320
 msgid "Unknown object"
 msgstr "Nieznany obiekt"
 
-#: ../../../core/core_st.cpp:305
+#: ../../../core/core_st.cpp:321
 msgid "Internal error: Unexpected error number"
 msgstr "Błąd wewnętrzny: Nieoczekiwany numer błędu"
 
-#: ../../../core/core_st.cpp:307
+#: ../../../core/core_st.cpp:323
 #, c-format
 msgid "\tName: %s; Filename: %s"
 msgstr ""
 
-#: ../../../core/core_st.cpp:308
+#: ../../../core/core_st.cpp:324
 msgid ""
 "The following entries had an invalid UUID field.  This has been corrected."
 msgstr "Skorygowano następujące wpisy z nieprawidłowym polem UUID."
 
-#: ../../../core/core_st.cpp:309
+#: ../../../core/core_st.cpp:325
 #, fuzzy, c-format
 msgid ""
 "The following entries have passwords in the correct form for %ls, but the "
@@ -6213,17 +6284,17 @@ msgstr ""
 "Następujące wpisy mają hasła w prawidłowej postaci dla %ls, ale wpis bazowy "
 "nie istnieje."
 
-#: ../../../core/core_st.cpp:310
+#: ../../../core/core_st.cpp:326
 msgid "The following entries were duplicates of an existing entry."
 msgstr "Następujące wpisy były duplikatami istniejącego wpisu."
 
-#: ../../../core/core_st.cpp:311
+#: ../../../core/core_st.cpp:327
 #, fuzzy
 msgid ""
 "The following entries had a duplicate UUID field.  This has been corrected."
 msgstr "Skorygowano następujące wpisy ze zduplikowanymi polami UUID."
 
-#: ../../../core/core_st.cpp:312
+#: ../../../core/core_st.cpp:328
 #, fuzzy, c-format
 msgid ""
 "The following entries had an empty Password field, which is not permitted. "
@@ -6232,36 +6303,36 @@ msgstr ""
 "Następujące wpisy mają puste pole z hasłem, co nie jest dozwolone. Zostało "
 "ustawione hasło '%ls'"
 
-#: ../../../core/core_st.cpp:313
+#: ../../../core/core_st.cpp:329
 #, fuzzy
 msgid "The following entries had an empty Title field, which is not permitted."
 msgstr "Następujące wpisy mają puste pole z tytułem, co nie jest dozwolone."
 
-#: ../../../core/core_st.cpp:314
+#: ../../../core/core_st.cpp:330
 #, fuzzy, c-format
 msgid "\tGroup='%ls', Title='%ls', User='%ls' %ls"
 msgstr "\tGrupa='%ls', Nazwa='%ls', Użytkownik='%ls' %ls"
 
-#: ../../../core/core_st.cpp:315
+#: ../../../core/core_st.cpp:331
 #, fuzzy, c-format
 msgid "- Its title has been changed to:'%ls'"
 msgstr "- Nazwa została zmieniona na:'%ls'"
 
-#: ../../../core/core_st.cpp:316
+#: ../../../core/core_st.cpp:332
 msgid "The following ERRORS were detected and were FIXED."
 msgstr "Następujące BŁĘDY zostały wykryte i POPRAWIONE."
 
-#: ../../../core/core_st.cpp:317
+#: ../../../core/core_st.cpp:333
 #, fuzzy
 msgid "The following entries refer to missing attachments."
 msgstr "Następujące wpisy były duplikatami istniejącego wpisu."
 
-#: ../../../core/core_st.cpp:318
+#: ../../../core/core_st.cpp:334
 #, fuzzy
 msgid "The following attachments are not referred to by any entry."
 msgstr "Następujące wpisy były duplikatami istniejącego wpisu."
 
-#: ../../../core/core_st.cpp:319
+#: ../../../core/core_st.cpp:335
 msgid ""
 "The following entries had an invalid Password History.  This has been "
 "rebuilt with available data.  There may be some loss of history."
@@ -6269,7 +6340,7 @@ msgstr ""
 "Następujące wpisy miały nieprawidłową historię haseł.  Zostało to odbudowane "
 "z dostępnych danych.  Część historii może być utracona."
 
-#: ../../../core/core_st.cpp:320
+#: ../../../core/core_st.cpp:336
 #, fuzzy, c-format
 msgid ""
 "The following entries have one or more text fields too long to display or "
@@ -6279,7 +6350,7 @@ msgstr ""
 "lub edytować (ponad %d znaków).  Największy rozmiar wpisu jaki znaleziono to "
 "~%d %ls."
 
-#: ../../../core/core_st.cpp:321
+#: ../../../core/core_st.cpp:337
 msgid ""
 "The following WARNINGS were detected - you should review and fix them "
 "manually."
@@ -6287,12 +6358,12 @@ msgstr ""
 "Następujące OSTRZEŻENIA zostały wykryte - należy je przejrzeć i naprawić "
 "ręcznie."
 
-#: ../../../core/core_st.cpp:324
+#: ../../../core/core_st.cpp:340
 #, fuzzy
 msgid "will expire"
 msgstr "wygaśnie"
 
-#: ../../../core/core_st.cpp:325
+#: ../../../core/core_st.cpp:341
 #, fuzzy, c-format
 msgid ""
 "SAX Parse Error during %ls\n"
@@ -6301,36 +6372,36 @@ msgstr ""
 "Błąd parsowania SAX podczas %ls\n"
 "%ls."
 
-#: ../../../core/core_st.cpp:326
+#: ../../../core/core_st.cpp:342
 #, fuzzy, c-format
 msgid "XML %ls: line %d character %d: %ls"
 msgstr "XML %ls: wiersz %d znak %d: %ls"
 
-#: ../../../core/core_st.cpp:327
+#: ../../../core/core_st.cpp:343
 msgid ""
 "*** Invalid XML characters found - see exported XML file for more details ***"
 msgstr ""
 "*** Nieprawidłowe znaki XML - więcej szczegułów w wyeksportowanym pliku XML "
 "***"
 
-#: ../../../core/core_st.cpp:328
+#: ../../../core/core_st.cpp:344
 msgid "Internal error: Couldn't initialize config file XML structure"
 msgstr ""
 "Błąd wewnętrzny: Nie powiodło się zainicjowanie pliku konfiguracyjnego "
 "struktury XML"
 
-#: ../../../core/core_st.cpp:329
+#: ../../../core/core_st.cpp:345
 msgid ""
 "A filter was active. Export of data was restricted to include only those "
 "displayed."
 msgstr ""
 "Filtr był aktywny. Eksport danych był ograniczony do danych wyświetlanych."
 
-#: ../../../core/core_st.cpp:330
+#: ../../../core/core_st.cpp:346
 msgid "Export of data was restricted to certain fields by the user."
 msgstr "Eksport danych jest zawężony przez użytkownika do wskazanych pól."
 
-#: ../../../core/core_st.cpp:331
+#: ../../../core/core_st.cpp:347
 msgid ""
 "Note: These Password Policies will not replace existing policies with the "
 "same name in the current database."
@@ -6338,22 +6409,22 @@ msgstr ""
 "Uwaga: ta polityka haseł nie zastąpi w aktualnej bazie istniejących polityk "
 "o takiej samej nazwie."
 
-#: ../../../core/core_st.cpp:332
+#: ../../../core/core_st.cpp:348
 msgid ""
 "Note: These preferences are only used when importing into an empty database."
 msgstr ""
 "Uwaga: te ustawienia są używane wyłącznie podczas importu do pustej bazy."
 
-#: ../../../core/core_st.cpp:333
+#: ../../../core/core_st.cpp:349
 msgid "Subset of entries restricted by the following rule:"
 msgstr "Podzbiór wpisów zawężony przez nastepujące reguły:"
 
-#: ../../../core/core_st.cpp:334
+#: ../../../core/core_st.cpp:350
 msgid ""
 "The user specified that the following fields be excluded from the export:"
 msgstr "Użytkownik wybrał, że następujące pola będą wyłączone z eksportu:"
 
-#: ../../../core/core_st.cpp:335
+#: ../../../core/core_st.cpp:351
 #, fuzzy, c-format
 msgid ""
 "Configuration file error:\n"
@@ -6366,15 +6437,15 @@ msgstr ""
 "%ls\n"
 "przybliżone przesunięcie w %d"
 
-#: ../../../core/core_st.cpp:336
+#: ../../../core/core_st.cpp:352
 msgid "import"
 msgstr "import"
 
-#: ../../../core/core_st.cpp:337
+#: ../../../core/core_st.cpp:353
 msgid "Unable to load configuration file"
 msgstr "Niemożliwe załadowanie pliku konfiguracyjnego"
 
-#: ../../../core/core_st.cpp:338
+#: ../../../core/core_st.cpp:354
 #, fuzzy
 msgid ""
 "Failed to lock configuration file - opened by another instance of "
@@ -6383,112 +6454,58 @@ msgstr ""
 "Nie udało się zablokować pliku konfiguracyjnego - sprawdź czy nie jest "
 "otwarty przez inną instancję PasswordSafe?"
 
-#: ../../../core/core_st.cpp:339
+#: ../../../core/core_st.cpp:355
 msgid "Unable to save configuration file"
 msgstr "Nie można zapisać pliku konfiguracyjnego"
 
-#: ../../../core/core_st.cpp:340
+#: ../../../core/core_st.cpp:356
 #, fuzzy
 msgid "validation"
 msgstr "sprawdzenie"
 
-#: ../../../core/core_st.cpp:342
+#: ../../../core/core_st.cpp:358
 #, fuzzy
 msgid " (EasyVision Symbols)"
 msgstr "Tak - symbole EasyVision: %ls"
 
-#: ../../../core/core_st.cpp:343
+#: ../../../core/core_st.cpp:359
 #, fuzzy, c-format
 msgid "Yes (at least %d)"
 msgstr "Tak (co najmniej %d)"
 
-#: ../../../core/core_st.cpp:344
+#: ../../../core/core_st.cpp:360
 #, fuzzy
 msgid " (Pronounceable Symbols)"
 msgstr "Tak - wymiawialne symbole: %ls"
 
-#: ../../../core/core_st.cpp:345
+#: ../../../core/core_st.cpp:361
 #, fuzzy, c-format
 msgid "Yes - At least %d from %ls: %ls%ls"
 msgstr "Tak - co najwyżej %d z %ls: %ls"
 
-#: ../../../core/core_st.cpp:346
 #, fuzzy, c-format
-msgid "\tGroup='%ls', Title='%ls', User='%ls'"
-msgstr "\tGrupa='%ls', Nazwa='%ls', Użytkownik='%ls' %ls"
+#~ msgid "\tGroup='%ls', Title='%ls', User='%ls'"
+#~ msgstr "\tGrupa='%ls', Nazwa='%ls', Użytkownik='%ls' %ls"
 
-#: ../../../core/core_st.cpp:347
-#, fuzzy, c-format
-msgid ""
-"Compare complete of current database:\n"
-"\t %ls\n"
-" and:\n"
-"\t %ls\n"
-msgstr ""
-"Zakończono porównanie bieżącej bazy danych:\n"
-"\t %s\n"
-" i:\n"
-"\t %s"
-
-#: ../../../core/core_st.cpp:348
-#, fuzzy, c-format
-msgid "\tNo entries were found containing search string '%ls' %ls"
-msgstr "\tNie znaleziono żadnego wpisu zawierającego szukany ciąg '%s'"
-
-#: ../../../core/core_st.cpp:349
-#, fuzzy, c-format
-msgid "\tThe following entries contain search string '%ls' %ls"
-msgstr "\tNastępujące wpisy zawierają szukany ciąg '%s'"
-
-#: ../../../core/core_st.cpp:350
 #, fuzzy
-msgid "Export DB"
-msgstr "&Eksportuj"
+#~ msgid "Import KeePassV1 CSV"
+#~ msgstr "Import KeePass V1 CSV"
 
-#: ../../../core/core_st.cpp:351
 #, fuzzy
-msgid "Import KeePassV1 CSV"
-msgstr "Import KeePass V1 CSV"
+#~ msgid "Import KeePassV1 TXT"
+#~ msgstr "Import KeePass V1 TXT"
 
-#: ../../../core/core_st.cpp:352
 #, fuzzy
-msgid "Import KeePassV1 TXT"
-msgstr "Import KeePass V1 TXT"
+#~ msgid "Import XML"
+#~ msgstr ""
+#~ "\n"
+#~ "Importuj XML"
 
-#: ../../../core/core_st.cpp:353
 #, fuzzy
-msgid "Import XML"
-msgstr ""
-"\n"
-"Importuj XML"
-
-#: ../../../core/core_st.cpp:354
-#, fuzzy
-msgid "Import Text"
-msgstr ""
-"\n"
-"Importuj Text"
-
-#: ../../../core/core_st.cpp:355
-#, fuzzy
-msgid "Merge"
-msgstr "Scal"
-
-#: ../../../core/core_st.cpp:356
-msgid "Compare"
-msgstr "Porównaj"
-
-#~ msgid "Import_Text"
-#~ msgstr "Import_Text"
-
-#~ msgid "Import_XML"
-#~ msgstr "Import_XML"
-
-#~ msgid "Import_KeePassV1_CSV"
-#~ msgstr "Import_KeePassV1_CSV"
-
-#~ msgid "Import_KeePassV1_TXT"
-#~ msgstr "Import_KeePassV1_TXT"
+#~ msgid "Import Text"
+#~ msgstr ""
+#~ "\n"
+#~ "Importuj Text"
 
 #, fuzzy
 #~ msgid "Advanced..."
@@ -8030,12 +8047,6 @@ msgstr "Porównaj"
 #~ "Pli eksportu: '%s' już istnieje.\n"
 #~ "Chcesz go zastąpić?"
 
-#~ msgid "Export_Text"
-#~ msgstr "Export_Text"
-
-#~ msgid "Export_XML"
-#~ msgstr "Export_XML"
-
 #~ msgid "Exporting to file:"
 #~ msgstr "Eksportowanie do pliku:"
 
@@ -8803,9 +8814,6 @@ msgstr "Porównaj"
 #~ msgstr ""
 #~ "Odzyskuj automatycznie zachowane dokumenty\n"
 #~ "Otwórz automatycznie zachowane wersje zamiast samodzielnie zapisanych"
-
-#~ msgid "Relative"
-#~ msgstr "Względny"
 
 #~ msgid ""
 #~ "Relative dates are in days relative to today e.g. '-1' is yesterday and "
@@ -10104,9 +10112,6 @@ msgstr "Porównaj"
 #~ msgstr ""
 #~ "\tWpis - grupa:\"%s\"; tytuł:\"%s\"; użytkownik:\"%s\"\n"
 #~ "\t\tróżni się w nastepujących polach:"
-
-#~ msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-#~ msgstr "\tGrupa:'%s'; Nazwa:'%s'; Użytkownik:'%s'"
 
 #~ msgid ""
 #~ "\tThe following restrictions were selected:\n"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Password Safe\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-28 12:52+0100\n"
+"POT-Creation-Date: 2021-03-19 21:58+0100\n"
 "PO-Revision-Date: 2021-01-31 19:50+0300\n"
 "Last-Translator: Andrey Kuznetsov <pm_kan@users.sourceforge.net>\n"
 "Language-Team: none\n"
@@ -212,7 +212,7 @@ msgstr "Дата и время"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:348
 #: ../../../ui/wxWidgets/HelpMap.h:41 ../../../ui/wxWidgets/HelpMap.h:49
-#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:141
+#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:143
 msgid "Password Policy"
 msgstr "Политика создания паролей"
 
@@ -226,7 +226,7 @@ msgid "Set Date/Time"
 msgstr "Дата/время создания"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:370
-#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:137
+#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:139
 msgid "Password"
 msgstr "Пароль"
 
@@ -506,14 +506,14 @@ msgstr "ПРОПИСНЫЕ буквы"
 # урезано, в информации о политике
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:747
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:281
-#: ../../../core/core_st.cpp:260
+#: ../../../core/core_st.cpp:262
 msgid "Use digits"
 msgstr "Использовать цифры"
 
 # урезано, в информации о политике
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:771
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:305
-#: ../../../core/core_st.cpp:262
+#: ../../../core/core_st.cpp:264
 msgid "Use symbols"
 msgstr "Символы"
 
@@ -545,7 +545,7 @@ msgstr "Создавать произносимые пароли"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:815
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:350
-#: ../../../core/core_st.cpp:253
+#: ../../../core/core_st.cpp:255
 msgid "Or"
 msgstr "Или"
 
@@ -594,7 +594,7 @@ msgstr "Свойства"
 #: ../../../ui/wxWidgets/CreateShortcutDlg.cpp:219
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:269
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:274
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
 msgid "Text"
 msgstr "Текстовый"
 
@@ -648,7 +648,7 @@ msgstr "Вложение отсутствует"
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:160
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:173
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:192
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:301
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:317
 msgid "Unknown"
 msgstr "Неизвестно"
 
@@ -755,7 +755,7 @@ msgstr "[Заметки скрыты. Кликните здесь, чтобы п
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:1653
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2145
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2820
-#: ../../../core/core_st.cpp:74
+#: ../../../core/core_st.cpp:76
 msgid "Default Policy"
 msgstr "Политика по умолчанию"
 
@@ -776,7 +776,7 @@ msgstr "Ошибка при создании пароля: некорректн�
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:144
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:151
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:159
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:200
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:201
 #: ../../../ui/wxWidgets/PWSafeApp.cpp:367
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:737
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:756
@@ -800,7 +800,7 @@ msgstr "Ошибка при создании пароля: некорректн�
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:249
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:277
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:316
-#: ../../../core/core_st.cpp:274
+#: ../../../core/core_st.cpp:288
 msgid "Error"
 msgstr "Ошибка"
 
@@ -949,7 +949,7 @@ msgid "Synchronize this item..."
 msgstr "Синхронизировать элемент..."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:482
-#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:357
+#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:286
 msgid "Synchronize"
 msgstr "Синхронизация"
 
@@ -1018,8 +1018,8 @@ msgid "Current safe was opened read-only"
 msgstr "Контейнер открыт «только для чтения»"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:793
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:996
-#: ../../../ui/wxWidgets/SyncWizard.cpp:618
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
+#: ../../../ui/wxWidgets/SyncWizard.cpp:619
 #, c-format
 msgid ""
 "The database:\n"
@@ -1037,7 +1037,7 @@ msgstr ""
 "пользователя. Для исправления запустите проверку."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:794
-#: ../../../ui/wxWidgets/SyncWizard.cpp:617
+#: ../../../ui/wxWidgets/SyncWizard.cpp:618
 msgid "Synchronization failed"
 msgstr "Сбой при синхронизации"
 
@@ -1394,7 +1394,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/GridCtrl.cpp:164
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:292
-#: ../../../core/core_st.cpp:147
+#: ../../../core/core_st.cpp:149
 msgid "Title"
 msgstr "Заголовок"
 
@@ -1600,7 +1600,7 @@ msgid "Value"
 msgstr "Значение"
 
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:291
-#: ../../../core/core_st.cpp:133
+#: ../../../core/core_st.cpp:135
 msgid "Group"
 msgstr "Группа"
 
@@ -1683,23 +1683,23 @@ msgstr ""
 msgid "Error parsing Run Command"
 msgstr "Ошибка разбора команды для запуска"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:56
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:57
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:355
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:362
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:166
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:623
 msgid "Write Error"
 msgstr "Ошибка записи"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:61
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:62
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:165
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:622
 msgid "Could not open file for writing!"
 msgstr "Невозможно открыть файл для записи!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:64
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:65
 msgid ""
 "Write operation failed!\n"
 "File may have been corrupted.\n"
@@ -1709,25 +1709,25 @@ msgstr ""
 "Возможно, файл повреждён.\n"
 "Попробуйте сохранить файл в другом месте."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:69
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:70
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "Unknown error"
 msgstr "Неопознанная ошибка"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:90
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:91
 msgid "Do you want to save changes to the password database: "
 msgstr "Сохранить изменения в контейнер "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:145
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:146
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:557
 msgid "Please choose a name for the new database"
 msgstr "Укажите имя файла для нового контейнера"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:155
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:156
 msgid "psafe3 files (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 msgstr "Контейнеры Password Safe (*.psafe3)|*.psafe3|Все файлы (*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
@@ -1735,7 +1735,7 @@ msgid "Lock is done by yourself"
 msgstr ""
 
 # кнопка на вкладке вложения
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
@@ -1743,24 +1743,24 @@ msgstr ""
 msgid "Remove Lock?"
 msgstr "Удалить"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:194
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:195
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:602
 #, fuzzy
 msgid "Could not lock file.\n"
 msgstr "Невозможно получить доступ к файлу: %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:196
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:197
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:452
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:604
 msgid "Locked by "
 msgstr "Заблокирован "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:236
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:237
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:515
 msgid "Please Choose a Database to Open:"
 msgstr "Укажите контейнер для открытия"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:353
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
 msgid ""
 "Unable to create intermediate backup.  Save database elsewhere or with "
 "another name?\n"
@@ -1772,7 +1772,7 @@ msgstr ""
 "\n"
 "Нажмите «Нет» для выхода без сохранения."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:360
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
 msgid ""
 "Unable to create intermediate backup.  Do you wish to save changes to your "
 "database without it?"
@@ -1780,12 +1780,12 @@ msgstr ""
 "Невозможно создать промежуточную резервную копию.  Пропустить создание копии "
 "и сохранить изменения?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 msgid "Unable to create intermediate backup."
 msgstr "Невозможно создать промежуточную резервную копию."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:386
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:387
 #, c-format
 msgid ""
 "The original database, \"%ls\", is in pre-3.0 format. It will be unchanged.\n"
@@ -1800,12 +1800,12 @@ msgstr ""
 "старом формате используйте пункты меню «Файл->Экспорт в->Старый (1.x или 2) "
 "формат»."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:388
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:389
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:447
 msgid "File version warning"
 msgstr "Предупреждение о версии файла"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:445
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
 #, c-format
 msgid ""
 "The original database, '%ls', is in pre-3.0 format. The data will now be "
@@ -1818,15 +1818,15 @@ msgstr ""
 "версиями Password Safe. Для сохранения данных в старом формате используйте "
 "пункты меню «Файл->Экспорт в->Старый (1.x или 2) формат»."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:458
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
 msgid "Please choose a name for the current (Untitled) database:"
 msgstr "Укажите имя для текущего (безымянного) контейнера:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:460
 msgid "Please choose a new name for the current database:"
 msgstr "Укажите имя нового файла для текущего контейнера"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:467
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:468
 msgid ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|"
 "*.*;*"
@@ -1834,7 +1834,7 @@ msgstr ""
 "Контейнеры Password Safe (*.psafe3; *.dat)|*.psafe3;*.dat|Все файлы (*.*; *)|"
 "*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:479
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
 #, c-format
 msgid ""
 "%ls\n"
@@ -1845,230 +1845,230 @@ msgstr ""
 "\n"
 "Файл заблокирован %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:481
 msgid "File lock error"
 msgstr "Ошибка при блокировке файла"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:547
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
 msgid "Do you wish to save this restored database as new database?"
 msgstr "Сохранить восстановленный контейнер как новый?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:549
 msgid "Unsaved restored database"
 msgstr "Восстановленный контейнер с изменениями"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:580
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:581
 msgid "Do you want to save changes to the password database"
 msgstr "Сохранить изменения в контейнер"
 
 # урезано (кнопка в мастере)
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:617
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:618
 msgid "Export Text"
 msgstr "Экспорт"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:621
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:622
 msgid "Export Text failed"
 msgstr "Сбой при экспорте в простой текст"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:623
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
 msgid "Please name the plaintext file"
 msgstr "Укажите имя текстового файла"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1143
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:625
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1144
 msgid ""
 "Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
 msgstr ""
 "Текстовые файлы (*.txt)|*.txt|CSV-файлы (*.csv)|*.csv|Все файлы (*.*; *)|*.*;"
 "*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:634
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:635
 msgid "Advanced Text Export Options"
 msgstr "Расширенные настройки экспорта в простой текст"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:654
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:697
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:655
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:698
 msgid "export"
 msgstr "экспорт"
 
 # урезано (кнопка в мастере)
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:660
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:661
 msgid "Export XML"
 msgstr "Экспорт"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:664
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:665
 msgid "Export XML failed"
 msgstr "Сбой при экспорте в XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:666
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
 msgid "Please name the XML file"
 msgstr "Укажите имя XML-файла"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:668
 msgid "XML files (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 msgstr "XML-файлы (*.xml)|*.xml|Все файлы (*.*; *)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:678
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:679
 msgid "Advanced XML Export Options"
 msgstr "Расширенные настройки экспорта в XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:712
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:716
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:713
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:717
 msgid "Password Safe Databases (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 msgstr "Контейнеры Password Safe (*.dat)|*.dat|Все файлы (*.*)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:720
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:721
 msgid "Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 msgstr "Контейнеры Password Safe (*.psafe4)|*.psafe4|Все файлы (*.*)|*.*;*"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:731
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:732
 msgid "Please name the exported database"
 msgstr "Укажите имя экспортируемого контейнера"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:748
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:749
 msgid "Could not figure out why PasswordSafeFrame::OnExportVx was invoked"
 msgstr "Неожиданный вызов PasswordSafeFrame::OnExportVx"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:782
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:783
 msgid "You must save this database before it can be exported."
 msgstr "Перед экспортом контейнер должен быть сохранён."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid "Exporting database: "
 msgstr "Экспорт контейнера: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid " to "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:841
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:842
 msgid "Export complete.  Do you wish to see a detailed report?"
 msgstr "Экспорт завершён.  Открыть подробный отчёт?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:852
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:853
 msgid "No entries satisfied your selection criteria and so none were exported!"
 msgstr ""
 "Отсутствуют данные для экспорта: нет элементов, удовлетворяющих условиям "
 "фильтра!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:865
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:866
 msgid "Passkey incorrect"
 msgstr "Неверный пароль"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:873
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
 msgid ""
 "The current database was opened in read-only mode.  You cannot import into "
 "it."
 msgstr "Контейнер открыт «только для чтения»  Импорт невозможен."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:875
 msgid "Import text"
 msgstr "Импорт из простого текста"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:882
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
 msgid "The database:"
 msgstr "Контейнер:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
 msgid "has duplicate entries with the same group/title/user combination."
 msgstr ""
 "содержит дубликаты с совпадающими комбинациями Группа/Заголовок/Имя "
 "пользователя."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
 msgid "  Please fix by validating database."
 msgstr "  Для исправления запустите проверку."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:931
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:886
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:932
 msgid "Import Text failed"
 msgstr "Сбой при импорте из простого текста"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 #, c-format
 msgid "%ls file being imported: %ls"
 msgstr "%ls файл импортирован: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:921
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:926
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:223
-#: ../../../ui/wxWidgets/SyncWizard.cpp:572
+#: ../../../ui/wxWidgets/SyncWizard.cpp:573
 #: ../../../ui/wxWidgets/wxUtilities.cpp:59
 #: ../../../ui/wxWidgets/wxUtilities.cpp:64
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "File Read Error"
 msgstr "Ошибка при чтении файла"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:923
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:222
 #: ../../../ui/wxWidgets/wxUtilities.cpp:58
 msgid "Could not open file for reading!"
 msgstr "Невозможно открыть файл для чтения!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:928
 msgid "Invalid format"
 msgstr "Недопустимый формат"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 msgid "Updated "
 msgstr "Обновлено "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 msgid "Imported "
 msgstr "Импортировано "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 msgid " entry"
 msgstr " элемент"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 msgid " entries"
 msgstr " элементов"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
 msgid "Skipped "
 msgstr "Пропущено "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:957
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:958
 msgid "with Password History errors "
 msgstr "с ошибками в истории паролей "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 msgid "Renamed "
 msgstr "Переименовано "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed successfully"
 msgstr "Завершено успешно"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed but ...."
 msgstr "Завершено, но ..."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:981
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1127
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1197
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1218
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1279
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:982
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1128
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1219
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
 msgid "Do you wish to see a detailed report?"
 msgstr "Открыть подробный отчёт?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1045
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:998
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1046
 msgid "Import XML failed"
 msgstr "Сбой при импорте из XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1007
-#: ../../../core/core_st.cpp:238
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../core/core_st.cpp:240
 #, c-format
 msgid ""
 "Can't find XML Schema Definition file (%ls) in your PasswordSafe Application "
@@ -2079,19 +2079,19 @@ msgstr ""
 "Safe.\n"
 "Скопируйте этот файл из дистрибутива или переустановите Password Safe."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid "Missing XSD File - "
 msgstr "XSD-файл не указан — "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid " Build"
 msgstr " Сборка"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 msgid "XML"
 msgstr "XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1051
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1052
 #, c-format
 msgid ""
 "File: %ls failed validation against XML Schema:\n"
@@ -2102,7 +2102,7 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1057
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1058
 #, c-format
 msgid ""
 "File: %ls passed Validation but had the following errors during import:\n"
@@ -2113,25 +2113,25 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1078
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1079
 msgid "The following records were skipped:"
 msgstr "Следующие записи были пропущены:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1080
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1081
 #, c-format
 msgid " / skipped %d"
 msgstr " / пропущено %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1085
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1086
 msgid "The following records had errors in their Password History:"
 msgstr "Указанные записи содержали ошибки в истории паролей:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1087
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1088
 #, c-format
 msgid " / with Password History errors %d"
 msgstr " / с ошибками в истории паролей %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1092
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1093
 msgid ""
 "The following records were renamed as an entry already exists in your "
 "database or in the Import file:"
@@ -2139,12 +2139,12 @@ msgstr ""
 "Указанные записи были переименованы, т. к. такой элемент уже существует в "
 "контейнере или импортируемом файле:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1094
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1095
 #, c-format
 msgid " / renamed %d"
 msgstr " / переименовано %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1099
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1100
 #, c-format
 msgid ""
 "File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See "
@@ -2153,26 +2153,26 @@ msgstr ""
 "Файл %ls был импортирован (проверено элементов %d / импортировано %d%ls%ls"
 "%ls). Подробная информация находится в отчёте."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:95
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:97
 msgid "entry"
 msgstr "элемент"
 
 # Ex.: 5 entries
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:93
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:95
 msgid "entries"
 msgstr "элементов"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1107
 #, c-format
 msgid ""
 "Validated %d %ls\n"
@@ -2183,26 +2183,26 @@ msgstr ""
 "\n"
 "Импортировано %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1114
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1115
 msgid "XML import not supported in this release"
 msgstr "Данная версия не поддерживает импорт из XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1117
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1118
 #, c-format
 msgid "XML import: Unexpected return code(%d)"
 msgstr "Импорт из XML: неизвестный код возврата (%d)"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1141
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1142
 msgid "Please Choose a KeePass Text File to Import"
 msgstr "Укажите текстовый файл KeePass для импорта"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1163
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1164
 #, c-format
 msgid "Text file being imported: %ls"
 msgstr "Текстовый файл импортирован: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1180
-#: ../../../ui/wxWidgets/SyncWizard.cpp:602
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/SyncWizard.cpp:603
 #, c-format
 msgid ""
 "%ls\n"
@@ -2213,11 +2213,11 @@ msgstr ""
 "\n"
 "Невозможно открыть файл для чтения!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1182
 msgid "File open error"
 msgstr "Ошибка при открытии файла"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1195
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1196
 #, c-format
 msgid ""
 "%ls\n"
@@ -2228,20 +2228,20 @@ msgstr ""
 "\n"
 "Недопустимый формат"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1199
 msgid "Import failed"
 msgstr "Сбой при импорте"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1214
 #, c-format
 msgid "Imported %d %ls"
 msgstr "Импортировано %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1265
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1266
 msgid "Merging database: "
 msgstr "Слияние с контейнером: "
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1281
 msgid "Merge Complete"
 msgstr "Слияние завершено"
 
@@ -2354,16 +2354,16 @@ msgstr ""
 "файла блокировок.\n"
 "Попробуйте выйти из программы и запустить её заново."
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #, fuzzy
 msgid " file '"
 msgstr "Файлы изображений "
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid "' not readable"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #: ../../../ui/wxWidgets/ViewReportDlg.cpp:32
 msgid "View Report"
 msgstr "Просмотр отчёта"
@@ -2406,7 +2406,7 @@ msgstr "Укажите подходящий файл"
 
 # Встречается в отчётах при указании отсутствия элементов
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:123
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:249
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:251
 msgid "None"
 msgstr "Нет"
 
@@ -2419,7 +2419,7 @@ msgid "Incremented Number [001-999]"
 msgstr "Автонумератор [001-999]"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:132
-#: ../../../core/core_st.cpp:66
+#: ../../../core/core_st.cpp:68
 msgid "Copy password to clipboard"
 msgstr "Копировать пароль в буфер обмена"
 
@@ -2429,38 +2429,38 @@ msgstr "Редактирование/просмотр выбранного эл�
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:134
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:623
-#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:62
+#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:64
 msgid "Autotype"
 msgstr "Автонабор"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:135
-#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:63
+#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:65
 msgid "Browse to URL"
 msgstr "Перейти по ссылке"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:136
-#: ../../../core/core_st.cpp:65
+#: ../../../core/core_st.cpp:67
 msgid "Copy notes to clipboard"
 msgstr "Копировать заметки в буфер обмена"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:137
-#: ../../../core/core_st.cpp:68
+#: ../../../core/core_st.cpp:70
 msgid "Copy username to clipboard"
 msgstr "Копировать имя пользователя в буфер"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:138
-#: ../../../core/core_st.cpp:67
+#: ../../../core/core_st.cpp:69
 msgid "Copy password to clipboard, minimize"
 msgstr "Копировать пароль в буфер и свернуть"
 
 # урезано (в настройках вып. меню для двойного клика)
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:139
-#: ../../../core/core_st.cpp:64
+#: ../../../core/core_st.cpp:66
 msgid "Browse to URL + Autotype"
 msgstr "Перейти по ссылке и выполнить автонабор"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:140
-#: ../../../core/core_st.cpp:69 ../../../core/core_st.cpp:144
+#: ../../../core/core_st.cpp:71 ../../../core/core_st.cpp:146
 msgid "Run Command"
 msgstr "Выполнить команду"
 
@@ -2885,23 +2885,23 @@ msgstr "Password Safe: Ошибка при инициализации справ
 msgid "Don't show this warning again"
 msgstr "Больше не показывать это предупреждение"
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:849
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:854
 msgid "Missing help definition for page \""
 msgstr "Не найдена справка для вкладки \""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:850
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
 msgid "\" of \""
 msgstr "\" из \""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:860
 msgid "Missing help definition for window \""
 msgstr "Не найдена справка для окна \""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:866
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:871
 msgid "Please inform the developers."
 msgstr "Пожалуйста, сообщите об этом разработчикам."
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:867
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:872
 msgid "Help Undefined"
 msgstr "Справка отсутствует"
 
@@ -3574,6 +3574,7 @@ msgid "search"
 msgstr "поиск"
 
 #: ../../../ui/wxWidgets/PasswordSafeSearch.cpp:427
+#: ../../../core/core_st.cpp:280
 msgid "Find"
 msgstr "Поиск"
 
@@ -3690,20 +3691,20 @@ msgid " empty)"
 msgstr " пустых)"
 
 # Ex.: "Saved by: qq on MAIN"
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:306
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:322
 #, c-format
 msgid "%ls on %ls"
 msgstr "%ls на %ls"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:341
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:357
 msgid "Yes"
 msgstr "Да"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:244
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:246
 msgid "No"
 msgstr "Нет"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:302
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:318
 #, c-format
 msgid "In Headers(%ls)/In Entries("
 msgstr "В заголовках(%ls)/в элементах("
@@ -3876,7 +3877,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:457
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:269
-#: ../../../core/core_st.cpp:276
+#: ../../../core/core_st.cpp:290
 msgid "Warning"
 msgstr "Предупреждение"
 
@@ -3944,11 +3945,11 @@ msgstr "Укажите ключ и подтвердите его."
 msgid "Please try another"
 msgstr "Попробуйте другой"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:96
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:98
 msgid "equals"
 msgstr "совпадает с"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:83
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:85
 msgid "does not equal"
 msgstr "не совпадает с"
 
@@ -3956,23 +3957,23 @@ msgstr "не совпадает с"
 msgid "begins with"
 msgstr "начинается с"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:78
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:80
 msgid "does not begin with"
 msgstr "не начинается с"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:90
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:92
 msgid "ends with"
 msgstr "заканчивается на"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:82
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:84
 msgid "does not end with"
 msgstr "не заканчивается на"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:56
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:58
 msgid "contains"
 msgstr "содержит"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:79
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:81
 msgid "does not contain"
 msgstr "не содержит"
 
@@ -4026,19 +4027,19 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Отмена"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:143
+#: ../../../ui/wxWidgets/SyncWizard.cpp:144
 msgid "synchronize"
 msgstr "синхронизация"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:220
+#: ../../../ui/wxWidgets/SyncWizard.cpp:221
 msgid "Synchronize another database with currently open database"
 msgstr "Синхронизация контейнеров"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:349
+#: ../../../ui/wxWidgets/SyncWizard.cpp:350
 msgid "Introduction"
 msgstr "Введение"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:353
+#: ../../../ui/wxWidgets/SyncWizard.cpp:354
 msgid ""
 "Synchronizing with another database will update the entries in your\n"
 "database with matching entries from the other database."
@@ -4047,11 +4048,11 @@ msgstr ""
 "текущего контейнера данными из соответствующих элементов другого\n"
 "контейнера"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:356
+#: ../../../ui/wxWidgets/SyncWizard.cpp:357
 msgid "More Info"
 msgstr "Дополнительная информация"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:359
+#: ../../../ui/wxWidgets/SyncWizard.cpp:360
 msgid ""
 "1. Two entries from different databases match if their Group, Title\n"
 "and User fields match."
@@ -4060,7 +4061,7 @@ msgstr ""
 "соответствующими, если у них совпадают поля «Группа», «Заголовок» и\n"
 "«Имя пользователя»."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:360
+#: ../../../ui/wxWidgets/SyncWizard.cpp:361
 msgid ""
 "2. You can select the fields to update, as well as filter the entries\n"
 "for synchronization."
@@ -4068,7 +4069,7 @@ msgstr ""
 "2. Вы можете выбрать поля для обновления и указать фильтр для отбора\n"
 "синхронизируемых элементов."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:361
+#: ../../../ui/wxWidgets/SyncWizard.cpp:362
 msgid ""
 "3. Only existing entries in your database are updated.  No new entries are\n"
 "added or existing entries removed during this process."
@@ -4077,7 +4078,7 @@ msgstr ""
 "контейнере.  Во время синхронизации не происходит удаления или добавления\n"
 "элементов."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:362
+#: ../../../ui/wxWidgets/SyncWizard.cpp:363
 msgid ""
 "4. You can undo the operation once it is complete, but won't be\n"
 "able to abort it mid-way."
@@ -4085,27 +4086,27 @@ msgstr ""
 "4. Действия могут быть отменены после завершения, но сам\n"
 "процесс не может быть прерван."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:379
+#: ../../../ui/wxWidgets/SyncWizard.cpp:380
 msgid "Select another database"
 msgstr "Выберите контейнер"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:381
+#: ../../../ui/wxWidgets/SyncWizard.cpp:382
 msgid "Choose Database to Synchronize with \""
 msgstr "Укажите контейнер для синхронизации с \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:382
+#: ../../../ui/wxWidgets/SyncWizard.cpp:383
 msgid "Please Choose a Database to Synchronize with current database"
 msgstr "Укажите контейнер для синхронизации с открытым контейнером"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:405
+#: ../../../ui/wxWidgets/SyncWizard.cpp:406
 msgid "Synchronization options"
 msgstr "Параметры синхронизации"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:429
+#: ../../../ui/wxWidgets/SyncWizard.cpp:430
 msgid "Options Summary"
 msgstr "Сводка настроек"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:454
+#: ../../../ui/wxWidgets/SyncWizard.cpp:455
 msgid ""
 "WARNING!!\n"
 "\n"
@@ -4117,53 +4118,53 @@ msgstr ""
 "В случае продолжения, значения элементов текущего контейнера будут заменены "
 "на значения из указанного контейнера"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:471
+#: ../../../ui/wxWidgets/SyncWizard.cpp:472
 msgid " will be updated with corresponding entries from \""
 msgstr " будут обновлены с использованием значений из \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:478
+#: ../../../ui/wxWidgets/SyncWizard.cpp:479
 msgid "All fields in matching entries will be updated"
 msgstr "Все поля соответствующих элементов будут обновлены"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:484
+#: ../../../ui/wxWidgets/SyncWizard.cpp:485
 msgid "Following fields in matching entries will be updated:"
 msgstr "В соответствующих элементах будут обновлены следующие поля:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:488
+#: ../../../ui/wxWidgets/SyncWizard.cpp:489
 msgid "Following fields will not be updated:"
 msgstr "Следующие поля не будут обновлены:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:507
+#: ../../../ui/wxWidgets/SyncWizard.cpp:508
 msgid "Synchronization status"
 msgstr "Состояние синхронизации"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:525
+#: ../../../ui/wxWidgets/SyncWizard.cpp:526
 msgid "See a detailed report"
 msgstr "Открыть подробный отчёт"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:561
+#: ../../../ui/wxWidgets/SyncWizard.cpp:562
 msgid "Your database is being synchronized with \""
 msgstr "Контейнер синхронизируется с \""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:571
+#: ../../../ui/wxWidgets/SyncWizard.cpp:572
 msgid "There was an error during synchronization"
 msgstr "Во время синхронизации произошла ошибка"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:585
+#: ../../../ui/wxWidgets/SyncWizard.cpp:586
 #, c-format
 msgid "Your database has been synchronized with \"%ls\""
 msgstr "Контейнер был синхронизирован с «%ls»"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:586
+#: ../../../ui/wxWidgets/SyncWizard.cpp:587
 #, c-format
 msgid "%ld %ls updated"
 msgstr "%ld %ls обновлено"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:589
 msgid "Synchronization completed successfully"
 msgstr "Синхронизация успешно завершена"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:604
+#: ../../../ui/wxWidgets/SyncWizard.cpp:605
 #, c-format
 msgid ""
 "%ls\n"
@@ -4176,7 +4177,7 @@ msgstr ""
 "Файл повреждён или усечён!\n"
 "Возможно изменение или потеря данных."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:606
+#: ../../../ui/wxWidgets/SyncWizard.cpp:607
 #, c-format
 msgid ""
 "%ls\n"
@@ -4187,24 +4188,24 @@ msgstr ""
 "\n"
 "Неопознанная ошибка"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:640
+#: ../../../ui/wxWidgets/SyncWizard.cpp:641
 #, c-format
 msgid "Synchronizing from database: %ls\n"
 msgstr "Синхронизация с контейнером: %ls\n"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:643
+#: ../../../ui/wxWidgets/SyncWizard.cpp:644
 msgid "synchronized"
 msgstr "синхронизировано"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:322
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:338
 msgid "was"
 msgstr "был"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:323
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:339
 msgid "were"
 msgstr "были"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:298
+#: ../../../ui/wxWidgets/SyncWizard.cpp:733 ../../../core/core_st.cpp:314
 #, c-format
 msgid ""
 "\n"
@@ -4213,7 +4214,7 @@ msgstr ""
 "\n"
 "Следующие %ls %ls обновлены:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:297
+#: ../../../ui/wxWidgets/SyncWizard.cpp:749 ../../../core/core_st.cpp:313
 #, c-format
 msgid ""
 "\n"
@@ -4381,7 +4382,7 @@ msgid "This shortcut's target [%s:%s:%s] is not a normal entry."
 msgstr ""
 "Целевой элемент [%s:%s:%s] для данного ярлыка не является обычным элементом."
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:94
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:96
 #, c-format
 msgid ""
 "The following entries had a policy name that already existed in this "
@@ -4484,7 +4485,7 @@ msgstr ""
 "Возможно изменение или потеря данных.\n"
 "Всё равно продолжить?"
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:381
+#: ../../../ui/wxWidgets/wxUtilities.cpp:390
 msgid ""
 "An error occurred while trying to get the image data from database item.\n"
 "Therefore, the image cannot be displayed in the preview."
@@ -4492,7 +4493,7 @@ msgstr ""
 "Ошибка при получении данных об изображении из элемента контейнера.\n"
 "Поэтому, картинка не может быть отображена."
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:394
+#: ../../../ui/wxWidgets/wxUtilities.cpp:403
 msgid ""
 "An error occurred while trying to load the image data into the preview "
 "area.\n"
@@ -4612,7 +4613,7 @@ msgstr "Сохранить контейнер"
 msgid "Copy Password to Clipboard"
 msgstr "Копировать пароль в буфер обмена"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:149
+#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:151
 msgid "Username"
 msgstr "Имя пользователя"
 
@@ -4620,7 +4621,7 @@ msgstr "Имя пользователя"
 msgid "Copy Username to Clipboard"
 msgstr "Копировать имя пользователя в буфер"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:136
+#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:138
 msgid "Notes"
 msgstr "Заметки"
 
@@ -4644,7 +4645,7 @@ msgstr "Автонабор"
 msgid "Browse URL"
 msgstr "Перейти по ссылке"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:70
+#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:72
 msgid "Send Email"
 msgstr "Отправить письмо"
 
@@ -4829,81 +4830,99 @@ msgstr "(без учёта регистра)"
 msgid "(case sensitive)"
 msgstr "(с учётом регистра)"
 
+#: ../../../core/core_st.cpp:50
+#, fuzzy, c-format
+msgid ""
+"Compare complete of current database:\n"
+"\t %ls\n"
+" and:\n"
+"\t %ls\n"
+msgstr ""
+"Завершено сравнение текущего контейнера:\n"
+"\t %s\n"
+" и:\n"
+"\t %s"
+
+#: ../../../core/core_st.cpp:51
+#, fuzzy, c-format
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tГруппа: «%s»; Заголовок: «%s»; Имя пользователя: «%s»"
+
 # Отображается в статус-строке и указывает источник настроек. С - файл
 # настроек, F - файл [RO]/[R/W], None - нет, Reg - реестр.
-#: ../../../core/core_st.cpp:50
+#: ../../../core/core_st.cpp:52
 msgid "C:F[R-O]"
 msgstr "C:F[R-O]"
 
 # Отображается в статус-строке и указывает источник настроек. С - файл
 # настроек, F - файл [RO]/[R/W], None - нет, Reg - реестр.
-#: ../../../core/core_st.cpp:51
+#: ../../../core/core_st.cpp:53
 msgid "C:F[R/W]"
 msgstr "C:F[R/W]"
 
 # Отображается в статус-строке и указывает источник настроек. С - файл
 # настроек, F - файл [RO]/[R/W], None - нет, Reg - реестр.
-#: ../../../core/core_st.cpp:52
+#: ../../../core/core_st.cpp:54
 msgid "C:None  "
 msgstr "C:None  "
 
 # Отображается в статус-строке и указывает источник настроек. С - файл
 # настроек, F - файл [RO]/[R/W], None - нет, Reg - реестр.
-#: ../../../core/core_st.cpp:53
+#: ../../../core/core_st.cpp:55
 msgid "C:Reg   "
 msgstr "C:Reg   "
 
-#: ../../../core/core_st.cpp:54
+#: ../../../core/core_st.cpp:56
 msgid "conflict"
 msgstr "конфликт"
 
 # Ex.: 5 confilicts
-#: ../../../core/core_st.cpp:55
+#: ../../../core/core_st.cpp:57
 msgid "conflicts"
 msgstr "конфликтов"
 
-#: ../../../core/core_st.cpp:57
+#: ../../../core/core_st.cpp:59
 msgid "contains all of"
 msgstr "содержит все из"
 
-#: ../../../core/core_st.cpp:58
+#: ../../../core/core_st.cpp:60
 msgid "contains any of"
 msgstr "содержит любой из"
 
 # подстановка в "Entry keyboard shortcut %s entry %s is already allocated ..."
 # и "They have been removed from the %s entries"
-#: ../../../core/core_st.cpp:59
+#: ../../../core/core_st.cpp:61
 msgid "copied"
 msgstr "скопированного"
 
-#: ../../../core/core_st.cpp:60
+#: ../../../core/core_st.cpp:62
 #, c-format
 msgid "%ls - Copied %ls"
 msgstr "%ls — скопировано %ls"
 
 # Используется в фильтре для DCA (начинается с пробела для того, чт. было
 # первым в списке)
-#: ../../../core/core_st.cpp:61
+#: ../../../core/core_st.cpp:63
 #, c-format
 msgid " Current default (%ls)"
 msgstr " Текущие умолчания (%ls)"
 
 # урезано из-за ограничения длины
-#: ../../../core/core_st.cpp:71
+#: ../../../core/core_st.cpp:73
 msgid "View/Edit selected entry"
 msgstr "Просмотр/редактирование элемента"
 
 # урезано, в click/double click action
-#: ../../../core/core_st.cpp:72
+#: ../../../core/core_st.cpp:74
 msgid " (application default)"
 msgstr " (по умолчанию)"
 
 # не менее X из набора ... в информации о политике
-#: ../../../core/core_st.cpp:73
+#: ../../../core/core_st.cpp:75
 msgid "default symbol set"
 msgstr "набора символов по умолчанию"
 
-#: ../../../core/core_st.cpp:75
+#: ../../../core/core_st.cpp:77
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -4916,13 +4935,13 @@ msgstr ""
 "Продолжить выполнение (пароли для псевдонимов будут заменены на пароль этого "
 "элемента)?"
 
-#: ../../../core/core_st.cpp:76
+#: ../../../core/core_st.cpp:78
 msgid "Delete Base Entry Confirmation"
 msgstr "Подтверждение удаления исходного элемента"
 
 # Ex.: "This entry has the following 3 shortcuts: foo, bar, zog" or
 # "This entry has the following 3 aliases: foo, bar, zog"
-#: ../../../core/core_st.cpp:77
+#: ../../../core/core_st.cpp:79
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -4933,41 +4952,41 @@ msgstr ""
 "%ls\n"
 "Продолжить выполнение (все ярлыки для этого элемента будут удалены)?"
 
-#: ../../../core/core_st.cpp:80
+#: ../../../core/core_st.cpp:82
 msgid "does not contain all of"
 msgstr "не содержит ни одного из"
 
-#: ../../../core/core_st.cpp:81
+#: ../../../core/core_st.cpp:83
 msgid "does not contain any of"
 msgstr "не содержит любого из"
 
 # Используется для автоименования элементов при перетаскивании
-#: ../../../core/core_st.cpp:84
+#: ../../../core/core_st.cpp:86
 #, c-format
 msgid " Drag # %d"
 msgstr " (перетянуто № %d)"
 
-#: ../../../core/core_st.cpp:85
-#, c-format
-msgid "%s - Drag & Drop %s"
+#: ../../../core/core_st.cpp:87
+#, fuzzy, c-format
+msgid "%ls - Drag & Drop %ls"
 msgstr "%s — перетянуто %s"
 
-#: ../../../core/core_st.cpp:86
+#: ../../../core/core_st.cpp:88
 #, c-format
 msgid " Duplicate # %d"
 msgstr " (дубликат № %d)"
 
 # core, "1 empty group"
-#: ../../../core/core_st.cpp:87
+#: ../../../core/core_st.cpp:89
 msgid "empty group"
 msgstr "пустая группа"
 
 # core, "N empty groups", N!=1
-#: ../../../core/core_st.cpp:88
+#: ../../../core/core_st.cpp:90
 msgid "empty groups"
 msgstr "пустых групп"
 
-#: ../../../core/core_st.cpp:89
+#: ../../../core/core_st.cpp:91
 #, c-format
 msgid ""
 "Trouble with a non-textual (e.g., time) field in record '%ls' - please check "
@@ -4976,262 +4995,262 @@ msgstr ""
 "Проблемы с нетекстовыми полями (напр., время) в записи «%ls». Проверьте "
 "корректность данных."
 
-#: ../../../core/core_st.cpp:91
+#: ../../../core/core_st.cpp:93
 msgid "End Report"
 msgstr "Конец отчёта"
 
-#: ../../../core/core_st.cpp:92
+#: ../../../core/core_st.cpp:94
 msgid "--------------------------------------------------------------------------------"
 msgstr "--------------------------------------------------------------------------------"
 
-#: ../../../core/core_st.cpp:97
+#: ../../../core/core_st.cpp:99
 msgid "has expired"
 msgstr "истёк"
 
 # имя внутреннего фильтра
-#: ../../../core/core_st.cpp:98
+#: ../../../core/core_st.cpp:100
 msgid "Entries with a password expiry"
 msgstr "Элементы с истекающим паролем"
 
-#: ../../../core/core_st.cpp:99
+#: ../../../core/core_st.cpp:101
 #, c-format
 msgid "within %d day(s)"
 msgstr "в течение %d дней"
 
 # описание для нового контейнера
-#: ../../../core/core_st.cpp:100
+#: ../../../core/core_st.cpp:102
 #, c-format
 msgid "DB Export from database: '%s'"
 msgstr "Экспортировано из контейнера: '%s'"
 
-#: ../../../core/core_st.cpp:101
+#: ../../../core/core_st.cpp:103
 msgid "First character of variable name must be alphabetic"
 msgstr "Первый символ в имени переменной должен быть буквой"
 
 # message for core
-#: ../../../core/core_st.cpp:102
+#: ../../../core/core_st.cpp:104
 msgid "Index not numeric"
 msgstr "Индекс не является числовым"
 
-#: ../../../core/core_st.cpp:103
+#: ../../../core/core_st.cpp:105
 msgid "Input string is empty"
 msgstr "Пустая строка ввода"
 
-#: ../../../core/core_st.cpp:104
+#: ../../../core/core_st.cpp:106
 msgid "Characters present between end of index ']' and '}'"
 msgstr "Символы после индекса (между «]» и «}») недопустимы"
 
 # message for core
-#: ../../../core/core_st.cpp:105
+#: ../../../core/core_st.cpp:107
 msgid "Index is invalid or missing"
 msgstr "Индекс не указан или недопустим"
 
-#: ../../../core/core_st.cpp:106
+#: ../../../core/core_st.cpp:108
 msgid "Missing ending curly bracket for variable name"
 msgstr "Отсутствует фигурная скобка после имени переменной"
 
-#: ../../../core/core_st.cpp:107
+#: ../../../core/core_st.cpp:109
 msgid "Missing ending round bracket for Autotype value"
 msgstr "Отсутствует закрывающая круглая скобка после значения для автонабора"
 
-#: ../../../core/core_st.cpp:108
+#: ../../../core/core_st.cpp:110
 msgid "Missing ending square bracket for index value"
 msgstr "Отсутствует закрывающая квадратная скобка после значения индекса"
 
-#: ../../../core/core_st.cpp:109
+#: ../../../core/core_st.cpp:111
 msgid "There are unmatched quotes in the run command"
 msgstr "В команде присутствуют непарные кавычки"
 
-#: ../../../core/core_st.cpp:110
+#: ../../../core/core_st.cpp:112
 msgid "Variable name is empty"
 msgstr "Имя переменной не указано"
 
-#: ../../../core/core_st.cpp:111
+#: ../../../core/core_st.cpp:113
 msgid "Variable name must be alphanumeric"
 msgstr "Имя переменной может содержать только буквы и цифры"
 
-#: ../../../core/core_st.cpp:112
+#: ../../../core/core_st.cpp:114
 msgid "an alias entry"
 msgstr "псевдоним"
 
-#: ../../../core/core_st.cpp:113
+#: ../../../core/core_st.cpp:115
 msgid "a base entry of an alias"
 msgstr "исходный элемент для псевдонима"
 
-#: ../../../core/core_st.cpp:114
+#: ../../../core/core_st.cpp:116
 msgid "  Field is too long."
 msgstr "  Поле слишком велико."
 
-#: ../../../core/core_st.cpp:115
+#: ../../../core/core_st.cpp:117
 msgid "  Field is too short."
 msgstr "  Поле слишком мало."
 
-#: ../../../core/core_st.cpp:116
+#: ../../../core/core_st.cpp:118
 msgid "Error: A file with this name already exists"
 msgstr "Ошибка: файл с указанным именем уже существует"
 
-#: ../../../core/core_st.cpp:117
+#: ../../../core/core_st.cpp:119
 msgid "The file was not found."
 msgstr "Файл не найден."
 
-#: ../../../core/core_st.cpp:118
+#: ../../../core/core_st.cpp:120
 msgid "Error: File is read-only"
 msgstr "Ошибка: файл доступен только для чтения"
 
-#: ../../../core/core_st.cpp:119
+#: ../../../core/core_st.cpp:121
 msgid "Error while writing file! Try saving in a different location"
 msgstr "Ошибка при записи файла! Попробуйте сохранить файл в другом месте."
 
 # 2Gb+ when encrypting file (core error)
-#: ../../../core/core_st.cpp:120
+#: ../../../core/core_st.cpp:122
 msgid "File is too big."
 msgstr "Слишком большой файл."
 
 # when decryptiong file (core error)
-#: ../../../core/core_st.cpp:121
+#: ../../../core/core_st.cpp:123
 msgid "File is too short."
 msgstr "Недостаточный размер файла."
 
-#: ../../../core/core_st.cpp:122
+#: ../../../core/core_st.cpp:124
 msgid "File is truncated or otherwise corrupt. Please use backup database."
 msgstr "Файл усечён или повреждён. Используйте резервную копию."
 
-#: ../../../core/core_st.cpp:123
+#: ../../../core/core_st.cpp:125
 msgid "Cannot read file. Please check file permissions."
 msgstr "Невозможно прочитать файл. Проверьте права доступа."
 
-#: ../../../core/core_st.cpp:124
+#: ../../../core/core_st.cpp:126
 #, c-format
 msgid ""
 "Filter %ls already exists in the database, do you wish to replace it with "
 "this?"
 msgstr "Фильтр %ls уже существует в контейнере. Заменить его?"
 
-#: ../../../core/core_st.cpp:125
+#: ../../../core/core_st.cpp:127
 msgid "Current database filters have been exported to this database."
 msgstr "В данный контейнер были экспортированы фильтры из текущего контейнера."
 
-#: ../../../core/core_st.cpp:126
+#: ../../../core/core_st.cpp:128
 msgid "Stored filters will be unusable until the file's restored."
 msgstr "Сохранённые фильтры будут недоступны, пока файл не будет восстановлен."
 
-#: ../../../core/core_st.cpp:127
+#: ../../../core/core_st.cpp:129
 msgid "Last Access Time"
 msgstr "Время последнего доступа"
 
 # имя поля с UUID вложения
-#: ../../../core/core_st.cpp:128
+#: ../../../core/core_st.cpp:130
 msgid "Attachment Reference"
 msgstr "Ссылка на вложение"
 
-#: ../../../core/core_st.cpp:129
+#: ../../../core/core_st.cpp:131
 msgid "AutoType"
 msgstr "Автонабор"
 
-#: ../../../core/core_st.cpp:130
+#: ../../../core/core_st.cpp:132
 msgid "Created Time"
 msgstr "Время создания"
 
-#: ../../../core/core_st.cpp:131
+#: ../../../core/core_st.cpp:133
 msgid "DCA"
 msgstr "Действие по двойному клику"
 
-#: ../../../core/core_st.cpp:132
+#: ../../../core/core_st.cpp:134
 msgid "e-mail"
 msgstr "E-mail"
 
-#: ../../../core/core_st.cpp:134
+#: ../../../core/core_st.cpp:136
 msgid "Group/Title"
 msgstr "Группа/заголовок"
 
-#: ../../../core/core_st.cpp:135
+#: ../../../core/core_st.cpp:137
 msgid "Keyboard Shortcut"
 msgstr "Горячая клавиша"
 
-#: ../../../core/core_st.cpp:138
+#: ../../../core/core_st.cpp:140
 msgid "Password Modified Time"
 msgstr "Время изменения пароля"
 
-#: ../../../core/core_st.cpp:139
+#: ../../../core/core_st.cpp:141
 msgid "Protected"
 msgstr "Защищён"
 
-#: ../../../core/core_st.cpp:140
+#: ../../../core/core_st.cpp:142
 msgid "History"
 msgstr "История"
 
-#: ../../../core/core_st.cpp:142
+#: ../../../core/core_st.cpp:144
 msgid "Password Policy Name"
 msgstr "Имя политики создания паролей"
 
-#: ../../../core/core_st.cpp:143
+#: ../../../core/core_st.cpp:145
 msgid "Record Modified Time"
 msgstr "Время изменения элемента"
 
-#: ../../../core/core_st.cpp:145
+#: ../../../core/core_st.cpp:147
 msgid "Shift+DCA"
 msgstr "Действие по Shift + двойной клик"
 
-#: ../../../core/core_st.cpp:146
+#: ../../../core/core_st.cpp:148
 msgid "Symbols"
 msgstr "Символы"
 
-#: ../../../core/core_st.cpp:148
+#: ../../../core/core_st.cpp:150
 msgid "URL"
 msgstr "Ссылка"
 
-#: ../../../core/core_st.cpp:150
+#: ../../../core/core_st.cpp:152
 msgid "UUID"
 msgstr "UUID"
 
 # В фильтрах
-#: ../../../core/core_st.cpp:151
+#: ../../../core/core_st.cpp:153
 msgid "Password Expiry Date"
 msgstr "Дата истечения пароля"
 
 # В фильтрах
-#: ../../../core/core_st.cpp:152
+#: ../../../core/core_st.cpp:154
 msgid "Password Expiry Interval"
 msgstr "Срок истечения пароля"
 
-#: ../../../core/core_st.cpp:153
+#: ../../../core/core_st.cpp:155
 msgid "a normal entry"
 msgstr "обычный элемент"
 
 # имя встроенного фильтра
-#: ../../../core/core_st.cpp:154
+#: ../../../core/core_st.cpp:156
 msgid "Last found entries"
 msgstr "Найденные элементы"
 
-#: ../../../core/core_st.cpp:155
+#: ../../../core/core_st.cpp:157
 msgid "added but not yet saved to database"
 msgstr "добавлены, но ещё не сохранены в контейнер"
 
-#: ../../../core/core_st.cpp:156
+#: ../../../core/core_st.cpp:158
 msgid "in the database"
 msgstr "в контейнере"
 
-#: ../../../core/core_st.cpp:157
+#: ../../../core/core_st.cpp:159
 msgid "a shortcut entry"
 msgstr "ярлык"
 
-#: ../../../core/core_st.cpp:158
+#: ../../../core/core_st.cpp:160
 msgid "a base entry of a shortcut"
 msgstr "исходный элемент для ярлыка"
 
-#: ../../../core/core_st.cpp:159
+#: ../../../core/core_st.cpp:161
 msgid "changed but not yet saved to database"
 msgstr "изменены, но ещё не сохранены в контейнер"
 
-#: ../../../core/core_st.cpp:160
+#: ../../../core/core_st.cpp:162
 msgid "greater than"
 msgstr "больше чем"
 
-#: ../../../core/core_st.cpp:161
+#: ../../../core/core_st.cpp:163
 msgid "greater than or equal to"
 msgstr "больше либо равно"
 
-#: ../../../core/core_st.cpp:162
+#: ../../../core/core_st.cpp:164
 #, c-format
 msgid ""
 "Invalid input on line %d.  Number of fields separated by '%c' is not as "
@@ -5240,12 +5259,12 @@ msgstr ""
 "Недопустимый ввод в строке %d.  Количество полей разделённых «%c» не "
 "совпадает с ожидаемым."
 
-#: ../../../core/core_st.cpp:163
+#: ../../../core/core_st.cpp:165
 #, c-format
 msgid "Line %d: "
 msgstr "Строка %d: "
 
-#: ../../../core/core_st.cpp:164
+#: ../../../core/core_st.cpp:166
 #, c-format
 msgid ""
 "File ends on line %d before ending double quote of last entry's note field."
@@ -5253,11 +5272,11 @@ msgstr ""
 "Обнаружен конец файла в строке %d до того как была найдена закрывающая "
 "двойная кавычка для последнего поля с заметками."
 
-#: ../../../core/core_st.cpp:165
+#: ../../../core/core_st.cpp:167
 msgid "Import aborted. Please see report."
 msgstr "Импорт прерван. Причина указана в отчёте."
 
-#: ../../../core/core_st.cpp:166
+#: ../../../core/core_st.cpp:168
 msgid ""
 "The TXT or CSV file was not imported as required as entry records span "
 "multiple lines in the CSV file.\n"
@@ -5269,7 +5288,7 @@ msgstr ""
 "\n"
 "Импорт прерван."
 
-#: ../../../core/core_st.cpp:167
+#: ../../../core/core_st.cpp:169
 #, c-format
 msgid ""
 "%ls, Title=\"%ls\", User=\"%ls\" already exists in your database or in the "
@@ -5279,71 +5298,71 @@ msgstr ""
 "контейнере или импортируемом файле. Импортированный элемент добавлен с "
 "заголовком «%ls».\n"
 
-#: ../../../core/core_st.cpp:168
+#: ../../../core/core_st.cpp:170
 #, c-format
 msgid "Entry on line %d with Group=\"%ls\""
 msgstr "Элемент, описанный в строке %d, из группы «%ls»"
 
-#: ../../../core/core_st.cpp:169
+#: ../../../core/core_st.cpp:171
 #, c-format
 msgid "Entry on line %d with no group"
 msgstr "Элемент, описанный в строке %d, без имени группы"
 
-#: ../../../core/core_st.cpp:170
+#: ../../../core/core_st.cpp:172
 #, c-format
 msgid "Entry with Group=\"%ls\""
 msgstr "Элемент из группы «%ls»"
 
-#: ../../../core/core_st.cpp:171
+#: ../../../core/core_st.cpp:173
 msgid "Entry with no group"
 msgstr "Элемент без имени группы"
 
 # подстановка в "Entry keyboard shortcut %s entry %s is already allocated ..."
 # и "They have been removed from the %s entries"
-#: ../../../core/core_st.cpp:172
+#: ../../../core/core_st.cpp:174
 msgid "imported"
 msgstr "импортированного"
 
 # report
-#: ../../../core/core_st.cpp:173
+#: ../../../core/core_st.cpp:175
 #, c-format
 msgid "including %d empty group(s)."
 msgstr "пустых групп: %d."
 
-#: ../../../core/core_st.cpp:174
+#: ../../../core/core_st.cpp:176
 #, c-format
 msgid "Empty line %d skipped"
 msgstr "Пустые строки %d пропущены"
 
-#: ../../../core/core_st.cpp:175
+#: ../../../core/core_st.cpp:177
 #, c-format
 msgid "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 msgstr ""
 "Элемент %ls%d с группой «%ls», заголовком «%ls» и именем пользователя «%ls»"
 
-#: ../../../core/core_st.cpp:176
+#: ../../../core/core_st.cpp:178
 msgid "Internal error. Import failed. No records imported."
 msgstr "Внутренняя ошибка. Сбой при импорте. Записи не были импортированы."
 
-#: ../../../core/core_st.cpp:177
+#: ../../../core/core_st.cpp:179
 #, c-format
 msgid "Found %d known column headers:"
 msgstr "Обнаружено %d известных заголовков столбцов:"
 
-#: ../../../core/core_st.cpp:178
+#: ../../../core/core_st.cpp:180
 msgid "Invalid field delimiter: must be within ASCII range."
 msgstr "Неверный разделитель полей: должен быть ASCII-символом."
 
-#: ../../../core/core_st.cpp:179
+#: ../../../core/core_st.cpp:181
 #, c-format
 msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
 msgstr "Элемент в строке %d содержит недопустимое поле «%ls». Проигнорировано."
 
-#: ../../../core/core_st.cpp:180
+#: ../../../core/core_st.cpp:182
 msgid "The following columns will be processed: "
 msgstr "Были обработаны следующие столбцы: "
 
-#: ../../../core/core_st.cpp:181
+#: ../../../core/core_st.cpp:183
 msgid ""
 "The following columns were recognised but only Group/Title, Username and "
 "Password will be processed:"
@@ -5351,7 +5370,7 @@ msgstr ""
 "Указанные столбцы распознаны, но только группа/заголовок, имя пользователя и "
 "пароль будут обработаны:"
 
-#: ../../../core/core_st.cpp:182
+#: ../../../core/core_st.cpp:184
 #, c-format
 msgid ""
 "Line %d skipped - Only %d fields found, whereas parsing the Header says "
@@ -5360,7 +5379,7 @@ msgstr ""
 "Строка %d пропущена: указано лишь %d элементов (согласно заголовку должно "
 "быть %d)."
 
-#: ../../../core/core_st.cpp:183
+#: ../../../core/core_st.cpp:185
 msgid ""
 "Either or both of the Group/Title and Password columns are missing. No "
 "records imported."
@@ -5368,7 +5387,7 @@ msgstr ""
 "Столбец с группой/заголовком и/или паролем отсутствует. Записи не были "
 "импортированы."
 
-#: ../../../core/core_st.cpp:184
+#: ../../../core/core_st.cpp:186
 msgid ""
 "Could not find the next entry's title field in the KeePass V1 TXT (should be "
 "within square brackets)."
@@ -5376,39 +5395,39 @@ msgstr ""
 "Не найден заголовок следующего элемента в TXT-файле KeePass V1 (должен быть "
 "заключён в квадратные скобки)."
 
-#: ../../../core/core_st.cpp:185
+#: ../../../core/core_st.cpp:187
 msgid "Column header row not recognised as first record. No records imported."
 msgstr ""
 "Невозможно определить строку заголовков по первой записи. Записи не были "
 "импортированы."
 
-#: ../../../core/core_st.cpp:186
+#: ../../../core/core_st.cpp:188
 msgid "No records in import file!"
 msgstr "В импортируемом файле нет записей!"
 
-#: ../../../core/core_st.cpp:187
+#: ../../../core/core_st.cpp:189
 #, c-format
 msgid "Line %d skipped: Empty mandatory Password field."
 msgstr "Строка %d пропущена: обязательное поле «пароль» не заполнено."
 
-#: ../../../core/core_st.cpp:188
+#: ../../../core/core_st.cpp:190
 #, c-format
 msgid "Line %d skipped: Empty mandatory Title field."
 msgstr "Строка %d пропущена: обязательное поле «заголовок» не заполнено."
 
 # Используется для автоименования элементов при импортировании из неродных
 # форматов
-#: ../../../core/core_st.cpp:189
+#: ../../../core/core_st.cpp:191
 #, c-format
 msgid " Import # %d"
 msgstr " (импортировано № %d)"
 
-#: ../../../core/core_st.cpp:190
+#: ../../../core/core_st.cpp:192
 #, c-format
 msgid "%ls - Imported %ls"
 msgstr "%ls — Импортировано %ls"
 
-#: ../../../core/core_st.cpp:191
+#: ../../../core/core_st.cpp:193
 msgid ""
 "To replace passwords of existing entries, all the following columns must be "
 "present: Group/Title, Username and Password.  One or more are missing and no "
@@ -5418,17 +5437,17 @@ msgstr ""
 "поля: группа/заголовок, имя пользователя, пароль.  Один или несколько из них "
 "отсутствуют, поэтому элементы не будут обновлены."
 
-#: ../../../core/core_st.cpp:192
+#: ../../../core/core_st.cpp:194
 #, c-format
 msgid "%ls not found. Cannot update entry's password.\n"
 msgstr "Файл %ls не найден. Невозможно обновить пароль для элемента.\n"
 
-#: ../../../core/core_st.cpp:193
+#: ../../../core/core_st.cpp:195
 #, c-format
 msgid "%ls has an empty %ls.\n"
 msgstr "у %ls пустой %ls.\n"
 
-#: ../../../core/core_st.cpp:194
+#: ../../../core/core_st.cpp:196
 #, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5437,12 +5456,12 @@ msgstr ""
 "Пароль для элемента «%ls, %ls, %ls» имеет вид псевдонима, но исходный "
 "элемент является псевдонимом."
 
-#: ../../../core/core_st.cpp:195
+#: ../../../core/core_st.cpp:197
 msgid "\tThis entry has been made an alias of associated base entry."
 msgstr ""
 "\tЭтот элемент является псевдонимом соответствующего исходного элемента."
 
-#: ../../../core/core_st.cpp:196
+#: ../../../core/core_st.cpp:198
 #, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5451,12 +5470,12 @@ msgstr ""
 "Пароль для элемента «%ls, %ls, %ls» имеет вид псевдонима, но исходный "
 "элемент не найден."
 
-#: ../../../core/core_st.cpp:197
+#: ../../../core/core_st.cpp:199
 msgid ""
 "\tThis entry remains a normal entry and the password has not been changed."
 msgstr "\tЭтот элемент остаётся обычным элементом. Пароль не изменён."
 
-#: ../../../core/core_st.cpp:198
+#: ../../../core/core_st.cpp:200
 #, c-format
 msgid ""
 "The %ls entry \"%ls, %ls, %ls\" doesn't point to a normal or existing %ls "
@@ -5465,70 +5484,70 @@ msgstr ""
 "Элемент %ls «%ls, %ls, %ls» не указывает на нормальный или существующий %ls "
 "исходный элемент. Импорт невозможен."
 
-#: ../../../core/core_st.cpp:199
+#: ../../../core/core_st.cpp:201
 msgid "Entry import warnings"
 msgstr "Предупреждения при импорте элементов"
 
-#: ../../../core/core_st.cpp:200
+#: ../../../core/core_st.cpp:202
 msgid "id="
 msgstr "id="
 
-#: ../../../core/core_st.cpp:201
+#: ../../../core/core_st.cpp:203
 msgid "on line "
 msgstr "в строке "
 
-#: ../../../core/core_st.cpp:202
+#: ../../../core/core_st.cpp:204
 msgid "Internal error: Invalid oflag or pmode argument"
 msgstr "Внутренняя ошибка: неверный аргумент oflag или pmode"
 
-#: ../../../core/core_st.cpp:203
+#: ../../../core/core_st.cpp:205
 msgid "invalid!"
 msgstr "недопустимый!"
 
-#: ../../../core/core_st.cpp:204
+#: ../../../core/core_st.cpp:206
 msgid "  Invalid date/time value."
 msgstr "  Недопустимое значение даты/времени."
 
-#: ../../../core/core_st.cpp:205
+#: ../../../core/core_st.cpp:207
 msgid "  Field length is incorrect."
 msgstr "  Некорректная длина файла."
 
-#: ../../../core/core_st.cpp:206
+#: ../../../core/core_st.cpp:208
 msgid "Internal error: An invalid flag was specified"
 msgstr "Внутренняя ошибка: указан недопустимый флаг"
 
-#: ../../../core/core_st.cpp:207
+#: ../../../core/core_st.cpp:209
 #, c-format
 msgid "  Invalid header: '%ls' (must be 5 hexadecimal characters)."
 msgstr ""
 "  Недопустимый заголовок: «%ls» (должен состоять из 5 шестнадцатеричных "
 "цифр)."
 
-#: ../../../core/core_st.cpp:208
+#: ../../../core/core_st.cpp:210
 #, c-format
 msgid "Invalid lock file \"%ls\"."
 msgstr "Некорректный файл блокировки \"%ls\"."
 
-#: ../../../core/core_st.cpp:209
+#: ../../../core/core_st.cpp:211
 #, c-format
 msgid "  Invalid number of saved old passwords %d."
 msgstr "  Недопустимое количество сохранённых паролей %d."
 
-#: ../../../core/core_st.cpp:210
+#: ../../../core/core_st.cpp:212
 #, c-format
 msgid "  Invalid status value: %d (must be either 0 or 1)."
 msgstr "  Недопустимое значение статуса: %d (должно быть 0 или 1)"
 
-#: ../../../core/core_st.cpp:211
+#: ../../../core/core_st.cpp:213
 msgid "  Invalid password length found (not a hexadecimal number)."
 msgstr "  Недопустимая длина пароля (не является шестнадцатеричным числом)."
 
-#: ../../../core/core_st.cpp:212
+#: ../../../core/core_st.cpp:214
 msgid ""
 "  Invalid password length found (differs from length of following password)."
 msgstr "  Неверная длина пароля (отличается от длины указанного пароля)."
 
-#: ../../../core/core_st.cpp:213
+#: ../../../core/core_st.cpp:215
 msgid ""
 "  Invalid field separator character found - only a single blank is allowed "
 "between fields."
@@ -5536,20 +5555,20 @@ msgstr ""
 "  Обнаружен недопустимый разделитель полей. В качестве разделителя может "
 "использовать только одиночный пробел."
 
-#: ../../../core/core_st.cpp:214
+#: ../../../core/core_st.cpp:216
 msgid "Invalid Filter schema."
 msgstr "Неверная схема фильтра."
 
-#: ../../../core/core_st.cpp:215
+#: ../../../core/core_st.cpp:217
 msgid "Schema does not have a version number."
 msgstr "В схеме не указан номер версии."
 
-#: ../../../core/core_st.cpp:216
+#: ../../../core/core_st.cpp:218
 #, c-format
 msgid "The filter XML version (%d) is greater than the current schema (%d)."
 msgstr "Версия XML-фильтра (%d) больше, чем у текущей схемы (%d)."
 
-#: ../../../core/core_st.cpp:217
+#: ../../../core/core_st.cpp:219
 #, c-format
 msgid ""
 "The filter XML version (%d) is greater than that supported by this instance "
@@ -5559,34 +5578,34 @@ msgstr ""
 "(%d)."
 
 # условие фильтра (is in container, is alias)
-#: ../../../core/core_st.cpp:218
+#: ../../../core/core_st.cpp:220
 msgid "is"
 msgstr "выполняется:"
 
-#: ../../../core/core_st.cpp:219
+#: ../../../core/core_st.cpp:221
 msgid "is active"
 msgstr "активно"
 
-#: ../../../core/core_st.cpp:220
+#: ../../../core/core_st.cpp:222
 msgid "is inactive"
 msgstr "неактивно"
 
 # условие фильтра (is not in container, is not alias)
-#: ../../../core/core_st.cpp:221
+#: ../../../core/core_st.cpp:223
 msgid "is not"
 msgstr "не выполняется:"
 
-#: ../../../core/core_st.cpp:222
+#: ../../../core/core_st.cpp:224
 msgid "is not present"
 msgstr "отсутствует"
 
-#: ../../../core/core_st.cpp:223
+#: ../../../core/core_st.cpp:225
 msgid "is present"
 msgstr "присутствует"
 
 # %s1,%s4 - imported/merged/copied %s2 - imp/mer/cp entry name, %s3 - existing
 # emtry name
-#: ../../../core/core_st.cpp:224
+#: ../../../core/core_st.cpp:226
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to entry %ls. It "
@@ -5596,7 +5615,7 @@ msgstr ""
 "отвязана от %ls элемента."
 
 # %s1 - imported/merged/copied %s2 - imp/mer/cp entry name
-#: ../../../core/core_st.cpp:225
+#: ../../../core/core_st.cpp:227
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to the "
@@ -5605,19 +5624,19 @@ msgstr ""
 "Горячая клавиша для %ls элемента %ls уже назначена для вызова Password Safe. "
 "Она была отвязана от элемента."
 
-#: ../../../core/core_st.cpp:226
+#: ../../../core/core_st.cpp:228
 msgid "less than"
 msgstr "меньше чем"
 
-#: ../../../core/core_st.cpp:227
+#: ../../../core/core_st.cpp:229
 msgid "less than or equal to"
 msgstr "меньше либо равно"
 
-#: ../../../core/core_st.cpp:228
+#: ../../../core/core_st.cpp:230
 msgid "File or path not found"
 msgstr "Файл или путь к файлу не найден"
 
-#: ../../../core/core_st.cpp:229
+#: ../../../core/core_st.cpp:231
 #, c-format
 msgid ""
 "\n"
@@ -5626,7 +5645,7 @@ msgstr ""
 "\n"
 "Новые %ls %ls добавлены в данный контейнер:"
 
-#: ../../../core/core_st.cpp:230
+#: ../../../core/core_st.cpp:232
 #, c-format
 msgid ""
 "\n"
@@ -5635,7 +5654,7 @@ msgstr ""
 "\n"
 "Слияние завершено: %d %ls добавлено (%d %ls, %d %ls, %d %ls, %d %ls)"
 
-#: ../../../core/core_st.cpp:231
+#: ../../../core/core_st.cpp:233
 #, c-format
 msgid ""
 "Conflicting entries for \"%ls\" \"%ls\" \"%ls\".\n"
@@ -5649,25 +5668,25 @@ msgstr ""
 # подстановка в "Entry keyboard shortcut %s entry %s is already allocated ..."
 # и "They have been removed from the %s entries" и в имени нового элемента,
 # полученного при конфликте слияния (yandex-объединяемого-20150608 203915)
-#: ../../../core/core_st.cpp:232
+#: ../../../core/core_st.cpp:234
 msgid "merged"
 msgstr "объединяемого"
 
-#: ../../../core/core_st.cpp:233
+#: ../../../core/core_st.cpp:235
 #, c-format
 msgid "%ls - Merged %ls"
 msgstr "%ls — объединено %ls"
 
-#: ../../../core/core_st.cpp:234
+#: ../../../core/core_st.cpp:236
 msgid "MISSING PASSWORD"
 msgstr "ОТСУТСТВУЕТ ПАРОЛЬ"
 
-#: ../../../core/core_st.cpp:235
+#: ../../../core/core_st.cpp:237
 #, c-format
 msgid "\tPassword policy name '%ls' is not in the database."
 msgstr "\tПолитика создания паролей «%ls» отсутствует в контейнере."
 
-#: ../../../core/core_st.cpp:236
+#: ../../../core/core_st.cpp:238
 msgid ""
 "\tOne or more Password Policy Names were not found in the database. The "
 "affected entries have been changed to use the database's default policy."
@@ -5675,21 +5694,21 @@ msgstr ""
 "\tВ контейнере отсутствуют одна или несколько политик создания паролей. В "
 "связанных с ними элементах была настроена политика контейнера по умолчанию."
 
-#: ../../../core/core_st.cpp:237
+#: ../../../core/core_st.cpp:239
 #, c-format
 msgid "MISSING TITLE # %d"
 msgstr "ОТСУТСТВУЕТ ЗАГОЛОВОК # %d"
 
-#: ../../../core/core_st.cpp:239
+#: ../../../core/core_st.cpp:241
 msgid "Can't obtain the schema version."
 msgstr "Невозможно определить версию схемы."
 
-#: ../../../core/core_st.cpp:240
+#: ../../../core/core_st.cpp:242
 msgid "The filter XML version is missing."
 msgstr "Не указана версия XML-фильтра."
 
 # First substitution is a number, second is either "import" or "validation"
-#: ../../../core/core_st.cpp:241
+#: ../../../core/core_st.cpp:243
 #, c-format
 msgid "Create SchemaCache60 Error 0x%08X during %ls."
 msgstr ""
@@ -5697,17 +5716,17 @@ msgstr ""
 "«%ls»)."
 
 # First two substitutions are numbers, last is either "import" or "validation"
-#: ../../../core/core_st.cpp:242
+#: ../../../core/core_st.cpp:244
 #, c-format
 msgid "SAX Parse60 Error 0x%08X during %ls."
 msgstr "Ошибка разбора SAX Parse60 0x%08X при выполнении операции «%ls»."
 
-#: ../../../core/core_st.cpp:243
+#: ../../../core/core_st.cpp:245
 #, c-format
 msgid "Error (%08X): line %d character %d %ls"
 msgstr "Ошибка (%08X): строка %d символ %d %ls"
 
-#: ../../../core/core_st.cpp:245
+#: ../../../core/core_st.cpp:247
 msgid ""
 "Unable to get configuration file lock.\n"
 "\n"
@@ -5717,15 +5736,15 @@ msgstr ""
 "\n"
 "Будет использован реестр."
 
-#: ../../../core/core_st.cpp:246
+#: ../../../core/core_st.cpp:248
 msgid "Cannot create lock file - no permission in directory?"
 msgstr "Невозможно создать файл блокировок. Проверьте права доступа."
 
-#: ../../../core/core_st.cpp:247
+#: ../../../core/core_st.cpp:249
 msgid "Internal error: Out of file handles"
 msgstr "Внутренняя ошибка: исчерпаны дескрипторы (handles) файлов"
 
-#: ../../../core/core_st.cpp:248
+#: ../../../core/core_st.cpp:250
 msgid ""
 "Unable to use a MS XML reader on your system.  Neither MS XML V3, V4 or V6 "
 "seems available."
@@ -5733,16 +5752,16 @@ msgstr ""
 "Невозможно использовать MS XML reader.  Библиотека MS XML V3, V4 или V6 не "
 "обнаружена."
 
-#: ../../../core/core_st.cpp:250
+#: ../../../core/core_st.cpp:252
 msgid "Unsaved changes"
 msgstr "Несохранённые изменения"
 
 # условие фильтра по флажкам
-#: ../../../core/core_st.cpp:251
+#: ../../../core/core_st.cpp:253
 msgid "is not set"
 msgstr "выключено"
 
-#: ../../../core/core_st.cpp:252
+#: ../../../core/core_st.cpp:254
 #, c-format
 msgid ""
 "Number of entries processed: %d\n"
@@ -5782,7 +5801,7 @@ msgstr ""
 "\n"
 "Рекомендуется сохранить изменения в контейнере."
 
-#: ../../../core/core_st.cpp:254
+#: ../../../core/core_st.cpp:256
 msgid ""
 "Password should be mixed case, with at least one digit or punctuation "
 "character"
@@ -5790,42 +5809,42 @@ msgstr ""
 "Пароль должен содержать буквы обоих регистров и не менее одной цифры или "
 "знака препинания"
 
-#: ../../../core/core_st.cpp:255
+#: ../../../core/core_st.cpp:257
 msgid "Password is too short"
 msgstr "Пароль слишком короткий"
 
-#: ../../../core/core_st.cpp:256
+#: ../../../core/core_st.cpp:258
 msgid "Easyvision characters"
 msgstr "Удобочитаемые символы"
 
-#: ../../../core/core_st.cpp:257
+#: ../../../core/core_st.cpp:259
 msgid "Hexadecimal characters"
 msgstr "Шестнадцатеричные цифры"
 
-#: ../../../core/core_st.cpp:258
+#: ../../../core/core_st.cpp:260
 msgid "Password length"
 msgstr "Длина пароля"
 
-#: ../../../core/core_st.cpp:259
+#: ../../../core/core_st.cpp:261
 msgid "Pronounceable passwords"
 msgstr "Произносимые пароли"
 
 # урезано, в информации о политике
-#: ../../../core/core_st.cpp:261
+#: ../../../core/core_st.cpp:263
 msgid "Use lowercase characters"
 msgstr "Строчные буквы"
 
 # урезано, в информации о политике?
-#: ../../../core/core_st.cpp:263
+#: ../../../core/core_st.cpp:265
 msgid "Use uppercase characters"
 msgstr "Прописные буквы"
 
-#: ../../../core/core_st.cpp:264
+#: ../../../core/core_st.cpp:266
 #, c-format
 msgid "Error in a Password History %ls:"
 msgstr "Ошибка в поле истории паролей %ls:"
 
-#: ../../../core/core_st.cpp:265
+#: ../../../core/core_st.cpp:267
 #, c-format
 msgid "sub-field starting at position %d (within the History field): "
 msgstr "поле, начинающееся с позиции %d (относительно поля истории): "
@@ -5889,16 +5908,21 @@ msgstr "поле, начинающееся с позиции %d (относит�
 # "Edit" - "Правка"
 # "View" - "Вид"
 # "Manage" - "Сервис"
-#: ../../../core/core_st.cpp:266
+#: ../../../core/core_st.cpp:268
 msgid "  All Password History ignored."
 msgstr "  Вся история паролей проигнорирована."
 
-#: ../../../core/core_st.cpp:267
+#: ../../../core/core_st.cpp:269
 msgid "Read Error"
 msgstr "Ошибка чтения"
 
+# При задании даты
+#: ../../../core/core_st.cpp:270
+msgid "Relative"
+msgstr "Относительное"
+
 # конфликт падежей %s - imported
-#: ../../../core/core_st.cpp:268
+#: ../../../core/core_st.cpp:271
 #, c-format
 msgid ""
 "\tOne or more entry keyboard shortcuts were already assigned to entries in "
@@ -5907,7 +5931,7 @@ msgstr ""
 "\tОдна или несколько комбинаций клавиш уже назначены элементам из "
 "контейнера. Она была отвязана от %ls элемента."
 
-#: ../../../core/core_st.cpp:269
+#: ../../../core/core_st.cpp:272
 msgid ""
 "\tOne or more Password Policy Names were already in this database but had "
 "different settings. They have been renamed."
@@ -5915,32 +5939,76 @@ msgstr ""
 "\tОдна или несколько политик создания паролей уже есть в данном контейнере, "
 "но имеют другие настройки. Они были переименованы."
 
-#: ../../../core/core_st.cpp:270
+#: ../../../core/core_st.cpp:273
 #, c-format
 msgid "%ls%ls%ls_Report.txt"
 msgstr "%ls%ls%ls_Report.txt"
 
 # Ex.: "Report of Import Text function started at 24 February 2007  18:43"
-#: ../../../core/core_st.cpp:271
+#: ../../../core/core_st.cpp:274
 #, c-format
 msgid "Report of %ls function started at %ls"
 msgstr "Отчёт «%ls» начат %ls"
 
 # в отчёте
-#: ../../../core/core_st.cpp:272
+#: ../../../core/core_st.cpp:275
 #, c-format
 msgid "on database %ls"
 msgstr "в контейнере %ls"
 
-#: ../../../core/core_st.cpp:273
+#: ../../../core/core_st.cpp:276
+msgid "Compare"
+msgstr "Сравнить"
+
+# Часть имени с отчётом. Оставлять без изменений.
+#: ../../../core/core_st.cpp:277
+#, fuzzy
+msgid "Export_DB"
+msgstr "Export_DB"
+
+# Часть имени с отчётом. Оставлять без изменений.
+#: ../../../core/core_st.cpp:278
+msgid "Export_Text"
+msgstr "Export_Text"
+
+# Часть имени с отчётом. Оставлять без изменений.
+#: ../../../core/core_st.cpp:279
+msgid "Export_XML"
+msgstr "Export_XML"
+
+# Часть имени с отчётом. Оставлять без изменений.
+#: ../../../core/core_st.cpp:281
+msgid "Import_KeePassV1_CSV"
+msgstr "Import_KeePassV1_CSV"
+
+# Часть имени с отчётом. Оставлять без изменений.
+#: ../../../core/core_st.cpp:282
+msgid "Import_KeePassV1_TXT"
+msgstr "Import_KeePassV1_TXT"
+
+# Часть имени с отчётом. Оставлять без изменений.
+#: ../../../core/core_st.cpp:283
+msgid "Import_Text"
+msgstr "Import_Text"
+
+# Часть имени с отчётом. Оставлять без изменений.
+#: ../../../core/core_st.cpp:284
+msgid "Import_XML"
+msgstr "Import_XML"
+
+#: ../../../core/core_st.cpp:285
+msgid "Merge"
+msgstr "Слияние"
+
+#: ../../../core/core_st.cpp:287
 msgid "Validate"
 msgstr "Проверить"
 
-#: ../../../core/core_st.cpp:275
+#: ../../../core/core_st.cpp:289
 msgid "Fatal Error"
 msgstr "Фатальная ошибка"
 
-#: ../../../core/core_st.cpp:277
+#: ../../../core/core_st.cpp:291
 #, c-format
 msgid ""
 "\n"
@@ -5949,120 +6017,130 @@ msgstr ""
 "\n"
 "Ошибка в истории паролей для элемента: »%ls»%ls»%ls»: "
 
+#: ../../../core/core_st.cpp:292
+#, fuzzy, c-format
+msgid "\tNo entries were found containing search string '%ls' %ls"
+msgstr "\tНе найдено элементов, содержащих строку «%s»"
+
+#: ../../../core/core_st.cpp:293
+#, fuzzy, c-format
+msgid "\tThe following entries contain search string '%ls' %ls"
+msgstr "\tСледующие элементы содержат искомую строку «%s»"
+
 # в деталях фильтра в диалоге управления
-#: ../../../core/core_st.cpp:278
+#: ../../../core/core_st.cpp:294
 msgid "See Attachment filters"
 msgstr "См. группу фильтров вложений"
 
-#: ../../../core/core_st.cpp:279
+#: ../../../core/core_st.cpp:295
 msgid "See Password History filters"
 msgstr "Просмотреть фильтры по истории паролей"
 
-#: ../../../core/core_st.cpp:280
+#: ../../../core/core_st.cpp:296
 msgid "See Password Policy filters"
 msgstr "Просмотреть фильтры по политике создания паролей"
 
 # условие фильтра по флажкам
-#: ../../../core/core_st.cpp:281
+#: ../../../core/core_st.cpp:297
 msgid "is set"
 msgstr "включено"
 
-#: ../../../core/core_st.cpp:282
+#: ../../../core/core_st.cpp:298
 msgid "shortcut"
 msgstr "ярлык"
 
 # Ex.: 5 shortcuts
-#: ../../../core/core_st.cpp:283
+#: ../../../core/core_st.cpp:299
 msgid "shortcuts"
 msgstr "ярлыков"
 
 # не менее X из символов... (в информации о политике)
-#: ../../../core/core_st.cpp:284
+#: ../../../core/core_st.cpp:300
 msgid "policy specific symbols"
 msgstr "символов, определённых в политике"
 
-#: ../../../core/core_st.cpp:285
+#: ../../../core/core_st.cpp:301
 msgid "Start Report"
 msgstr "Начало отчёта"
 
-#: ../../../core/core_st.cpp:286
+#: ../../../core/core_st.cpp:302
 msgid "Double-Click on entry to Autotype"
 msgstr "Щёлкните дважды для автонабора"
 
-#: ../../../core/core_st.cpp:287
+#: ../../../core/core_st.cpp:303
 msgid "Double-Click on entry to Browse to URL"
 msgstr "Щёлкните дважды для перехода по ссылке"
 
-#: ../../../core/core_st.cpp:288
+#: ../../../core/core_st.cpp:304
 msgid "Double-Click on entry to Browse to URL + Autotype"
 msgstr "Щёлкните дважды для перехода по ссылке и выполнения автонабора"
 
-#: ../../../core/core_st.cpp:289
+#: ../../../core/core_st.cpp:305
 msgid "https://pwsafe.org/"
 msgstr "https://pwsafe.org/"
 
-#: ../../../core/core_st.cpp:290
+#: ../../../core/core_st.cpp:306
 msgid "Double-Click on entry to Copy Notes"
 msgstr "Щёлкните дважды для копирования заметок"
 
-#: ../../../core/core_st.cpp:291
+#: ../../../core/core_st.cpp:307
 msgid "Double-Click on entry to Copy Password"
 msgstr "Щёлкните дважды для копирования паролей"
 
-#: ../../../core/core_st.cpp:292
+#: ../../../core/core_st.cpp:308
 msgid "Double-Click on entry to Copy Password and Minimize"
 msgstr "Щёлкните дважды для копирования пароля и сворачивания"
 
-#: ../../../core/core_st.cpp:293
+#: ../../../core/core_st.cpp:309
 msgid "Double-Click on entry to Copy Username"
 msgstr "Щёлкните дважды для копирования имени пользователя"
 
-#: ../../../core/core_st.cpp:294
+#: ../../../core/core_st.cpp:310
 msgid "Double-Click on entry to Run Command"
 msgstr "Щёлкните дважды для копирования связанной команды"
 
-#: ../../../core/core_st.cpp:295
+#: ../../../core/core_st.cpp:311
 msgid "Double-Click on entry to Send Email"
 msgstr "Щёлкните дважды для отправки письма по этому адресу"
 
-#: ../../../core/core_st.cpp:296
+#: ../../../core/core_st.cpp:312
 msgid "Double-Click on entry to View/Edit it"
 msgstr "Щёлкните дважды для просмотра/редактирования"
 
-#: ../../../core/core_st.cpp:299
+#: ../../../core/core_st.cpp:315
 #, c-format
 msgid "%ls - Sync'd %ls"
 msgstr "%ls — синхронизировано %ls"
 
-#: ../../../core/core_st.cpp:300
+#: ../../../core/core_st.cpp:316
 msgid "System error: No more file handles available"
 msgstr "Системная ошибка: исчерпаны дескрипторы (handles) файлов"
 
-#: ../../../core/core_st.cpp:303
+#: ../../../core/core_st.cpp:319
 msgid "Unknown function"
 msgstr "Неизвестная функция"
 
-#: ../../../core/core_st.cpp:304
+#: ../../../core/core_st.cpp:320
 msgid "Unknown object"
 msgstr "Неизвестный объект"
 
-#: ../../../core/core_st.cpp:305
+#: ../../../core/core_st.cpp:321
 msgid "Internal error: Unexpected error number"
 msgstr "Внутренняя ошибка: неизвестный номер ошибки"
 
-#: ../../../core/core_st.cpp:307
+#: ../../../core/core_st.cpp:323
 #, c-format
 msgid "\tName: %s; Filename: %s"
 msgstr "\tИмя: %s; Имя файла: %s"
 
-#: ../../../core/core_st.cpp:308
+#: ../../../core/core_st.cpp:324
 msgid ""
 "The following entries had an invalid UUID field.  This has been corrected."
 msgstr ""
 "Указанные элементы содержали недопустимые значения UUID.  Ошибки были "
 "исправлены."
 
-#: ../../../core/core_st.cpp:309
+#: ../../../core/core_st.cpp:325
 #, c-format
 msgid ""
 "The following entries have passwords in the correct form for %ls, but the "
@@ -6071,18 +6149,18 @@ msgstr ""
 "Следующие элементы содержат указатель на пароль из элемента %ls, но исходный "
 "элемент не существует."
 
-#: ../../../core/core_st.cpp:310
+#: ../../../core/core_st.cpp:326
 msgid "The following entries were duplicates of an existing entry."
 msgstr "Указанные элементы были дубликатами существующих элементов."
 
-#: ../../../core/core_st.cpp:311
+#: ../../../core/core_st.cpp:327
 msgid ""
 "The following entries had a duplicate UUID field.  This has been corrected."
 msgstr ""
 "Указанные элементы содержали повторяющиеся значения UUID.  Ошибки были "
 "исправлены."
 
-#: ../../../core/core_st.cpp:312
+#: ../../../core/core_st.cpp:328
 #, c-format
 msgid ""
 "The following entries had an empty Password field, which is not permitted. "
@@ -6091,33 +6169,33 @@ msgstr ""
 "В указанных элементах не было заполнено поле с паролем. Это недопустимо. Был "
 "установлен пароль «%ls»"
 
-#: ../../../core/core_st.cpp:313
+#: ../../../core/core_st.cpp:329
 msgid "The following entries had an empty Title field, which is not permitted."
 msgstr "В указанных элементах не заполнено поле с заголовком. Это недопустимо."
 
-#: ../../../core/core_st.cpp:314
+#: ../../../core/core_st.cpp:330
 #, c-format
 msgid "\tGroup='%ls', Title='%ls', User='%ls' %ls"
 msgstr "\tГруппа=«%ls», Заголовок=«%ls», Имя пользователя=«%ls» %ls"
 
-#: ../../../core/core_st.cpp:315
+#: ../../../core/core_st.cpp:331
 #, c-format
 msgid "- Its title has been changed to:'%ls'"
 msgstr "— Его заголовок был изменён на: «%ls»"
 
-#: ../../../core/core_st.cpp:316
+#: ../../../core/core_st.cpp:332
 msgid "The following ERRORS were detected and were FIXED."
 msgstr "Были обнаружены и исправлены следующие ошибки."
 
-#: ../../../core/core_st.cpp:317
+#: ../../../core/core_st.cpp:333
 msgid "The following entries refer to missing attachments."
 msgstr "Указанные элементы ссылаются на отсутствующие вложения."
 
-#: ../../../core/core_st.cpp:318
+#: ../../../core/core_st.cpp:334
 msgid "The following attachments are not referred to by any entry."
 msgstr "Указанные вложения не привязаны к элементам."
 
-#: ../../../core/core_st.cpp:319
+#: ../../../core/core_st.cpp:335
 msgid ""
 "The following entries had an invalid Password History.  This has been "
 "rebuilt with available data.  There may be some loss of history."
@@ -6126,7 +6204,7 @@ msgstr ""
 "восстановлены по имеющимся данным.  Возможно, что некоторые данные из "
 "истории были потеряны."
 
-#: ../../../core/core_st.cpp:320
+#: ../../../core/core_st.cpp:336
 #, c-format
 msgid ""
 "The following entries have one or more text fields too long to display or "
@@ -6136,7 +6214,7 @@ msgstr ""
 "могут быть отредактированы или показаны полностью (больше %d символов).  "
 "Размер наибольшего из этих элементов ~%d %ls."
 
-#: ../../../core/core_st.cpp:321
+#: ../../../core/core_st.cpp:337
 msgid ""
 "The following WARNINGS were detected - you should review and fix them "
 "manually."
@@ -6144,11 +6222,11 @@ msgstr ""
 "Есть несколько предупреждений. Вы должны просмотреть их и исправить "
 "самостоятельно."
 
-#: ../../../core/core_st.cpp:324
+#: ../../../core/core_st.cpp:340
 msgid "will expire"
 msgstr "истекает"
 
-#: ../../../core/core_st.cpp:325
+#: ../../../core/core_st.cpp:341
 #, c-format
 msgid ""
 "SAX Parse Error during %ls\n"
@@ -6157,24 +6235,24 @@ msgstr ""
 "Ошибка разбора SAX при выполнении %ls\n"
 "%ls."
 
-#: ../../../core/core_st.cpp:326
+#: ../../../core/core_st.cpp:342
 #, c-format
 msgid "XML %ls: line %d character %d: %ls"
 msgstr "XML %ls: строка %d символ %d: %ls"
 
 # message from core
-#: ../../../core/core_st.cpp:327
+#: ../../../core/core_st.cpp:343
 msgid ""
 "*** Invalid XML characters found - see exported XML file for more details ***"
 msgstr ""
 "*** В XML-файле обнаружен недопустимый символ (подробности в "
 "экспортированном XML-файле ***"
 
-#: ../../../core/core_st.cpp:328
+#: ../../../core/core_st.cpp:344
 msgid "Internal error: Couldn't initialize config file XML structure"
 msgstr "Внутренняя ошибка: невозможно инициализировать структуру XML-файла"
 
-#: ../../../core/core_st.cpp:329
+#: ../../../core/core_st.cpp:345
 msgid ""
 "A filter was active. Export of data was restricted to include only those "
 "displayed."
@@ -6182,11 +6260,11 @@ msgstr ""
 "При экспорте был активен фильтр. Включены только элементы удовлетворяющие "
 "фильтру."
 
-#: ../../../core/core_st.cpp:330
+#: ../../../core/core_st.cpp:346
 msgid "Export of data was restricted to certain fields by the user."
 msgstr "При экспорте пользователь ограничил список полей."
 
-#: ../../../core/core_st.cpp:331
+#: ../../../core/core_st.cpp:347
 msgid ""
 "Note: These Password Policies will not replace existing policies with the "
 "same name in the current database."
@@ -6194,22 +6272,22 @@ msgstr ""
 "Примечание: эти политики создания паролей не заменят существующие "
 "одноимённые политики в текущем контейнере."
 
-#: ../../../core/core_st.cpp:332
+#: ../../../core/core_st.cpp:348
 msgid ""
 "Note: These preferences are only used when importing into an empty database."
 msgstr ""
 "Примечание: эти настройки используются только при импорте в пустой контейнер."
 
-#: ../../../core/core_st.cpp:333
+#: ../../../core/core_st.cpp:349
 msgid "Subset of entries restricted by the following rule:"
 msgstr "Подмножество элементов отобрано по правилу:"
 
-#: ../../../core/core_st.cpp:334
+#: ../../../core/core_st.cpp:350
 msgid ""
 "The user specified that the following fields be excluded from the export:"
 msgstr "Пользователь исключил следующие столбцы из экспорта:"
 
-#: ../../../core/core_st.cpp:335
+#: ../../../core/core_st.cpp:351
 #, c-format
 msgid ""
 "Configuration file error:\n"
@@ -6222,15 +6300,15 @@ msgstr ""
 "%ls\n"
 "примерная позиция: %d"
 
-#: ../../../core/core_st.cpp:336
+#: ../../../core/core_st.cpp:352
 msgid "import"
 msgstr "импорт"
 
-#: ../../../core/core_st.cpp:337
+#: ../../../core/core_st.cpp:353
 msgid "Unable to load configuration file"
 msgstr "Невозможно загрузить файл настроек"
 
-#: ../../../core/core_st.cpp:338
+#: ../../../core/core_st.cpp:354
 msgid ""
 "Failed to lock configuration file - opened by another instance of "
 "PasswordSafe?"
@@ -6238,113 +6316,55 @@ msgstr ""
 "Ошибка при блокировке файла настроек. Проверьте, не открыт ли другой "
 "экземпляр Password Safe?"
 
-#: ../../../core/core_st.cpp:339
+#: ../../../core/core_st.cpp:355
 msgid "Unable to save configuration file"
 msgstr "Невозможно сохранить файл настроек"
 
-#: ../../../core/core_st.cpp:340
+#: ../../../core/core_st.cpp:356
 msgid "validation"
 msgstr "проверка"
 
-#: ../../../core/core_st.cpp:342
+#: ../../../core/core_st.cpp:358
 msgid " (EasyVision Symbols)"
 msgstr " (удобочитаемые символы)"
 
-#: ../../../core/core_st.cpp:343
+#: ../../../core/core_st.cpp:359
 #, c-format
 msgid "Yes (at least %d)"
 msgstr "Да (не менее %d)"
 
-#: ../../../core/core_st.cpp:344
+#: ../../../core/core_st.cpp:360
 msgid " (Pronounceable Symbols)"
 msgstr " (произносимые символы)"
 
-#: ../../../core/core_st.cpp:345
+#: ../../../core/core_st.cpp:361
 #, c-format
 msgid "Yes - At least %d from %ls: %ls%ls"
 msgstr "Да: не менее %d из %ls: %ls%ls"
 
-#: ../../../core/core_st.cpp:346
 #, fuzzy, c-format
-msgid "\tGroup='%ls', Title='%ls', User='%ls'"
-msgstr "\tГруппа=«%ls», Заголовок=«%ls», Имя пользователя=«%ls» %ls"
+#~ msgid "\tGroup='%ls', Title='%ls', User='%ls'"
+#~ msgstr "\tГруппа=«%ls», Заголовок=«%ls», Имя пользователя=«%ls» %ls"
 
-#: ../../../core/core_st.cpp:347
-#, fuzzy, c-format
-msgid ""
-"Compare complete of current database:\n"
-"\t %ls\n"
-" and:\n"
-"\t %ls\n"
-msgstr ""
-"Завершено сравнение текущего контейнера:\n"
-"\t %s\n"
-" и:\n"
-"\t %s"
-
-#: ../../../core/core_st.cpp:348
-#, fuzzy, c-format
-msgid "\tNo entries were found containing search string '%ls' %ls"
-msgstr "\tНе найдено элементов, содержащих строку «%s»"
-
-#: ../../../core/core_st.cpp:349
-#, fuzzy, c-format
-msgid "\tThe following entries contain search string '%ls' %ls"
-msgstr "\tСледующие элементы содержат искомую строку «%s»"
-
-# Часть имени с отчётом. Оставлять без изменений.
-#: ../../../core/core_st.cpp:350
 #, fuzzy
-msgid "Export DB"
-msgstr "Export_DB"
+#~ msgid "Import KeePassV1 CSV"
+#~ msgstr "Импорт KeePass V1 CSV"
 
-#: ../../../core/core_st.cpp:351
 #, fuzzy
-msgid "Import KeePassV1 CSV"
-msgstr "Импорт KeePass V1 CSV"
+#~ msgid "Import KeePassV1 TXT"
+#~ msgstr "Импорт KeePass V1 TXT"
 
-#: ../../../core/core_st.cpp:352
 #, fuzzy
-msgid "Import KeePassV1 TXT"
-msgstr "Импорт KeePass V1 TXT"
+#~ msgid "Import XML"
+#~ msgstr ""
+#~ "\n"
+#~ "Импортировать из XML"
 
-#: ../../../core/core_st.cpp:353
 #, fuzzy
-msgid "Import XML"
-msgstr ""
-"\n"
-"Импортировать из XML"
-
-#: ../../../core/core_st.cpp:354
-#, fuzzy
-msgid "Import Text"
-msgstr ""
-"\n"
-"Импортировать из простого текста"
-
-#: ../../../core/core_st.cpp:355
-msgid "Merge"
-msgstr "Слияние"
-
-#: ../../../core/core_st.cpp:356
-msgid "Compare"
-msgstr "Сравнить"
-
-# Часть имени с отчётом. Оставлять без изменений.
-#~ msgid "Import_Text"
-#~ msgstr "Import_Text"
-
-# Часть имени с отчётом. Оставлять без изменений.
-#~ msgid "Import_XML"
-#~ msgstr "Import_XML"
-
-# Часть имени с отчётом. Оставлять без изменений.
-#~ msgid "Import_KeePassV1_CSV"
-#~ msgstr "Import_KeePassV1_CSV"
-
-# Часть имени с отчётом. Оставлять без изменений.
-#~ msgid "Import_KeePassV1_TXT"
-#~ msgstr "Import_KeePassV1_TXT"
+#~ msgid "Import Text"
+#~ msgstr ""
+#~ "\n"
+#~ "Импортировать из простого текста"
 
 #~ msgid "Advanced..."
 #~ msgstr "Расширенные..."
@@ -8335,14 +8355,6 @@ msgstr "Сравнить"
 #~ "уже существует.\n"
 #~ "Заменить?"
 
-# Часть имени с отчётом. Оставлять без изменений.
-#~ msgid "Export_Text"
-#~ msgstr "Export_Text"
-
-# Часть имени с отчётом. Оставлять без изменений.
-#~ msgid "Export_XML"
-#~ msgstr "Export_XML"
-
 #~ msgid "Exporting to file:"
 #~ msgstr "Экспорт в файл:"
 
@@ -9657,10 +9669,6 @@ msgstr "Сравнить"
 #~ msgid "Redo the last change to password policies that was previously undone"
 #~ msgstr ""
 #~ "Восстановить последние отменённые изменения в политике создания паролей"
-
-# При задании даты
-#~ msgid "Relative"
-#~ msgstr "Относительное"
 
 #~ msgid ""
 #~ "Relative dates are in days relative to today e.g. '-1' is yesterday and "
@@ -11809,10 +11817,6 @@ msgstr "Сравнить"
 #~ msgstr ""
 #~ "\tЭлемент — Группа: «%s»; Заголовок: «%s»; Имя пользователя: «%s»\n"
 #~ "\t\tсодержит следующие отличающиеся поля:"
-
-#, c-format
-#~ msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-#~ msgstr "\tГруппа: «%s»; Заголовок: «%s»; Имя пользователя: «%s»"
 
 #, c-format
 #~ msgid ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-28 12:52+0100\n"
+"POT-Creation-Date: 2021-03-19 21:58+0100\n"
 "PO-Revision-Date: 2011-10-04 21:44+0100\n"
 "Last-Translator: Björn Nordwall <pro.bn@telia.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -238,7 +238,7 @@ msgstr "Datum och tider"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:348
 #: ../../../ui/wxWidgets/HelpMap.h:41 ../../../ui/wxWidgets/HelpMap.h:49
-#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:141
+#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:143
 msgid "Password Policy"
 msgstr "Lösenordspolicy"
 
@@ -252,7 +252,7 @@ msgid "Set Date/Time"
 msgstr "Reg.datum/tid"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:370
-#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:137
+#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:139
 msgid "Password"
 msgstr "Lösenord"
 
@@ -536,14 +536,14 @@ msgstr "Använd &VERSALER"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:747
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:281
-#: ../../../core/core_st.cpp:260
+#: ../../../core/core_st.cpp:262
 #, fuzzy
 msgid "Use digits"
 msgstr "Använd &siffror"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:771
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:305
-#: ../../../core/core_st.cpp:262
+#: ../../../core/core_st.cpp:264
 #, fuzzy
 msgid "Use symbols"
 msgstr "symboler"
@@ -578,7 +578,7 @@ msgstr "Generera &uttalbara lösenord"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:815
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:350
-#: ../../../core/core_st.cpp:253
+#: ../../../core/core_st.cpp:255
 msgid "Or"
 msgstr "eller"
 
@@ -626,7 +626,7 @@ msgstr "Egenskaper"
 #: ../../../ui/wxWidgets/CreateShortcutDlg.cpp:219
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:269
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:274
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
 msgid "Text"
 msgstr "Text"
 
@@ -682,7 +682,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:160
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:173
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:192
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:301
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:317
 msgid "Unknown"
 msgstr "Okänd"
 
@@ -797,7 +797,7 @@ msgstr "[Noteringar är dolda - klicka här för att visa]"
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:1653
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2145
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2820
-#: ../../../core/core_st.cpp:74
+#: ../../../core/core_st.cpp:76
 #, fuzzy
 msgid "Default Policy"
 msgstr "Förvalt set"
@@ -819,7 +819,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:144
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:151
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:159
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:200
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:201
 #: ../../../ui/wxWidgets/PWSafeApp.cpp:367
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:737
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:756
@@ -843,7 +843,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:249
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:277
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:316
-#: ../../../core/core_st.cpp:274
+#: ../../../core/core_st.cpp:288
 msgid "Error"
 msgstr "Fel"
 
@@ -1016,7 +1016,7 @@ msgid "Synchronize this item..."
 msgstr "S&ynkronisera"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:482
-#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:357
+#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:286
 msgid "Synchronize"
 msgstr "Synkronisera"
 
@@ -1098,8 +1098,8 @@ msgid "Current safe was opened read-only"
 msgstr "Öppna som läs-bara"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:793
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:996
-#: ../../../ui/wxWidgets/SyncWizard.cpp:618
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
+#: ../../../ui/wxWidgets/SyncWizard.cpp:619
 #, fuzzy, c-format
 msgid ""
 "The database:\n"
@@ -1117,7 +1117,7 @@ msgstr ""
 "Vänligen, ordna dettta genom att validera databasen."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:794
-#: ../../../ui/wxWidgets/SyncWizard.cpp:617
+#: ../../../ui/wxWidgets/SyncWizard.cpp:618
 msgid "Synchronization failed"
 msgstr "Synkroniseringen misslyckades"
 
@@ -1485,7 +1485,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/GridCtrl.cpp:164
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:292
-#: ../../../core/core_st.cpp:147
+#: ../../../core/core_st.cpp:149
 msgid "Title"
 msgstr "Titel"
 
@@ -1709,7 +1709,7 @@ msgid "Value"
 msgstr "Värde:"
 
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:291
-#: ../../../core/core_st.cpp:133
+#: ../../../core/core_st.cpp:135
 msgid "Group"
 msgstr "Grupp"
 
@@ -1794,17 +1794,17 @@ msgstr ""
 msgid "Error parsing Run Command"
 msgstr "Fel vid körning av körkommando"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:56
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:57
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:355
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:362
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:166
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:623
 msgid "Write Error"
 msgstr "Skrivfel"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:61
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:62
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:165
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:622
 #, fuzzy
@@ -1814,7 +1814,7 @@ msgstr ""
 "\n"
 "Kunde inte öppna filen för skrivning!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:64
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:65
 msgid ""
 "Write operation failed!\n"
 "File may have been corrupted.\n"
@@ -1824,7 +1824,7 @@ msgstr ""
 "Filen kan ha skadats.\n"
 "Försök att spara någon annan stans"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:69
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:70
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 #, fuzzy
 msgid "Unknown error"
@@ -1833,36 +1833,36 @@ msgstr ""
 "\n"
 "Okänt fel"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:90
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:91
 #, fuzzy
 msgid "Do you want to save changes to the password database: "
 msgstr "Vill du spara ändringar i lösenordsdatabasen: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:145
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:146
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:557
 msgid "Please choose a name for the new database"
 msgstr "Vänligen, ange ett namn på den nya databasen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:155
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:156
 #, fuzzy
 msgid "psafe3 files (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 msgstr "Password Safe databaser (*.psafe3)|*.psafe3|Alla filer (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Lock is done by yourself"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Remove Lock?"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:194
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:195
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:602
 #, fuzzy
 msgid "Could not lock file.\n"
@@ -1871,18 +1871,18 @@ msgstr ""
 "\n"
 "Kunde inte öppna filen för läsning!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:196
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:197
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:452
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:604
 msgid "Locked by "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:236
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:237
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:515
 msgid "Please Choose a Database to Open:"
 msgstr "Vänligen, välj en databas att öppna:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:353
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Save database elsewhere or with "
@@ -1893,7 +1893,7 @@ msgstr ""
 "%s. Försök antingen spara databasen med ett annat namn eller avsluta utan "
 "att spara."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:360
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Do you wish to save changes to your "
@@ -1902,12 +1902,12 @@ msgstr ""
 "%s. Försök antingen spara databasen med ett annat namn eller avsluta utan "
 "att spara."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 msgid "Unable to create intermediate backup."
 msgstr "Kunde inte göra mellanlagrande säkerhetskopia."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:386
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:387
 #, fuzzy, c-format
 msgid ""
 "The original database, \"%ls\", is in pre-3.0 format. It will be unchanged.\n"
@@ -1922,12 +1922,12 @@ msgstr ""
 "formatet, använd \"Arkiv->Exportera till->Äldre (1.x or 2) format\" "
 "kommandon."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:388
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:389
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:447
 msgid "File version warning"
 msgstr "Varning för filversion"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:445
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
 #, fuzzy, c-format
 msgid ""
 "The original database, '%ls', is in pre-3.0 format. The data will now be "
@@ -1940,15 +1940,15 @@ msgstr ""
 "versioner av PasswordSafe. För att spara data i det äldre formatet, använd "
 "\"Arkiv->Exportera till->Gamla (1.x or 2) formatet\" kommandot."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:458
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
 msgid "Please choose a name for the current (Untitled) database:"
 msgstr "Vänligen, välj ett namn på den nuvarande (ej namngivna) databasen:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:460
 msgid "Please choose a new name for the current database:"
 msgstr "Vänligen, välj ett nytt namn på den nuvarande databasen:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:467
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:468
 #, fuzzy
 msgid ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|"
@@ -1957,7 +1957,7 @@ msgstr ""
 "Password Safe databaser (*.psafe3; *.dat)|*.psafe3; *.dat|Alla filer (*.*)|*."
 "*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:479
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -1968,145 +1968,145 @@ msgstr ""
 "\n"
 "Filen är för närvarande låst av %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:481
 msgid "File lock error"
 msgstr "Fel vid filstängning"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:547
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
 #, fuzzy
 msgid "Do you wish to save this restored database as new database?"
 msgstr "Vill du spara ändringar i lösenordsdatabasen: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:549
 #, fuzzy
 msgid "Unsaved restored database"
 msgstr "i databasen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:580
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:581
 #, fuzzy
 msgid "Do you want to save changes to the password database"
 msgstr "Vill du spara ändringar i lösenordsdatabasen: %s?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:617
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:618
 msgid "Export Text"
 msgstr "Exportera text"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:621
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:622
 #, fuzzy
 msgid "Export Text failed"
 msgstr "Textimport misslyckades"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:623
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
 msgid "Please name the plaintext file"
 msgstr "Vänligen, namnge den rena textfilen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1143
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:625
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1144
 #, fuzzy
 msgid ""
 "Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
 msgstr ""
 "Textfiler (*.txt)|*.txt|CSV filer (*.csv)|*.csv|Allla filer (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:634
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:635
 msgid "Advanced Text Export Options"
 msgstr "Avancerade Text exportalternativ"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:654
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:697
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:655
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:698
 #, fuzzy
 msgid "export"
 msgstr "exporterat"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:660
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:661
 msgid "Export XML"
 msgstr "Exportera XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:664
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:665
 #, fuzzy
 msgid "Export XML failed"
 msgstr "XML-import misslyckades"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:666
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
 msgid "Please name the XML file"
 msgstr "Vänligen, namnge XML-filen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:668
 #, fuzzy
 msgid "XML files (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 msgstr "XML filer (*.xml)|*.xml|Alla filer (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:678
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:679
 msgid "Advanced XML Export Options"
 msgstr "Avancerade XML exportalternativ"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:712
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:716
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:713
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:717
 #, fuzzy
 msgid "Password Safe Databases (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 msgstr ""
 "Password Safe databaser (*.psafe3; *.dat)|*.psafe3; *.dat|Alla filer (*.*)|*."
 "*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:720
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:721
 #, fuzzy
 msgid "Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 msgstr ""
 "Password Safe databaser (*.psafe3; *.dat)|*.psafe3; *.dat|Alla filer (*.*)|*."
 "*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:731
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:732
 msgid "Please name the exported database"
 msgstr "Vänligen, namnge den exporterade databasen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:748
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:749
 msgid "Could not figure out why PasswordSafeFrame::OnExportVx was invoked"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:782
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:783
 msgid "You must save this database before it can be exported."
 msgstr "Du måste spara denna databas innan den kan exporteras."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 #, fuzzy
 msgid "Exporting database: "
 msgstr "Sammanslående databas: %s\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid " to "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:841
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:842
 #, fuzzy
 msgid "Export complete.  Do you wish to see a detailed report?"
 msgstr "Vill du ersätta det?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:852
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:853
 #, fuzzy
 msgid "No entries satisfied your selection criteria and so none were exported!"
 msgstr "Inga poster motsvarade dina urvalskriteria, så ingen kan vara %s!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:865
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:866
 msgid "Passkey incorrect"
 msgstr "Felaktigt lösenord"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:873
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
 msgid ""
 "The current database was opened in read-only mode.  You cannot import into "
 "it."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:875
 #, fuzzy
 msgid "Import text"
 msgstr "Importerad &text"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:882
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
 #, fuzzy
 msgid "The database:"
 msgstr "i databasen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
 #, fuzzy
 msgid "has duplicate entries with the same group/title/user combination."
 msgstr ""
@@ -2117,33 +2117,33 @@ msgstr ""
 "har duplicerade poster med samma grupp/titel/användare-kombination. "
 "Vänligen, ordna dettta genom att validera databasen."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
 msgid "  Please fix by validating database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:931
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:886
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:932
 #, fuzzy
 msgid "Import Text failed"
 msgstr "Textimport misslyckades"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 #, fuzzy, c-format
 msgid "%ls file being imported: %ls"
 msgstr "%ls fil som importeras: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:921
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:926
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:223
-#: ../../../ui/wxWidgets/SyncWizard.cpp:572
+#: ../../../ui/wxWidgets/SyncWizard.cpp:573
 #: ../../../ui/wxWidgets/wxUtilities.cpp:59
 #: ../../../ui/wxWidgets/wxUtilities.cpp:64
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "File Read Error"
 msgstr "Läsfel i filen"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:923
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:222
 #: ../../../ui/wxWidgets/wxUtilities.cpp:58
 #, fuzzy
@@ -2153,7 +2153,7 @@ msgstr ""
 "\n"
 "Kunde inte öppna filen för läsning!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:928
 #, fuzzy
 msgid "Invalid format"
 msgstr ""
@@ -2161,77 +2161,77 @@ msgstr ""
 "\n"
 "Felaktigt format"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Updated "
 msgstr "Uppdaterad %d %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Imported "
 msgstr "Importerad"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entry"
 msgstr "post"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entries"
 msgstr "poster"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
 #, fuzzy
 msgid "Skipped "
 msgstr ""
 "\n"
 "Överhoppat %d %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:957
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:958
 #, fuzzy
 msgid "with Password History errors "
 msgstr ""
 "\n"
 "med lösenordshistoriska fel %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid "Renamed "
 msgstr "Byt namn"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed successfully"
 msgstr "Operationen lyckades"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed but ...."
 msgstr "Genomfört men ...."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:981
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1127
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1197
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1218
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1279
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:982
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1128
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1219
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
 #, fuzzy
 msgid "Do you wish to see a detailed report?"
 msgstr "Vill du ersätta det?"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1045
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:998
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1046
 msgid "Import XML failed"
 msgstr "XML-import misslyckades"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1007
-#: ../../../core/core_st.cpp:238
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../core/core_st.cpp:240
 #, fuzzy, c-format
 msgid ""
 "Can't find XML Schema Definition file (%ls) in your PasswordSafe Application "
@@ -2243,20 +2243,20 @@ msgstr ""
 "Vänligen, kopiera den från din installationsmapp eller ominstallera "
 "PasswordSafe."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 #, fuzzy
 msgid "Missing XSD File - "
 msgstr "Saknas XSD-fil"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid " Build"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 msgid "XML"
 msgstr "XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1051
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1052
 #, fuzzy, c-format
 msgid ""
 "File: %ls failed validation against XML Schema:\n"
@@ -2267,7 +2267,7 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1057
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1058
 #, fuzzy, c-format
 msgid ""
 "File: %ls passed Validation but had the following errors during import:\n"
@@ -2278,25 +2278,25 @@ msgstr ""
 "\n"
 "%ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1078
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1079
 msgid "The following records were skipped:"
 msgstr "Följande registreringar hoppades över:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1080
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1081
 #, c-format
 msgid " / skipped %d"
 msgstr " / överhoppad %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1085
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1086
 msgid "The following records had errors in their Password History:"
 msgstr "Följande registreringar hade fel i deras lösenordshistorik:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1087
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1088
 #, c-format
 msgid " / with Password History errors %d"
 msgstr " / med Password historikfel %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1092
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1093
 msgid ""
 "The following records were renamed as an entry already exists in your "
 "database or in the Import file:"
@@ -2304,12 +2304,12 @@ msgstr ""
 "Följande registreringar döptes om som en post som redan finns i din databas "
 "eller i importfilen:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1094
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1095
 #, c-format
 msgid " / renamed %d"
 msgstr " / omdöpt %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1099
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1100
 #, fuzzy, c-format
 msgid ""
 "File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See "
@@ -2318,25 +2318,25 @@ msgstr ""
 "Fil: %ls importerades (validerade poster %d / importerade %d%ls%ls%ls). Se "
 "rapporten för detaljinformation."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:95
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:97
 msgid "entry"
 msgstr "post"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:93
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:95
 msgid "entries"
 msgstr "poster"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1107
 #, fuzzy, c-format
 msgid ""
 "Validated %d %ls\n"
@@ -2347,26 +2347,26 @@ msgstr ""
 "\n"
 "Importerat %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1114
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1115
 msgid "XML import not supported in this release"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1117
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1118
 #, c-format
 msgid "XML import: Unexpected return code(%d)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1141
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1142
 msgid "Please Choose a KeePass Text File to Import"
 msgstr "Vänligen, välj en KeePass Text-fil att importera"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1163
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1164
 #, fuzzy, c-format
 msgid "Text file being imported: %ls"
 msgstr "Text fil som importeras: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1180
-#: ../../../ui/wxWidgets/SyncWizard.cpp:602
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/SyncWizard.cpp:603
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2377,11 +2377,11 @@ msgstr ""
 "\n"
 "Kunde inte öppna filen för läsning!"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1182
 msgid "File open error"
 msgstr "Fel vid filöppning"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1195
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1196
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2392,21 +2392,21 @@ msgstr ""
 "\n"
 "Felaktigt format"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1199
 msgid "Import failed"
 msgstr "Importen misslyckades"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1214
 #, fuzzy, c-format
 msgid "Imported %d %ls"
 msgstr "Importerat %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1265
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1266
 #, fuzzy
 msgid "Merging database: "
 msgstr "Sammanslående databas: %s\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1281
 #, fuzzy
 msgid "Merge Complete"
 msgstr "Jämförelsen klar"
@@ -2517,16 +2517,16 @@ msgstr ""
 "Misslyckades byta från R/W till R-O: Kunde inte öppna databaslåset.\n"
 "Prova att avsluta och starta om programmet."
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #, fuzzy
 msgid " file '"
 msgstr "Hantera filter"
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid "' not readable"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #: ../../../ui/wxWidgets/ViewReportDlg.cpp:32
 msgid "View Report"
 msgstr "Rapport"
@@ -2576,7 +2576,7 @@ msgid "Please select a valid file"
 msgstr "Vänligen, välj rapport att visa."
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:123
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:249
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:251
 msgid "None"
 msgstr "Inga"
 
@@ -2590,7 +2590,7 @@ msgid "Incremented Number [001-999]"
 msgstr "Ökande tal [001-999]"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:132
-#: ../../../core/core_st.cpp:66
+#: ../../../core/core_st.cpp:68
 #, fuzzy
 msgid "Copy password to clipboard"
 msgstr "&Kopiera lösenordet till Urklipp"
@@ -2602,37 +2602,37 @@ msgstr "Visa/redigera vald post"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:134
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:623
-#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:62
+#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:64
 msgid "Autotype"
 msgstr "Autoskriv"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:135
-#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:63
+#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:65
 msgid "Browse to URL"
 msgstr "Gå till URL"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:136
-#: ../../../core/core_st.cpp:65
+#: ../../../core/core_st.cpp:67
 msgid "Copy notes to clipboard"
 msgstr "Kopiera noteringar till Urklipp"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:137
-#: ../../../core/core_st.cpp:68
+#: ../../../core/core_st.cpp:70
 msgid "Copy username to clipboard"
 msgstr "Kopiera användarnamnet till Urklipp"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:138
-#: ../../../core/core_st.cpp:67
+#: ../../../core/core_st.cpp:69
 msgid "Copy password to clipboard, minimize"
 msgstr "Kopiera lösenordet till Urklipp, minimera"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:139
-#: ../../../core/core_st.cpp:64
+#: ../../../core/core_st.cpp:66
 msgid "Browse to URL + Autotype"
 msgstr "Gå till URL + Autoskriv"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:140
-#: ../../../core/core_st.cpp:69 ../../../core/core_st.cpp:144
+#: ../../../core/core_st.cpp:71 ../../../core/core_st.cpp:146
 msgid "Run Command"
 msgstr "Kör kommando"
 
@@ -3058,24 +3058,24 @@ msgstr ""
 msgid "Don't show this warning again"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:849
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:854
 msgid "Missing help definition for page \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:850
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
 msgid "\" of \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:860
 msgid "Missing help definition for window \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:866
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:871
 #, fuzzy
 msgid "Please inform the developers."
 msgstr "Vänligen, namnge detta filter"
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:867
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:872
 msgid "Help Undefined"
 msgstr ""
 
@@ -3812,6 +3812,7 @@ msgid "search"
 msgstr "&Sök"
 
 #: ../../../ui/wxWidgets/PasswordSafeSearch.cpp:427
+#: ../../../core/core_st.cpp:280
 msgid "Find"
 msgstr "Sök"
 
@@ -3933,20 +3934,20 @@ msgstr "validering"
 msgid " empty)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:306
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:322
 #, fuzzy, c-format
 msgid "%ls on %ls"
 msgstr "%ls på %ls"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:341
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:357
 msgid "Yes"
 msgstr "Ja"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:244
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:246
 msgid "No"
 msgstr "Nej"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:302
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:318
 #, fuzzy, c-format
 msgid "In Headers(%ls)/In Entries("
 msgstr "I rubriker(%ls)/I poster("
@@ -4132,7 +4133,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:457
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:269
-#: ../../../core/core_st.cpp:276
+#: ../../../core/core_st.cpp:290
 msgid "Warning"
 msgstr "Varning"
 
@@ -4207,11 +4208,11 @@ msgstr ""
 "\n"
 "Vänligen, försök med en annan"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:96
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:98
 msgid "equals"
 msgstr "är lika med"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:83
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:85
 msgid "does not equal"
 msgstr "är inte lika med"
 
@@ -4219,23 +4220,23 @@ msgstr "är inte lika med"
 msgid "begins with"
 msgstr "börjar med"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:78
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:80
 msgid "does not begin with"
 msgstr "börjar inte med"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:90
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:92
 msgid "ends with"
 msgstr "slutar med"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:82
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:84
 msgid "does not end with"
 msgstr "slutar inte med"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:56
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:58
 msgid "contains"
 msgstr "innehåller"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:79
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:81
 msgid "does not contain"
 msgstr "innehåller inte"
 
@@ -4294,80 +4295,80 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:143
+#: ../../../ui/wxWidgets/SyncWizard.cpp:144
 #, fuzzy
 msgid "synchronize"
 msgstr "synkroniserad"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:220
+#: ../../../ui/wxWidgets/SyncWizard.cpp:221
 #, fuzzy
 msgid "Synchronize another database with currently open database"
 msgstr "Slå samman denna databas med den aktuella databasen:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:349
+#: ../../../ui/wxWidgets/SyncWizard.cpp:350
 msgid "Introduction"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:353
+#: ../../../ui/wxWidgets/SyncWizard.cpp:354
 msgid ""
 "Synchronizing with another database will update the entries in your\n"
 "database with matching entries from the other database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:356
+#: ../../../ui/wxWidgets/SyncWizard.cpp:357
 msgid "More Info"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:359
+#: ../../../ui/wxWidgets/SyncWizard.cpp:360
 msgid ""
 "1. Two entries from different databases match if their Group, Title\n"
 "and User fields match."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:360
+#: ../../../ui/wxWidgets/SyncWizard.cpp:361
 msgid ""
 "2. You can select the fields to update, as well as filter the entries\n"
 "for synchronization."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:361
+#: ../../../ui/wxWidgets/SyncWizard.cpp:362
 msgid ""
 "3. Only existing entries in your database are updated.  No new entries are\n"
 "added or existing entries removed during this process."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:362
+#: ../../../ui/wxWidgets/SyncWizard.cpp:363
 msgid ""
 "4. You can undo the operation once it is complete, but won't be\n"
 "able to abort it mid-way."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:379
+#: ../../../ui/wxWidgets/SyncWizard.cpp:380
 #, fuzzy
 msgid "Select another database"
 msgstr "Välj databas"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:381
+#: ../../../ui/wxWidgets/SyncWizard.cpp:382
 #, fuzzy
 msgid "Choose Database to Synchronize with \""
 msgstr "Vänligen, välj en databas att synkronisera med nuvarande databas"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:382
+#: ../../../ui/wxWidgets/SyncWizard.cpp:383
 #, fuzzy
 msgid "Please Choose a Database to Synchronize with current database"
 msgstr "Vänligen, välj en databas att synkronisera med nuvarande databas"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:405
+#: ../../../ui/wxWidgets/SyncWizard.cpp:406
 #, fuzzy
 msgid "Synchronization options"
 msgstr "Synkroniseringen misslyckades"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:429
+#: ../../../ui/wxWidgets/SyncWizard.cpp:430
 #, fuzzy
 msgid "Options Summary"
 msgstr "Alternativ"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:454
+#: ../../../ui/wxWidgets/SyncWizard.cpp:455
 #, fuzzy
 msgid ""
 "WARNING!!\n"
@@ -4378,58 +4379,58 @@ msgstr ""
 "VARNING: Om du fortsätter kommer postfält i din existerande databas att "
 "uppdateras från din valda databas' ingående data."
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:471
+#: ../../../ui/wxWidgets/SyncWizard.cpp:472
 msgid " will be updated with corresponding entries from \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:478
+#: ../../../ui/wxWidgets/SyncWizard.cpp:479
 msgid "All fields in matching entries will be updated"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:484
+#: ../../../ui/wxWidgets/SyncWizard.cpp:485
 msgid "Following fields in matching entries will be updated:"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:488
+#: ../../../ui/wxWidgets/SyncWizard.cpp:489
 #, fuzzy
 msgid "Following fields will not be updated:"
 msgstr "Följande kolumner kommer att köras:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:507
+#: ../../../ui/wxWidgets/SyncWizard.cpp:508
 #, fuzzy
 msgid "Synchronization status"
 msgstr "Synkroniseringen misslyckades"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:525
+#: ../../../ui/wxWidgets/SyncWizard.cpp:526
 msgid "See a detailed report"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:561
+#: ../../../ui/wxWidgets/SyncWizard.cpp:562
 msgid "Your database is being synchronized with \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:571
+#: ../../../ui/wxWidgets/SyncWizard.cpp:572
 msgid "There was an error during synchronization"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:585
+#: ../../../ui/wxWidgets/SyncWizard.cpp:586
 #, fuzzy, c-format
 msgid "Your database has been synchronized with \"%ls\""
 msgstr "Vänligen, välj en databas att synkronisera med \"%ls\""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:586
+#: ../../../ui/wxWidgets/SyncWizard.cpp:587
 #, fuzzy, c-format
 msgid "%ld %ls updated"
 msgstr ""
 "\n"
 "Följande %ls %ls uppdaterades:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:589
 #, fuzzy
 msgid "Synchronization completed successfully"
 msgstr "Operationen lyckades"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:604
+#: ../../../ui/wxWidgets/SyncWizard.cpp:605
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4443,7 +4444,7 @@ msgstr ""
 "Data kan ha förlorats eller ändrats.\n"
 "Fortsätta ändå?"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:606
+#: ../../../ui/wxWidgets/SyncWizard.cpp:607
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4454,24 +4455,24 @@ msgstr ""
 "\n"
 "Okänt fel"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:640
+#: ../../../ui/wxWidgets/SyncWizard.cpp:641
 #, fuzzy, c-format
 msgid "Synchronizing from database: %ls\n"
 msgstr "Synkronisering från databas: %ls\n"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:643
+#: ../../../ui/wxWidgets/SyncWizard.cpp:644
 msgid "synchronized"
 msgstr "synkroniserad"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:322
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:338
 msgid "was"
 msgstr "var"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:323
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:339
 msgid "were"
 msgstr "var"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:298
+#: ../../../ui/wxWidgets/SyncWizard.cpp:733 ../../../core/core_st.cpp:314
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4480,7 +4481,7 @@ msgstr ""
 "\n"
 "Följande %ls %ls uppdaterades:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:297
+#: ../../../ui/wxWidgets/SyncWizard.cpp:749 ../../../core/core_st.cpp:313
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4652,7 +4653,7 @@ msgstr ""
 "Denna genvägs mål [%s:%s:%s] är inte en vanlig post eller redan en "
 "genvägsbas."
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:94
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:96
 #, c-format
 msgid ""
 "The following entries had a policy name that already existed in this "
@@ -4757,13 +4758,13 @@ msgstr ""
 "Data kan ha förlorats eller ändrats.\n"
 "Fortsätta ändå?"
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:381
+#: ../../../ui/wxWidgets/wxUtilities.cpp:390
 msgid ""
 "An error occurred while trying to get the image data from database item.\n"
 "Therefore, the image cannot be displayed in the preview."
 msgstr ""
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:394
+#: ../../../ui/wxWidgets/wxUtilities.cpp:403
 msgid ""
 "An error occurred while trying to load the image data into the preview "
 "area.\n"
@@ -4905,7 +4906,7 @@ msgstr ""
 "\n"
 "Kopiera lösenordet till Urklipp"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:149
+#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:151
 msgid "Username"
 msgstr "Användarnamn"
 
@@ -4916,7 +4917,7 @@ msgstr ""
 "\n"
 "Kopiera användarnamnet till Urklipp"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:136
+#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:138
 #, fuzzy
 msgid "Notes"
 msgstr "&Noteringar:"
@@ -4952,7 +4953,7 @@ msgstr ""
 msgid "Browse URL"
 msgstr "Gå till URL"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:70
+#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:72
 #, fuzzy
 msgid "Send Email"
 msgstr "Skicka e-post"
@@ -5146,67 +5147,85 @@ msgid "(case sensitive)"
 msgstr "(storlekskänslig)"
 
 #: ../../../core/core_st.cpp:50
+#, fuzzy, c-format
+msgid ""
+"Compare complete of current database:\n"
+"\t %ls\n"
+" and:\n"
+"\t %ls\n"
+msgstr ""
+"Jämförelsen klar med nuvarande databas:\n"
+"\t %s\n"
+" och:\n"
+"\t %s"
+
+#: ../../../core/core_st.cpp:51
+#, fuzzy, c-format
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\tGrupp:'%s'; Titel:'%s'; Användare:'%s'"
+
+#: ../../../core/core_st.cpp:52
 msgid "C:F[R-O]"
 msgstr "C:F[R-O]"
 
-#: ../../../core/core_st.cpp:51
+#: ../../../core/core_st.cpp:53
 msgid "C:F[R/W]"
 msgstr "C:F[R/W]"
 
-#: ../../../core/core_st.cpp:52
+#: ../../../core/core_st.cpp:54
 msgid "C:None  "
 msgstr "C:Inga"
 
-#: ../../../core/core_st.cpp:53
+#: ../../../core/core_st.cpp:55
 msgid "C:Reg   "
 msgstr "C:Reg   "
 
-#: ../../../core/core_st.cpp:54
+#: ../../../core/core_st.cpp:56
 msgid "conflict"
 msgstr "konflikt"
 
-#: ../../../core/core_st.cpp:55
+#: ../../../core/core_st.cpp:57
 msgid "conflicts"
 msgstr "konflikter"
 
-#: ../../../core/core_st.cpp:57
+#: ../../../core/core_st.cpp:59
 msgid "contains all of"
 msgstr "innehåller allt av"
 
-#: ../../../core/core_st.cpp:58
+#: ../../../core/core_st.cpp:60
 msgid "contains any of"
 msgstr "innehåller något av"
 
-#: ../../../core/core_st.cpp:59
+#: ../../../core/core_st.cpp:61
 #, fuzzy
 msgid "copied"
 msgstr "URL kopierad"
 
-#: ../../../core/core_st.cpp:60
+#: ../../../core/core_st.cpp:62
 #, fuzzy, c-format
 msgid "%ls - Copied %ls"
 msgstr "%ls - Kopierad %ls"
 
-#: ../../../core/core_st.cpp:61
+#: ../../../core/core_st.cpp:63
 #, fuzzy, c-format
 msgid " Current default (%ls)"
 msgstr " Nuvarande förval (%ls)"
 
-#: ../../../core/core_st.cpp:71
+#: ../../../core/core_st.cpp:73
 msgid "View/Edit selected entry"
 msgstr "Visa/redigera vald post"
 
-#: ../../../core/core_st.cpp:72
+#: ../../../core/core_st.cpp:74
 #, fuzzy
 msgid " (application default)"
 msgstr "Använt program:"
 
-#: ../../../core/core_st.cpp:73
+#: ../../../core/core_st.cpp:75
 #, fuzzy
 msgid "default symbol set"
 msgstr "Förvalt set"
 
-#: ../../../core/core_st.cpp:75
+#: ../../../core/core_st.cpp:77
 #, fuzzy, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5219,12 +5238,12 @@ msgstr ""
 "Vänligen, bekräfta för att fortsätta (alias posts lösenord kommer att "
 "ersättas med denna posts lösenord)?"
 
-#: ../../../core/core_st.cpp:76
+#: ../../../core/core_st.cpp:78
 #, fuzzy
 msgid "Delete Base Entry Confirmation"
 msgstr "Radera en basposts ?"
 
-#: ../../../core/core_st.cpp:77
+#: ../../../core/core_st.cpp:79
 #, fuzzy, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5236,40 +5255,40 @@ msgstr ""
 "Vänligen, bekräfta för att fortsätta (Alla genvägar till denna post kommer "
 "att raderas)?"
 
-#: ../../../core/core_st.cpp:80
+#: ../../../core/core_st.cpp:82
 msgid "does not contain all of"
 msgstr "innehåller inte allt"
 
-#: ../../../core/core_st.cpp:81
+#: ../../../core/core_st.cpp:83
 msgid "does not contain any of"
 msgstr "innehåller inte något av"
 
-#: ../../../core/core_st.cpp:84
+#: ../../../core/core_st.cpp:86
 #, c-format
 msgid " Drag # %d"
 msgstr " Drag # %d"
 
-#: ../../../core/core_st.cpp:85
-#, c-format
-msgid "%s - Drag & Drop %s"
-msgstr ""
+#: ../../../core/core_st.cpp:87
+#, fuzzy, c-format
+msgid "%ls - Drag & Drop %ls"
+msgstr "%ls - Kopierad %ls"
 
-#: ../../../core/core_st.cpp:86
+#: ../../../core/core_st.cpp:88
 #, c-format
 msgid " Duplicate # %d"
 msgstr " Duplicera # %d"
 
-#: ../../../core/core_st.cpp:87
+#: ../../../core/core_st.cpp:89
 #, fuzzy
 msgid "empty group"
 msgstr "Importera undergrupp?"
 
-#: ../../../core/core_st.cpp:88
+#: ../../../core/core_st.cpp:90
 #, fuzzy
 msgid "empty groups"
 msgstr "#grupper"
 
-#: ../../../core/core_st.cpp:89
+#: ../../../core/core_st.cpp:91
 #, fuzzy, c-format
 msgid ""
 "Trouble with a non-textual (e.g., time) field in record '%ls' - please check "
@@ -5278,262 +5297,262 @@ msgstr ""
 "Svårigheter med en icke textbaserat (t. ex. tid) fält i posten '%ls* - "
 "vänligen, kontrollera data noggrant."
 
-#: ../../../core/core_st.cpp:91
+#: ../../../core/core_st.cpp:93
 msgid "End Report"
 msgstr "Rapportslut"
 
-#: ../../../core/core_st.cpp:92
+#: ../../../core/core_st.cpp:94
 msgid "--------------------------------------------------------------------------------"
 msgstr "--------------------------------------------------------------------------------"
 
-#: ../../../core/core_st.cpp:97
+#: ../../../core/core_st.cpp:99
 msgid "has expired"
 msgstr "har utgått"
 
-#: ../../../core/core_st.cpp:98
+#: ../../../core/core_st.cpp:100
 msgid "Entries with a password expiry"
 msgstr "Poster med utgående lösenord"
 
-#: ../../../core/core_st.cpp:99
+#: ../../../core/core_st.cpp:101
 #, c-format
 msgid "within %d day(s)"
 msgstr "inom %d dag(ar)"
 
-#: ../../../core/core_st.cpp:100
+#: ../../../core/core_st.cpp:102
 #, fuzzy, c-format
 msgid "DB Export from database: '%s'"
 msgstr "Sammanslående databas: %s\n"
 
-#: ../../../core/core_st.cpp:101
+#: ../../../core/core_st.cpp:103
 msgid "First character of variable name must be alphabetic"
 msgstr "Första tecknet i variabelnamnet måste vara alfabetiskt"
 
-#: ../../../core/core_st.cpp:102
+#: ../../../core/core_st.cpp:104
 msgid "Index not numeric"
 msgstr "Index är inte numeriskt"
 
-#: ../../../core/core_st.cpp:103
+#: ../../../core/core_st.cpp:105
 msgid "Input string is empty"
 msgstr "Inmatningssträngen är tom"
 
-#: ../../../core/core_st.cpp:104
+#: ../../../core/core_st.cpp:106
 msgid "Characters present between end of index ']' and '}'"
 msgstr "Tecken som finns mellan indexslutet ']' och '}'"
 
-#: ../../../core/core_st.cpp:105
+#: ../../../core/core_st.cpp:107
 msgid "Index is invalid or missing"
 msgstr "Index är ogiltigt eller saknas"
 
-#: ../../../core/core_st.cpp:106
+#: ../../../core/core_st.cpp:108
 msgid "Missing ending curly bracket for variable name"
 msgstr "Saknas avslutande krullparentes till variabelnamnet"
 
-#: ../../../core/core_st.cpp:107
+#: ../../../core/core_st.cpp:109
 msgid "Missing ending round bracket for Autotype value"
 msgstr "Saknas avslutande rund parentes till autoskriv-värdet"
 
-#: ../../../core/core_st.cpp:108
+#: ../../../core/core_st.cpp:110
 msgid "Missing ending square bracket for index value"
 msgstr "Saknas avslutande klammerparentes till indexvärdet"
 
-#: ../../../core/core_st.cpp:109
+#: ../../../core/core_st.cpp:111
 msgid "There are unmatched quotes in the run command"
 msgstr "Det finns omatchade förslag i körkommandot"
 
-#: ../../../core/core_st.cpp:110
+#: ../../../core/core_st.cpp:112
 msgid "Variable name is empty"
 msgstr "Variabelnamn är tomt"
 
-#: ../../../core/core_st.cpp:111
+#: ../../../core/core_st.cpp:113
 msgid "Variable name must be alphanumeric"
 msgstr "Variaelnamnet måste vara alfanumeriskt"
 
-#: ../../../core/core_st.cpp:112
+#: ../../../core/core_st.cpp:114
 msgid "an alias entry"
 msgstr "en aliaspost"
 
-#: ../../../core/core_st.cpp:113
+#: ../../../core/core_st.cpp:115
 msgid "a base entry of an alias"
 msgstr "en alias baspost"
 
-#: ../../../core/core_st.cpp:114
+#: ../../../core/core_st.cpp:116
 msgid "  Field is too long."
 msgstr "  Fältet är för långt."
 
-#: ../../../core/core_st.cpp:115
+#: ../../../core/core_st.cpp:117
 msgid "  Field is too short."
 msgstr "  Fältet är för kort."
 
-#: ../../../core/core_st.cpp:116
+#: ../../../core/core_st.cpp:118
 msgid "Error: A file with this name already exists"
 msgstr "Fel: En fil med detta namn finns redan"
 
-#: ../../../core/core_st.cpp:117
+#: ../../../core/core_st.cpp:119
 msgid "The file was not found."
 msgstr "Filen hittades inte."
 
-#: ../../../core/core_st.cpp:118
+#: ../../../core/core_st.cpp:120
 msgid "Error: File is read-only"
 msgstr "Fel: Filen är bara läsbar"
 
-#: ../../../core/core_st.cpp:119
+#: ../../../core/core_st.cpp:121
 msgid "Error while writing file! Try saving in a different location"
 msgstr "Fel vid filskrivning! Försök att spara i ett annat format"
 
-#: ../../../core/core_st.cpp:120
+#: ../../../core/core_st.cpp:122
 #, fuzzy
 msgid "File is too big."
 msgstr "  Fältet är för långt."
 
-#: ../../../core/core_st.cpp:121
+#: ../../../core/core_st.cpp:123
 #, fuzzy
 msgid "File is too short."
 msgstr "  Fältet är för kort."
 
-#: ../../../core/core_st.cpp:122
+#: ../../../core/core_st.cpp:124
 msgid "File is truncated or otherwise corrupt. Please use backup database."
 msgstr ""
 "Filen är trunkerad eller på annat sett felaktig. Vänligen, använd databasens "
 "backup."
 
-#: ../../../core/core_st.cpp:123
+#: ../../../core/core_st.cpp:125
 msgid "Cannot read file. Please check file permissions."
 msgstr "Kan inte läsa filen. Vänligen, kontrollera filrättigheterna."
 
-#: ../../../core/core_st.cpp:124
+#: ../../../core/core_st.cpp:126
 #, fuzzy, c-format
 msgid ""
 "Filter %ls already exists in the database, do you wish to replace it with "
 "this?"
 msgstr "Filter %ls finns redan i databasen, vill du ersätta det med detta?"
 
-#: ../../../core/core_st.cpp:125
+#: ../../../core/core_st.cpp:127
 #, fuzzy
 msgid "Current database filters have been exported to this database."
 msgstr "Jämför nuvarande databas med: %s"
 
-#: ../../../core/core_st.cpp:126
+#: ../../../core/core_st.cpp:128
 msgid "Stored filters will be unusable until the file's restored."
 msgstr "Sparade filter är inte användbara tills dess filen har startats om."
 
-#: ../../../core/core_st.cpp:127
+#: ../../../core/core_st.cpp:129
 msgid "Last Access Time"
 msgstr "Senaste åtkomsttid"
 
-#: ../../../core/core_st.cpp:128
+#: ../../../core/core_st.cpp:130
 msgid "Attachment Reference"
 msgstr ""
 
-#: ../../../core/core_st.cpp:129
+#: ../../../core/core_st.cpp:131
 msgid "AutoType"
 msgstr "Autoskriv"
 
-#: ../../../core/core_st.cpp:130
+#: ../../../core/core_st.cpp:132
 msgid "Created Time"
 msgstr "Skapad den"
 
-#: ../../../core/core_st.cpp:131
+#: ../../../core/core_st.cpp:133
 msgid "DCA"
 msgstr "DCA"
 
-#: ../../../core/core_st.cpp:132
+#: ../../../core/core_st.cpp:134
 msgid "e-mail"
 msgstr "e-post"
 
-#: ../../../core/core_st.cpp:134
+#: ../../../core/core_st.cpp:136
 msgid "Group/Title"
 msgstr "Grupp/Titel"
 
-#: ../../../core/core_st.cpp:135
+#: ../../../core/core_st.cpp:137
 #, fuzzy
 msgid "Keyboard Shortcut"
 msgstr "Skapa genväg"
 
-#: ../../../core/core_st.cpp:138
+#: ../../../core/core_st.cpp:140
 msgid "Password Modified Time"
 msgstr "Lösenordets ändringstidpunkt"
 
-#: ../../../core/core_st.cpp:139
+#: ../../../core/core_st.cpp:141
 msgid "Protected"
 msgstr "Skyddad"
 
-#: ../../../core/core_st.cpp:140
+#: ../../../core/core_st.cpp:142
 msgid "History"
 msgstr "Historik"
 
-#: ../../../core/core_st.cpp:142
+#: ../../../core/core_st.cpp:144
 #, fuzzy
 msgid "Password Policy Name"
 msgstr "Lösenordspolicy"
 
-#: ../../../core/core_st.cpp:143
+#: ../../../core/core_st.cpp:145
 msgid "Record Modified Time"
 msgstr "Registrerad ändringstidpunkt"
 
-#: ../../../core/core_st.cpp:145
+#: ../../../core/core_st.cpp:147
 msgid "Shift+DCA"
 msgstr "Skift+DCA"
 
-#: ../../../core/core_st.cpp:146
+#: ../../../core/core_st.cpp:148
 msgid "Symbols"
 msgstr "Symboler"
 
-#: ../../../core/core_st.cpp:148
+#: ../../../core/core_st.cpp:150
 msgid "URL"
 msgstr "URL"
 
-#: ../../../core/core_st.cpp:150
+#: ../../../core/core_st.cpp:152
 msgid "UUID"
 msgstr "UUID"
 
-#: ../../../core/core_st.cpp:151
+#: ../../../core/core_st.cpp:153
 msgid "Password Expiry Date"
 msgstr "Lösenordets utgångsdatum"
 
-#: ../../../core/core_st.cpp:152
+#: ../../../core/core_st.cpp:154
 msgid "Password Expiry Interval"
 msgstr "Lösenordets utgångsperiod"
 
-#: ../../../core/core_st.cpp:153
+#: ../../../core/core_st.cpp:155
 msgid "a normal entry"
 msgstr "en normal post"
 
-#: ../../../core/core_st.cpp:154
+#: ../../../core/core_st.cpp:156
 #, fuzzy
 msgid "Last found entries"
 msgstr "poster"
 
-#: ../../../core/core_st.cpp:155
+#: ../../../core/core_st.cpp:157
 msgid "added but not yet saved to database"
 msgstr "tillagd men ännu inte sparad i databasen"
 
-#: ../../../core/core_st.cpp:156
+#: ../../../core/core_st.cpp:158
 #, fuzzy
 msgid "in the database"
 msgstr "i databasen"
 
-#: ../../../core/core_st.cpp:157
+#: ../../../core/core_st.cpp:159
 msgid "a shortcut entry"
 msgstr "en genvägspost"
 
-#: ../../../core/core_st.cpp:158
+#: ../../../core/core_st.cpp:160
 #, fuzzy
 msgid "a base entry of a shortcut"
 msgstr "en alias baspost"
 
-#: ../../../core/core_st.cpp:159
+#: ../../../core/core_st.cpp:161
 msgid "changed but not yet saved to database"
 msgstr "ändrad men ännu inte sparad i databasen"
 
-#: ../../../core/core_st.cpp:160
+#: ../../../core/core_st.cpp:162
 msgid "greater than"
 msgstr "större än"
 
-#: ../../../core/core_st.cpp:161
+#: ../../../core/core_st.cpp:163
 msgid "greater than or equal to"
 msgstr "större eller lika med"
 
-#: ../../../core/core_st.cpp:162
+#: ../../../core/core_st.cpp:164
 #, c-format
 msgid ""
 "Invalid input on line %d.  Number of fields separated by '%c' is not as "
@@ -5542,23 +5561,23 @@ msgstr ""
 "Ogiltig inmatning på rad %d. Antalet fält separerade med '%c' förväntades "
 "inte."
 
-#: ../../../core/core_st.cpp:163
+#: ../../../core/core_st.cpp:165
 #, c-format
 msgid "Line %d: "
 msgstr "Rad %d: "
 
-#: ../../../core/core_st.cpp:164
+#: ../../../core/core_st.cpp:166
 #, c-format
 msgid ""
 "File ends on line %d before ending double quote of last entry's note field."
 msgstr ""
 "Filen slutar på rad %d före avslutande citattecken i senaste posts notatfält."
 
-#: ../../../core/core_st.cpp:165
+#: ../../../core/core_st.cpp:167
 msgid "Import aborted. Please see report."
 msgstr "Importen avbröts. Vänligen, se rapporten."
 
-#: ../../../core/core_st.cpp:166
+#: ../../../core/core_st.cpp:168
 #, fuzzy
 msgid ""
 "The TXT or CSV file was not imported as required as entry records span "
@@ -5571,7 +5590,7 @@ msgstr ""
 "\n"
 "Importen avbröts."
 
-#: ../../../core/core_st.cpp:167
+#: ../../../core/core_st.cpp:169
 #, fuzzy, c-format
 msgid ""
 "%ls, Title=\"%ls\", User=\"%ls\" already exists in your database or in the "
@@ -5580,69 +5599,69 @@ msgstr ""
 "%ls, Titel=\"%ls\", Användare=\"%ls\" finns redan i din databas eller i "
 "importfilen. La till importerad post med namn=\"%ls\".\n"
 
-#: ../../../core/core_st.cpp:168
+#: ../../../core/core_st.cpp:170
 #, fuzzy, c-format
 msgid "Entry on line %d with Group=\"%ls\""
 msgstr "Post på rade %d med Grupp=\"%ls\""
 
-#: ../../../core/core_st.cpp:169
+#: ../../../core/core_st.cpp:171
 #, c-format
 msgid "Entry on line %d with no group"
 msgstr "Post på rad %d utan grupp"
 
-#: ../../../core/core_st.cpp:170
+#: ../../../core/core_st.cpp:172
 #, fuzzy, c-format
 msgid "Entry with Group=\"%ls\""
 msgstr "Post med Grupp=\"%ls\""
 
-#: ../../../core/core_st.cpp:171
+#: ../../../core/core_st.cpp:173
 msgid "Entry with no group"
 msgstr "Post utan grupp"
 
-#: ../../../core/core_st.cpp:172
+#: ../../../core/core_st.cpp:174
 #, fuzzy
 msgid "imported"
 msgstr "import"
 
-#: ../../../core/core_st.cpp:173
+#: ../../../core/core_st.cpp:175
 #, fuzzy, c-format
 msgid "including %d empty group(s)."
 msgstr "#grupper"
 
-#: ../../../core/core_st.cpp:174
+#: ../../../core/core_st.cpp:176
 #, c-format
 msgid "Empty line %d skipped"
 msgstr "Tom rad %d överhoppad"
 
-#: ../../../core/core_st.cpp:175
+#: ../../../core/core_st.cpp:177
 #, fuzzy, c-format
 msgid "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 msgstr "Post %ls%d med Grupp=\"%ls\", Titel=\"%ls\", Användare=\"%ls\""
 
-#: ../../../core/core_st.cpp:176
+#: ../../../core/core_st.cpp:178
 msgid "Internal error. Import failed. No records imported."
 msgstr "Internt fel. Importen misslyckades. Ingenting har importerades."
 
-#: ../../../core/core_st.cpp:177
+#: ../../../core/core_st.cpp:179
 #, c-format
 msgid "Found %d known column headers:"
 msgstr "Fann %d kända kolumnrubriker:"
 
-#: ../../../core/core_st.cpp:178
+#: ../../../core/core_st.cpp:180
 msgid "Invalid field delimiter: must be within ASCII range."
 msgstr ""
 
-#: ../../../core/core_st.cpp:179
+#: ../../../core/core_st.cpp:181
 #, fuzzy, c-format
 msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
 msgstr ""
 "Posten på rad %d innehåller ett ogiltigt \"%ls\" fält. Den har ignorerats."
 
-#: ../../../core/core_st.cpp:180
+#: ../../../core/core_st.cpp:182
 msgid "The following columns will be processed: "
 msgstr "Följande kolumner kommer att köras:"
 
-#: ../../../core/core_st.cpp:181
+#: ../../../core/core_st.cpp:183
 msgid ""
 "The following columns were recognised but only Group/Title, Username and "
 "Password will be processed:"
@@ -5650,7 +5669,7 @@ msgstr ""
 "Följande kolumner återfanns, men bara Grupp/Titel, Användare och Lösenord "
 "kommer att behandlas."
 
-#: ../../../core/core_st.cpp:182
+#: ../../../core/core_st.cpp:184
 #, c-format
 msgid ""
 "Line %d skipped - Only %d fields found, whereas parsing the Header says "
@@ -5659,7 +5678,7 @@ msgstr ""
 "Rad %d överhoppad - Bara %d fält funna, emedan körning av rubriken visar att "
 "det borde vara %d."
 
-#: ../../../core/core_st.cpp:183
+#: ../../../core/core_st.cpp:185
 msgid ""
 "Either or both of the Group/Title and Password columns are missing. No "
 "records imported."
@@ -5667,7 +5686,7 @@ msgstr ""
 "Endera av eller både grupp-/titel- och lösenords-kolumner saknas. Ingenting "
 "har importerades."
 
-#: ../../../core/core_st.cpp:184
+#: ../../../core/core_st.cpp:186
 msgid ""
 "Could not find the next entry's title field in the KeePass V1 TXT (should be "
 "within square brackets)."
@@ -5675,38 +5694,38 @@ msgstr ""
 "Hittade inte nästa posts Titel-fält i KeePass V1 TXT (borde vara inom "
 "fyrkantsparentes)."
 
-#: ../../../core/core_st.cpp:185
+#: ../../../core/core_st.cpp:187
 msgid "Column header row not recognised as first record. No records imported."
 msgstr ""
 "Kolumnens rubrikrad känns inte igen som första post. Ingenting har "
 "importerats."
 
-#: ../../../core/core_st.cpp:186
+#: ../../../core/core_st.cpp:188
 msgid "No records in import file!"
 msgstr "Inga värden i importerad fil!"
 
-#: ../../../core/core_st.cpp:187
+#: ../../../core/core_st.cpp:189
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Password field."
 msgstr ""
 "Rad %d överhoppad. Den innehåller ett tomt obligatoriskt Lösenord-fält."
 
-#: ../../../core/core_st.cpp:188
+#: ../../../core/core_st.cpp:190
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Title field."
 msgstr "Rad %d överhoppad. Den innehåller ett tomt obligatoriskt Titel-fält."
 
-#: ../../../core/core_st.cpp:189
+#: ../../../core/core_st.cpp:191
 #, c-format
 msgid " Import # %d"
 msgstr " Importera # %d"
 
-#: ../../../core/core_st.cpp:190
+#: ../../../core/core_st.cpp:192
 #, fuzzy, c-format
 msgid "%ls - Imported %ls"
 msgstr "%ls - Importerat %ls"
 
-#: ../../../core/core_st.cpp:191
+#: ../../../core/core_st.cpp:193
 msgid ""
 "To replace passwords of existing entries, all the following columns must be "
 "present: Group/Title, Username and Password.  One or more are missing and no "
@@ -5716,17 +5735,17 @@ msgstr ""
 "kolumner vara med: Grupp/Titel, Användare och Lösenord. En eller fler saknas "
 "och inga poster har uppdaterats."
 
-#: ../../../core/core_st.cpp:192
+#: ../../../core/core_st.cpp:194
 #, fuzzy, c-format
 msgid "%ls not found. Cannot update entry's password.\n"
 msgstr "%ls hittades inte. Kan inte uppdatera posters lösenord.\n"
 
-#: ../../../core/core_st.cpp:193
+#: ../../../core/core_st.cpp:195
 #, fuzzy, c-format
 msgid "%ls has an empty %ls.\n"
 msgstr "%ls har en tom %ls.\n"
 
-#: ../../../core/core_st.cpp:194
+#: ../../../core/core_st.cpp:196
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5735,11 +5754,11 @@ msgstr ""
 "Posten \"%ls, %ls, %ls\" har ett lösenord i rätt format för ett alias, men "
 "basposten är redan en alias."
 
-#: ../../../core/core_st.cpp:195
+#: ../../../core/core_st.cpp:197
 msgid "\tThis entry has been made an alias of associated base entry."
 msgstr "\tDenna post har gjorts till en alias till associerad baspost."
 
-#: ../../../core/core_st.cpp:196
+#: ../../../core/core_st.cpp:198
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5748,12 +5767,12 @@ msgstr ""
 "Posten\"%ls, %ls, %ls\" har ett lösenord i rätt format för en alias, men "
 "basposten finns inte."
 
-#: ../../../core/core_st.cpp:197
+#: ../../../core/core_st.cpp:199
 msgid ""
 "\tThis entry remains a normal entry and the password has not been changed."
 msgstr "\tDenna post förblir en vanlig post och lösenordet har inte ändrats."
 
-#: ../../../core/core_st.cpp:198
+#: ../../../core/core_st.cpp:200
 #, fuzzy, c-format
 msgid ""
 "The %ls entry \"%ls, %ls, %ls\" doesn't point to a normal or existing %ls "
@@ -5762,69 +5781,69 @@ msgstr ""
 "%ls posten \"%ls, %ls, %ls\"pekar inte på en normal eller existerande %ls "
 "baspost. Den kan inte importeras."
 
-#: ../../../core/core_st.cpp:199
+#: ../../../core/core_st.cpp:201
 msgid "Entry import warnings"
 msgstr "Postimportvarningar"
 
-#: ../../../core/core_st.cpp:200
+#: ../../../core/core_st.cpp:202
 msgid "id="
 msgstr "id="
 
-#: ../../../core/core_st.cpp:201
+#: ../../../core/core_st.cpp:203
 msgid "on line "
 msgstr "on line"
 
-#: ../../../core/core_st.cpp:202
+#: ../../../core/core_st.cpp:204
 msgid "Internal error: Invalid oflag or pmode argument"
 msgstr "Internt fel: Ogiltig oflag- eller pmodeargument"
 
-#: ../../../core/core_st.cpp:203
+#: ../../../core/core_st.cpp:205
 msgid "invalid!"
 msgstr "ogiltig!"
 
-#: ../../../core/core_st.cpp:204
+#: ../../../core/core_st.cpp:206
 msgid "  Invalid date/time value."
 msgstr "  Felaktigt datum/tidsangivelse."
 
-#: ../../../core/core_st.cpp:205
+#: ../../../core/core_st.cpp:207
 msgid "  Field length is incorrect."
 msgstr "  Fältlängden är felaktig."
 
-#: ../../../core/core_st.cpp:206
+#: ../../../core/core_st.cpp:208
 msgid "Internal error: An invalid flag was specified"
 msgstr "Internt fel: En ogiltig flagga angavs"
 
-#: ../../../core/core_st.cpp:207
+#: ../../../core/core_st.cpp:209
 #, fuzzy, c-format
 msgid "  Invalid header: '%ls' (must be 5 hexadecimal characters)."
 msgstr "  Ogiltig rubrik: '%ls' (måste vara 5 hexadecimala tecken)."
 
-#: ../../../core/core_st.cpp:208
+#: ../../../core/core_st.cpp:210
 #, fuzzy, c-format
 msgid "Invalid lock file \"%ls\"."
 msgstr "Ogiltigt filterschema."
 
-#: ../../../core/core_st.cpp:209
+#: ../../../core/core_st.cpp:211
 #, c-format
 msgid "  Invalid number of saved old passwords %d."
 msgstr "  Felaktigt antal sparade gamla lösenord %d."
 
-#: ../../../core/core_st.cpp:210
+#: ../../../core/core_st.cpp:212
 #, c-format
 msgid "  Invalid status value: %d (must be either 0 or 1)."
 msgstr "  Ogiltigt statusvärde: %d (måste vara antingen 0 eller 1)."
 
-#: ../../../core/core_st.cpp:211
+#: ../../../core/core_st.cpp:213
 msgid "  Invalid password length found (not a hexadecimal number)."
 msgstr "  Ogiltig lösenordslängd hittades (inte ett hexadecimalt tal)"
 
-#: ../../../core/core_st.cpp:212
+#: ../../../core/core_st.cpp:214
 msgid ""
 "  Invalid password length found (differs from length of following password)."
 msgstr ""
 "  Ogiltig lösenordslängd hittades (avviker i längd från följande lösenord)."
 
-#: ../../../core/core_st.cpp:213
+#: ../../../core/core_st.cpp:215
 msgid ""
 "  Invalid field separator character found - only a single blank is allowed "
 "between fields."
@@ -5832,20 +5851,20 @@ msgstr ""
 "  Hittat felaktigt fältavgränsande tecken - endast ett enda blanksteg är "
 "tillåtet mellan fälten."
 
-#: ../../../core/core_st.cpp:214
+#: ../../../core/core_st.cpp:216
 msgid "Invalid Filter schema."
 msgstr "Ogiltigt filterschema."
 
-#: ../../../core/core_st.cpp:215
+#: ../../../core/core_st.cpp:217
 msgid "Schema does not have a version number."
 msgstr "Schemat har inget versionsnummer."
 
-#: ../../../core/core_st.cpp:216
+#: ../../../core/core_st.cpp:218
 #, c-format
 msgid "The filter XML version (%d) is greater than the current schema (%d)."
 msgstr "XML-filtrets version (%d) är större än nuvarande schema (%d)."
 
-#: ../../../core/core_st.cpp:217
+#: ../../../core/core_st.cpp:219
 #, c-format
 msgid ""
 "The filter XML version (%d) is greater than that supported by this instance "
@@ -5854,57 +5873,57 @@ msgstr ""
 "XML-filtrets version (%d) är större än det som stöds av denna session av "
 "PasswordSafe (%d)."
 
-#: ../../../core/core_st.cpp:218
+#: ../../../core/core_st.cpp:220
 msgid "is"
 msgstr "är"
 
-#: ../../../core/core_st.cpp:219
+#: ../../../core/core_st.cpp:221
 msgid "is active"
 msgstr "är aktiv"
 
-#: ../../../core/core_st.cpp:220
+#: ../../../core/core_st.cpp:222
 msgid "is inactive"
 msgstr "är inaktiv"
 
-#: ../../../core/core_st.cpp:221
+#: ../../../core/core_st.cpp:223
 msgid "is not"
 msgstr "är inte"
 
-#: ../../../core/core_st.cpp:222
+#: ../../../core/core_st.cpp:224
 msgid "is not present"
 msgstr "inte aktuell"
 
-#: ../../../core/core_st.cpp:223
+#: ../../../core/core_st.cpp:225
 msgid "is present"
 msgstr "är aktuell"
 
-#: ../../../core/core_st.cpp:224
+#: ../../../core/core_st.cpp:226
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to entry %ls. It "
 "has been removed from the %ls entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:225
+#: ../../../core/core_st.cpp:227
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to the "
 "PasswordSafe application. It has been removed from the entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:226
+#: ../../../core/core_st.cpp:228
 msgid "less than"
 msgstr "mindre än"
 
-#: ../../../core/core_st.cpp:227
+#: ../../../core/core_st.cpp:229
 msgid "less than or equal to"
 msgstr "mindre än eller lika med"
 
-#: ../../../core/core_st.cpp:228
+#: ../../../core/core_st.cpp:230
 msgid "File or path not found"
 msgstr "Fil eller sökväg hittades inte"
 
-#: ../../../core/core_st.cpp:229
+#: ../../../core/core_st.cpp:231
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5913,7 +5932,7 @@ msgstr ""
 "\n"
 "Följande nya%ls %ls slogs samman med denna databas:"
 
-#: ../../../core/core_st.cpp:230
+#: ../../../core/core_st.cpp:232
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5922,7 +5941,7 @@ msgstr ""
 "\n"
 "Sammanslagningen genomförd: %d %ls added (%d %ls, %d %ls, %d %ls)"
 
-#: ../../../core/core_st.cpp:231
+#: ../../../core/core_st.cpp:233
 #, fuzzy, c-format
 msgid ""
 "Conflicting entries for \"%ls\" \"%ls\" \"%ls\".\n"
@@ -5933,60 +5952,60 @@ msgstr ""
 "  La till sammanslagen post som«%ls» «%ls» «%ls».\n"
 "    Skiljande fält(s): %ls"
 
-#: ../../../core/core_st.cpp:232
+#: ../../../core/core_st.cpp:234
 #, fuzzy
 msgid "merged"
 msgstr "Slå ihop"
 
-#: ../../../core/core_st.cpp:233
+#: ../../../core/core_st.cpp:235
 #, fuzzy, c-format
 msgid "%ls - Merged %ls"
 msgstr "%ls - Slå ihop %ls"
 
-#: ../../../core/core_st.cpp:234
+#: ../../../core/core_st.cpp:236
 msgid "MISSING PASSWORD"
 msgstr ""
 
-#: ../../../core/core_st.cpp:235
+#: ../../../core/core_st.cpp:237
 #, c-format
 msgid "\tPassword policy name '%ls' is not in the database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:236
+#: ../../../core/core_st.cpp:238
 msgid ""
 "\tOne or more Password Policy Names were not found in the database. The "
 "affected entries have been changed to use the database's default policy."
 msgstr ""
 
-#: ../../../core/core_st.cpp:237
+#: ../../../core/core_st.cpp:239
 #, c-format
 msgid "MISSING TITLE # %d"
 msgstr ""
 
-#: ../../../core/core_st.cpp:239
+#: ../../../core/core_st.cpp:241
 msgid "Can't obtain the schema version."
 msgstr "Kan inte hitta schemaversionen."
 
-#: ../../../core/core_st.cpp:240
+#: ../../../core/core_st.cpp:242
 msgid "The filter XML version is missing."
 msgstr "XML-filtrets version saknas."
 
-#: ../../../core/core_st.cpp:241
+#: ../../../core/core_st.cpp:243
 #, fuzzy, c-format
 msgid "Create SchemaCache60 Error 0x%08X during %ls."
 msgstr "Skapa SchemaCache%2d Fel 0x%08X vid %ls."
 
-#: ../../../core/core_st.cpp:242
+#: ../../../core/core_st.cpp:244
 #, fuzzy, c-format
 msgid "SAX Parse60 Error 0x%08X during %ls."
 msgstr "SAX parse%2d fel 0x%08X under %ls."
 
-#: ../../../core/core_st.cpp:243
+#: ../../../core/core_st.cpp:245
 #, fuzzy, c-format
 msgid "Error (%08X): line %d character %d %ls"
 msgstr "Fel (%08X): rad %d tecken %d %ls"
 
-#: ../../../core/core_st.cpp:245
+#: ../../../core/core_st.cpp:247
 msgid ""
 "Unable to get configuration file lock.\n"
 "\n"
@@ -5996,15 +6015,15 @@ msgstr ""
 "\n"
 "Använder registret."
 
-#: ../../../core/core_st.cpp:246
+#: ../../../core/core_st.cpp:248
 msgid "Cannot create lock file - no permission in directory?"
 msgstr "Kan inte skapa nyckelfil - saknar du rättigheter i mappen?"
 
-#: ../../../core/core_st.cpp:247
+#: ../../../core/core_st.cpp:249
 msgid "Internal error: Out of file handles"
 msgstr "Internt fel: Slut på filhanterare"
 
-#: ../../../core/core_st.cpp:248
+#: ../../../core/core_st.cpp:250
 msgid ""
 "Unable to use a MS XML reader on your system.  Neither MS XML V3, V4 or V6 "
 "seems available."
@@ -6012,15 +6031,15 @@ msgstr ""
 "Kan inte använda en MS XML-läsare i ditt system. Varken MS XML V3, V4 eller "
 "V6 verkar tillgänglig."
 
-#: ../../../core/core_st.cpp:250
+#: ../../../core/core_st.cpp:252
 msgid "Unsaved changes"
 msgstr "Icke sparade ändringar"
 
-#: ../../../core/core_st.cpp:251
+#: ../../../core/core_st.cpp:253
 msgid "is not set"
 msgstr "inte vald"
 
-#: ../../../core/core_st.cpp:252
+#: ../../../core/core_st.cpp:254
 #, fuzzy, c-format
 msgid ""
 "Number of entries processed: %d\n"
@@ -6055,7 +6074,7 @@ msgstr ""
 "\n"
 "Antal poster med fält som inte kan visas fullständigt: %d"
 
-#: ../../../core/core_st.cpp:254
+#: ../../../core/core_st.cpp:256
 msgid ""
 "Password should be mixed case, with at least one digit or punctuation "
 "character"
@@ -6063,92 +6082,133 @@ msgstr ""
 "Lösenordet borde bestå av blandade tecken med åtminståne en siffra eller "
 "interpunkteringstecken"
 
-#: ../../../core/core_st.cpp:255
+#: ../../../core/core_st.cpp:257
 msgid "Password is too short"
 msgstr "Lösenordet är för kort"
 
-#: ../../../core/core_st.cpp:256
+#: ../../../core/core_st.cpp:258
 msgid "Easyvision characters"
 msgstr "Lättlästa tecken"
 
-#: ../../../core/core_st.cpp:257
+#: ../../../core/core_st.cpp:259
 msgid "Hexadecimal characters"
 msgstr "Hexadecimala tecken"
 
-#: ../../../core/core_st.cpp:258
+#: ../../../core/core_st.cpp:260
 #, fuzzy
 msgid "Password length"
 msgstr "Lösenordets längd:"
 
-#: ../../../core/core_st.cpp:259
+#: ../../../core/core_st.cpp:261
 msgid "Pronounceable passwords"
 msgstr "Uttalbara lösenord"
 
-#: ../../../core/core_st.cpp:261
+#: ../../../core/core_st.cpp:263
 #, fuzzy
 msgid "Use lowercase characters"
 msgstr "Minsta antal versala tecken"
 
-#: ../../../core/core_st.cpp:263
+#: ../../../core/core_st.cpp:265
 #, fuzzy
 msgid "Use uppercase characters"
 msgstr "Minsta antal versala tecken"
 
-#: ../../../core/core_st.cpp:264
+#: ../../../core/core_st.cpp:266
 #, fuzzy, c-format
 msgid "Error in a Password History %ls:"
 msgstr "Fel i en lösenordshistorik %ls:"
 
-#: ../../../core/core_st.cpp:265
+#: ../../../core/core_st.cpp:267
 #, c-format
 msgid "sub-field starting at position %d (within the History field): "
 msgstr "underfält börjar vid positionen %d (inom Historik-fältet):"
 
-#: ../../../core/core_st.cpp:266
+#: ../../../core/core_st.cpp:268
 msgid "  All Password History ignored."
 msgstr "  All lösenordshistorik har ignorerats."
 
-#: ../../../core/core_st.cpp:267
+#: ../../../core/core_st.cpp:269
 msgid "Read Error"
 msgstr "Läsfel"
 
-#: ../../../core/core_st.cpp:268
+#: ../../../core/core_st.cpp:270
+msgid "Relative"
+msgstr "Relativt"
+
+#: ../../../core/core_st.cpp:271
 #, c-format
 msgid ""
 "\tOne or more entry keyboard shortcuts were already assigned to entries in "
 "this database. They have been removed from the %ls entries."
 msgstr ""
 
-#: ../../../core/core_st.cpp:269
+#: ../../../core/core_st.cpp:272
 msgid ""
 "\tOne or more Password Policy Names were already in this database but had "
 "different settings. They have been renamed."
 msgstr ""
 
-#: ../../../core/core_st.cpp:270
+#: ../../../core/core_st.cpp:273
 #, fuzzy, c-format
 msgid "%ls%ls%ls_Report.txt"
 msgstr "%ls%ls%ls_Rapport.txt"
 
-#: ../../../core/core_st.cpp:271
+#: ../../../core/core_st.cpp:274
 #, fuzzy, c-format
 msgid "Report of %ls function started at %ls"
 msgstr "Rapport på funktionen %ls som startade %ls "
 
-#: ../../../core/core_st.cpp:272
+#: ../../../core/core_st.cpp:275
 #, fuzzy, c-format
 msgid "on database %ls"
 msgstr "på databas %ls"
 
-#: ../../../core/core_st.cpp:273
+#: ../../../core/core_st.cpp:276
+msgid "Compare"
+msgstr "Jämför"
+
+#: ../../../core/core_st.cpp:277
+#, fuzzy
+msgid "Export_DB"
+msgstr "&Exportera"
+
+#: ../../../core/core_st.cpp:278
+msgid "Export_Text"
+msgstr "Exporterad_Text"
+
+#: ../../../core/core_st.cpp:279
+msgid "Export_XML"
+msgstr "Exporterad_XML"
+
+#: ../../../core/core_st.cpp:281
+msgid "Import_KeePassV1_CSV"
+msgstr "Importera_KeePassV1_CSV"
+
+#: ../../../core/core_st.cpp:282
+msgid "Import_KeePassV1_TXT"
+msgstr "Importera_KeePassV1_TXT"
+
+#: ../../../core/core_st.cpp:283
+msgid "Import_Text"
+msgstr "Importera_text"
+
+#: ../../../core/core_st.cpp:284
+msgid "Import_XML"
+msgstr "Importera_XML"
+
+#: ../../../core/core_st.cpp:285
+msgid "Merge"
+msgstr "Slå ihop"
+
+#: ../../../core/core_st.cpp:287
 msgid "Validate"
 msgstr "Validera"
 
-#: ../../../core/core_st.cpp:275
+#: ../../../core/core_st.cpp:289
 msgid "Fatal Error"
 msgstr "Fatalt fel"
 
-#: ../../../core/core_st.cpp:277
+#: ../../../core/core_st.cpp:291
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -6157,117 +6217,127 @@ msgstr ""
 "\n"
 "Fel i lösenordshistoriken för post: »%ls»%ls»%ls»: "
 
-#: ../../../core/core_st.cpp:278
+#: ../../../core/core_st.cpp:292
+#, fuzzy, c-format
+msgid "\tNo entries were found containing search string '%ls' %ls"
+msgstr "\tInga poster hittades som innehåller söksträngen '%s'"
+
+#: ../../../core/core_st.cpp:293
+#, fuzzy, c-format
+msgid "\tThe following entries contain search string '%ls' %ls"
+msgstr "\tFöljande poster innehåller söksträngen '%s'"
+
+#: ../../../core/core_st.cpp:294
 msgid "See Attachment filters"
 msgstr ""
 
-#: ../../../core/core_st.cpp:279
+#: ../../../core/core_st.cpp:295
 msgid "See Password History filters"
 msgstr "Se lösenords historiska filter"
 
-#: ../../../core/core_st.cpp:280
+#: ../../../core/core_st.cpp:296
 msgid "See Password Policy filters"
 msgstr "Se lösenords policyfilter"
 
-#: ../../../core/core_st.cpp:281
+#: ../../../core/core_st.cpp:297
 msgid "is set"
 msgstr "är vald"
 
-#: ../../../core/core_st.cpp:282
+#: ../../../core/core_st.cpp:298
 msgid "shortcut"
 msgstr "genväg"
 
-#: ../../../core/core_st.cpp:283
+#: ../../../core/core_st.cpp:299
 msgid "shortcuts"
 msgstr "genvägar"
 
-#: ../../../core/core_st.cpp:284
+#: ../../../core/core_st.cpp:300
 msgid "policy specific symbols"
 msgstr ""
 
-#: ../../../core/core_st.cpp:285
+#: ../../../core/core_st.cpp:301
 msgid "Start Report"
 msgstr "Att rapportera"
 
-#: ../../../core/core_st.cpp:286
+#: ../../../core/core_st.cpp:302
 msgid "Double-Click on entry to Autotype"
 msgstr "Dubbelklicka på posten för att autoskriva"
 
-#: ../../../core/core_st.cpp:287
+#: ../../../core/core_st.cpp:303
 msgid "Double-Click on entry to Browse to URL"
 msgstr "Dubbelklicka på posten för att gå till URL"
 
-#: ../../../core/core_st.cpp:288
+#: ../../../core/core_st.cpp:304
 msgid "Double-Click on entry to Browse to URL + Autotype"
 msgstr "Dubbelklicka på posten för att gå till URL + autoskriva"
 
-#: ../../../core/core_st.cpp:289
+#: ../../../core/core_st.cpp:305
 #, fuzzy
 msgid "https://pwsafe.org/"
 msgstr "https://pwsafe.org/"
 
-#: ../../../core/core_st.cpp:290
+#: ../../../core/core_st.cpp:306
 msgid "Double-Click on entry to Copy Notes"
 msgstr "Dubbelklicka på posten för att kopiera noteringar"
 
-#: ../../../core/core_st.cpp:291
+#: ../../../core/core_st.cpp:307
 msgid "Double-Click on entry to Copy Password"
 msgstr "Dubbelklicka på posten för att kopiera lösenordet"
 
-#: ../../../core/core_st.cpp:292
+#: ../../../core/core_st.cpp:308
 msgid "Double-Click on entry to Copy Password and Minimize"
 msgstr "Dubbelklicka på posten för att kopiera lösenordet och minimera"
 
-#: ../../../core/core_st.cpp:293
+#: ../../../core/core_st.cpp:309
 msgid "Double-Click on entry to Copy Username"
 msgstr "Dubbelklicka på posten för att kopiera användarnamnet"
 
-#: ../../../core/core_st.cpp:294
+#: ../../../core/core_st.cpp:310
 msgid "Double-Click on entry to Run Command"
 msgstr "Dubbelklicka på posten för att köra kommandot"
 
-#: ../../../core/core_st.cpp:295
+#: ../../../core/core_st.cpp:311
 #, fuzzy
 msgid "Double-Click on entry to Send Email"
 msgstr "Dubbelklicka på posten för att skicka e-post"
 
-#: ../../../core/core_st.cpp:296
+#: ../../../core/core_st.cpp:312
 msgid "Double-Click on entry to View/Edit it"
 msgstr "Dubbelklicka på posten för att visa/redigera"
 
-#: ../../../core/core_st.cpp:299
+#: ../../../core/core_st.cpp:315
 #, fuzzy, c-format
 msgid "%ls - Sync'd %ls"
 msgstr "%ls på %ls"
 
-#: ../../../core/core_st.cpp:300
+#: ../../../core/core_st.cpp:316
 msgid "System error: No more file handles available"
 msgstr "Systemfel: Finns inga fler fil-hanterare"
 
-#: ../../../core/core_st.cpp:303
+#: ../../../core/core_st.cpp:319
 msgid "Unknown function"
 msgstr "Okänd funktion"
 
-#: ../../../core/core_st.cpp:304
+#: ../../../core/core_st.cpp:320
 msgid "Unknown object"
 msgstr "Okänt objekt"
 
-#: ../../../core/core_st.cpp:305
+#: ../../../core/core_st.cpp:321
 msgid "Internal error: Unexpected error number"
 msgstr "Internt fel: oväntat felnummer"
 
-#: ../../../core/core_st.cpp:307
+#: ../../../core/core_st.cpp:323
 #, c-format
 msgid "\tName: %s; Filename: %s"
 msgstr ""
 
-#: ../../../core/core_st.cpp:308
+#: ../../../core/core_st.cpp:324
 msgid ""
 "The following entries had an invalid UUID field.  This has been corrected."
 msgstr ""
 "Följande poster innehöll ett ogiltigt UUID-fält.  Detta har korrigerats."
 
-#: ../../../core/core_st.cpp:309
+#: ../../../core/core_st.cpp:325
 #, fuzzy, c-format
 msgid ""
 "The following entries have passwords in the correct form for %ls, but the "
@@ -6276,18 +6346,18 @@ msgstr ""
 "Posten\"%ls, %ls, %ls\" har ett lösenord i rätt format för en alias, men "
 "basposten finns inte."
 
-#: ../../../core/core_st.cpp:310
+#: ../../../core/core_st.cpp:326
 msgid "The following entries were duplicates of an existing entry."
 msgstr "Följande poster är duplikat av en existerande post."
 
-#: ../../../core/core_st.cpp:311
+#: ../../../core/core_st.cpp:327
 #, fuzzy
 msgid ""
 "The following entries had a duplicate UUID field.  This has been corrected."
 msgstr ""
 "Följande poster innehöll ett ogiltigt UUID-fält.  Detta har korrigerats."
 
-#: ../../../core/core_st.cpp:312
+#: ../../../core/core_st.cpp:328
 #, fuzzy, c-format
 msgid ""
 "The following entries had an empty Password field, which is not permitted. "
@@ -6295,37 +6365,37 @@ msgid ""
 msgstr ""
 "Följande poster innehöll ett ogiltigt UUID-fält.  Detta har korrigerats."
 
-#: ../../../core/core_st.cpp:313
+#: ../../../core/core_st.cpp:329
 #, fuzzy
 msgid "The following entries had an empty Title field, which is not permitted."
 msgstr ""
 "Följande poster innehöll ett ogiltigt UUID-fält.  Detta har korrigerats."
 
-#: ../../../core/core_st.cpp:314
+#: ../../../core/core_st.cpp:330
 #, fuzzy, c-format
 msgid "\tGroup='%ls', Title='%ls', User='%ls' %ls"
 msgstr "\tGrupp='%ls'; Titel='%ls'; Användare='%ls' %ls"
 
-#: ../../../core/core_st.cpp:315
+#: ../../../core/core_st.cpp:331
 #, fuzzy, c-format
 msgid "- Its title has been changed to:'%ls'"
 msgstr "- Dess titel har ändrats till:'%ls'"
 
-#: ../../../core/core_st.cpp:316
+#: ../../../core/core_st.cpp:332
 msgid "The following ERRORS were detected and were FIXED."
 msgstr ""
 
-#: ../../../core/core_st.cpp:317
+#: ../../../core/core_st.cpp:333
 #, fuzzy
 msgid "The following entries refer to missing attachments."
 msgstr "Följande poster är duplikat av en existerande post."
 
-#: ../../../core/core_st.cpp:318
+#: ../../../core/core_st.cpp:334
 #, fuzzy
 msgid "The following attachments are not referred to by any entry."
 msgstr "Följande poster är duplikat av en existerande post."
 
-#: ../../../core/core_st.cpp:319
+#: ../../../core/core_st.cpp:335
 msgid ""
 "The following entries had an invalid Password History.  This has been "
 "rebuilt with available data.  There may be some loss of history."
@@ -6333,24 +6403,24 @@ msgstr ""
 "Följande poster hade en ogiltig lösenordshistorik. Denna har återskapats med "
 "tillgängliga data. Det kan förekomma viss förlust av historik."
 
-#: ../../../core/core_st.cpp:320
+#: ../../../core/core_st.cpp:336
 #, c-format
 msgid ""
 "The following entries have one or more text fields too long to display or "
 "edit (over %d characters).  The largest entry size found was ~%d %ls."
 msgstr ""
 
-#: ../../../core/core_st.cpp:321
+#: ../../../core/core_st.cpp:337
 msgid ""
 "The following WARNINGS were detected - you should review and fix them "
 "manually."
 msgstr ""
 
-#: ../../../core/core_st.cpp:324
+#: ../../../core/core_st.cpp:340
 msgid "will expire"
 msgstr "går ut"
 
-#: ../../../core/core_st.cpp:325
+#: ../../../core/core_st.cpp:341
 #, fuzzy, c-format
 msgid ""
 "SAX Parse Error during %ls\n"
@@ -6359,21 +6429,21 @@ msgstr ""
 "SAX parsefel i %ls\n"
 "%ls."
 
-#: ../../../core/core_st.cpp:326
+#: ../../../core/core_st.cpp:342
 #, fuzzy, c-format
 msgid "XML %ls: line %d character %d: %ls"
 msgstr "XML %ls: rad %d tecken %d: %ls"
 
-#: ../../../core/core_st.cpp:327
+#: ../../../core/core_st.cpp:343
 msgid ""
 "*** Invalid XML characters found - see exported XML file for more details ***"
 msgstr ""
 
-#: ../../../core/core_st.cpp:328
+#: ../../../core/core_st.cpp:344
 msgid "Internal error: Couldn't initialize config file XML structure"
 msgstr "Internt fel: Kunde inte initiera konfigurationsfilens XML-struktur"
 
-#: ../../../core/core_st.cpp:329
+#: ../../../core/core_st.cpp:345
 msgid ""
 "A filter was active. Export of data was restricted to include only those "
 "displayed."
@@ -6381,31 +6451,31 @@ msgstr ""
 "Ett filter var aktivt. Export av data begränsades till att bara inkludera de "
 "som visas."
 
-#: ../../../core/core_st.cpp:330
+#: ../../../core/core_st.cpp:346
 msgid "Export of data was restricted to certain fields by the user."
 msgstr "Export av data begränsades till vissa fält av användaren."
 
-#: ../../../core/core_st.cpp:331
+#: ../../../core/core_st.cpp:347
 msgid ""
 "Note: These Password Policies will not replace existing policies with the "
 "same name in the current database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:332
+#: ../../../core/core_st.cpp:348
 msgid ""
 "Note: These preferences are only used when importing into an empty database."
 msgstr "Not: Dessa preferenser används bara vid import till en tom databas."
 
-#: ../../../core/core_st.cpp:333
+#: ../../../core/core_st.cpp:349
 msgid "Subset of entries restricted by the following rule:"
 msgstr "Delmängd av poster vilka begränsas av följande regel:"
 
-#: ../../../core/core_st.cpp:334
+#: ../../../core/core_st.cpp:350
 msgid ""
 "The user specified that the following fields be excluded from the export:"
 msgstr "Användaren specificerade att följande fält ska uteslutas vid export:"
 
-#: ../../../core/core_st.cpp:335
+#: ../../../core/core_st.cpp:351
 #, fuzzy, c-format
 msgid ""
 "Configuration file error:\n"
@@ -6418,15 +6488,15 @@ msgstr ""
 "%ls\n"
 "rad %d kolumn %d"
 
-#: ../../../core/core_st.cpp:336
+#: ../../../core/core_st.cpp:352
 msgid "import"
 msgstr "import"
 
-#: ../../../core/core_st.cpp:337
+#: ../../../core/core_st.cpp:353
 msgid "Unable to load configuration file"
 msgstr "Kan inte starta konfigurationsfilen"
 
-#: ../../../core/core_st.cpp:338
+#: ../../../core/core_st.cpp:354
 msgid ""
 "Failed to lock configuration file - opened by another instance of "
 "PasswordSafe?"
@@ -6434,110 +6504,57 @@ msgstr ""
 "Kunde inte låsa konfigurationsfilen - öppnad av en annan instans av "
 "PasswordSafe?"
 
-#: ../../../core/core_st.cpp:339
+#: ../../../core/core_st.cpp:355
 msgid "Unable to save configuration file"
 msgstr "Kan inte spara konfigurationsfilen"
 
-#: ../../../core/core_st.cpp:340
+#: ../../../core/core_st.cpp:356
 #, fuzzy
 msgid "validation"
 msgstr "validering"
 
-#: ../../../core/core_st.cpp:342
+#: ../../../core/core_st.cpp:358
 msgid " (EasyVision Symbols)"
 msgstr ""
 
-#: ../../../core/core_st.cpp:343
+#: ../../../core/core_st.cpp:359
 #, fuzzy, c-format
 msgid "Yes (at least %d)"
 msgstr "Måste vara åtminstonde %d"
 
-#: ../../../core/core_st.cpp:344
+#: ../../../core/core_st.cpp:360
 #, fuzzy
 msgid " (Pronounceable Symbols)"
 msgstr "Uttalbara lösenord"
 
-#: ../../../core/core_st.cpp:345
+#: ../../../core/core_st.cpp:361
 #, c-format
 msgid "Yes - At least %d from %ls: %ls%ls"
 msgstr ""
 
-#: ../../../core/core_st.cpp:346
 #, fuzzy, c-format
-msgid "\tGroup='%ls', Title='%ls', User='%ls'"
-msgstr "\tGrupp='%ls'; Titel='%ls'; Användare='%ls' %ls"
+#~ msgid "\tGroup='%ls', Title='%ls', User='%ls'"
+#~ msgstr "\tGrupp='%ls'; Titel='%ls'; Användare='%ls' %ls"
 
-#: ../../../core/core_st.cpp:347
-#, fuzzy, c-format
-msgid ""
-"Compare complete of current database:\n"
-"\t %ls\n"
-" and:\n"
-"\t %ls\n"
-msgstr ""
-"Jämförelsen klar med nuvarande databas:\n"
-"\t %s\n"
-" och:\n"
-"\t %s"
-
-#: ../../../core/core_st.cpp:348
-#, fuzzy, c-format
-msgid "\tNo entries were found containing search string '%ls' %ls"
-msgstr "\tInga poster hittades som innehåller söksträngen '%s'"
-
-#: ../../../core/core_st.cpp:349
-#, fuzzy, c-format
-msgid "\tThe following entries contain search string '%ls' %ls"
-msgstr "\tFöljande poster innehåller söksträngen '%s'"
-
-#: ../../../core/core_st.cpp:350
 #, fuzzy
-msgid "Export DB"
-msgstr "&Exportera"
+#~ msgid "Import KeePassV1 CSV"
+#~ msgstr "Importera KeePass V1 CSV"
 
-#: ../../../core/core_st.cpp:351
 #, fuzzy
-msgid "Import KeePassV1 CSV"
-msgstr "Importera KeePass V1 CSV"
+#~ msgid "Import KeePassV1 TXT"
+#~ msgstr "Importera KeePass V1 TXT"
 
-#: ../../../core/core_st.cpp:352
 #, fuzzy
-msgid "Import KeePassV1 TXT"
-msgstr "Importera KeePass V1 TXT"
+#~ msgid "Import XML"
+#~ msgstr ""
+#~ "\n"
+#~ "Importerad XML"
 
-#: ../../../core/core_st.cpp:353
 #, fuzzy
-msgid "Import XML"
-msgstr ""
-"\n"
-"Importerad XML"
-
-#: ../../../core/core_st.cpp:354
-#, fuzzy
-msgid "Import Text"
-msgstr ""
-"\n"
-"Importerad text"
-
-#: ../../../core/core_st.cpp:355
-msgid "Merge"
-msgstr "Slå ihop"
-
-#: ../../../core/core_st.cpp:356
-msgid "Compare"
-msgstr "Jämför"
-
-#~ msgid "Import_Text"
-#~ msgstr "Importera_text"
-
-#~ msgid "Import_XML"
-#~ msgstr "Importera_XML"
-
-#~ msgid "Import_KeePassV1_CSV"
-#~ msgstr "Importera_KeePassV1_CSV"
-
-#~ msgid "Import_KeePassV1_TXT"
-#~ msgstr "Importera_KeePassV1_TXT"
+#~ msgid "Import Text"
+#~ msgstr ""
+#~ "\n"
+#~ "Importerad text"
 
 #, fuzzy
 #~ msgid "Advanced..."
@@ -7994,12 +8011,6 @@ msgstr "Jämför"
 #~ "Exportfil: '%s' finns redan.\n"
 #~ "Vill du ersätta den?"
 
-#~ msgid "Export_Text"
-#~ msgstr "Exporterad_Text"
-
-#~ msgid "Export_XML"
-#~ msgstr "Exporterad_XML"
-
 #~ msgid "Exporting to file:"
 #~ msgstr "Exporterar till fil:"
 
@@ -8768,9 +8779,6 @@ msgstr "Jämför"
 #~ "Återskapa de auto-sparade dokumenten\n"
 #~ "Öppna de auto-sparade versionerna istället för de aktivt sparade "
 #~ "versionerna"
-
-#~ msgid "Relative"
-#~ msgstr "Relativt"
 
 #~ msgid ""
 #~ "Relative dates are in days relative to today e.g. '-1' is yesterday and "
@@ -10072,9 +10080,6 @@ msgstr "Jämför"
 #~ msgstr ""
 #~ "\tPost - Grupp:\"%s\"; Titel:\"%s\"; Användare:\"%s\"\n"
 #~ "\t\thar skillnader i följande fält:"
-
-#~ msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-#~ msgstr "\tGrupp:'%s'; Titel:'%s'; Användare:'%s'"
 
 #~ msgid ""
 #~ "\tThe following restrictions were selected:\n"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_zh.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_zh.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-28 12:52+0100\n"
+"POT-Creation-Date: 2021-03-19 21:58+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr "日期和时间"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:348
 #: ../../../ui/wxWidgets/HelpMap.h:41 ../../../ui/wxWidgets/HelpMap.h:49
-#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:141
+#: ../../../ui/wxWidgets/PasswordPolicyDlg.h:69 ../../../core/core_st.cpp:143
 msgid "Password Policy"
 msgstr "密码策略"
 
@@ -248,7 +248,7 @@ msgid "Set Date/Time"
 msgstr "设定日期/时间"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:370
-#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:137
+#: ../../../ui/wxWidgets/ToolbarButtons.h:203 ../../../core/core_st.cpp:139
 msgid "Password"
 msgstr "密码"
 
@@ -531,14 +531,14 @@ msgstr "使用大写字母(&U)"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:747
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:281
-#: ../../../core/core_st.cpp:260
+#: ../../../core/core_st.cpp:262
 #, fuzzy
 msgid "Use digits"
 msgstr "使用数字(&D)"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:771
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:305
-#: ../../../core/core_st.cpp:262
+#: ../../../core/core_st.cpp:264
 #, fuzzy
 msgid "Use symbols"
 msgstr "默认用户名"
@@ -573,7 +573,7 @@ msgstr "生成可发音密码(&P)"
 
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:815
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:350
-#: ../../../core/core_st.cpp:253
+#: ../../../core/core_st.cpp:255
 msgid "Or"
 msgstr "或"
 
@@ -621,7 +621,7 @@ msgstr "属性"
 #: ../../../ui/wxWidgets/CreateShortcutDlg.cpp:219
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:269
 #: ../../../ui/wxWidgets/EditShortcutDlg.cpp:274
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
 msgid "Text"
 msgstr "文本"
 
@@ -677,7 +677,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:160
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:173
 #: ../../../ui/wxWidgets/PropertiesDlg.cpp:192
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:301
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:202 ../../../core/core_st.cpp:317
 msgid "Unknown"
 msgstr "未知"
 
@@ -792,7 +792,7 @@ msgstr "[备注已隐藏 - 单击这里显示]"
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:1653
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2145
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2820
-#: ../../../core/core_st.cpp:74
+#: ../../../core/core_st.cpp:76
 msgid "Default Policy"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:144
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:151
 #: ../../../ui/wxWidgets/DbSelectionPanel.cpp:159
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:200
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:201
 #: ../../../ui/wxWidgets/PWSafeApp.cpp:367
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:737
 #: ../../../ui/wxWidgets/PasswordPolicyDlg.cpp:756
@@ -837,7 +837,7 @@ msgstr ""
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:249
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:277
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:316
-#: ../../../core/core_st.cpp:274
+#: ../../../core/core_st.cpp:288
 msgid "Error"
 msgstr "错误"
 
@@ -1009,7 +1009,7 @@ msgid "Synchronize this item..."
 msgstr "同步(&Y)..."
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:482
-#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:357
+#: ../../../ui/wxWidgets/CompareDlg.cpp:786 ../../../core/core_st.cpp:286
 msgid "Synchronize"
 msgstr "同步"
 
@@ -1091,8 +1091,8 @@ msgid "Current safe was opened read-only"
 msgstr "打开为只读"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:793
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:996
-#: ../../../ui/wxWidgets/SyncWizard.cpp:618
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
+#: ../../../ui/wxWidgets/SyncWizard.cpp:619
 #, fuzzy, c-format
 msgid ""
 "The database:\n"
@@ -1109,7 +1109,7 @@ msgstr ""
 "有重复项目相同的 组/标题/用户 密码。请调整确认数据库！"
 
 #: ../../../ui/wxWidgets/CompareDlg.cpp:794
-#: ../../../ui/wxWidgets/SyncWizard.cpp:617
+#: ../../../ui/wxWidgets/SyncWizard.cpp:618
 msgid "Synchronization failed"
 msgstr "同步失败"
 
@@ -1467,7 +1467,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/GridCtrl.cpp:164
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:292
-#: ../../../core/core_st.cpp:147
+#: ../../../core/core_st.cpp:149
 msgid "Title"
 msgstr "标题"
 
@@ -1690,7 +1690,7 @@ msgid "Value"
 msgstr "值:"
 
 #: ../../../ui/wxWidgets/ManagePasswordPoliciesDlg.cpp:291
-#: ../../../core/core_st.cpp:133
+#: ../../../core/core_st.cpp:135
 msgid "Group"
 msgstr "组"
 
@@ -1775,17 +1775,17 @@ msgstr ""
 msgid "Error parsing Run Command"
 msgstr "错误分析运行命令"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:56
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:57
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:355
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:362
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:166
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:623
 msgid "Write Error"
 msgstr "写入错误！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:61
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:62
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:165
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:622
 #, fuzzy
@@ -1795,7 +1795,7 @@ msgstr ""
 "\n"
 "不能写入打开的文件！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:64
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:65
 msgid ""
 "Write operation failed!\n"
 "File may have been corrupted.\n"
@@ -1805,7 +1805,7 @@ msgstr ""
 "文件可能已经被破坏！\n"
 "请尝试保存在一个不同的位置！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:69
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:70
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 #, fuzzy
 msgid "Unknown error"
@@ -1814,36 +1814,36 @@ msgstr ""
 "\n"
 "未知错误！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:90
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:91
 #, fuzzy
 msgid "Do you want to save changes to the password database: "
 msgstr "你是否需要保存更改到密码数据库: %s？"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:145
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:146
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:557
 msgid "Please choose a name for the new database"
 msgstr "请选择作为新建数据库的名称"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:155
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:156
 #, fuzzy
 msgid "psafe3 files (*.psafe3)|*.psafe3|All files(*.*; *)|*.*;*"
 msgstr "Password Safe 数据库 (*.psafe3)|*.psafe3|所有文件 (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Lock is done by yourself"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:184
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:185
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:420
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:439
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:592
 msgid "Remove Lock?"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:194
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:195
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:602
 #, fuzzy
 msgid "Could not lock file.\n"
@@ -1852,18 +1852,18 @@ msgstr ""
 "\n"
 "不能读取打开的文件！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:196
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:197
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:452
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:604
 msgid "Locked by "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:236
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:237
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:515
 msgid "Please Choose a Database to Open:"
 msgstr "请选择打开一个数据库"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:353
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:354
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Save database elsewhere or with "
@@ -1872,19 +1872,19 @@ msgid ""
 "Click 'No' to exit without saving."
 msgstr "%s. 选择尝试保存数据库为其它名称或退出不保存！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:360
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:361
 #, fuzzy
 msgid ""
 "Unable to create intermediate backup.  Do you wish to save changes to your "
 "database without it?"
 msgstr "%s. 选择尝试保存数据库为其它名称或退出不保存！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:367
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:375
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:368
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:376
 msgid "Unable to create intermediate backup."
 msgstr "不能创建中间备份！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:386
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:387
 #, c-format
 msgid ""
 "The original database, \"%ls\", is in pre-3.0 format. It will be unchanged.\n"
@@ -1893,12 +1893,12 @@ msgid ""
 "the \"File->Export To-> Old (1.x or 2) format\" command."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:388
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:389
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:447
 msgid "File version warning"
 msgstr "文件版本警告"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:445
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:446
 #, c-format
 msgid ""
 "The original database, '%ls', is in pre-3.0 format. The data will now be "
@@ -1907,15 +1907,15 @@ msgid ""
 "Old (1.x or 2) format' command."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:458
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
 msgid "Please choose a name for the current (Untitled) database:"
 msgstr "请选择作为当前(未命名)数据库的名称"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:459
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:460
 msgid "Please choose a new name for the current database:"
 msgstr "请选择作为当前数据库的新名称"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:467
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:468
 #, fuzzy
 msgid ""
 "Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|"
@@ -1923,7 +1923,7 @@ msgid ""
 msgstr ""
 "Password Safe 数据库 (*.psafe3; *.dat)|*.psafe3; *.dat|所有文件 (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:479
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -1934,141 +1934,141 @@ msgstr ""
 "\n"
 "文件当前被锁定在 %ls！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:480
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:481
 msgid "File lock error"
 msgstr "文件锁定错误！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:547
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
 #, fuzzy
 msgid "Do you wish to save this restored database as new database?"
 msgstr "你是否需要保存更改到密码数据库: %s？"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:548
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:549
 #, fuzzy
 msgid "Unsaved restored database"
 msgstr "在数据库"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:580
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:581
 #, fuzzy
 msgid "Do you want to save changes to the password database"
 msgstr "你是否需要保存更改到密码数据库: %s？"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:617
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:618
 msgid "Export Text"
 msgstr "导出文本"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:621
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:622
 #, fuzzy
 msgid "Export Text failed"
 msgstr "导入文本失败！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:623
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
 msgid "Please name the plaintext file"
 msgstr "请命名纯文本文件"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:624
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1143
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:625
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1144
 #, fuzzy
 msgid ""
 "Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"
 msgstr "文本文件 (*.txt)|*.txt|CSV 文件 (*.csv)|*.csv|所有文件 (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:634
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:635
 msgid "Advanced Text Export Options"
 msgstr "高级文本文件导出选项"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:654
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:697
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:655
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:698
 #, fuzzy
 msgid "export"
 msgstr "导出"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:660
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:661
 msgid "Export XML"
 msgstr "导出 XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:664
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:665
 #, fuzzy
 msgid "Export XML failed"
 msgstr "导入 XML 失败！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:666
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
 msgid "Please name the XML file"
 msgstr "请命名 XML 文件！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:667
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:668
 #, fuzzy
 msgid "XML files (*.xml)|*.xml|All files (*.*; *)|*.*;*"
 msgstr "XML 文件 (*.xml)|*.xml|所有文件 (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:678
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:679
 msgid "Advanced XML Export Options"
 msgstr "高级 XML 导出选项"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:712
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:716
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:713
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:717
 #, fuzzy
 msgid "Password Safe Databases (*.dat)|*.dat|All files (*.*; *)|*.*;*"
 msgstr ""
 "Password Safe 数据库 (*.psafe3; *.dat)|*.psafe3; *.dat|所有文件 (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:720
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:721
 #, fuzzy
 msgid "Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*"
 msgstr ""
 "Password Safe 数据库 (*.psafe3; *.dat)|*.psafe3; *.dat|所有文件 (*.*)|*.*||"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:731
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:732
 msgid "Please name the exported database"
 msgstr "请命名导出的数据库"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:748
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:749
 msgid "Could not figure out why PasswordSafeFrame::OnExportVx was invoked"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:782
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:783
 msgid "You must save this database before it can be exported."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 #, fuzzy
 msgid "Exporting database: "
 msgstr "合并数据库: %s\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:828
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:829
 msgid " to "
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:841
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:842
 #, fuzzy
 msgid "Export complete.  Do you wish to see a detailed report?"
 msgstr "你是否需要替换它？"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:852
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:853
 msgid "No entries satisfied your selection criteria and so none were exported!"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:865
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:866
 msgid "Passkey incorrect"
 msgstr "密匙错误！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:873
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
 msgid ""
 "The current database was opened in read-only mode.  You cannot import into "
 "it."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:874
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:875
 #, fuzzy
 msgid "Import text"
 msgstr "导入文本(&T)"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:882
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
 #, fuzzy
 msgid "The database:"
 msgstr "在数据库"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:883
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
 #, fuzzy
 msgid "has duplicate entries with the same group/title/user combination."
 msgstr ""
@@ -2078,33 +2078,33 @@ msgstr ""
 "\n"
 "有重复项目相同的 组/标题/用户 密码。请调整确认数据库！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:884
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
 msgid "  Please fix by validating database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:885
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:931
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:886
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:932
 #, fuzzy
 msgid "Import Text failed"
 msgstr "导入文本失败！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:906
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:907
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 #, fuzzy, c-format
 msgid "%ls file being imported: %ls"
 msgstr "%ls 文件被导入: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:921
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:926
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:223
-#: ../../../ui/wxWidgets/SyncWizard.cpp:572
+#: ../../../ui/wxWidgets/SyncWizard.cpp:573
 #: ../../../ui/wxWidgets/wxUtilities.cpp:59
 #: ../../../ui/wxWidgets/wxUtilities.cpp:64
 #: ../../../ui/wxWidgets/wxUtilities.cpp:71
 msgid "File Read Error"
 msgstr "文件读取错误！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:922
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:923
 #: ../../../ui/wxWidgets/MenuManageHandlers.cpp:222
 #: ../../../ui/wxWidgets/wxUtilities.cpp:58
 #, fuzzy
@@ -2114,7 +2114,7 @@ msgstr ""
 "\n"
 "不能读取打开的文件！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:927
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:928
 #, fuzzy
 msgid "Invalid format"
 msgstr ""
@@ -2122,77 +2122,77 @@ msgstr ""
 "\n"
 "无效格式！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Updated "
 msgstr "已更新 %d %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:944
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
 #, fuzzy
 msgid "Imported "
 msgstr "导入"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entry"
 msgstr "项目"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:945
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:946
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid " entries"
 msgstr "个项目"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:950
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:951
 #, fuzzy
 msgid "Skipped "
 msgstr ""
 "\n"
 "跳过 %d %s"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:957
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:958
 #, fuzzy
 msgid "with Password History errors "
 msgstr ""
 "\n"
 "密码历史错误%d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:964
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:965
 #, fuzzy
 msgid "Renamed "
 msgstr "重命名"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed successfully"
 msgstr "成功完成"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:969
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1063
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1216
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:970
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1064
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1217
 msgid "Completed but ...."
 msgstr "完成，但..."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:981
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1127
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1197
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1218
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1279
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:982
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1128
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1219
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
 #, fuzzy
 msgid "Do you wish to see a detailed report?"
 msgstr "你是否需要替换它？"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:997
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1045
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:998
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1046
 msgid "Import XML failed"
 msgstr "导入 XML 失败！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1007
-#: ../../../core/core_st.cpp:238
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../core/core_st.cpp:240
 #, fuzzy, c-format
 msgid ""
 "Can't find XML Schema Definition file (%ls) in your PasswordSafe Application "
@@ -2202,20 +2202,20 @@ msgstr ""
 "未能找到 XML 模式定义文件 (%ls) 在你的应用程序目录，\n"
 "请从你的安装文件复制它或重新安装本应用程序！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 #, fuzzy
 msgid "Missing XSD File - "
 msgstr "缺少 XSD 文件！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1008
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1009
 msgid " Build"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1030
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1031
 msgid "XML"
 msgstr "XML"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1051
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1052
 #, fuzzy, c-format
 msgid ""
 "File: %ls failed validation against XML Schema:\n"
@@ -2226,7 +2226,7 @@ msgstr ""
 "\n"
 "%ls！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1057
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1058
 #, fuzzy, c-format
 msgid ""
 "File: %ls passed Validation but had the following errors during import:\n"
@@ -2237,61 +2237,61 @@ msgstr ""
 "\n"
 "%ls！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1078
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1079
 msgid "The following records were skipped:"
 msgstr "下列记录被跳过:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1080
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1081
 #, c-format
 msgid " / skipped %d"
 msgstr " / 跳过 %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1085
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1086
 msgid "The following records had errors in their Password History:"
 msgstr "下列历史密码记录存在错误:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1087
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1088
 #, c-format
 msgid " / with Password History errors %d"
 msgstr " / 使用错误历史密码 %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1092
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1093
 msgid ""
 "The following records were renamed as an entry already exists in your "
 "database or in the Import file:"
 msgstr "下列记录被重命名为一个已存在你的数据库或导入文件的项目:"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1094
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1095
 #, c-format
 msgid " / renamed %d"
 msgstr " / 重命名 %d"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1099
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1100
 #, fuzzy, c-format
 msgid ""
 "File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See "
 "report for details."
 msgstr "文件: %ls 被导入 (项目验证 %d / 导入 %d%ls%ls%ls)。请参阅报告的细节。"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:95
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:97
 msgid "entry"
 msgstr "项目"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1104
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1105
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1212
-#: ../../../ui/wxWidgets/SyncWizard.cpp:587
-#: ../../../ui/wxWidgets/SyncWizard.cpp:730
-#: ../../../ui/wxWidgets/SyncWizard.cpp:747 ../../../core/core_st.cpp:93
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:731
+#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:95
 msgid "entries"
 msgstr "个项目"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1106
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1107
 #, fuzzy, c-format
 msgid ""
 "Validated %d %ls\n"
@@ -2302,26 +2302,26 @@ msgstr ""
 "\n"
 "导入 %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1114
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1115
 msgid "XML import not supported in this release"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1117
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1118
 #, c-format
 msgid "XML import: Unexpected return code(%d)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1141
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1142
 msgid "Please Choose a KeePass Text File to Import"
 msgstr "请选择一个要导入存储密码的文本文件"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1163
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1164
 #, fuzzy, c-format
 msgid "Text file being imported: %ls"
 msgstr "Text 文件被导入: %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1180
-#: ../../../ui/wxWidgets/SyncWizard.cpp:602
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/SyncWizard.cpp:603
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2332,11 +2332,11 @@ msgstr ""
 "\n"
 "不能读取打开的文件！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1181
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1182
 msgid "File open error"
 msgstr "打开文件错误！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1195
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1196
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -2347,21 +2347,21 @@ msgstr ""
 "\n"
 "无效格式！"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1198
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1199
 msgid "Import failed"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1213
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1214
 #, fuzzy, c-format
 msgid "Imported %d %ls"
 msgstr "导入 %d %ls"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1265
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1266
 #, fuzzy
 msgid "Merging database: "
 msgstr "合并数据库: %s\n"
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1280
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:1281
 #, fuzzy
 msgid "Merge Complete"
 msgstr "比较完成"
@@ -2456,16 +2456,16 @@ msgid ""
 "Try exiting and restarting program."
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #, fuzzy
 msgid " file '"
 msgstr "管理筛选"
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 msgid "' not readable"
 msgstr ""
 
-#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:218
+#: ../../../ui/wxWidgets/MenuViewHandlers.cpp:220
 #: ../../../ui/wxWidgets/ViewReportDlg.cpp:32
 msgid "View Report"
 msgstr "查看报告"
@@ -2515,7 +2515,7 @@ msgid "Please select a valid file"
 msgstr "请选择报告查看！"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:123
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:249
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:245 ../../../core/core_st.cpp:251
 msgid "None"
 msgstr "无"
 
@@ -2529,7 +2529,7 @@ msgid "Incremented Number [001-999]"
 msgstr "递增数字 [001-999]"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:132
-#: ../../../core/core_st.cpp:66
+#: ../../../core/core_st.cpp:68
 #, fuzzy
 msgid "Copy password to clipboard"
 msgstr "复制密码到剪贴板(&C)"
@@ -2541,37 +2541,37 @@ msgstr "查看/编辑选定项目"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:134
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:623
-#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:62
+#: ../../../ui/wxWidgets/ToolbarButtons.h:208 ../../../core/core_st.cpp:64
 msgid "Autotype"
 msgstr "自动输入"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:135
-#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:63
+#: ../../../ui/wxWidgets/ToolbarButtons.h:209 ../../../core/core_st.cpp:65
 msgid "Browse to URL"
 msgstr "浏览网址"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:136
-#: ../../../core/core_st.cpp:65
+#: ../../../core/core_st.cpp:67
 msgid "Copy notes to clipboard"
 msgstr "复制备注到剪贴板"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:137
-#: ../../../core/core_st.cpp:68
+#: ../../../core/core_st.cpp:70
 msgid "Copy username to clipboard"
 msgstr "复制用户名到剪贴板"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:138
-#: ../../../core/core_st.cpp:67
+#: ../../../core/core_st.cpp:69
 msgid "Copy password to clipboard, minimize"
 msgstr "复制密码到剪贴板后立即最小化"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:139
-#: ../../../core/core_st.cpp:64
+#: ../../../core/core_st.cpp:66
 msgid "Browse to URL + Autotype"
 msgstr "浏览网址+自动输入"
 
 #: ../../../ui/wxWidgets/OptionsPropertySheetDlg.cpp:140
-#: ../../../core/core_st.cpp:69 ../../../core/core_st.cpp:144
+#: ../../../core/core_st.cpp:71 ../../../core/core_st.cpp:146
 msgid "Run Command"
 msgstr "运行命令"
 
@@ -2995,24 +2995,24 @@ msgstr ""
 msgid "Don't show this warning again"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:849
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:854
 msgid "Missing help definition for page \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:850
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
 msgid "\" of \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:855
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:860
 msgid "Missing help definition for window \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:866
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:871
 #, fuzzy
 msgid "Please inform the developers."
 msgstr "请命名该筛选！"
 
-#: ../../../ui/wxWidgets/PWSafeApp.cpp:867
+#: ../../../ui/wxWidgets/PWSafeApp.cpp:872
 msgid "Help Undefined"
 msgstr ""
 
@@ -3746,6 +3746,7 @@ msgid "search"
 msgstr "搜索(&S)"
 
 #: ../../../ui/wxWidgets/PasswordSafeSearch.cpp:427
+#: ../../../core/core_st.cpp:280
 msgid "Find"
 msgstr "查找"
 
@@ -3866,20 +3867,20 @@ msgstr "验证"
 msgid " empty)"
 msgstr ""
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:306
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:182 ../../../core/core_st.cpp:322
 #, fuzzy, c-format
 msgid "%ls on %ls"
 msgstr "%ls 在 %ls 上"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:341
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:357
 msgid "Yes"
 msgstr "是"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:244
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:232 ../../../core/core_st.cpp:246
 msgid "No"
 msgstr "否"
 
-#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:302
+#: ../../../ui/wxWidgets/PropertiesDlg.cpp:234 ../../../core/core_st.cpp:318
 #, fuzzy, c-format
 msgid "In Headers(%ls)/In Entries("
 msgstr "在标题(%ls)/在项目("
@@ -4068,7 +4069,7 @@ msgstr ""
 
 #: ../../../ui/wxWidgets/SafeCombinationEntryDlg.cpp:457
 #: ../../../ui/wxWidgets/SafeCombinationSetupDlg.cpp:269
-#: ../../../core/core_st.cpp:276
+#: ../../../core/core_st.cpp:290
 msgid "Warning"
 msgstr "警告"
 
@@ -4140,11 +4141,11 @@ msgstr ""
 "\n"
 "请尝试其它"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:96
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:38 ../../../core/core_st.cpp:98
 msgid "equals"
 msgstr "等于"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:83
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:39 ../../../core/core_st.cpp:85
 msgid "does not equal"
 msgstr "不等于"
 
@@ -4152,23 +4153,23 @@ msgstr "不等于"
 msgid "begins with"
 msgstr "开始"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:78
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:41 ../../../core/core_st.cpp:80
 msgid "does not begin with"
 msgstr "未开始"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:90
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:42 ../../../core/core_st.cpp:92
 msgid "ends with"
 msgstr "结束"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:82
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:43 ../../../core/core_st.cpp:84
 msgid "does not end with"
 msgstr "未结束"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:56
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:44 ../../../core/core_st.cpp:58
 msgid "contains"
 msgstr "包含"
 
-#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:79
+#: ../../../ui/wxWidgets/SelectionCriteria.cpp:45 ../../../core/core_st.cpp:81
 msgid "does not contain"
 msgstr "不包含"
 
@@ -4227,79 +4228,79 @@ msgstr "确定"
 msgid "Cancel"
 msgstr "取消"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:143
+#: ../../../ui/wxWidgets/SyncWizard.cpp:144
 #, fuzzy
 msgid "synchronize"
 msgstr "同步"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:220
+#: ../../../ui/wxWidgets/SyncWizard.cpp:221
 #, fuzzy
 msgid "Synchronize another database with currently open database"
 msgstr "合并该数据库到当前数据库中:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:349
+#: ../../../ui/wxWidgets/SyncWizard.cpp:350
 msgid "Introduction"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:353
+#: ../../../ui/wxWidgets/SyncWizard.cpp:354
 msgid ""
 "Synchronizing with another database will update the entries in your\n"
 "database with matching entries from the other database."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:356
+#: ../../../ui/wxWidgets/SyncWizard.cpp:357
 msgid "More Info"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:359
+#: ../../../ui/wxWidgets/SyncWizard.cpp:360
 msgid ""
 "1. Two entries from different databases match if their Group, Title\n"
 "and User fields match."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:360
+#: ../../../ui/wxWidgets/SyncWizard.cpp:361
 msgid ""
 "2. You can select the fields to update, as well as filter the entries\n"
 "for synchronization."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:361
+#: ../../../ui/wxWidgets/SyncWizard.cpp:362
 msgid ""
 "3. Only existing entries in your database are updated.  No new entries are\n"
 "added or existing entries removed during this process."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:362
+#: ../../../ui/wxWidgets/SyncWizard.cpp:363
 msgid ""
 "4. You can undo the operation once it is complete, but won't be\n"
 "able to abort it mid-way."
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:379
+#: ../../../ui/wxWidgets/SyncWizard.cpp:380
 #, fuzzy
 msgid "Select another database"
 msgstr "选择数据库"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:381
+#: ../../../ui/wxWidgets/SyncWizard.cpp:382
 msgid "Choose Database to Synchronize with \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:382
+#: ../../../ui/wxWidgets/SyncWizard.cpp:383
 #, fuzzy
 msgid "Please Choose a Database to Synchronize with current database"
 msgstr "请选定一个数据库和当前打开数据库相比较"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:405
+#: ../../../ui/wxWidgets/SyncWizard.cpp:406
 #, fuzzy
 msgid "Synchronization options"
 msgstr "同步失败"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:429
+#: ../../../ui/wxWidgets/SyncWizard.cpp:430
 #, fuzzy
 msgid "Options Summary"
 msgstr "选项"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:454
+#: ../../../ui/wxWidgets/SyncWizard.cpp:455
 #, fuzzy
 msgid ""
 "WARNING!!\n"
@@ -4308,58 +4309,58 @@ msgid ""
 "from your selected input database"
 msgstr "警告: 如果继续，来自你选定输入数据库中现有数据库项目的字段将被更新！"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:471
+#: ../../../ui/wxWidgets/SyncWizard.cpp:472
 msgid " will be updated with corresponding entries from \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:478
+#: ../../../ui/wxWidgets/SyncWizard.cpp:479
 msgid "All fields in matching entries will be updated"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:484
+#: ../../../ui/wxWidgets/SyncWizard.cpp:485
 msgid "Following fields in matching entries will be updated:"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:488
+#: ../../../ui/wxWidgets/SyncWizard.cpp:489
 #, fuzzy
 msgid "Following fields will not be updated:"
 msgstr "下列栏目将被处理:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:507
+#: ../../../ui/wxWidgets/SyncWizard.cpp:508
 #, fuzzy
 msgid "Synchronization status"
 msgstr "同步失败"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:525
+#: ../../../ui/wxWidgets/SyncWizard.cpp:526
 msgid "See a detailed report"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:561
+#: ../../../ui/wxWidgets/SyncWizard.cpp:562
 msgid "Your database is being synchronized with \""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:571
+#: ../../../ui/wxWidgets/SyncWizard.cpp:572
 msgid "There was an error during synchronization"
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:585
+#: ../../../ui/wxWidgets/SyncWizard.cpp:586
 #, c-format
 msgid "Your database has been synchronized with \"%ls\""
 msgstr ""
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:586
+#: ../../../ui/wxWidgets/SyncWizard.cpp:587
 #, fuzzy, c-format
 msgid "%ld %ls updated"
 msgstr ""
 "\n"
 "下列 %ls %ls 已更新:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:588
+#: ../../../ui/wxWidgets/SyncWizard.cpp:589
 #, fuzzy
 msgid "Synchronization completed successfully"
 msgstr "成功完成"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:604
+#: ../../../ui/wxWidgets/SyncWizard.cpp:605
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4372,7 +4373,7 @@ msgstr ""
 "文件被破坏或被删节其中部份，数据可能已经丢失或被修改！\n"
 "仍然继续吗？"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:606
+#: ../../../ui/wxWidgets/SyncWizard.cpp:607
 #, fuzzy, c-format
 msgid ""
 "%ls\n"
@@ -4383,24 +4384,24 @@ msgstr ""
 "\n"
 "未知错误！"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:640
+#: ../../../ui/wxWidgets/SyncWizard.cpp:641
 #, fuzzy, c-format
 msgid "Synchronizing from database: %ls\n"
 msgstr "同步的数据库源: %ls\n"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:643
+#: ../../../ui/wxWidgets/SyncWizard.cpp:644
 msgid "synchronized"
 msgstr "同步"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:322
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:338
 msgid "was"
 msgstr "是"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:731 ../../../core/core_st.cpp:323
+#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:339
 msgid "were"
 msgstr "是"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:732 ../../../core/core_st.cpp:298
+#: ../../../ui/wxWidgets/SyncWizard.cpp:733 ../../../core/core_st.cpp:314
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4409,7 +4410,7 @@ msgstr ""
 "\n"
 "下列 %ls %ls 已更新:"
 
-#: ../../../ui/wxWidgets/SyncWizard.cpp:748 ../../../core/core_st.cpp:297
+#: ../../../ui/wxWidgets/SyncWizard.cpp:749 ../../../core/core_st.cpp:313
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -4577,7 +4578,7 @@ msgstr "该别名目标 [%s:%s:%s] 不是一个正常项目或已有一个基本
 msgid "This shortcut's target [%s:%s:%s] is not a normal entry."
 msgstr "该快捷方式目标 [%s:%s:%s] 不是一个正常项目或已经有一个快捷方式存在！"
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:94
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:2440 ../../../core/core_st.cpp:96
 #, c-format
 msgid ""
 "The following entries had a policy name that already existed in this "
@@ -4681,13 +4682,13 @@ msgstr ""
 "文件被破坏或被删节其中部份，数据可能已经丢失或被修改！\n"
 "仍然继续吗？"
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:381
+#: ../../../ui/wxWidgets/wxUtilities.cpp:390
 msgid ""
 "An error occurred while trying to get the image data from database item.\n"
 "Therefore, the image cannot be displayed in the preview."
 msgstr ""
 
-#: ../../../ui/wxWidgets/wxUtilities.cpp:394
+#: ../../../ui/wxWidgets/wxUtilities.cpp:403
 msgid ""
 "An error occurred while trying to load the image data into the preview "
 "area.\n"
@@ -4829,7 +4830,7 @@ msgstr ""
 "\n"
 "复制密码到剪贴板"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:149
+#: ../../../ui/wxWidgets/ToolbarButtons.h:204 ../../../core/core_st.cpp:151
 msgid "Username"
 msgstr "用户名"
 
@@ -4840,7 +4841,7 @@ msgstr ""
 "\n"
 "复制用户名到剪贴板"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:136
+#: ../../../ui/wxWidgets/ToolbarButtons.h:205 ../../../core/core_st.cpp:138
 #, fuzzy
 msgid "Notes"
 msgstr "备注(&N):"
@@ -4876,7 +4877,7 @@ msgstr ""
 msgid "Browse URL"
 msgstr "浏览网址"
 
-#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:70
+#: ../../../ui/wxWidgets/ToolbarButtons.h:210 ../../../core/core_st.cpp:72
 #, fuzzy
 msgid "Send Email"
 msgstr "发送邮件"
@@ -5059,69 +5060,87 @@ msgid "(case sensitive)"
 msgstr "(区分大小写)"
 
 #: ../../../core/core_st.cpp:50
+#, fuzzy, c-format
+msgid ""
+"Compare complete of current database:\n"
+"\t %ls\n"
+" and:\n"
+"\t %ls\n"
+msgstr ""
+"当前数据库比较完成:\n"
+"\t %s\n"
+" 和:\n"
+"\t %s"
+
+#: ../../../core/core_st.cpp:51
+#, fuzzy, c-format
+msgid "\tGroup:'%ls'; Title:'%ls'; User:'%ls'"
+msgstr "\t组:'%s'; 标题:'%s'; 用户:'%s'"
+
+#: ../../../core/core_st.cpp:52
 msgid "C:F[R-O]"
 msgstr "C:F[只读]"
 
-#: ../../../core/core_st.cpp:51
+#: ../../../core/core_st.cpp:53
 msgid "C:F[R/W]"
 msgstr "C:F[存取]"
 
-#: ../../../core/core_st.cpp:52
+#: ../../../core/core_st.cpp:54
 msgid "C:None  "
 msgstr "C:无  "
 
-#: ../../../core/core_st.cpp:53
+#: ../../../core/core_st.cpp:55
 msgid "C:Reg   "
 msgstr "C:Reg   "
 
-#: ../../../core/core_st.cpp:54
+#: ../../../core/core_st.cpp:56
 msgid "conflict"
 msgstr "冲突"
 
-#: ../../../core/core_st.cpp:55
+#: ../../../core/core_st.cpp:57
 msgid "conflicts"
 msgstr "个冲突"
 
-#: ../../../core/core_st.cpp:57
+#: ../../../core/core_st.cpp:59
 #, fuzzy
 msgid "contains all of"
 msgstr "包含"
 
-#: ../../../core/core_st.cpp:58
+#: ../../../core/core_st.cpp:60
 #, fuzzy
 msgid "contains any of"
 msgstr "包含"
 
-#: ../../../core/core_st.cpp:59
+#: ../../../core/core_st.cpp:61
 #, fuzzy
 msgid "copied"
 msgstr "复制网址"
 
-#: ../../../core/core_st.cpp:60
+#: ../../../core/core_st.cpp:62
 #, fuzzy, c-format
 msgid "%ls - Copied %ls"
 msgstr "%ls - 复制网址 %ls"
 
-#: ../../../core/core_st.cpp:61
+#: ../../../core/core_st.cpp:63
 #, fuzzy, c-format
 msgid " Current default (%ls)"
 msgstr " 当前默认 (%ls)"
 
-#: ../../../core/core_st.cpp:71
+#: ../../../core/core_st.cpp:73
 msgid "View/Edit selected entry"
 msgstr "查看/编辑选定项目"
 
-#: ../../../core/core_st.cpp:72
+#: ../../../core/core_st.cpp:74
 #, fuzzy
 msgid " (application default)"
 msgstr "使用应用程序:"
 
-#: ../../../core/core_st.cpp:73
+#: ../../../core/core_st.cpp:75
 #, fuzzy
 msgid "default symbol set"
 msgstr "默认用户名"
 
-#: ../../../core/core_st.cpp:75
+#: ../../../core/core_st.cpp:77
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5130,12 +5149,12 @@ msgid ""
 "entry's password)?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:76
+#: ../../../core/core_st.cpp:78
 #, fuzzy
 msgid "Delete Base Entry Confirmation"
 msgstr "确认删除一个基本项目？"
 
-#: ../../../core/core_st.cpp:77
+#: ../../../core/core_st.cpp:79
 #, c-format
 msgid ""
 "This entry has the following %d %ls:\n"
@@ -5143,325 +5162,325 @@ msgid ""
 "Please confirm to continue (All shortcuts to this entry will be deleted)?"
 msgstr ""
 
-#: ../../../core/core_st.cpp:80
+#: ../../../core/core_st.cpp:82
 #, fuzzy
 msgid "does not contain all of"
 msgstr "不包含"
 
-#: ../../../core/core_st.cpp:81
+#: ../../../core/core_st.cpp:83
 #, fuzzy
 msgid "does not contain any of"
 msgstr "不包含"
 
-#: ../../../core/core_st.cpp:84
+#: ../../../core/core_st.cpp:86
 #, c-format
 msgid " Drag # %d"
 msgstr " 拖放 # %d"
 
-#: ../../../core/core_st.cpp:85
-#, c-format
-msgid "%s - Drag & Drop %s"
-msgstr ""
+#: ../../../core/core_st.cpp:87
+#, fuzzy, c-format
+msgid "%ls - Drag & Drop %ls"
+msgstr "%ls - 复制网址 %ls"
 
-#: ../../../core/core_st.cpp:86
+#: ../../../core/core_st.cpp:88
 #, c-format
 msgid " Duplicate # %d"
 msgstr " 复制 # %d"
 
-#: ../../../core/core_st.cpp:87
+#: ../../../core/core_st.cpp:89
 #, fuzzy
 msgid "empty group"
 msgstr "导入下列组？"
 
-#: ../../../core/core_st.cpp:88
+#: ../../../core/core_st.cpp:90
 #, fuzzy
 msgid "empty groups"
 msgstr "#组"
 
-#: ../../../core/core_st.cpp:89
+#: ../../../core/core_st.cpp:91
 #, fuzzy, c-format
 msgid ""
 "Trouble with a non-textual (e.g., time) field in record '%ls' - please check "
 "data carefully."
 msgstr "让人深感不安的一个无原文(例如：时间) 字段在档案“%ls”- 请小心校验数据！"
 
-#: ../../../core/core_st.cpp:91
+#: ../../../core/core_st.cpp:93
 msgid "End Report"
 msgstr "结束报告"
 
-#: ../../../core/core_st.cpp:92
+#: ../../../core/core_st.cpp:94
 msgid "--------------------------------------------------------------------------------"
 msgstr "--------------------------------------------------------------------------------"
 
-#: ../../../core/core_st.cpp:97
+#: ../../../core/core_st.cpp:99
 msgid "has expired"
 msgstr "已失效"
 
-#: ../../../core/core_st.cpp:98
+#: ../../../core/core_st.cpp:100
 msgid "Entries with a password expiry"
 msgstr "项目使用的一个密码到期"
 
-#: ../../../core/core_st.cpp:99
+#: ../../../core/core_st.cpp:101
 #, c-format
 msgid "within %d day(s)"
 msgstr "在 %d 天内"
 
-#: ../../../core/core_st.cpp:100
+#: ../../../core/core_st.cpp:102
 #, fuzzy, c-format
 msgid "DB Export from database: '%s'"
 msgstr "合并数据库: %s\n"
 
-#: ../../../core/core_st.cpp:101
+#: ../../../core/core_st.cpp:103
 msgid "First character of variable name must be alphabetic"
 msgstr "首字符变量名称必须按字母排序！"
 
-#: ../../../core/core_st.cpp:102
+#: ../../../core/core_st.cpp:104
 msgid "Index not numeric"
 msgstr "索引没有数值！"
 
-#: ../../../core/core_st.cpp:103
+#: ../../../core/core_st.cpp:105
 msgid "Input string is empty"
 msgstr "导入字串空缺！"
 
-#: ../../../core/core_st.cpp:104
+#: ../../../core/core_st.cpp:106
 msgid "Characters present between end of index ']' and '}'"
 msgstr "符号显示在索引 ']' 和 '}' 之间结束！"
 
-#: ../../../core/core_st.cpp:105
+#: ../../../core/core_st.cpp:107
 msgid "Index is invalid or missing"
 msgstr "索引无效或缺少！"
 
-#: ../../../core/core_st.cpp:106
+#: ../../../core/core_st.cpp:108
 msgid "Missing ending curly bracket for variable name"
 msgstr "缺少波浪号作为结束变量名称！"
 
-#: ../../../core/core_st.cpp:107
+#: ../../../core/core_st.cpp:109
 msgid "Missing ending round bracket for Autotype value"
 msgstr "缺少圆括号作为结束自动输入值！"
 
-#: ../../../core/core_st.cpp:108
+#: ../../../core/core_st.cpp:110
 msgid "Missing ending square bracket for index value"
 msgstr "缺少方括号作为结束索引值！"
 
-#: ../../../core/core_st.cpp:109
+#: ../../../core/core_st.cpp:111
 msgid "There are unmatched quotes in the run command"
 msgstr "运行命令不匹配引号！"
 
-#: ../../../core/core_st.cpp:110
+#: ../../../core/core_st.cpp:112
 msgid "Variable name is empty"
 msgstr "变量名空缺"
 
-#: ../../../core/core_st.cpp:111
+#: ../../../core/core_st.cpp:113
 msgid "Variable name must be alphanumeric"
 msgstr "变量名必须包含字母与数字！"
 
-#: ../../../core/core_st.cpp:112
+#: ../../../core/core_st.cpp:114
 msgid "an alias entry"
 msgstr "一个别名项目"
 
-#: ../../../core/core_st.cpp:113
+#: ../../../core/core_st.cpp:115
 msgid "a base entry of an alias"
 msgstr "一个基本项目的别名"
 
-#: ../../../core/core_st.cpp:114
+#: ../../../core/core_st.cpp:116
 msgid "  Field is too long."
 msgstr "  字段太长！"
 
-#: ../../../core/core_st.cpp:115
+#: ../../../core/core_st.cpp:117
 msgid "  Field is too short."
 msgstr "  字段太短！"
 
-#: ../../../core/core_st.cpp:116
+#: ../../../core/core_st.cpp:118
 msgid "Error: A file with this name already exists"
 msgstr "错误: 该文件名称已经存在！"
 
-#: ../../../core/core_st.cpp:117
+#: ../../../core/core_st.cpp:119
 msgid "The file was not found."
 msgstr "没有找到文件！"
 
-#: ../../../core/core_st.cpp:118
+#: ../../../core/core_st.cpp:120
 msgid "Error: File is read-only"
 msgstr "错误: 文件为只读属性！"
 
-#: ../../../core/core_st.cpp:119
+#: ../../../core/core_st.cpp:121
 msgid "Error while writing file! Try saving in a different location"
 msgstr "写入文件时错误，尝试保存在一个不同的位置！"
 
-#: ../../../core/core_st.cpp:120
+#: ../../../core/core_st.cpp:122
 #, fuzzy
 msgid "File is too big."
 msgstr "  字段太长！"
 
-#: ../../../core/core_st.cpp:121
+#: ../../../core/core_st.cpp:123
 #, fuzzy
 msgid "File is too short."
 msgstr "  字段太短！"
 
-#: ../../../core/core_st.cpp:122
+#: ../../../core/core_st.cpp:124
 msgid "File is truncated or otherwise corrupt. Please use backup database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:123
+#: ../../../core/core_st.cpp:125
 msgid "Cannot read file. Please check file permissions."
 msgstr "无法读取文件，请检查文件权限！"
 
-#: ../../../core/core_st.cpp:124
+#: ../../../core/core_st.cpp:126
 #, fuzzy, c-format
 msgid ""
 "Filter %ls already exists in the database, do you wish to replace it with "
 "this?"
 msgstr "筛选 %ls 已存在数据库中，你是否需要使用它代替？"
 
-#: ../../../core/core_st.cpp:125
+#: ../../../core/core_st.cpp:127
 #, fuzzy
 msgid "Current database filters have been exported to this database."
 msgstr "比较当前数据库与: %s"
 
-#: ../../../core/core_st.cpp:126
+#: ../../../core/core_st.cpp:128
 msgid "Stored filters will be unusable until the file's restored."
 msgstr "存储筛选器将不可用，直到文件被还原。"
 
-#: ../../../core/core_st.cpp:127
+#: ../../../core/core_st.cpp:129
 msgid "Last Access Time"
 msgstr "最后访问时间"
 
-#: ../../../core/core_st.cpp:128
+#: ../../../core/core_st.cpp:130
 msgid "Attachment Reference"
 msgstr ""
 
-#: ../../../core/core_st.cpp:129
+#: ../../../core/core_st.cpp:131
 msgid "AutoType"
 msgstr "自动输入"
 
-#: ../../../core/core_st.cpp:130
+#: ../../../core/core_st.cpp:132
 msgid "Created Time"
 msgstr "创建时间"
 
-#: ../../../core/core_st.cpp:131
+#: ../../../core/core_st.cpp:133
 msgid "DCA"
 msgstr "DCA"
 
-#: ../../../core/core_st.cpp:132
+#: ../../../core/core_st.cpp:134
 msgid "e-mail"
 msgstr "电子邮件"
 
-#: ../../../core/core_st.cpp:134
+#: ../../../core/core_st.cpp:136
 msgid "Group/Title"
 msgstr "组/标题"
 
-#: ../../../core/core_st.cpp:135
+#: ../../../core/core_st.cpp:137
 #, fuzzy
 msgid "Keyboard Shortcut"
 msgstr "创建快捷方式"
 
-#: ../../../core/core_st.cpp:138
+#: ../../../core/core_st.cpp:140
 msgid "Password Modified Time"
 msgstr "密码修改时间"
 
-#: ../../../core/core_st.cpp:139
+#: ../../../core/core_st.cpp:141
 msgid "Protected"
 msgstr "保护"
 
-#: ../../../core/core_st.cpp:140
+#: ../../../core/core_st.cpp:142
 msgid "History"
 msgstr "历史"
 
-#: ../../../core/core_st.cpp:142
+#: ../../../core/core_st.cpp:144
 #, fuzzy
 msgid "Password Policy Name"
 msgstr "密码策略"
 
-#: ../../../core/core_st.cpp:143
+#: ../../../core/core_st.cpp:145
 msgid "Record Modified Time"
 msgstr "档案修改时间"
 
-#: ../../../core/core_st.cpp:145
+#: ../../../core/core_st.cpp:147
 #, fuzzy
 msgid "Shift+DCA"
 msgstr "Shift+"
 
-#: ../../../core/core_st.cpp:146
+#: ../../../core/core_st.cpp:148
 #, fuzzy
 msgid "Symbols"
 msgstr "默认用户名"
 
-#: ../../../core/core_st.cpp:148
+#: ../../../core/core_st.cpp:150
 msgid "URL"
 msgstr "网址"
 
-#: ../../../core/core_st.cpp:150
+#: ../../../core/core_st.cpp:152
 msgid "UUID"
 msgstr "UUID"
 
-#: ../../../core/core_st.cpp:151
+#: ../../../core/core_st.cpp:153
 msgid "Password Expiry Date"
 msgstr "密码失效日期"
 
-#: ../../../core/core_st.cpp:152
+#: ../../../core/core_st.cpp:154
 msgid "Password Expiry Interval"
 msgstr "密码失效间隔"
 
-#: ../../../core/core_st.cpp:153
+#: ../../../core/core_st.cpp:155
 msgid "a normal entry"
 msgstr "一个正常项目"
 
-#: ../../../core/core_st.cpp:154
+#: ../../../core/core_st.cpp:156
 #, fuzzy
 msgid "Last found entries"
 msgstr "个项目"
 
-#: ../../../core/core_st.cpp:155
+#: ../../../core/core_st.cpp:157
 msgid "added but not yet saved to database"
 msgstr "已添加，但尚未被保存到数据库！"
 
-#: ../../../core/core_st.cpp:156
+#: ../../../core/core_st.cpp:158
 #, fuzzy
 msgid "in the database"
 msgstr "在数据库"
 
-#: ../../../core/core_st.cpp:157
+#: ../../../core/core_st.cpp:159
 msgid "a shortcut entry"
 msgstr "一个项目的快捷方式"
 
-#: ../../../core/core_st.cpp:158
+#: ../../../core/core_st.cpp:160
 msgid "a base entry of a shortcut"
 msgstr "一个基本项目的快捷方式"
 
-#: ../../../core/core_st.cpp:159
+#: ../../../core/core_st.cpp:161
 msgid "changed but not yet saved to database"
 msgstr "已更改但未保存到数据库！"
 
-#: ../../../core/core_st.cpp:160
+#: ../../../core/core_st.cpp:162
 msgid "greater than"
 msgstr "大于"
 
-#: ../../../core/core_st.cpp:161
+#: ../../../core/core_st.cpp:163
 msgid "greater than or equal to"
 msgstr "大于或等于"
 
-#: ../../../core/core_st.cpp:162
+#: ../../../core/core_st.cpp:164
 #, c-format
 msgid ""
 "Invalid input on line %d.  Number of fields separated by '%c' is not as "
 "expected."
 msgstr "无效导入在行 %d，各字段的编号 '%c' 是未意料的！"
 
-#: ../../../core/core_st.cpp:163
+#: ../../../core/core_st.cpp:165
 #, c-format
 msgid "Line %d: "
 msgstr "行 %d:"
 
-#: ../../../core/core_st.cpp:164
+#: ../../../core/core_st.cpp:166
 #, c-format
 msgid ""
 "File ends on line %d before ending double quote of last entry's note field."
 msgstr "文件结尾行 %d 在最后项目备注字段的双引号之前结束！"
 
-#: ../../../core/core_st.cpp:165
+#: ../../../core/core_st.cpp:167
 msgid "Import aborted. Please see report."
 msgstr ""
 
-#: ../../../core/core_st.cpp:166
+#: ../../../core/core_st.cpp:168
 msgid ""
 "The TXT or CSV file was not imported as required as entry records span "
 "multiple lines in the CSV file.\n"
@@ -5469,7 +5488,7 @@ msgid ""
 "Import aborted."
 msgstr ""
 
-#: ../../../core/core_st.cpp:167
+#: ../../../core/core_st.cpp:169
 #, fuzzy, c-format
 msgid ""
 "%ls, Title=\"%ls\", User=\"%ls\" already exists in your database or in the "
@@ -5478,121 +5497,121 @@ msgstr ""
 "%ls, 标题=“%ls”，用户=“%ls”已存在你的数据库或导入文件中。添加导入项目标题"
 "=“%ls”。\n"
 
-#: ../../../core/core_st.cpp:168
+#: ../../../core/core_st.cpp:170
 #, fuzzy, c-format
 msgid "Entry on line %d with Group=\"%ls\""
 msgstr "项目在行 %d 与组=“%ls”。"
 
-#: ../../../core/core_st.cpp:169
+#: ../../../core/core_st.cpp:171
 #, c-format
 msgid "Entry on line %d with no group"
 msgstr "项目在行 %d 上没有组。"
 
-#: ../../../core/core_st.cpp:170
+#: ../../../core/core_st.cpp:172
 #, fuzzy, c-format
 msgid "Entry with Group=\"%ls\""
 msgstr "项目与组=“%ls”。"
 
-#: ../../../core/core_st.cpp:171
+#: ../../../core/core_st.cpp:173
 msgid "Entry with no group"
 msgstr "项目没有组"
 
-#: ../../../core/core_st.cpp:172
+#: ../../../core/core_st.cpp:174
 #, fuzzy
 msgid "imported"
 msgstr "导入"
 
-#: ../../../core/core_st.cpp:173
+#: ../../../core/core_st.cpp:175
 #, fuzzy, c-format
 msgid "including %d empty group(s)."
 msgstr "#组"
 
-#: ../../../core/core_st.cpp:174
+#: ../../../core/core_st.cpp:176
 #, c-format
 msgid "Empty line %d skipped"
 msgstr "跳过空行 %d"
 
-#: ../../../core/core_st.cpp:175
+#: ../../../core/core_st.cpp:177
 #, fuzzy, c-format
 msgid "Entry %ls%d with Group=\"%ls\", Title=\"%ls\", User=\"%ls\""
 msgstr "项目 %ls%d 与组=“%ls”，标题=“%ls”，用户=“%ls”。"
 
-#: ../../../core/core_st.cpp:176
+#: ../../../core/core_st.cpp:178
 msgid "Internal error. Import failed. No records imported."
 msgstr "内部错误，导入失败，无记录导入！"
 
-#: ../../../core/core_st.cpp:177
+#: ../../../core/core_st.cpp:179
 #, c-format
 msgid "Found %d known column headers:"
 msgstr "找到 %d 已知栏目标题:"
 
-#: ../../../core/core_st.cpp:178
+#: ../../../core/core_st.cpp:180
 msgid "Invalid field delimiter: must be within ASCII range."
 msgstr ""
 
-#: ../../../core/core_st.cpp:179
+#: ../../../core/core_st.cpp:181
 #, fuzzy, c-format
 msgid "Entry of line %d has an invalid \"%ls\" field. It has been ignored."
 msgstr "项目行 %d 有一个无效“%ls”字段，它已经被忽略！"
 
-#: ../../../core/core_st.cpp:180
+#: ../../../core/core_st.cpp:182
 msgid "The following columns will be processed: "
 msgstr "下列栏目将被处理:"
 
-#: ../../../core/core_st.cpp:181
+#: ../../../core/core_st.cpp:183
 msgid ""
 "The following columns were recognised but only Group/Title, Username and "
 "Password will be processed:"
 msgstr "下列栏目被认可，但只有 组/标题、用户名称和密码可以被处理:"
 
-#: ../../../core/core_st.cpp:182
+#: ../../../core/core_st.cpp:184
 #, c-format
 msgid ""
 "Line %d skipped - Only %d fields found, whereas parsing the Header says "
 "there should be %d."
 msgstr "第 %d 行跳过，仅找到 %d 字段，但句法分析标题提示应该存在 %d 行(字段)。"
 
-#: ../../../core/core_st.cpp:183
+#: ../../../core/core_st.cpp:185
 msgid ""
 "Either or both of the Group/Title and Password columns are missing. No "
 "records imported."
 msgstr "组/标题或密码栏目缺少，没有导入记录！"
 
-#: ../../../core/core_st.cpp:184
+#: ../../../core/core_st.cpp:186
 msgid ""
 "Could not find the next entry's title field in the KeePass V1 TXT (should be "
 "within square brackets)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:185
+#: ../../../core/core_st.cpp:187
 msgid "Column header row not recognised as first record. No records imported."
 msgstr "栏目标题行不认可为首记录，无记录导入！"
 
-#: ../../../core/core_st.cpp:186
+#: ../../../core/core_st.cpp:188
 msgid "No records in import file!"
 msgstr "导入文件没有记录！"
 
-#: ../../../core/core_st.cpp:187
+#: ../../../core/core_st.cpp:189
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Password field."
 msgstr "跳过行 %d，它是一个空白强制的密码字段！"
 
-#: ../../../core/core_st.cpp:188
+#: ../../../core/core_st.cpp:190
 #, fuzzy, c-format
 msgid "Line %d skipped: Empty mandatory Title field."
 msgstr "跳过行 %d，它是一个空白强制的标题字段！"
 
-#: ../../../core/core_st.cpp:189
+#: ../../../core/core_st.cpp:191
 #, c-format
 msgid " Import # %d"
 msgstr " 导入 # %d"
 
-#: ../../../core/core_st.cpp:190
+#: ../../../core/core_st.cpp:192
 #, fuzzy, c-format
 msgid "%ls - Imported %ls"
 msgstr "%ls - 复制网址 %ls"
 
-#: ../../../core/core_st.cpp:191
+#: ../../../core/core_st.cpp:193
 msgid ""
 "To replace passwords of existing entries, all the following columns must be "
 "present: Group/Title, Username and Password.  One or more are missing and no "
@@ -5601,17 +5620,17 @@ msgstr ""
 "需要替换现有项目密码，所有下列栏目必须存在: 组/标题、用户名和密码。一个或更多"
 "缺少并且没有项目被更新！"
 
-#: ../../../core/core_st.cpp:192
+#: ../../../core/core_st.cpp:194
 #, fuzzy, c-format
 msgid "%ls not found. Cannot update entry's password.\n"
 msgstr "%ls 未找到，无法更新项目的密码！\n"
 
-#: ../../../core/core_st.cpp:193
+#: ../../../core/core_st.cpp:195
 #, fuzzy, c-format
 msgid "%ls has an empty %ls.\n"
 msgstr "%ls 有一个空白 %ls。\n"
 
-#: ../../../core/core_st.cpp:194
+#: ../../../core/core_st.cpp:196
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5619,11 +5638,11 @@ msgid ""
 msgstr ""
 "项目“%ls、%ls、%ls”有一个密码在为一个别名做格式校正，但基本项目已有一个别名！"
 
-#: ../../../core/core_st.cpp:195
+#: ../../../core/core_st.cpp:197
 msgid "\tThis entry has been made an alias of associated base entry."
 msgstr "\t该项目已生成关联基本项目的一个别名！"
 
-#: ../../../core/core_st.cpp:196
+#: ../../../core/core_st.cpp:198
 #, fuzzy, c-format
 msgid ""
 "Entry \"%ls, %ls, %ls\" has a password in the correct form for an alias, but "
@@ -5631,12 +5650,12 @@ msgid ""
 msgstr ""
 "项目“%ls、%ls、%ls”有一个密码在为一个别名做格式校正，但基本项目不存在！"
 
-#: ../../../core/core_st.cpp:197
+#: ../../../core/core_st.cpp:199
 msgid ""
 "\tThis entry remains a normal entry and the password has not been changed."
 msgstr "\t该项目剩余一个正常条目并且密码未经改变！"
 
-#: ../../../core/core_st.cpp:198
+#: ../../../core/core_st.cpp:200
 #, fuzzy, c-format
 msgid ""
 "The %ls entry \"%ls, %ls, %ls\" doesn't point to a normal or existing %ls "
@@ -5645,145 +5664,145 @@ msgstr ""
 "“%ls” 项目 “%ls， %ls， %ls”未表明一个正常或现有的 “%ls” 项目位置，所以它不能"
 "被导入！"
 
-#: ../../../core/core_st.cpp:199
+#: ../../../core/core_st.cpp:201
 msgid "Entry import warnings"
 msgstr "项目导入警告"
 
-#: ../../../core/core_st.cpp:200
+#: ../../../core/core_st.cpp:202
 msgid "id="
 msgstr "id="
 
-#: ../../../core/core_st.cpp:201
+#: ../../../core/core_st.cpp:203
 msgid "on line "
 msgstr "在线"
 
-#: ../../../core/core_st.cpp:202
+#: ../../../core/core_st.cpp:204
 msgid "Internal error: Invalid oflag or pmode argument"
 msgstr "内部错误: 无效标记或 pmode 参数！"
 
-#: ../../../core/core_st.cpp:203
+#: ../../../core/core_st.cpp:205
 msgid "invalid!"
 msgstr "无效！"
 
-#: ../../../core/core_st.cpp:204
+#: ../../../core/core_st.cpp:206
 msgid "  Invalid date/time value."
 msgstr "  无效的日期/时间值！"
 
-#: ../../../core/core_st.cpp:205
+#: ../../../core/core_st.cpp:207
 #, fuzzy
 msgid "  Field length is incorrect."
 msgstr "  字段太短！"
 
-#: ../../../core/core_st.cpp:206
+#: ../../../core/core_st.cpp:208
 msgid "Internal error: An invalid flag was specified"
 msgstr "内部错误: 一个无效标记指定！"
 
-#: ../../../core/core_st.cpp:207
+#: ../../../core/core_st.cpp:209
 #, c-format
 msgid "  Invalid header: '%ls' (must be 5 hexadecimal characters)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:208
+#: ../../../core/core_st.cpp:210
 #, fuzzy, c-format
 msgid "Invalid lock file \"%ls\"."
 msgstr "无效筛选模式！"
 
-#: ../../../core/core_st.cpp:209
+#: ../../../core/core_st.cpp:211
 #, c-format
 msgid "  Invalid number of saved old passwords %d."
 msgstr "  保存的旧密码 %d 数量无效！"
 
-#: ../../../core/core_st.cpp:210
+#: ../../../core/core_st.cpp:212
 #, c-format
 msgid "  Invalid status value: %d (must be either 0 or 1)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:211
+#: ../../../core/core_st.cpp:213
 msgid "  Invalid password length found (not a hexadecimal number)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:212
+#: ../../../core/core_st.cpp:214
 msgid ""
 "  Invalid password length found (differs from length of following password)."
 msgstr ""
 
-#: ../../../core/core_st.cpp:213
+#: ../../../core/core_st.cpp:215
 msgid ""
 "  Invalid field separator character found - only a single blank is allowed "
 "between fields."
 msgstr "  无效字段分隔符建立 - 在字段之间只允许一个空格！"
 
-#: ../../../core/core_st.cpp:214
+#: ../../../core/core_st.cpp:216
 msgid "Invalid Filter schema."
 msgstr "无效筛选模式！"
 
-#: ../../../core/core_st.cpp:215
+#: ../../../core/core_st.cpp:217
 msgid "Schema does not have a version number."
 msgstr "该模式没有一个版本号！"
 
-#: ../../../core/core_st.cpp:216
+#: ../../../core/core_st.cpp:218
 #, c-format
 msgid "The filter XML version (%d) is greater than the current schema (%d)."
 msgstr "筛选 XML 版本 (%d) 大于当前模式的 (%d)！"
 
-#: ../../../core/core_st.cpp:217
+#: ../../../core/core_st.cpp:219
 #, c-format
 msgid ""
 "The filter XML version (%d) is greater than that supported by this instance "
 "of PasswordSafe (%d)."
 msgstr "筛选 XML 版本 (%d) 大于可支持该实例的 PasswordSafe (%d)！"
 
-#: ../../../core/core_st.cpp:218
+#: ../../../core/core_st.cpp:220
 msgid "is"
 msgstr "是"
 
-#: ../../../core/core_st.cpp:219
+#: ../../../core/core_st.cpp:221
 msgid "is active"
 msgstr "活动"
 
-#: ../../../core/core_st.cpp:220
+#: ../../../core/core_st.cpp:222
 msgid "is inactive"
 msgstr "非活动"
 
-#: ../../../core/core_st.cpp:221
+#: ../../../core/core_st.cpp:223
 msgid "is not"
 msgstr "不是"
 
-#: ../../../core/core_st.cpp:222
+#: ../../../core/core_st.cpp:224
 msgid "is not present"
 msgstr "未显示"
 
-#: ../../../core/core_st.cpp:223
+#: ../../../core/core_st.cpp:225
 msgid "is present"
 msgstr "已显示"
 
-#: ../../../core/core_st.cpp:224
+#: ../../../core/core_st.cpp:226
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to entry %ls. It "
 "has been removed from the %ls entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:225
+#: ../../../core/core_st.cpp:227
 #, c-format
 msgid ""
 "Entry keyboard shortcut %ls entry %ls is already allocated to the "
 "PasswordSafe application. It has been removed from the entry."
 msgstr ""
 
-#: ../../../core/core_st.cpp:226
+#: ../../../core/core_st.cpp:228
 msgid "less than"
 msgstr "小于"
 
-#: ../../../core/core_st.cpp:227
+#: ../../../core/core_st.cpp:229
 msgid "less than or equal to"
 msgstr "小于或等于"
 
-#: ../../../core/core_st.cpp:228
+#: ../../../core/core_st.cpp:230
 msgid "File or path not found"
 msgstr "文件或路径未建立"
 
-#: ../../../core/core_st.cpp:229
+#: ../../../core/core_st.cpp:231
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5792,7 +5811,7 @@ msgstr ""
 "\n"
 "新建 %ls %ls 合并到下面数据库中:"
 
-#: ../../../core/core_st.cpp:230
+#: ../../../core/core_st.cpp:232
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -5801,7 +5820,7 @@ msgstr ""
 "\n"
 "合并完成: 已增加 %d 个 %ls (%d %ls, %d %ls, %d %ls)"
 
-#: ../../../core/core_st.cpp:231
+#: ../../../core/core_st.cpp:233
 #, fuzzy, c-format
 msgid ""
 "Conflicting entries for \"%ls\" \"%ls\" \"%ls\".\n"
@@ -5812,91 +5831,91 @@ msgstr ""
 "  增加的合并项目为 «%ls» «%ls» «%ls».\n"
 "    不一致字段: %ls"
 
-#: ../../../core/core_st.cpp:232
+#: ../../../core/core_st.cpp:234
 #, fuzzy
 msgid "merged"
 msgstr "合并"
 
-#: ../../../core/core_st.cpp:233
+#: ../../../core/core_st.cpp:235
 #, fuzzy, c-format
 msgid "%ls - Merged %ls"
 msgstr "%ls - 合并 %ls"
 
-#: ../../../core/core_st.cpp:234
+#: ../../../core/core_st.cpp:236
 msgid "MISSING PASSWORD"
 msgstr ""
 
-#: ../../../core/core_st.cpp:235
+#: ../../../core/core_st.cpp:237
 #, c-format
 msgid "\tPassword policy name '%ls' is not in the database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:236
+#: ../../../core/core_st.cpp:238
 msgid ""
 "\tOne or more Password Policy Names were not found in the database. The "
 "affected entries have been changed to use the database's default policy."
 msgstr ""
 
-#: ../../../core/core_st.cpp:237
+#: ../../../core/core_st.cpp:239
 #, c-format
 msgid "MISSING TITLE # %d"
 msgstr ""
 
-#: ../../../core/core_st.cpp:239
+#: ../../../core/core_st.cpp:241
 msgid "Can't obtain the schema version."
 msgstr "不能获得计划版本！"
 
-#: ../../../core/core_st.cpp:240
+#: ../../../core/core_st.cpp:242
 msgid "The filter XML version is missing."
 msgstr "缺少筛选 XML 版本！"
 
-#: ../../../core/core_st.cpp:241
+#: ../../../core/core_st.cpp:243
 #, fuzzy, c-format
 msgid "Create SchemaCache60 Error 0x%08X during %ls."
 msgstr "创建计划缓存%2d 发生错误 0x%08X 在 %ls 期间！"
 
-#: ../../../core/core_st.cpp:242
+#: ../../../core/core_st.cpp:244
 #, fuzzy, c-format
 msgid "SAX Parse60 Error 0x%08X during %ls."
 msgstr "SAX 分析%2d 错误 0x%08X 在 %ls 期间！"
 
-#: ../../../core/core_st.cpp:243
+#: ../../../core/core_st.cpp:245
 #, fuzzy, c-format
 msgid "Error (%08X): line %d character %d %ls"
 msgstr "错误 (%08X): 行 %d 字符 %d %ls"
 
-#: ../../../core/core_st.cpp:245
+#: ../../../core/core_st.cpp:247
 msgid ""
 "Unable to get configuration file lock.\n"
 "\n"
 "Will use registry."
 msgstr "未能获得锁配置文件，将使用注册表！"
 
-#: ../../../core/core_st.cpp:246
+#: ../../../core/core_st.cpp:248
 msgid "Cannot create lock file - no permission in directory?"
 msgstr "不能创建文件锁 - 你是否没有该目录权限？"
 
-#: ../../../core/core_st.cpp:247
+#: ../../../core/core_st.cpp:249
 msgid "Internal error: Out of file handles"
 msgstr "内部错误: 文件句柄溢出！"
 
-#: ../../../core/core_st.cpp:248
+#: ../../../core/core_st.cpp:250
 msgid ""
 "Unable to use a MS XML reader on your system.  Neither MS XML V3, V4 or V6 "
 "seems available."
 msgstr ""
 "不能使用一个 MS XML 阅读器在你的系统，MS XML V3, V4 或 V6 好像也都不可用！"
 
-#: ../../../core/core_st.cpp:250
+#: ../../../core/core_st.cpp:252
 #, fuzzy
 msgid "Unsaved changes"
 msgstr "显示未保存更改(&U)"
 
-#: ../../../core/core_st.cpp:251
+#: ../../../core/core_st.cpp:253
 msgid "is not set"
 msgstr "未设定"
 
-#: ../../../core/core_st.cpp:252
+#: ../../../core/core_st.cpp:254
 #, fuzzy, c-format
 msgid ""
 "Number of entries processed: %d\n"
@@ -5931,100 +5950,143 @@ msgstr ""
 "\n"
 "不能被完全显示的项目字段数量: %d"
 
-#: ../../../core/core_st.cpp:254
+#: ../../../core/core_st.cpp:256
 msgid ""
 "Password should be mixed case, with at least one digit or punctuation "
 "character"
 msgstr "密码应该混合大小写和至少一个数字或标点字符！"
 
-#: ../../../core/core_st.cpp:255
+#: ../../../core/core_st.cpp:257
 msgid "Password is too short"
 msgstr "密码太短！"
 
-#: ../../../core/core_st.cpp:256
+#: ../../../core/core_st.cpp:258
 msgid "Easyvision characters"
 msgstr "易懂字符"
 
-#: ../../../core/core_st.cpp:257
+#: ../../../core/core_st.cpp:259
 msgid "Hexadecimal characters"
 msgstr "十六进制字符"
 
-#: ../../../core/core_st.cpp:258
+#: ../../../core/core_st.cpp:260
 #, fuzzy
 msgid "Password length"
 msgstr "密码长度:"
 
-#: ../../../core/core_st.cpp:259
+#: ../../../core/core_st.cpp:261
 msgid "Pronounceable passwords"
 msgstr "可发音密码"
 
-#: ../../../core/core_st.cpp:261
+#: ../../../core/core_st.cpp:263
 #, fuzzy
 msgid "Use lowercase characters"
 msgstr "最少大写字母字符"
 
-#: ../../../core/core_st.cpp:263
+#: ../../../core/core_st.cpp:265
 #, fuzzy
 msgid "Use uppercase characters"
 msgstr "最少大写字母字符"
 
-#: ../../../core/core_st.cpp:264
+#: ../../../core/core_st.cpp:266
 #, fuzzy, c-format
 msgid "Error in a Password History %ls:"
 msgstr ""
 "\n"
 "历史密码错误作为项目: »%ls»%ls»%ls»: "
 
-#: ../../../core/core_st.cpp:265
+#: ../../../core/core_st.cpp:267
 #, c-format
 msgid "sub-field starting at position %d (within the History field): "
 msgstr ""
 
-#: ../../../core/core_st.cpp:266
+#: ../../../core/core_st.cpp:268
 msgid "  All Password History ignored."
 msgstr "  忽略所有历史密码！"
 
-#: ../../../core/core_st.cpp:267
+#: ../../../core/core_st.cpp:269
 msgid "Read Error"
 msgstr "读取错误！"
 
-#: ../../../core/core_st.cpp:268
+#: ../../../core/core_st.cpp:270
+msgid "Relative"
+msgstr "相对"
+
+#: ../../../core/core_st.cpp:271
 #, c-format
 msgid ""
 "\tOne or more entry keyboard shortcuts were already assigned to entries in "
 "this database. They have been removed from the %ls entries."
 msgstr ""
 
-#: ../../../core/core_st.cpp:269
+#: ../../../core/core_st.cpp:272
 msgid ""
 "\tOne or more Password Policy Names were already in this database but had "
 "different settings. They have been renamed."
 msgstr ""
 
-#: ../../../core/core_st.cpp:270
+#: ../../../core/core_st.cpp:273
 #, fuzzy, c-format
 msgid "%ls%ls%ls_Report.txt"
 msgstr "%ls%ls%ls_Report.txt"
 
-#: ../../../core/core_st.cpp:271
+#: ../../../core/core_st.cpp:274
 #, fuzzy, c-format
 msgid "Report of %ls function started at %ls"
 msgstr "%ls 的报告函数开始于 %ls"
 
-#: ../../../core/core_st.cpp:272
+#: ../../../core/core_st.cpp:275
 #, fuzzy, c-format
 msgid "on database %ls"
 msgstr "在数据库 %ls"
 
-#: ../../../core/core_st.cpp:273
+#: ../../../core/core_st.cpp:276
+msgid "Compare"
+msgstr "比较"
+
+#: ../../../core/core_st.cpp:277
+#, fuzzy
+msgid "Export_DB"
+msgstr "导出(&E)"
+
+#: ../../../core/core_st.cpp:278
+msgid "Export_Text"
+msgstr "Export_Text"
+
+#: ../../../core/core_st.cpp:279
+msgid "Export_XML"
+msgstr "Export_XML"
+
+#: ../../../core/core_st.cpp:281
+#, fuzzy
+msgid "Import_KeePassV1_CSV"
+msgstr "导入文本(&T)"
+
+#: ../../../core/core_st.cpp:282
+#, fuzzy
+msgid "Import_KeePassV1_TXT"
+msgstr "导入文本(&T)"
+
+#: ../../../core/core_st.cpp:283
+msgid "Import_Text"
+msgstr "Import_Text"
+
+#: ../../../core/core_st.cpp:284
+msgid "Import_XML"
+msgstr "Import_XML"
+
+#: ../../../core/core_st.cpp:285
+msgid "Merge"
+msgstr "合并"
+
+#: ../../../core/core_st.cpp:287
 msgid "Validate"
 msgstr "验证"
 
-#: ../../../core/core_st.cpp:275
+#: ../../../core/core_st.cpp:289
 msgid "Fatal Error"
 msgstr "不可恢复错误！"
 
-#: ../../../core/core_st.cpp:277
+#: ../../../core/core_st.cpp:291
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -6033,116 +6095,128 @@ msgstr ""
 "\n"
 "历史密码错误作为项目: »%ls»%ls»%ls»: "
 
-#: ../../../core/core_st.cpp:278
+#: ../../../core/core_st.cpp:292
+#, c-format
+msgid "\tNo entries were found containing search string '%ls' %ls"
+msgstr ""
+
+#: ../../../core/core_st.cpp:293
+#, fuzzy, c-format
+msgid "\tThe following entries contain search string '%ls' %ls"
+msgstr ""
+"\t限定下列所选:\n"
+"\t\t %s"
+
+#: ../../../core/core_st.cpp:294
 msgid "See Attachment filters"
 msgstr ""
 
-#: ../../../core/core_st.cpp:279
+#: ../../../core/core_st.cpp:295
 msgid "See Password History filters"
 msgstr "查看历史密码筛选"
 
-#: ../../../core/core_st.cpp:280
+#: ../../../core/core_st.cpp:296
 msgid "See Password Policy filters"
 msgstr "查看密码策略筛选"
 
-#: ../../../core/core_st.cpp:281
+#: ../../../core/core_st.cpp:297
 msgid "is set"
 msgstr "已设定"
 
-#: ../../../core/core_st.cpp:282
+#: ../../../core/core_st.cpp:298
 msgid "shortcut"
 msgstr "快捷方式"
 
-#: ../../../core/core_st.cpp:283
+#: ../../../core/core_st.cpp:299
 msgid "shortcuts"
 msgstr "快捷方式"
 
-#: ../../../core/core_st.cpp:284
+#: ../../../core/core_st.cpp:300
 msgid "policy specific symbols"
 msgstr ""
 
-#: ../../../core/core_st.cpp:285
+#: ../../../core/core_st.cpp:301
 msgid "Start Report"
 msgstr "开始报告"
 
-#: ../../../core/core_st.cpp:286
+#: ../../../core/core_st.cpp:302
 msgid "Double-Click on entry to Autotype"
 msgstr "双击项目自动输入"
 
-#: ../../../core/core_st.cpp:287
+#: ../../../core/core_st.cpp:303
 msgid "Double-Click on entry to Browse to URL"
 msgstr "双击项目浏览网址"
 
-#: ../../../core/core_st.cpp:288
+#: ../../../core/core_st.cpp:304
 msgid "Double-Click on entry to Browse to URL + Autotype"
 msgstr "双击项目浏览网址并自动输入"
 
-#: ../../../core/core_st.cpp:289
+#: ../../../core/core_st.cpp:305
 #, fuzzy
 msgid "https://pwsafe.org/"
 msgstr "https://pwsafe.org/"
 
-#: ../../../core/core_st.cpp:290
+#: ../../../core/core_st.cpp:306
 msgid "Double-Click on entry to Copy Notes"
 msgstr "双击项目复制备注"
 
-#: ../../../core/core_st.cpp:291
+#: ../../../core/core_st.cpp:307
 msgid "Double-Click on entry to Copy Password"
 msgstr "双击项目复制密码"
 
-#: ../../../core/core_st.cpp:292
+#: ../../../core/core_st.cpp:308
 msgid "Double-Click on entry to Copy Password and Minimize"
 msgstr "双击项目复制密码并最小化"
 
-#: ../../../core/core_st.cpp:293
+#: ../../../core/core_st.cpp:309
 msgid "Double-Click on entry to Copy Username"
 msgstr "双击项目复制用户名"
 
-#: ../../../core/core_st.cpp:294
+#: ../../../core/core_st.cpp:310
 msgid "Double-Click on entry to Run Command"
 msgstr "双击项目运行命令"
 
-#: ../../../core/core_st.cpp:295
+#: ../../../core/core_st.cpp:311
 #, fuzzy
 msgid "Double-Click on entry to Send Email"
 msgstr "双击项目发送邮件"
 
-#: ../../../core/core_st.cpp:296
+#: ../../../core/core_st.cpp:312
 msgid "Double-Click on entry to View/Edit it"
 msgstr "双击项目查看/编辑"
 
-#: ../../../core/core_st.cpp:299
+#: ../../../core/core_st.cpp:315
 #, fuzzy, c-format
 msgid "%ls - Sync'd %ls"
 msgstr "%ls 在 %ls 上"
 
-#: ../../../core/core_st.cpp:300
+#: ../../../core/core_st.cpp:316
 msgid "System error: No more file handles available"
 msgstr "系统错误: 没有更多文件句柄可用！"
 
-#: ../../../core/core_st.cpp:303
+#: ../../../core/core_st.cpp:319
 msgid "Unknown function"
 msgstr "未知函数"
 
-#: ../../../core/core_st.cpp:304
+#: ../../../core/core_st.cpp:320
 msgid "Unknown object"
 msgstr "未知对象"
 
-#: ../../../core/core_st.cpp:305
+#: ../../../core/core_st.cpp:321
 msgid "Internal error: Unexpected error number"
 msgstr "内部错误: 意外错误数字！"
 
-#: ../../../core/core_st.cpp:307
+#: ../../../core/core_st.cpp:323
 #, c-format
 msgid "\tName: %s; Filename: %s"
 msgstr ""
 
-#: ../../../core/core_st.cpp:308
+#: ../../../core/core_st.cpp:324
 msgid ""
 "The following entries had an invalid UUID field.  This has been corrected."
 msgstr "下列项目有一个无效 UUID 字段，这些已得到纠正！"
 
-#: ../../../core/core_st.cpp:309
+#: ../../../core/core_st.cpp:325
 #, fuzzy, c-format
 msgid ""
 "The following entries have passwords in the correct form for %ls, but the "
@@ -6150,53 +6224,53 @@ msgid ""
 msgstr ""
 "项目“%ls、%ls、%ls”有一个密码在为一个别名做格式校正，但基本项目不存在！"
 
-#: ../../../core/core_st.cpp:310
+#: ../../../core/core_st.cpp:326
 msgid "The following entries were duplicates of an existing entry."
 msgstr "下列项目是一个现有项目的副本！"
 
-#: ../../../core/core_st.cpp:311
+#: ../../../core/core_st.cpp:327
 #, fuzzy
 msgid ""
 "The following entries had a duplicate UUID field.  This has been corrected."
 msgstr "下列项目有一个无效 UUID 字段，这些已得到纠正！"
 
-#: ../../../core/core_st.cpp:312
+#: ../../../core/core_st.cpp:328
 #, fuzzy, c-format
 msgid ""
 "The following entries had an empty Password field, which is not permitted. "
 "The password has been set to '%ls'"
 msgstr "下列项目有一个无效 UUID 字段，这些已得到纠正！"
 
-#: ../../../core/core_st.cpp:313
+#: ../../../core/core_st.cpp:329
 #, fuzzy
 msgid "The following entries had an empty Title field, which is not permitted."
 msgstr "下列项目有一个无效 UUID 字段，这些已得到纠正！"
 
-#: ../../../core/core_st.cpp:314
+#: ../../../core/core_st.cpp:330
 #, fuzzy, c-format
 msgid "\tGroup='%ls', Title='%ls', User='%ls' %ls"
 msgstr "\t组='%ls', 标题='%ls', 用户='%ls' %ls"
 
-#: ../../../core/core_st.cpp:315
+#: ../../../core/core_st.cpp:331
 #, fuzzy, c-format
 msgid "- Its title has been changed to:'%ls'"
 msgstr "- 其名称已更改为:“%ls”"
 
-#: ../../../core/core_st.cpp:316
+#: ../../../core/core_st.cpp:332
 msgid "The following ERRORS were detected and were FIXED."
 msgstr ""
 
-#: ../../../core/core_st.cpp:317
+#: ../../../core/core_st.cpp:333
 #, fuzzy
 msgid "The following entries refer to missing attachments."
 msgstr "下列项目是一个现有项目的副本！"
 
-#: ../../../core/core_st.cpp:318
+#: ../../../core/core_st.cpp:334
 #, fuzzy
 msgid "The following attachments are not referred to by any entry."
 msgstr "下列项目是一个现有项目的副本！"
 
-#: ../../../core/core_st.cpp:319
+#: ../../../core/core_st.cpp:335
 msgid ""
 "The following entries had an invalid Password History.  This has been "
 "rebuilt with available data.  There may be some loss of history."
@@ -6204,24 +6278,24 @@ msgstr ""
 "下列项目有一个无效历史密码，该密码已重建于现有数据上，可能存在部分历史密码损"
 "失！"
 
-#: ../../../core/core_st.cpp:320
+#: ../../../core/core_st.cpp:336
 #, c-format
 msgid ""
 "The following entries have one or more text fields too long to display or "
 "edit (over %d characters).  The largest entry size found was ~%d %ls."
 msgstr ""
 
-#: ../../../core/core_st.cpp:321
+#: ../../../core/core_st.cpp:337
 msgid ""
 "The following WARNINGS were detected - you should review and fix them "
 "manually."
 msgstr ""
 
-#: ../../../core/core_st.cpp:324
+#: ../../../core/core_st.cpp:340
 msgid "will expire"
 msgstr "即将失效"
 
-#: ../../../core/core_st.cpp:325
+#: ../../../core/core_st.cpp:341
 #, fuzzy, c-format
 msgid ""
 "SAX Parse Error during %ls\n"
@@ -6230,51 +6304,51 @@ msgstr ""
 "在 %ls 期间 SAX 分析错误\n"
 "%ls。"
 
-#: ../../../core/core_st.cpp:326
+#: ../../../core/core_st.cpp:342
 #, fuzzy, c-format
 msgid "XML %ls: line %d character %d: %ls"
 msgstr "XML %ls: 行 %d 字符 %d: %ls"
 
-#: ../../../core/core_st.cpp:327
+#: ../../../core/core_st.cpp:343
 msgid ""
 "*** Invalid XML characters found - see exported XML file for more details ***"
 msgstr ""
 
-#: ../../../core/core_st.cpp:328
+#: ../../../core/core_st.cpp:344
 msgid "Internal error: Couldn't initialize config file XML structure"
 msgstr "内部错误: 不能初始化配置文件 XML 结构！"
 
-#: ../../../core/core_st.cpp:329
+#: ../../../core/core_st.cpp:345
 msgid ""
 "A filter was active. Export of data was restricted to include only those "
 "displayed."
 msgstr "筛选被激活，导出的数据被限制为仅包含所显示的内容！"
 
-#: ../../../core/core_st.cpp:330
+#: ../../../core/core_st.cpp:346
 msgid "Export of data was restricted to certain fields by the user."
 msgstr "导出的数据仅限于用户确定的某些字段！"
 
-#: ../../../core/core_st.cpp:331
+#: ../../../core/core_st.cpp:347
 msgid ""
 "Note: These Password Policies will not replace existing policies with the "
 "same name in the current database."
 msgstr ""
 
-#: ../../../core/core_st.cpp:332
+#: ../../../core/core_st.cpp:348
 msgid ""
 "Note: These preferences are only used when importing into an empty database."
 msgstr "注意: 这些参数选择仅当导入到一个空白数据库中时使用！"
 
-#: ../../../core/core_st.cpp:333
+#: ../../../core/core_st.cpp:349
 msgid "Subset of entries restricted by the following rule:"
 msgstr "以下列规则限定项目子集:"
 
-#: ../../../core/core_st.cpp:334
+#: ../../../core/core_st.cpp:350
 msgid ""
 "The user specified that the following fields be excluded from the export:"
 msgstr "用户指定需要从导出排除的下列字段:"
 
-#: ../../../core/core_st.cpp:335
+#: ../../../core/core_st.cpp:351
 #, fuzzy, c-format
 msgid ""
 "Configuration file error:\n"
@@ -6287,118 +6361,63 @@ msgstr ""
 "%ls\n"
 "行 %d 栏目 %d"
 
-#: ../../../core/core_st.cpp:336
+#: ../../../core/core_st.cpp:352
 msgid "import"
 msgstr "导入"
 
-#: ../../../core/core_st.cpp:337
+#: ../../../core/core_st.cpp:353
 msgid "Unable to load configuration file"
 msgstr "不能加载配置文件！"
 
-#: ../../../core/core_st.cpp:338
+#: ../../../core/core_st.cpp:354
 msgid ""
 "Failed to lock configuration file - opened by another instance of "
 "PasswordSafe?"
 msgstr "未能配置锁文件 - 打开其它 PasswordSafe 实例？"
 
-#: ../../../core/core_st.cpp:339
+#: ../../../core/core_st.cpp:355
 msgid "Unable to save configuration file"
 msgstr "不能保存配置文件！"
 
-#: ../../../core/core_st.cpp:340
+#: ../../../core/core_st.cpp:356
 #, fuzzy
 msgid "validation"
 msgstr "验证"
 
-#: ../../../core/core_st.cpp:342
+#: ../../../core/core_st.cpp:358
 msgid " (EasyVision Symbols)"
 msgstr ""
 
-#: ../../../core/core_st.cpp:343
+#: ../../../core/core_st.cpp:359
 #, fuzzy, c-format
 msgid "Yes (at least %d)"
 msgstr "至少必须 %d！"
 
-#: ../../../core/core_st.cpp:344
+#: ../../../core/core_st.cpp:360
 #, fuzzy
 msgid " (Pronounceable Symbols)"
 msgstr "可发音密码"
 
-#: ../../../core/core_st.cpp:345
+#: ../../../core/core_st.cpp:361
 #, c-format
 msgid "Yes - At least %d from %ls: %ls%ls"
 msgstr ""
 
-#: ../../../core/core_st.cpp:346
 #, fuzzy, c-format
-msgid "\tGroup='%ls', Title='%ls', User='%ls'"
-msgstr "\t组='%ls', 标题='%ls', 用户='%ls' %ls"
+#~ msgid "\tGroup='%ls', Title='%ls', User='%ls'"
+#~ msgstr "\t组='%ls', 标题='%ls', 用户='%ls' %ls"
 
-#: ../../../core/core_st.cpp:347
-#, fuzzy, c-format
-msgid ""
-"Compare complete of current database:\n"
-"\t %ls\n"
-" and:\n"
-"\t %ls\n"
-msgstr ""
-"当前数据库比较完成:\n"
-"\t %s\n"
-" 和:\n"
-"\t %s"
-
-#: ../../../core/core_st.cpp:348
-#, c-format
-msgid "\tNo entries were found containing search string '%ls' %ls"
-msgstr ""
-
-#: ../../../core/core_st.cpp:349
-#, fuzzy, c-format
-msgid "\tThe following entries contain search string '%ls' %ls"
-msgstr ""
-"\t限定下列所选:\n"
-"\t\t %s"
-
-#: ../../../core/core_st.cpp:350
 #, fuzzy
-msgid "Export DB"
-msgstr "导出(&E)"
+#~ msgid "Import XML"
+#~ msgstr ""
+#~ "\n"
+#~ "导入 XML"
 
-#: ../../../core/core_st.cpp:351
-msgid "Import KeePassV1 CSV"
-msgstr ""
-
-#: ../../../core/core_st.cpp:352
-msgid "Import KeePassV1 TXT"
-msgstr ""
-
-#: ../../../core/core_st.cpp:353
 #, fuzzy
-msgid "Import XML"
-msgstr ""
-"\n"
-"导入 XML"
-
-#: ../../../core/core_st.cpp:354
-#, fuzzy
-msgid "Import Text"
-msgstr ""
-"\n"
-"导入文本"
-
-#: ../../../core/core_st.cpp:355
-msgid "Merge"
-msgstr "合并"
-
-#: ../../../core/core_st.cpp:356
-msgid "Compare"
-msgstr "比较"
-
-#~ msgid "Import_Text"
-#~ msgstr "Import_Text"
-
-#~ msgid "Import_XML"
-#~ msgstr "Import_XML"
+#~ msgid "Import Text"
+#~ msgstr ""
+#~ "\n"
+#~ "导入文本"
 
 #, fuzzy
 #~ msgid "Advanced..."
@@ -7726,12 +7745,6 @@ msgstr "比较"
 #~ msgid "Export file:"
 #~ msgstr "导出文件:"
 
-#~ msgid "Export_Text"
-#~ msgstr "Export_Text"
-
-#~ msgid "Export_XML"
-#~ msgstr "Export_XML"
-
 #~ msgid "Exporting to file:"
 #~ msgstr "导出为文件:"
 
@@ -8431,9 +8444,6 @@ msgstr "比较"
 #~ msgstr ""
 #~ "恢复自动保存文档\n"
 #~ "打开自动保存版本取代明确保存版本"
-
-#~ msgid "Relative"
-#~ msgstr "相对"
 
 #~ msgid ""
 #~ "Relative dates are in days relative to today e.g. '-1' is yesterday and "
@@ -9624,9 +9634,6 @@ msgstr "比较"
 #~ msgstr ""
 #~ "\t项目 - 组:\"%s\"; 标题:\"%s\"; 用户:\"%s\"\n"
 #~ "\t\t与下列字段存在差异:"
-
-#~ msgid "\tGroup:'%s'; Title:'%s'; User:'%s'"
-#~ msgstr "\t组:'%s'; 标题:'%s'; 用户:'%s'"
 
 #~ msgid "an unnamed file"
 #~ msgstr "一个未命名文件"


### PR DESCRIPTION
Sorry, I did not noticed building core_st.cpp derived from core.rc2. Now it is corrected and building a Report on find will not crash in wxWidgets environment.