### PR TITLE
Add "StartupWMClass=pwsafe" to passwordsafe.desktop

### DIFF
--- a/install/desktop/pwsafe.desktop
+++ b/install/desktop/pwsafe.desktop
@@ -8,4 +8,5 @@ Icon=pwsafe
 Terminal=false
 Type=Application
 StartupNotify=true
+StartupWMClass=pwsafe
 Categories=GTK;Utility;Security;


### PR DESCRIPTION
The app icon is missing from the dash, the top panel and the window switcher in GNOME Shell under Wayland.

This is solved by adding "StartupWMClass=pwsafe" to passwordsafe.desktop to enable GNOME Shell to map the application to its icon under Wayland.

Closes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=988062