### PR TITLE
Hotfix to avoid assert with no delimiter configured in menu bar, enable compilation for MacOS using Xcode

### DIFF
--- a/Misc/osx-build-wx
+++ b/Misc/osx-build-wx
@@ -175,6 +175,7 @@ doCarbonBuild() {
                             --disable-shared            \
                             --disable-compat24          \
                             --enable-unicode            \
+                            --enable-aui                \
                             --enable-universal-binary   \
                             --with-osx_carbon           \
                             --with-macosx-sdk=$SDKPATH  \
@@ -230,6 +231,7 @@ else
                               --with-osx_cocoa                  \
                               --disable-shared                  \
                               --enable-unicode                  \
+                              --enable-aui                      \
                               --with-macosx-version-min=10.10   \
                               $COMPATFLAG                       \
                               --without-liblzma                 \

--- a/Xcode/generate-configs
+++ b/Xcode/generate-configs
@@ -30,7 +30,7 @@ die "wx-config \"$wxconfig\" is not executable" unless -x $wxconfig;
 my $dbgflag = $flag eq "-d" ? "yes" : "no";
 my $libflags;
 my $rpath;
-foreach(split /\s+/, `$wxconfig --libs --unicode=yes --debug=$dbgflag`) {
+foreach(split /\s+/, `$wxconfig --libs aui xrc html qa adv core xml net base --unicode=yes --debug=$dbgflag`) {
 	$libflags .= $_." " if /\A-[lL]|\.a\Z/;
 	$rpath .= $1." " if /\A-Wl,-rpath,(.*)\Z/;
 }

--- a/src/core/PWSprefs.cpp
+++ b/src/core/PWSprefs.cpp
@@ -134,7 +134,7 @@ const PWSprefs::boolPref PWSprefs::m_bool_prefs[NumBoolPrefs] = {
   {_T("EnableWindowTransparency"), false, ptApplication},   // application
   {_T("ShowMenuSeparator"), true, ptApplication},           // application
   {_T("AutoAdjColWidth"), false, ptApplication},            // application
-  {_T("ToolbarShowText"), false, ptApplication},            // application
+  {_T("ToolbarShowText"), true, ptApplication},             // application
   {_T("DragAndDropShowRoot"), false, ptApplication},        // application
   {_T("ShowAliasSelection"), false, ptApplication},         // application
 };

--- a/src/ui/wxWidgets/ComparisonGridTable.h
+++ b/src/ui/wxWidgets/ComparisonGridTable.h
@@ -18,7 +18,12 @@
 #include "../../core/DBCompareData.h"
 #include "../../core/UIinterface.h"
 
-#define CurrentBackgroundColor    *wxWHITE
+// #define CurrentBackgroundColor    *wxWHITE
+#if wxVERSION_NUMBER >= 3103
+#define CurrentBackgroundColor    (wxSystemSettings::GetAppearance().IsUsingDarkBackground() ? wxColor(29, 30, 32) : *wxWHITE)
+#else
+#define CurrentBackgroundColor    (*wxWHITE)
+#endif
 #define ComparisonBackgroundColor *wxWHITE
 
 struct SelectionCriteria;

--- a/src/ui/wxWidgets/DragBarCtrl.cpp
+++ b/src/ui/wxWidgets/DragBarCtrl.cpp
@@ -204,7 +204,7 @@ void DragBarCtrl::CalculateToolsWidth()
     }
   }
 
-  SetMinSize(wxSize(width, -1));
+  SetMinSize(wxSize(static_cast<int>(width), -1));
 }
 
 /**

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -890,21 +890,35 @@ void PasswordSafeFrame::RefreshToolbarButtons()
   if (toolbar->GetToolCount() > 0) {
     toolbar->ClearTools();
   }
+  bool toolbarShowText = pref->GetPref(PWSprefs::ToolbarShowText);
+  bool showMenuSeprator = pref->GetPref(PWSprefs::ShowMenuSeparator);
 
   for (const auto & PwsToolbarButton : PwsToolbarButtons) {
-    if (pref->GetPref(PWSprefs::ShowMenuSeparator) && (PwsToolbarButton.IsSeparator())) {
-      toolbar->AddSeparator()->SetId(PwsToolbarButton.id);
+    if (PwsToolbarButton.IsSeparator()) {
+      if (showMenuSeprator)
+        toolbar->AddSeparator()->SetId(PwsToolbarButton.id);
     }
     else {
-      toolbar->AddTool(
-        PwsToolbarButton.id,
-        wxGetTranslation(PwsToolbarButton.toollabel),
-        PwsToolbarButton.GetBitmapForEnabledButton(),
-        PwsToolbarButton.GetBitmapForDisabledButton(),
-        wxITEM_NORMAL,
-        wxGetTranslation(PwsToolbarButton.tooltip),
-        wxEmptyString,
-        nullptr);
+      if(toolbarShowText)
+        toolbar->AddTool(
+          PwsToolbarButton.id,
+          wxGetTranslation(PwsToolbarButton.toollabel),
+          PwsToolbarButton.GetBitmapForEnabledButton(),
+          PwsToolbarButton.GetBitmapForDisabledButton(),
+          wxITEM_NORMAL,
+          wxGetTranslation(PwsToolbarButton.tooltip),
+          wxEmptyString,
+          nullptr);
+      else
+        toolbar->AddTool(
+          PwsToolbarButton.id,
+          wxGetTranslation(PwsToolbarButton.toollabel),
+          PwsToolbarButton.GetBitmapForEnabledButton(),
+          PwsToolbarButton.GetBitmapForDisabledButton(),
+          wxITEM_NORMAL,
+          wxEmptyString,
+          wxEmptyString,
+          nullptr);
     }
   }
 
@@ -967,7 +981,7 @@ void PasswordSafeFrame::DeleteMainToolbarSeparators()
 
   for (size_t pos = 0; pos < toolbar->GetToolCount(); ++pos) {
     if(toolbar->FindToolByIndex(static_cast<int>(pos))->GetId() == ID_SEPARATOR)
-      toolbar->DeleteByIndex(pos);
+      toolbar->DeleteByIndex(static_cast<int>(pos));
   }
 
   toolbar->Realize();


### PR DESCRIPTION
- Avoid assert with no delimiter setting in display options
- Set/unset text beneath icons in menu bar according to display options
- Enable compilation/linking on MacOS using Xcode as build environment
Hint: wxWidgets 3.0.5 is not able to run with the actual development on MacOS, while 3.1.4 is able, but background of tree view is grey and not white as the icons background is - the last one is fixed with 3.1.5 development branch of wxWidgets.
