### PR TITLE
[wx] Attempt to fix some show/hide issues

### DIFF
--- a/CodeBlocks/pwsafe/pwsafe.cbp
+++ b/CodeBlocks/pwsafe/pwsafe.cbp
@@ -12,7 +12,6 @@
 				<Option object_output="obj/Debug64/" />
 				<Option type="0" />
 				<Option compiler="gcc" />
-				<Option parameters="-s" />
 				<Option projectLinkerOptionsRelation="2" />
 				<Compiler>
 					<Add option="-m64" />
@@ -32,7 +31,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m64" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=yes --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs adv,aui,base,core,html,net --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add library="core64d" />
 					<Add library="os64d" />
@@ -66,7 +65,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m32" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=yes --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs adv,aui,base,core,html,net --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add library="core32d" />
 					<Add library="os32d" />
@@ -97,7 +96,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m64" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs adv,aui,base,core,html,net --unicode=yes --debug=no --inplace`" />
 					<Add library="core64" />
 					<Add library="os64" />
 					<Add directory="../core" />
@@ -128,7 +127,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m32" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs adv,aui,base,core,html,net --unicode=yes --debug=no --inplace`" />
 					<Add library="core32" />
 					<Add library="os32" />
 					<Add directory="../core" />
@@ -159,7 +158,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m64" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=yes --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs adv,aui,base,core,html,net --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
@@ -194,7 +193,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m32" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=yes --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs adv,aui,base,core,html,net --unicode=yes --debug=yes --inplace`" />
 					<Add option="-fsanitize=address" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
@@ -226,7 +225,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m64" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs adv,aui,base,core,html,net --unicode=yes --debug=no --inplace`" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
 					<Add library="core64y" />
@@ -258,7 +257,7 @@
 				</Compiler>
 				<Linker>
 					<Add option="-m32" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs adv,aui,base,core,html,net --unicode=yes --debug=no --inplace`" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
 					<Add library="core32y" />
@@ -297,7 +296,7 @@
 				<Linker>
 					<Add option="-fsanitize=address" />
 					<Add option="-m64" />
-					<Add option="`wx-config --version=3.0 --libs --unicode=yes --debug=no --inplace`" />
+					<Add option="`wx-config --version=3.0 --libs adv,aui,base,core,html,net --unicode=yes --debug=no --inplace`" />
 					<Add option="`pkg-config --libs ykpers-1`" />
 					<Add option="`pkg-config --libs libqrencode`" />
 					<Add library="core64y" />
@@ -315,13 +314,12 @@
 			<Add option="-Wundef" />
 			<Add option="-Wfloat-equal" />
 			<Add option="-Wunreachable-code" />
-			<Add option="-Wmissing-include-dirs" />
 			<Add option="-Wswitch-default" />
-			<Add option="-Wzero-as-null-pointer-constant" />
 			<Add option="-Wextra" />
 			<Add option="-Wall" />
 			<Add option="-std=c11" />
 			<Add option="-fPIC" />
+			<Add option="-Wmissing-include-dirs" />
 			<Add option="-std=c++11" />
 			<Add option="-Wformat=2" />
 			<Add option="-Wno-unused-local-typedefs" />
@@ -331,7 +329,6 @@
 			<Add option="-Wduplicated-cond" />
 			<Add option="-Winvalid-pch" />
 			<Add option="-Wlogical-op" />
-			<Add option="-Wno-shadow-field-in-constructor" />
 			<Add option="-DUNICODE" />
 		</Compiler>
 		<Linker>
@@ -478,6 +475,8 @@
 			<Option target="Release_L32Y" />
 			<Option target="Release_L64YClang" />
 		</Unit>
+		<Unit filename="../../src/ui/wxWidgets/QueryCancelDlg.cpp" />
+		<Unit filename="../../src/ui/wxWidgets/QueryCancelDlg.h" />
 		<Unit filename="../../src/ui/wxWidgets/RecentDbList.h" />
 		<Unit filename="../../src/ui/wxWidgets/SafeCombinationChangeDlg.cpp" />
 		<Unit filename="../../src/ui/wxWidgets/SafeCombinationChangeDlg.h" />
@@ -489,6 +488,8 @@
 		<Unit filename="../../src/ui/wxWidgets/SafeCombinationPromptDlg.h" />
 		<Unit filename="../../src/ui/wxWidgets/SafeCombinationSetupDlg.cpp" />
 		<Unit filename="../../src/ui/wxWidgets/SafeCombinationSetupDlg.h" />
+		<Unit filename="../../src/ui/wxWidgets/SelectAliasDlg.cpp" />
+		<Unit filename="../../src/ui/wxWidgets/SelectAliasDlg.h" />
 		<Unit filename="../../src/ui/wxWidgets/SelectionCriteria.cpp" />
 		<Unit filename="../../src/ui/wxWidgets/SelectionCriteria.h" />
 		<Unit filename="../../src/ui/wxWidgets/SetFiltersDlg.cpp" />

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		A2FE25911C5ACF7500210C36 /* PWSfileHeader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25891C5ACF7500210C36 /* PWSfileHeader.cpp */; };
 		A2FE25921C5ACF7500210C36 /* PWSfileV4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE258B1C5ACF7500210C36 /* PWSfileV4.cpp */; };
 		A2FE25951C5ACFBD00210C36 /* PWStime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25931C5ACFBD00210C36 /* PWStime.cpp */; };
+		A6F2B3362832B0380096A7E4 /* QueryCancelDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A6F2B3342832B0380096A7E4 /* QueryCancelDlg.cpp */; };
 		D3012934262C731500FDF023 /* PWFiltersStringDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D3012932262C731500FDF023 /* PWFiltersStringDlg.cpp */; };
 		D31B027926384D29000EAA61 /* PWFiltersMediaDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D31B027726384D29000EAA61 /* PWFiltersMediaDlg.cpp */; };
 		D3206A1E25B8B22300F6E115 /* DnDPWSafeObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D3206A1D25B8B22200F6E115 /* DnDPWSafeObject.cpp */; };
@@ -282,6 +283,8 @@
 		A2FE258C1C5ACF7500210C36 /* PWSfileV4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PWSfileV4.h; sourceTree = "<group>"; };
 		A2FE25931C5ACFBD00210C36 /* PWStime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PWStime.cpp; sourceTree = "<group>"; };
 		A2FE25941C5ACFBD00210C36 /* PWStime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PWStime.h; sourceTree = "<group>"; };
+		A6F2B3342832B0380096A7E4 /* QueryCancelDlg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = QueryCancelDlg.cpp; sourceTree = "<group>"; };
+		A6F2B3352832B0380096A7E4 /* QueryCancelDlg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QueryCancelDlg.h; sourceTree = "<group>"; };
 		D3012932262C731500FDF023 /* PWFiltersStringDlg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PWFiltersStringDlg.cpp; sourceTree = "<group>"; };
 		D3012933262C731500FDF023 /* PWFiltersStringDlg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PWFiltersStringDlg.h; sourceTree = "<group>"; };
 		D31B027726384D29000EAA61 /* PWFiltersMediaDlg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PWFiltersMediaDlg.cpp; sourceTree = "<group>"; };
@@ -1309,6 +1312,8 @@
 		E6ADB9A411957099004E2BE5 /* wxWidgets */ = {
 			isa = PBXGroup;
 			children = (
+				A6F2B3342832B0380096A7E4 /* QueryCancelDlg.cpp */,
+				A6F2B3352832B0380096A7E4 /* QueryCancelDlg.h */,
 				D3F00B69268CBB2B00F299EE /* SelectAliasDlg.cpp */,
 				D3F00B68268CBB2B00F299EE /* SelectAliasDlg.h */,
 				D3610ABB2653D51900EDA799 /* HelpMap.h */,
@@ -1970,6 +1975,7 @@
 				D3A1DCD6261B15E80014A300 /* PWFiltersGrid.cpp in Sources */,
 				E6ADBA961195709A004E2BE5 /* TreeCtrl.cpp in Sources */,
 				E6ADBA981195709A004E2BE5 /* SafeCombinationChangeDlg.cpp in Sources */,
+				A6F2B3362832B0380096A7E4 /* QueryCancelDlg.cpp in Sources */,
 				E6ADBA991195709A004E2BE5 /* SafeCombinationEntryDlg.cpp in Sources */,
 				E6ADBA9A1195709A004E2BE5 /* SafeCombinationPromptDlg.cpp in Sources */,
 				E6ADBA9B1195709A004E2BE5 /* SafeCombinationSetupDlg.cpp in Sources */,

--- a/src/core/Command.cpp
+++ b/src/core/Command.cpp
@@ -298,7 +298,7 @@ void DBPrefsCommand::Undo()
 // ------------------------------------------------
 
 DBPolicyNamesCommand::DBPolicyNamesCommand(CommandInterface *pcomInt,
-                                           PSWDPolicyMap &MapPSWDPLC,
+                                           const PSWDPolicyMap &MapPSWDPLC,
                                            Function function)
   : Command(pcomInt), m_NewMapPSWDPLC(MapPSWDPLC), m_function(function),
   m_bSingleAdd(false)
@@ -307,8 +307,8 @@ DBPolicyNamesCommand::DBPolicyNamesCommand(CommandInterface *pcomInt,
 }
 
 DBPolicyNamesCommand::DBPolicyNamesCommand(CommandInterface *pcomInt,
-                                           StringX &sxPolicyName,
-                                           PWPolicy &st_pp)
+                                           const StringX &sxPolicyName,
+                                           const PWPolicy &st_pp)
   : Command(pcomInt), m_sxPolicyName(sxPolicyName), m_st_ppp(st_pp),
   m_bSingleAdd(true)
 {

--- a/src/core/Command.h
+++ b/src/core/Command.h
@@ -170,20 +170,20 @@ public:
   enum Function {NP_ADDNEW = 0, NP_REPLACEALL};
 
   static DBPolicyNamesCommand *Create(CommandInterface *pcomInt,
-                                PSWDPolicyMap &MapPSWDPLC,
+                                const PSWDPolicyMap &MapPSWDPLC,
                                 Function function)
   { return new DBPolicyNamesCommand(pcomInt, MapPSWDPLC, function); }
   static DBPolicyNamesCommand *Create(CommandInterface *pcomInt,
-                                StringX &sxPolicyName, PWPolicy &st_pp)
+                                const StringX &sxPolicyName, const PWPolicy &st_pp)
   { return new DBPolicyNamesCommand(pcomInt, sxPolicyName, st_pp); }
   int Execute();
   void Undo();
 
 private:
-  DBPolicyNamesCommand(CommandInterface *pcomInt, PSWDPolicyMap &MapPSWDPLC,
+  DBPolicyNamesCommand(CommandInterface *pcomInt, const PSWDPolicyMap &MapPSWDPLC,
                        Function function);
-  DBPolicyNamesCommand(CommandInterface *pcomInt, StringX &sxPolicyName,
-                       PWPolicy &st_pp);
+  DBPolicyNamesCommand(CommandInterface *pcomInt, const StringX &sxPolicyName,
+                       const PWPolicy &st_pp);
 
   PSWDPolicyMap m_OldMapPSWDPLC;
   PSWDPolicyMap m_NewMapPSWDPLC;

--- a/src/ui/wxWidgets/AboutDlg.cpp
+++ b/src/ui/wxWidgets/AboutDlg.cpp
@@ -63,27 +63,14 @@ const cstringT AboutDlg::s_URL_VERSION   =  "https://pwsafe.org/latest.xml";
  * AboutDlg constructors
  */
 
-AboutDlg::AboutDlg()
+AboutDlg::AboutDlg(wxWindow *parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
 {
-  Init();
-}
-
-AboutDlg::AboutDlg( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
-  Init();
-  Create(parent, id, caption, pos, size, style);
+  wxASSERT(!parent || parent->IsTopLevel());
 
   // Print version information on standard output which might be useful for error reports.
   pws_os::Trace(GetLibWxVersion().wc_str());
   pws_os::Trace(GetLibCurlVersion().wc_str());
-}
 
-/*!
- * AboutDlg creator
- */
-
-bool AboutDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create( parent, id, caption, pos, size, style );
 
@@ -99,27 +86,11 @@ bool AboutDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption,
     }
   }
   Centre();
-  return true;
 }
 
-/*!
- * AboutDlg destructor
- */
-
-AboutDlg::~AboutDlg()
+AboutDlg* AboutDlg::Create(wxWindow *parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
 {
-////@begin AboutDlg destruction
-////@end AboutDlg destruction
-}
-
-/*!
- * Member initialization
- */
-
-void AboutDlg::Init()
-{
-  m_VersionStatus = nullptr;
-  m_CurlHandle = nullptr;
+  return new AboutDlg(parent, id, caption, pos, size, style);
 }
 
 /*!

--- a/src/ui/wxWidgets/AboutDlg.h
+++ b/src/ui/wxWidgets/AboutDlg.h
@@ -82,6 +82,7 @@ public:
   /// Destructor
   ~AboutDlg() = default;
 
+  int ShowAndCheckForUpdate();
 protected:
   virtual wxThread::ExitCode Entry();
 

--- a/src/ui/wxWidgets/AboutDlg.h
+++ b/src/ui/wxWidgets/AboutDlg.h
@@ -75,22 +75,18 @@ class AboutDlg : public wxDialog, public wxThreadHelper
   static wxCriticalSection& CriticalSection();
   static size_t WriteCallback(char *receivedData, size_t size, size_t bytes, void *userData);
 
+public:
+  /// Creation
+  static AboutDlg* Create(wxWindow *parent, wxWindowID id = SYMBOL_ABOUTDLG_IDNAME, const wxString& caption = SYMBOL_ABOUTDLG_TITLE, const wxPoint& pos = SYMBOL_ABOUTDLG_POSITION, const wxSize& size = SYMBOL_ABOUTDLG_SIZE, long style = SYMBOL_ABOUTDLG_STYLE );
+
+  /// Destructor
+  ~AboutDlg() = default;
+
 protected:
   virtual wxThread::ExitCode Entry();
 
-public:
   /// Constructors
-  AboutDlg();
-  AboutDlg( wxWindow* parent, wxWindowID id = SYMBOL_ABOUTDLG_IDNAME, const wxString& caption = SYMBOL_ABOUTDLG_TITLE, const wxPoint& pos = SYMBOL_ABOUTDLG_POSITION, const wxSize& size = SYMBOL_ABOUTDLG_SIZE, long style = SYMBOL_ABOUTDLG_STYLE );
-
-  /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_ABOUTDLG_IDNAME, const wxString& caption = SYMBOL_ABOUTDLG_TITLE, const wxPoint& pos = SYMBOL_ABOUTDLG_POSITION, const wxSize& size = SYMBOL_ABOUTDLG_SIZE, long style = SYMBOL_ABOUTDLG_STYLE );
-
-  /// Destructor
-  ~AboutDlg();
-
-  /// Initialises member variables
-  void Init();
+  AboutDlg(wxWindow *parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style );
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -129,14 +125,14 @@ public:
 
 private:
 ////@begin AboutDlg member variables
-  wxTextCtrl* m_VersionStatus;
+  wxTextCtrl* m_VersionStatus = nullptr;
 ////@end AboutDlg member variables
 
   /// The CURL handle with connection specific options for request of version data
 #ifdef HAS_CURL
-  CURL *m_CurlHandle;
+  CURL *m_CurlHandle = nullptr;
 #else
-  void *m_CurlHandle;
+  void *m_CurlHandle = nullptr;
 #endif // HAS_CURL
 
   /// Set to downloaded data by worker thread, resp. WriteCallback, and read by main thread for final version check

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -824,8 +824,13 @@ void AddEditPropSheetDlg::InitAttachmentTab()
       // Show attachment data on UI.
       ShowAttachmentData(m_ItemAttachment);
 
-      // Attachment must be removed before a new one can be imported again.
-      DisableImport();
+      if (m_Core.IsReadOnly()) {
+        DisableAttachmentControls();
+      }
+      else {
+        // Attachment must be removed before a new one can be imported again.
+        DisableImport();
+      }
     }
     else {
       ResetAttachmentData();
@@ -834,7 +839,12 @@ void AddEditPropSheetDlg::InitAttachmentTab()
   else {
     ResetAttachmentData();
     HideImagePreview(_("No Attachment Available"));
-    EnableImport();
+    if (m_Core.IsReadOnly()) {
+      DisableAttachmentControls();
+    }
+    else {
+      EnableImport();
+    }
   }
 }
 
@@ -988,6 +998,13 @@ void AddEditPropSheetDlg::DisableImport()
   m_AttachmentButtonImport->Disable();
   m_AttachmentButtonExport->Enable();
   m_AttachmentButtonRemove->Enable();
+}
+
+void AddEditPropSheetDlg::DisableAttachmentControls()
+{
+  m_AttachmentButtonImport->Disable();
+  m_AttachmentButtonExport->Disable();
+  m_AttachmentButtonRemove->Disable();
 }
 
 void AddEditPropSheetDlg::OnImport(wxCommandEvent& WXUNUSED(event))

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -112,19 +112,6 @@ BEGIN_EVENT_TABLE( AddEditPropSheetDlg, wxPropertySheetDialog )
   EVT_UPDATE_UI(    ID_RADIOBUTTON_NEVER,    AddEditPropSheetDlg::OnUpdateUI                )
 END_EVENT_TABLE()
 
-//(*IdInit(AttachmentTab)
-const wxWindowID AddEditPropSheetDlg::ID_BUTTON_IMPORT = wxWindow::NewControlId();
-const wxWindowID AddEditPropSheetDlg::ID_BUTTON_EXPORT = wxWindow::NewControlId();
-const wxWindowID AddEditPropSheetDlg::ID_BUTTON_REMOVE = wxWindow::NewControlId();
-const wxWindowID AddEditPropSheetDlg::ID_TEXTCTRL2 = wxWindow::NewControlId();
-const wxWindowID AddEditPropSheetDlg::ID_STATICTEXT4 = wxWindow::NewControlId();
-const wxWindowID AddEditPropSheetDlg::ID_STATICTEXT5 = wxWindow::NewControlId();
-const wxWindowID AddEditPropSheetDlg::ID_STATICTEXT6 = wxWindow::NewControlId();
-const wxWindowID AddEditPropSheetDlg::ID_STATICTEXT8 = wxWindow::NewControlId();
-const wxWindowID AddEditPropSheetDlg::ID_STATICTEXT10 = wxWindow::NewControlId();
-//*)
-
-
 /*!
  * AddEditPropSheetDlg constructors
  */
@@ -735,6 +722,10 @@ wxPanel* AddEditPropSheetDlg::CreatePasswordPolicyPanel()
 
 wxPanel* AddEditPropSheetDlg::CreateAttachmentPanel()
 {
+  ID_BUTTON_IMPORT = wxWindow::NewControlId();
+  ID_BUTTON_EXPORT = wxWindow::NewControlId();
+  ID_BUTTON_REMOVE = wxWindow::NewControlId();
+
   auto *panel = new wxPanel(GetBookCtrl(), ID_PANEL_ADDITIONAL, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
   auto *BoxSizerMain = new wxBoxSizer(wxVERTICAL);
 
@@ -764,34 +755,34 @@ wxPanel* AddEditPropSheetDlg::CreateAttachmentPanel()
   auto *FlexGridSizer1 = new wxFlexGridSizer(0, 2, 0, 0);
   FlexGridSizer1->AddGrowableCol(1);
 
-  auto *StaticText3 = new wxStaticText(panel, wxID_ANY, _("Title:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+  auto *StaticText3 = new wxStaticText(panel, wxID_ANY, _("Title:"), wxDefaultPosition, wxDefaultSize, 0);
   FlexGridSizer1->Add(StaticText3, 0, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
-  m_AttachmentTitle = new wxTextCtrl(panel, ID_TEXTCTRL2, _("Text"), wxDefaultPosition, wxSize(217,35), 0, wxDefaultValidator, _T("ID_TEXTCTRL2"));
+  m_AttachmentTitle = new wxTextCtrl(panel, wxID_ANY, _("Text"), wxDefaultPosition, wxSize(217,35), 0, wxDefaultValidator);
   FlexGridSizer1->Add(m_AttachmentTitle, 1, wxALL|wxEXPAND, 5);
 
-  auto *StaticText2 = new wxStaticText(panel, wxID_ANY, _("Media Type:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+  auto *StaticText2 = new wxStaticText(panel, wxID_ANY, _("Media Type:"), wxDefaultPosition, wxDefaultSize, 0);
   FlexGridSizer1->Add(StaticText2, 0, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
-  m_AttachmentMediaType = new wxStaticText(panel, ID_STATICTEXT4, _T(""), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT4"));
+  m_AttachmentMediaType = new wxStaticText(panel, wxID_ANY, _T(""), wxDefaultPosition, wxDefaultSize, 0);
   FlexGridSizer1->Add(m_AttachmentMediaType, 1, wxALL|wxEXPAND, 5);
 
-  auto *StaticText4 = new wxStaticText(panel, wxID_ANY, _("Creation Date:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+  auto *StaticText4 = new wxStaticText(panel, wxID_ANY, _("Creation Date:"), wxDefaultPosition, wxDefaultSize, 0);
   FlexGridSizer1->Add(StaticText4, 0, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
-  m_AttachmentCreationDate = new wxStaticText(panel, ID_STATICTEXT5, _T(""), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT5"));
+  m_AttachmentCreationDate = new wxStaticText(panel, wxID_ANY, _T(""), wxDefaultPosition, wxDefaultSize, 0);
   FlexGridSizer1->Add(m_AttachmentCreationDate, 1, wxALL|wxEXPAND, 5);
 
-  auto *StaticText5 = new wxStaticText(panel, wxID_ANY, _("File Size:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+  auto *StaticText5 = new wxStaticText(panel, wxID_ANY, _("File Size:"), wxDefaultPosition, wxDefaultSize, 0);
   FlexGridSizer1->Add(StaticText5, 0, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
-  m_AttachmentFileSize = new wxStaticText(panel, ID_STATICTEXT6, _T(""), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT6"));
+  m_AttachmentFileSize = new wxStaticText(panel, wxID_ANY, _T(""), wxDefaultPosition, wxDefaultSize, 0);
   FlexGridSizer1->Add(m_AttachmentFileSize, 1, wxALL|wxEXPAND, 5);
 
-  auto *StaticText7 = new wxStaticText(panel, wxID_ANY, _("File Creation Date:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+  auto *StaticText7 = new wxStaticText(panel, wxID_ANY, _("File Creation Date:"), wxDefaultPosition, wxDefaultSize, 0);
   FlexGridSizer1->Add(StaticText7, 0, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
-  m_AttachmentFileCreationDate = new wxStaticText(panel, ID_STATICTEXT8, _T(""), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT8"));
+  m_AttachmentFileCreationDate = new wxStaticText(panel, wxID_ANY, _T(""), wxDefaultPosition, wxDefaultSize, 0);
   FlexGridSizer1->Add(m_AttachmentFileCreationDate, 1, wxALL|wxEXPAND, 5);
 
-  auto *StaticText9 = new wxStaticText(panel, wxID_ANY, _("File Last Modified Date:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+  auto *StaticText9 = new wxStaticText(panel, wxID_ANY, _("File Last Modified Date:"), wxDefaultPosition, wxDefaultSize, 0);
   FlexGridSizer1->Add(StaticText9, 0, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
-  m_AttachmentFileLastModifiedDate = new wxStaticText(panel, ID_STATICTEXT10, _T(""), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT10"));
+  m_AttachmentFileLastModifiedDate = new wxStaticText(panel, wxID_ANY, _T(""), wxDefaultPosition, wxDefaultSize, 0);
   FlexGridSizer1->Add(m_AttachmentFileLastModifiedDate, 1, wxALL|wxEXPAND, 5);
   StaticBoxSizerProperties->Add(FlexGridSizer1, 1, wxALL|wxEXPAND, 5);
   BoxSizerMain->Add(StaticBoxSizerProperties, 0, wxALL|wxEXPAND, 5);

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -127,7 +127,7 @@ const wxWindowID AddEditPropSheetDlg::ID_STATICTEXT10 = wxWindow::NewControlId()
  * AddEditPropSheetDlg constructors
  */
 
-AddEditPropSheetDlg::AddEditPropSheetDlg(wxWindow* parent, PWScore &core,
+AddEditPropSheetDlg::AddEditPropSheetDlg(wxWindow *parent, PWScore &core,
                                    SheetType type, const CItemData *item,
                                    const wxString& selectedGroup,
                                    wxWindowID id, const wxString& caption,
@@ -135,11 +135,17 @@ AddEditPropSheetDlg::AddEditPropSheetDlg(wxWindow* parent, PWScore &core,
                                    long style)
 : m_Core(core), m_SelectedGroup(selectedGroup), m_Type(type)
 {
-  if (item != nullptr)
+  wxASSERT(!parent || parent->IsTopLevel());
+
+  if (item != nullptr) {
     m_Item = *item; // copy existing item to display values
-  else
+  }
+  else {
     m_Item.CreateUUID(); // We're adding a new entry
-  Init();
+  }
+  
+  m_IsNotesHidden = !PWSprefs::GetInstance()->GetPref(PWSprefs::ShowNotesDefault);
+
   wxString dlgTitle;
   if (caption == SYMBOL_AUTOPROPSHEETDLG_TITLE) {
     switch(m_Type) {
@@ -157,19 +163,7 @@ AddEditPropSheetDlg::AddEditPropSheetDlg(wxWindow* parent, PWScore &core,
         break;
     }
   }
-  Create(parent, id, dlgTitle, pos, size, style);
 
-  if (m_Core.GetReadFileVersion() == PWSfile::V40) {
-    InitAttachmentTab();
-  }
-}
-
-/*!
- * AddEditPropSheetDlg creator
- */
-
-bool AddEditPropSheetDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
 ////@begin AddEditPropSheetDlg creation
   SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY|wxWS_EX_BLOCK_EVENTS);
   wxPropertySheetDialog::Create( parent, id, caption, pos, size, style );
@@ -186,87 +180,20 @@ bool AddEditPropSheetDlg::Create( wxWindow* parent, wxWindowID id, const wxStrin
   // Additional width is needed by static text (itemStaticText4) at "Basic" tab,
   // otherwise text is not correctly shown due to Auto Word Wrap. (At least at KDE)
   SetSizeHints(GetSize().GetWidth() + 20, GetSize().GetHeight());
-  return true;
+
+  if (m_Core.GetReadFileVersion() == PWSfile::V40) {
+    InitAttachmentTab();
+  }
 }
 
-/*!
- * AddEditPropSheetDlg destructor
- */
-
-AddEditPropSheetDlg::~AddEditPropSheetDlg()
+AddEditPropSheetDlg* AddEditPropSheetDlg::Create(wxWindow *parent, PWScore &core,
+  SheetType type, const CItemData *item, const wxString &selectedGroup,
+  wxWindowID id, const wxString &caption, const wxPoint &pos, 
+  const wxSize &size, long style)
 {
-////@begin AddEditPropSheetDlg destruction
-////@end AddEditPropSheetDlg destruction
+  return new AddEditPropSheetDlg(parent, core, type, item, selectedGroup, id, caption, pos, size, style);
 }
-
-/*!
- * Member initialisation
- */
-
-void AddEditPropSheetDlg::Init()
-{
-////@begin AddEditPropSheetDlg member initialisation
-  m_ExpirationTimeInterval = 0;
-  m_IsNotesHidden = !PWSprefs::GetInstance()->GetPref(PWSprefs::ShowNotesDefault);
-  m_BasicPanel = nullptr;
-  m_AdditionalPanel = nullptr;
-  m_PasswordPolicyPanel = nullptr;
-  m_BasicSizer = nullptr;
-  m_BasicGroupNamesCtrl = nullptr;
-  m_BasicUsernameTextCtrl = nullptr;
-  m_BasicPasswordTextCtrl = nullptr;
-  m_BasicPasswordTextLabel = nullptr;
-  m_BasicShowHideCtrl = nullptr;
-  m_BasicPasswordConfirmationTextCtrl = nullptr;
-  m_BasicPasswordConfirmationTextLabel = nullptr;
-  m_BasicNotesTextCtrl = nullptr;
-  m_AdditionalDoubleClickActionCtrl = nullptr;
-  m_AdditionalShiftDoubleClickActionCtrl = nullptr;
-  m_AdditionalMaxPasswordHistoryCtrl = nullptr;
-  m_AdditionalPasswordHistoryGrid = nullptr;
-  m_DatesTimesExpireOnCtrl = nullptr;
-  m_DatesTimesExpiryDateCtrl = nullptr;
-  m_DatesTimesExpireInCtrl = nullptr;
-  m_DatesTimesExpiryTimeCtrl = nullptr;
-  m_DatesTimesRecurringExpiryCtrl = nullptr;
-  m_DatesTimesNeverExpireCtrl = nullptr;
-  m_PasswordPolicyUseDatabaseCtrl = nullptr;
-  m_PasswordPolicyNamesCtrl = nullptr;
-  m_PasswordPolicyPasswordLengthText = nullptr;
-  m_PasswordPolicyPasswordLengthCtrl = nullptr;
-  m_PasswordPolicySizer = nullptr;
-  m_PasswordPolicyUseLowerCaseCtrl = nullptr;
-  m_PasswordPolicyLowerCaseMinSizer = nullptr;
-  m_PasswordPolicyLowerCaseMinCtrl = nullptr;
-  m_PasswordPolicyUseUpperCaseCtrl = nullptr;
-  m_PasswordPolicyUpperCaseMinSizer = nullptr;
-  m_PasswordPolicyUpperCaseMinCtrl = nullptr;
-  m_PasswordPolicyUseDigitsCtrl = nullptr;
-  m_PasswordPolicyDigitsMinSizer = nullptr;
-  m_PasswordPolicyDigitsMinCtrl = nullptr;
-  m_PasswordPolicyUseSymbolsCtrl = nullptr;
-  m_PasswordPolicySymbolsMinSizer = nullptr;
-  m_PasswordPolicySymbolsMinCtrl = nullptr;
-  m_PasswordPolicyOwnSymbolsTextCtrl = nullptr;
-  m_PasswordPolicyUseEasyCtrl = nullptr;
-  m_PasswordPolicyUsePronounceableCtrl = nullptr;
-  m_PasswordPolicyUseHexadecimalOnlyCtrl = nullptr;
-  m_AttachmentPanel = nullptr;
-  m_AttachmentImagePanel = nullptr;
-  m_AttachmentButtonImport = nullptr;
-  m_AttachmentButtonExport = nullptr;
-  m_AttachmentButtonRemove = nullptr;
-  m_AttachmentFilePath = nullptr;
-  m_AttachmentTitle = nullptr;
-  m_AttachmentMediaType = nullptr;
-  m_AttachmentCreationDate = nullptr;
-  m_AttachmentFileSize = nullptr;
-  m_AttachmentFileCreationDate = nullptr;
-  m_AttachmentFileLastModifiedDate = nullptr;
-  m_AttachmentPreviewStatus = nullptr;
-////@end AddEditPropSheetDlg member initialisation
-}
-
+                      
 static void setupDCAStrings(wxArrayString &as)
 {
   // semi-duplicated in SetupDCAComboBoxes(),
@@ -1698,14 +1625,19 @@ void AddEditPropSheetDlg::OnShowHideClick(wxCommandEvent& WXUNUSED(evt))
 
 void AddEditPropSheetDlg::OnAliasButtonClick(wxCommandEvent& WXUNUSED(evt))
 {
+  CallAfter(&AddEditPropSheetDlg::DoAliasButtonClick);
+}
+
+void AddEditPropSheetDlg::DoAliasButtonClick()
+{
   CItemData *pbci = (m_Item.IsAlias() ? m_Core.GetBaseEntry(&m_Item) : nullptr);
   
   if(m_Item.IsShortcutBase()) {
     wxMessageBox(_("On changing this entry of type Shortcut Base to an Alias all Shortcut to this entry will be removed!"), _("Warning"), wxOK | wxICON_EXCLAMATION);
   }
   
-  SelectAliasDlg dlg(this, &m_Core, &m_Item, &pbci);
-  int rc = dlg.ShowModal();
+  
+  int rc = ShowModalAndGetResult<SelectAliasDlg>(this, &m_Core, &m_Item, &pbci);
   if(rc == wxID_OK) {
     if(! m_Core.IsReadOnly()) {
       bool bChangeToBaseEntry = false;

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.h
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.h
@@ -281,6 +281,7 @@ private:
   wxString GetMimeTypeExtension(const stringT &mimeTypeDescription);
   void EnableImport();
   void DisableImport();
+  void DisableAttachmentControls();
 
   // Applies font preferences to corresponding controls
   void ApplyFontPreferences();

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.h
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.h
@@ -431,15 +431,9 @@ private:
   //*)
 
   //(*Identifiers(AttachmentTab)
-  static const wxWindowID ID_BUTTON_IMPORT;
-  static const wxWindowID ID_BUTTON_EXPORT;
-  static const wxWindowID ID_BUTTON_REMOVE;
-  static const wxWindowID ID_TEXTCTRL2;
-  static const wxWindowID ID_STATICTEXT4;
-  static const wxWindowID ID_STATICTEXT5;
-  static const wxWindowID ID_STATICTEXT6;
-  static const wxWindowID ID_STATICTEXT8;
-  static const wxWindowID ID_STATICTEXT10;
+  wxWindowID ID_BUTTON_IMPORT;
+  wxWindowID ID_BUTTON_EXPORT;
+  wxWindowID ID_BUTTON_REMOVE;
   //*)
 
   //(*Declarations(AttachmentTab)

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.h
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.h
@@ -226,6 +226,12 @@ protected:
   
   /// wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_OK
   void OnOk(wxCommandEvent &event);
+  
+  /// wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_CANCEL
+  void OnCancel(wxCommandEvent &event);
+  
+  /// wxEVT_CLOSE event handler
+  void OnClose(wxCloseEvent &event);
 
   /// wxEVT_SPINCTRL event handler for ID_SPINCTRL5, ID_SPINCTRL6, ID_SPINCTRL7, ID_SPINCTRL8
   void OnAtLeastPasswordChars(wxSpinEvent &event);
@@ -285,8 +291,8 @@ private:
   void SetXTime(wxObject *src); // sync controls + controls -> entry
   void UpdatePWPolicyControls(const PWPolicy &pwp);
   void EnablePWPolicyControls(bool enable);
-  PWPolicy GetPWPolicyFromUI();
-  PWPolicy GetSelectedPWPolicy();
+  PWPolicy GetPWPolicyFromUI() const;
+  PWPolicy GetSelectedPWPolicy() const;
   bool CheckPWPolicyFromUI();
   void ShowPWPSpinners(bool show);
   void EnableNonHexCBs(bool enable);
@@ -300,11 +306,37 @@ private:
   bool ValidateBasicData();
   bool ValidatePasswordPolicy();
   bool IsGroupUsernameTitleCombinationUnique();
-
+  bool SyncAndQueryCancel(bool showDialog);
+  
+  enum Changes : uint32_t {
+    None = 0,
+    Group = 1u,
+    Title = 1u << 1,
+    User = 1u << 2,
+    Notes = 1u << 3,
+    Url = 1u << 4,
+    Email = 1u << 5,
+    Autotype = 1u << 6,
+    RunCommand = 1u << 7,
+    History = 1u << 8,
+    Symbols = 1u << 9,
+    DCA = 1u << 10,
+    ShiftDCA = 1u << 11,
+    XTime = 1u << 12,
+    XTimeInt = 1u << 13,
+    Password = 1u << 14,
+    Policy = 1u << 15,
+    Attachment = 1u << 16,
+  };
+  
+  uint32_t GetChanges() const;
+  
   Command* NewAddEntryCommand(bool bNewCTime = true);
   Command* NewEditEntryCommand();
   
   void DoAliasButtonClick();
+  
+  StringX PreparePasswordHistory() const;
 
   // Tab: "Basic"
   wxPanel *m_BasicPanel = nullptr;

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.h
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.h
@@ -135,9 +135,8 @@ public:
     VIEW
   }; // to tweak UI, mainly
 
-  /// Constructor
   // item is nullptr for ADD, otherwise its values are retrieved and displayed
-  AddEditPropSheetDlg(wxWindow *parent, PWScore &core,
+  static AddEditPropSheetDlg* Create(wxWindow *parent, PWScore &core,
                       SheetType type, const CItemData *item = nullptr,
                       const wxString &selectedGroup = wxEmptyString,
                       wxWindowID id = SYMBOL_ADDEDITPROPSHEETDLG_IDNAME,
@@ -146,11 +145,14 @@ public:
                       const wxSize &size = SYMBOL_ADDEDITPROPSHEETDLG_SIZE,
                       long style = SYMBOL_ADDEDITPROPSHEETDLG_STYLE);
 
-  /// Creation
-  bool Create(wxWindow *parent, wxWindowID id = SYMBOL_ADDEDITPROPSHEETDLG_IDNAME, const wxString &caption = SYMBOL_AUTOPROPSHEETDLG_TITLE, const wxPoint &pos = SYMBOL_ADDEDITPROPSHEETDLG_POSITION, const wxSize &size = SYMBOL_ADDEDITPROPSHEETDLG_SIZE, long style = SYMBOL_ADDEDITPROPSHEETDLG_STYLE);
-
   /// Destructor
-  ~AddEditPropSheetDlg();
+  ~AddEditPropSheetDlg() = default;
+protected:
+  /// Constructor
+  AddEditPropSheetDlg(wxWindow *parent, PWScore &core,
+                      SheetType type, const CItemData *item, const wxString &selectedGroup,
+                      wxWindowID id,const wxString &caption, 
+                      const wxPoint &pos, const wxSize &size, long style);
 
   ////@begin AddEditPropSheetDlg event handler declarations
 
@@ -246,9 +248,6 @@ public:
   ////@begin AddEditPropSheetDlg member variables
 
 private:
-  // Initialises member variables
-  void Init();
-
   // Creates the controls and sizers
   void CreateControls();
 
@@ -304,21 +303,23 @@ private:
 
   Command* NewAddEntryCommand(bool bNewCTime = true);
   Command* NewEditEntryCommand();
+  
+  void DoAliasButtonClick();
 
   // Tab: "Basic"
-  wxPanel *m_BasicPanel;
-  wxGridBagSizer *m_BasicSizer;
-  wxComboBox *m_BasicGroupNamesCtrl;
-  wxTextCtrl *m_BasicTitleTextCtrl;
-  wxTextCtrl *m_BasicUsernameTextCtrl;
-  wxTextCtrl *m_BasicPasswordTextCtrl;
-  wxStaticText *m_BasicPasswordTextLabel;
-  wxButton *m_BasicShowHideCtrl;
-  wxTextCtrl *m_BasicPasswordConfirmationTextCtrl;
-  wxStaticText *m_BasicPasswordConfirmationTextLabel;
-  wxTextCtrl *m_BasicUrlTextCtrl;
-  wxTextCtrl *m_BasicEmailTextCtrl;
-  wxTextCtrl *m_BasicNotesTextCtrl;
+  wxPanel *m_BasicPanel = nullptr;
+  wxGridBagSizer *m_BasicSizer = nullptr;
+  wxComboBox *m_BasicGroupNamesCtrl = nullptr;
+  wxTextCtrl *m_BasicTitleTextCtrl = nullptr;
+  wxTextCtrl *m_BasicUsernameTextCtrl = nullptr;
+  wxTextCtrl *m_BasicPasswordTextCtrl = nullptr;
+  wxStaticText *m_BasicPasswordTextLabel = nullptr;
+  wxButton *m_BasicShowHideCtrl = nullptr;
+  wxTextCtrl *m_BasicPasswordConfirmationTextCtrl = nullptr;
+  wxStaticText *m_BasicPasswordConfirmationTextLabel = nullptr;
+  wxTextCtrl *m_BasicUrlTextCtrl = nullptr;
+  wxTextCtrl *m_BasicEmailTextCtrl = nullptr;
+  wxTextCtrl *m_BasicNotesTextCtrl = nullptr;
 
   wxString m_Title;
   wxString m_User;
@@ -330,11 +331,11 @@ private:
   bool m_IsPasswordHidden;
 
   // Tab: "Additional"
-  wxPanel *m_AdditionalPanel;
-  wxComboBox *m_AdditionalDoubleClickActionCtrl;
-  wxComboBox *m_AdditionalShiftDoubleClickActionCtrl;
-  wxSpinCtrl *m_AdditionalMaxPasswordHistoryCtrl;
-  wxGrid *m_AdditionalPasswordHistoryGrid;
+  wxPanel *m_AdditionalPanel = nullptr;
+  wxComboBox *m_AdditionalDoubleClickActionCtrl = nullptr;
+  wxComboBox *m_AdditionalShiftDoubleClickActionCtrl = nullptr;
+  wxSpinCtrl *m_AdditionalMaxPasswordHistoryCtrl = nullptr;
+  wxGrid *m_AdditionalPasswordHistoryGrid = nullptr;
 
   wxString m_Autotype;
   wxString m_RunCommand;
@@ -345,12 +346,12 @@ private:
   short m_ShiftDoubleClickAction;
 
   // Tab: "Dates and Times"
-  wxRadioButton *m_DatesTimesExpireOnCtrl;
-  wxDatePickerCtrl *m_DatesTimesExpiryDateCtrl;
-  wxRadioButton *m_DatesTimesExpireInCtrl;
-  wxSpinCtrl *m_DatesTimesExpiryTimeCtrl;
-  wxCheckBox *m_DatesTimesRecurringExpiryCtrl;
-  wxRadioButton *m_DatesTimesNeverExpireCtrl;
+  wxRadioButton *m_DatesTimesExpireOnCtrl = nullptr;
+  wxDatePickerCtrl *m_DatesTimesExpiryDateCtrl = nullptr;
+  wxRadioButton *m_DatesTimesExpireInCtrl = nullptr;
+  wxSpinCtrl *m_DatesTimesExpiryTimeCtrl = nullptr;
+  wxCheckBox *m_DatesTimesRecurringExpiryCtrl = nullptr;
+  wxRadioButton *m_DatesTimesNeverExpireCtrl = nullptr;
 
   wxString m_RMTime; // Any field modification time
   wxString m_AccessTime;
@@ -359,32 +360,32 @@ private:
   wxString m_ModificationTime;
   bool m_Recurring;
   wxString m_ExpirationTime;
-  int m_ExpirationTimeInterval; // Password expiration interval in days
+  int m_ExpirationTimeInterval = 0; // Password expiration interval in days
   time_t m_tttExpirationTime;   // Password expiration date in time_t
 
   // Tab: "Password Policy"
-  wxPanel *m_PasswordPolicyPanel;
-  wxCheckBox *m_PasswordPolicyUseDatabaseCtrl;
-  wxComboBox *m_PasswordPolicyNamesCtrl;
-  wxStaticText *m_PasswordPolicyPasswordLengthText;
-  wxSpinCtrl *m_PasswordPolicyPasswordLengthCtrl;
-  wxGridSizer *m_PasswordPolicySizer;
-  wxCheckBox *m_PasswordPolicyUseLowerCaseCtrl;
-  wxBoxSizer *m_PasswordPolicyLowerCaseMinSizer;
-  wxSpinCtrl *m_PasswordPolicyLowerCaseMinCtrl;
-  wxCheckBox *m_PasswordPolicyUseUpperCaseCtrl;
-  wxBoxSizer *m_PasswordPolicyUpperCaseMinSizer;
-  wxSpinCtrl *m_PasswordPolicyUpperCaseMinCtrl;
-  wxCheckBox *m_PasswordPolicyUseDigitsCtrl;
-  wxBoxSizer *m_PasswordPolicyDigitsMinSizer;
-  wxSpinCtrl *m_PasswordPolicyDigitsMinCtrl;
-  wxCheckBox *m_PasswordPolicyUseSymbolsCtrl;
-  wxBoxSizer *m_PasswordPolicySymbolsMinSizer;
-  wxSpinCtrl *m_PasswordPolicySymbolsMinCtrl;
-  wxTextCtrl *m_PasswordPolicyOwnSymbolsTextCtrl;
-  wxCheckBox *m_PasswordPolicyUseEasyCtrl;
-  wxCheckBox *m_PasswordPolicyUsePronounceableCtrl;
-  wxCheckBox *m_PasswordPolicyUseHexadecimalOnlyCtrl;
+  wxPanel *m_PasswordPolicyPanel = nullptr;
+  wxCheckBox *m_PasswordPolicyUseDatabaseCtrl = nullptr;
+  wxComboBox *m_PasswordPolicyNamesCtrl = nullptr;
+  wxStaticText *m_PasswordPolicyPasswordLengthText = nullptr;
+  wxSpinCtrl *m_PasswordPolicyPasswordLengthCtrl = nullptr;
+  wxGridSizer *m_PasswordPolicySizer = nullptr;
+  wxCheckBox *m_PasswordPolicyUseLowerCaseCtrl = nullptr;
+  wxBoxSizer *m_PasswordPolicyLowerCaseMinSizer = nullptr;
+  wxSpinCtrl *m_PasswordPolicyLowerCaseMinCtrl = nullptr;
+  wxCheckBox *m_PasswordPolicyUseUpperCaseCtrl = nullptr;
+  wxBoxSizer *m_PasswordPolicyUpperCaseMinSizer = nullptr;
+  wxSpinCtrl *m_PasswordPolicyUpperCaseMinCtrl = nullptr;
+  wxCheckBox *m_PasswordPolicyUseDigitsCtrl = nullptr;
+  wxBoxSizer *m_PasswordPolicyDigitsMinSizer = nullptr;
+  wxSpinCtrl *m_PasswordPolicyDigitsMinCtrl = nullptr;
+  wxCheckBox *m_PasswordPolicyUseSymbolsCtrl = nullptr;
+  wxBoxSizer *m_PasswordPolicySymbolsMinSizer = nullptr;
+  wxSpinCtrl *m_PasswordPolicySymbolsMinCtrl = nullptr;
+  wxTextCtrl *m_PasswordPolicyOwnSymbolsTextCtrl = nullptr;
+  wxCheckBox *m_PasswordPolicyUseEasyCtrl = nullptr;
+  wxCheckBox *m_PasswordPolicyUsePronounceableCtrl = nullptr;
+  wxCheckBox *m_PasswordPolicyUseHexadecimalOnlyCtrl = nullptr;
 
   wxString m_Symbols;
 
@@ -409,20 +410,20 @@ private:
   //*)
 
   //(*Declarations(AttachmentTab)
-  wxStaticBoxSizer *StaticBoxSizerPreview;
-  wxPanel *m_AttachmentPanel;
-  ImagePanel *m_AttachmentImagePanel;
-  wxButton *m_AttachmentButtonImport;
-  wxButton *m_AttachmentButtonExport;
-  wxButton *m_AttachmentButtonRemove;
-  wxStaticText *m_AttachmentFilePath;
-  wxTextCtrl *m_AttachmentTitle;
-  wxStaticText *m_AttachmentMediaType;
-  wxStaticText *m_AttachmentCreationDate;
-  wxStaticText *m_AttachmentFileSize;
-  wxStaticText *m_AttachmentFileCreationDate;
-  wxStaticText *m_AttachmentFileLastModifiedDate;
-  wxStaticText *m_AttachmentPreviewStatus;
+  wxStaticBoxSizer *StaticBoxSizerPreview = nullptr;
+  wxPanel *m_AttachmentPanel = nullptr;
+  ImagePanel *m_AttachmentImagePanel = nullptr;
+  wxButton *m_AttachmentButtonImport = nullptr;
+  wxButton *m_AttachmentButtonExport = nullptr;
+  wxButton *m_AttachmentButtonRemove = nullptr;
+  wxStaticText *m_AttachmentFilePath = nullptr;
+  wxTextCtrl *m_AttachmentTitle = nullptr;
+  wxStaticText *m_AttachmentMediaType = nullptr;
+  wxStaticText *m_AttachmentCreationDate = nullptr;
+  wxStaticText *m_AttachmentFileSize = nullptr;
+  wxStaticText *m_AttachmentFileCreationDate = nullptr;
+  wxStaticText *m_AttachmentFileLastModifiedDate = nullptr;
+  wxStaticText *m_AttachmentPreviewStatus = nullptr;
   //*)
   ////@end AddEditPropSheetDlg member variables
 

--- a/src/ui/wxWidgets/AdvancedSelectionDlg.cpp
+++ b/src/ui/wxWidgets/AdvancedSelectionDlg.cpp
@@ -49,7 +49,7 @@ AdvancedSelectionPanel::AdvancedSelectionPanel(wxWindow* parentWnd,
                                                   m_autoValidate(autoValidate)
 {
   UNREFERENCED_PARAMETER(parentWnd);
-  parentWnd->SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY);
+  parentWnd->SetExtraStyle(parentWnd->GetExtraStyle() | wxWS_EX_VALIDATE_RECURSIVELY);
 }
 
 void AdvancedSelectionPanel::CreateControls(wxWindow* parentWnd)

--- a/src/ui/wxWidgets/AdvancedSelectionDlg.h
+++ b/src/ui/wxWidgets/AdvancedSelectionDlg.h
@@ -142,12 +142,16 @@ class AdvancedSelectionDlg : public wxDialog
   PanelType* m_panel;
 
 public:
-  AdvancedSelectionDlg(wxWindow* parent, SelectionCriteria* existingCriteria): m_panel(nullptr)
+  static AdvancedSelectionDlg<DlgType>* Create(wxWindow *parent, SelectionCriteria* existingCriteria) {
+    return new AdvancedSelectionDlg(parent, existingCriteria);
+  }
+protected:
+  AdvancedSelectionDlg(wxWindow *parent, SelectionCriteria* existingCriteria): m_panel(nullptr)
   {
+    wxASSERT(!parent || parent->IsTopLevel());
     wxDialog::Create(parent, wxID_ANY, wxEmptyString, wxDefaultPosition, 
                             wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
   
-
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     sizer->AddSpacer(TopMargin);
 

--- a/src/ui/wxWidgets/CMakeLists.txt
+++ b/src/ui/wxWidgets/CMakeLists.txt
@@ -146,6 +146,7 @@ list(APPEND PWSAFE_SRC_LIST
     src/ui/wxWidgets/PWFiltersMediaDlg.cpp
     src/ui/wxWidgets/PWFiltersPasswordDlg.cpp
     src/ui/wxWidgets/ManageFiltersTable.cpp
+    src/ui/wxWidgets/QueryCancelDlg.cpp
     )
 
 if(HAVE_YKPERS_H)

--- a/src/ui/wxWidgets/CompareDlg.cpp
+++ b/src/ui/wxWidgets/CompareDlg.cpp
@@ -597,9 +597,8 @@ void CompareDlg::DoEditInCurrentDB(ContextMenuData menuContext) {
     else {
       wxFAIL_MSG(wxT("Could not find entry in core after editing it"));
     }
+    WriteReport();
   }
-  
-  WriteReport();
 }
 
 void CompareDlg::OnViewInComparisonDB(wxCommandEvent& evt)
@@ -898,9 +897,8 @@ void CompareDlg::DoSyncItemsWithCurrentDB(int menuId, ContextMenuData menuContex
         table.RefreshRow(syncIndexes[idx]*2);
       }
     }
+    WriteReport();
   }
-  
-  WriteReport();
 }
 
 void CompareDlg::WriteReportData()

--- a/src/ui/wxWidgets/CompareDlg.cpp
+++ b/src/ui/wxWidgets/CompareDlg.cpp
@@ -270,6 +270,10 @@ wxCollapsiblePane* CompareDlg::CreateDataPanel(wxSizer* dlgSizer, const wxString
     cd->grid = new ComparisonGrid(sizedPanel, wxID_ANY);
   else
     cd->grid = new wxGrid(sizedPanel, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0); //don't have wxWANTS_CHARS
+
+  // this grid is presentation only
+  cd->grid->EnableEditing(false);
+
   //create a way to get to the ComparisonData object from the grid, which is the only thing we have in events
   wxASSERT_MSG(cd->grid->GetClientData() == nullptr, wxT("wxGrid::ClientData is not nullptr on creation.  Need to use that for our purposes"));
   cd->grid->SetClientData(cd);

--- a/src/ui/wxWidgets/CompareDlg.cpp
+++ b/src/ui/wxWidgets/CompareDlg.cpp
@@ -105,8 +105,8 @@ CompareDlg::CompareDlg(wxWindow *parent, PWScore* currentCore): wxDialog(parent,
                                                         m_identical(new ComparisonData)
 {
   wxASSERT(!parent || parent->IsTopLevel());
-  SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY);
 
+  SetExtraStyle(GetExtraStyle() | wxWS_EX_VALIDATE_RECURSIVELY);
 
   //compare all fields by default
   m_selCriteria->SelectAllFields();

--- a/src/ui/wxWidgets/CompareDlg.h
+++ b/src/ui/wxWidgets/CompareDlg.h
@@ -75,9 +75,9 @@ private:
 
   void DoCompare(wxCommandEvent& evt);
   void DoShowReport();
-  void DoEditInCurrentDB(ContextMenuData* menuContext);
-  void DoViewInComparisonDB(ContextMenuData* menuContext);
-  void DoSyncItemsWithCurrentDB(int menuId, ContextMenuData *menuContext);
+  void DoEditInCurrentDB(ContextMenuData menuContext);
+  void DoViewInComparisonDB(ContextMenuData menuContext);
+  void DoSyncItemsWithCurrentDB(int menuId, ContextMenuData menuContext);
   
   bool ViewEditEntry(PWScore* core, const pws_os::CUUID& uuid, bool readOnly);
   

--- a/src/ui/wxWidgets/CompareDlg.h
+++ b/src/ui/wxWidgets/CompareDlg.h
@@ -51,24 +51,38 @@ class CompareDlg : public wxDialog
   void ReportAdvancedOptions();
   void WriteReport();
 
+protected:
+  explicit CompareDlg(wxWindow *parent, PWScore* core);
 public:
-  CompareDlg(wxWindow* parent, PWScore* core);
+  static CompareDlg* Create(wxWindow *parent, PWScore* core);
   ~CompareDlg();
 
 private:
-  PWScore*            m_currentCore;
-  PWSAuxCore*         m_otherCore;
-  SelectionCriteria*  m_selCriteria;
-  DbSelectionPanel*   m_dbPanel;
-  wxCollapsiblePane*  m_dbSelectionPane;
-  wxCollapsiblePane*  m_optionsPane;
-  ComparisonData      *m_current, *m_comparison, *m_conflicts, *m_identical;
+  struct ContextMenuData {
+    ComparisonData* cdata;
+    wxArrayInt selectedRows;    //indexes into the grid
+    wxArrayInt selectedItems;   //indexes into the table
+    CItemData::FieldType field;
+  };
+
+  PWScore*            m_currentCore = nullptr;
+  PWSAuxCore*         m_otherCore = nullptr;
+  SelectionCriteria*  m_selCriteria = nullptr;
+  DbSelectionPanel*   m_dbPanel = nullptr;
+  wxCollapsiblePane*  m_dbSelectionPane = nullptr;
+  wxCollapsiblePane*  m_optionsPane = nullptr;
+  ComparisonData      *m_current = nullptr, *m_comparison = nullptr, *m_conflicts = nullptr, *m_identical = nullptr;
 
   void DoCompare(wxCommandEvent& evt);
+  void DoShowReport();
+  void DoEditInCurrentDB(ContextMenuData* menuContext);
+  void DoViewInComparisonDB(ContextMenuData* menuContext);
+  void DoSyncItemsWithCurrentDB(int menuId, ContextMenuData *menuContext);
+  
   bool ViewEditEntry(PWScore* core, const pws_os::CUUID& uuid, bool readOnly);
   
   CReport            m_compReport;
-  wxButton*          m_compareButton;
+  wxButton*          m_compareButton = nullptr;
 
   DECLARE_EVENT_TABLE()
 };

--- a/src/ui/wxWidgets/CreateShortcutDlg.cpp
+++ b/src/ui/wxWidgets/CreateShortcutDlg.cpp
@@ -55,28 +55,12 @@ END_EVENT_TABLE()
  * CreateShortcutDlg constructors
  */
 
-CreateShortcutDlg::CreateShortcutDlg(wxWindow* parent, PWScore &core, CItemData *base)
+CreateShortcutDlg::CreateShortcutDlg(wxWindow *parent, PWScore &core, CItemData *base)
 : m_Core(core), m_Base(base)
 {
   ASSERT(m_Base != nullptr);
-  Init();
-  Create(parent);
-}
+  wxASSERT(!parent || parent->IsTopLevel());
 
-/*!
- * CreateShortcutDlg destructor
- */
-
-CreateShortcutDlg::~CreateShortcutDlg()
-{
-}
-
-/*!
- * CreateShortcutDlg creator
- */
-
-bool CreateShortcutDlg::Create(wxWindow* parent)
-{
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create(parent, wxID_ANY, _("Create Shortcut"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
@@ -89,7 +73,11 @@ bool CreateShortcutDlg::Create(wxWindow* parent)
   SetValidators();
   UpdateControls();
   ItemFieldsToDialog();
-  return true;
+}
+
+CreateShortcutDlg* CreateShortcutDlg::Create(wxWindow *parent, PWScore &core, CItemData *base)
+{
+  return new CreateShortcutDlg(parent, core, base);
 }
 
 void CreateShortcutDlg::ItemFieldsToDialog()
@@ -173,20 +161,6 @@ void CreateShortcutDlg::UpdateControls()
     m_TextCtrlShortcutTitle->Disable();
     m_TextCtrlShortcutUsername->Disable();
   }
-}
-
-/*!
- * Member initialisation
- */
-
-void CreateShortcutDlg::Init()
-{
-  m_ComboBoxShortcutGroup = nullptr;
-  m_TextCtrlShortcutTitle = nullptr;
-  m_TextCtrlShortcutUsername = nullptr;
-  m_StaticTextBaseEntryGroup = nullptr;
-  m_StaticTextBaseEntryTitle = nullptr;
-  m_StaticTextBaseEntryUsername = nullptr;
 }
 
 /*!

--- a/src/ui/wxWidgets/CreateShortcutDlg.h
+++ b/src/ui/wxWidgets/CreateShortcutDlg.h
@@ -18,13 +18,13 @@
  */
 
 #include <wx/choice.h>
-#include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
 
 #include "core/ItemData.h"
 #include "core/PWScore.h"
+#include "QueryCancelDlg.h"
 
 /*!
  * Forward declarations
@@ -37,7 +37,7 @@
  * CreateShortcutDlg class declaration
  */
 
-class CreateShortcutDlg : public wxDialog
+class CreateShortcutDlg : public QueryCancelDlg
 {
   DECLARE_CLASS(CreateShortcutDlg)
   DECLARE_EVENT_TABLE()
@@ -70,7 +70,20 @@ private:
   void ItemFieldsToDialog();
   void SetValidators();
   void UpdateControls();
+  bool SyncAndQueryCancel(bool showDialog) override;
 
+  enum Changes : uint32_t {
+    None = 0,
+    Group = 1u,
+    Title = 1u << 1,
+    User = 1u << 2,
+  };
+  
+  uint32_t GetChanges() const;
+  bool IsChanged() const override;
+
+  wxString GetDefaultShortcutTitle() const;
+  
   //(*Handlers(CreateShortcutDlg)
   void OnOk(wxCommandEvent& event);
   //*)

--- a/src/ui/wxWidgets/CreateShortcutDlg.h
+++ b/src/ui/wxWidgets/CreateShortcutDlg.h
@@ -43,17 +43,15 @@ class CreateShortcutDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
-  /// Constructors
-  CreateShortcutDlg(wxWindow* parent, PWScore &core, CItemData *base);
+  /// Creation
+  static CreateShortcutDlg* Create(wxWindow *parent, PWScore &core, CItemData *base);
 
   /// Destructor
-  virtual ~CreateShortcutDlg();
+  virtual ~CreateShortcutDlg() = default;
 
-  /// Creation
-  bool Create(wxWindow* parent);
-
-  /// Initialises member variables
-  void Init();
+protected:
+  /// Constructors
+  CreateShortcutDlg(wxWindow *parent, PWScore &core, CItemData *base);
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -87,13 +85,13 @@ private:
   //*)
 
   //(*Declarations(CreateShortcutDlg)
-  wxComboBox* m_ComboBoxShortcutGroup;
-  wxTextCtrl* m_TextCtrlShortcutTitle;
-  wxTextCtrl* m_TextCtrlShortcutUsername;
+  wxComboBox* m_ComboBoxShortcutGroup = nullptr;
+  wxTextCtrl* m_TextCtrlShortcutTitle = nullptr;
+  wxTextCtrl* m_TextCtrlShortcutUsername = nullptr;
 
-  wxStaticText* m_StaticTextBaseEntryGroup;
-  wxStaticText* m_StaticTextBaseEntryTitle;
-  wxStaticText* m_StaticTextBaseEntryUsername;
+  wxStaticText* m_StaticTextBaseEntryGroup = nullptr;
+  wxStaticText* m_StaticTextBaseEntryTitle = nullptr;
+  wxStaticText* m_StaticTextBaseEntryUsername = nullptr;
   //*)
 
   wxString m_ShortcutGroup;
@@ -105,7 +103,7 @@ private:
   wxString m_BaseEntryUsername;
 
   PWScore &m_Core;
-  CItemData *m_Base;
+  CItemData *m_Base = nullptr;
 };
 
 #endif // _CREATESHORTCUTDLG_H_

--- a/src/ui/wxWidgets/DbSelectionPanel.cpp
+++ b/src/ui/wxWidgets/DbSelectionPanel.cpp
@@ -119,7 +119,7 @@ DbSelectionPanel::DbSelectionPanel(wxWindow* parent,
 #endif
   
   //The parent window must call our TransferDataToWindow and TransferDataFromWindow
-  m_parent->SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY);
+  m_parent->SetExtraStyle(m_parent->GetExtraStyle() | wxWS_EX_VALIDATE_RECURSIVELY);
 }
 
 DbSelectionPanel::~DbSelectionPanel()

--- a/src/ui/wxWidgets/DeleteConfirmationDlg.cpp
+++ b/src/ui/wxWidgets/DeleteConfirmationDlg.cpp
@@ -55,25 +55,10 @@ END_EVENT_TABLE()
  * DeleteConfirmationDlg constructors
  */
 
-DeleteConfirmationDlg::DeleteConfirmationDlg(int num_children)
-: m_numchildren(num_children)
-{
-  Init();
-}
-
-DeleteConfirmationDlg::DeleteConfirmationDlg( wxWindow* parent, int num_children, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
+DeleteConfirmationDlg::DeleteConfirmationDlg(wxWindow *parent, int num_children, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
   : m_numchildren(num_children)
 {
-  Init();
-  Create(parent, id, caption, pos, size, style);
-}
-
-/*!
- * DeleteConfirmationDlg creator
- */
-
-bool DeleteConfirmationDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
+  wxASSERT(!parent || parent->IsTopLevel());
 ////@begin DeleteConfirmationDlg creation
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create( parent, id, caption, pos, size, style );
@@ -85,28 +70,11 @@ bool DeleteConfirmationDlg::Create( wxWindow* parent, wxWindowID id, const wxStr
   }
   Centre();
 ////@end DeleteConfirmationDlg creation
-  return true;
 }
 
-/*!
- * DeleteConfirmationDlg destructor
- */
-
-DeleteConfirmationDlg::~DeleteConfirmationDlg()
+DeleteConfirmationDlg* DeleteConfirmationDlg::Create(wxWindow *parent, int num_children, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
 {
-////@begin DeleteConfirmationDlg destruction
-////@end DeleteConfirmationDlg destruction
-}
-
-/*!
- * Member initialisation
- */
-
-void DeleteConfirmationDlg::Init()
-{
-////@begin DeleteConfirmationDlg member initialisation
-  m_areyousure = nullptr;
-////@end DeleteConfirmationDlg member initialisation
+  return new DeleteConfirmationDlg(parent, num_children, id, caption, pos, size, style);
 }
 
 /*!

--- a/src/ui/wxWidgets/DeleteConfirmationDlg.h
+++ b/src/ui/wxWidgets/DeleteConfirmationDlg.h
@@ -56,18 +56,17 @@ class DeleteConfirmationDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
-  /// Constructors
-  DeleteConfirmationDlg(int num_children);
-  DeleteConfirmationDlg( wxWindow* parent, int num_children, wxWindowID id = SYMBOL_DELETECONFIRMATIONDLG_IDNAME, const wxString& caption = SYMBOL_DELETECONFIRMATIONDLG_TITLE, const wxPoint& pos = SYMBOL_DELETECONFIRMATIONDLG_POSITION, const wxSize& size = SYMBOL_DELETECONFIRMATIONDLG_SIZE, long style = SYMBOL_DELETECONFIRMATIONDLG_STYLE );
-
   /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_DELETECONFIRMATIONDLG_IDNAME, const wxString& caption = SYMBOL_DELETECONFIRMATIONDLG_TITLE, const wxPoint& pos = SYMBOL_DELETECONFIRMATIONDLG_POSITION, const wxSize& size = SYMBOL_DELETECONFIRMATIONDLG_SIZE, long style = SYMBOL_DELETECONFIRMATIONDLG_STYLE );
+  static DeleteConfirmationDlg* Create(wxWindow *parent, int num_children, wxWindowID id = SYMBOL_DELETECONFIRMATIONDLG_IDNAME, const wxString& caption = SYMBOL_DELETECONFIRMATIONDLG_TITLE, const wxPoint& pos = SYMBOL_DELETECONFIRMATIONDLG_POSITION, const wxSize& size = SYMBOL_DELETECONFIRMATIONDLG_SIZE, long style = SYMBOL_DELETECONFIRMATIONDLG_STYLE );
 
   /// Destructor
-  ~DeleteConfirmationDlg();
+  ~DeleteConfirmationDlg() = default;
 
-  /// Initialises member variables
-  void Init();
+  bool GetConfirmdelete() const { return m_confirmdelete ; }
+  void SetConfirmdelete(bool value) { m_confirmdelete = value ; }
+protected:
+  /// Constructors
+  DeleteConfirmationDlg(wxWindow *parent, int num_children, wxWindowID id = SYMBOL_DELETECONFIRMATIONDLG_IDNAME, const wxString& caption = SYMBOL_DELETECONFIRMATIONDLG_TITLE, const wxPoint& pos = SYMBOL_DELETECONFIRMATIONDLG_POSITION, const wxSize& size = SYMBOL_DELETECONFIRMATIONDLG_SIZE, long style = SYMBOL_DELETECONFIRMATIONDLG_STYLE );
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -84,9 +83,6 @@ public:
 
 ////@begin DeleteConfirmationDlg member function declarations
 
-  bool GetConfirmdelete() const { return m_confirmdelete ; }
-  void SetConfirmdelete(bool value) { m_confirmdelete = value ; }
-
   /// Retrieves bitmap resources
   wxBitmap GetBitmapResource( const wxString& name );
 
@@ -98,7 +94,7 @@ public:
   static bool ShowToolTips();
 
 ////@begin DeleteConfirmationDlg member variables
-  wxStaticText* m_areyousure;
+  wxStaticText* m_areyousure = nullptr;
 private:
   bool m_confirmdelete;
 ////@end DeleteConfirmationDlg member variables

--- a/src/ui/wxWidgets/EditShortcutDlg.cpp
+++ b/src/ui/wxWidgets/EditShortcutDlg.cpp
@@ -58,28 +58,12 @@ END_EVENT_TABLE()
  * EditShortcutDlg constructors
  */
 
-EditShortcutDlg::EditShortcutDlg(wxWindow* parent, PWScore &core, CItemData *shortcut)
+EditShortcutDlg::EditShortcutDlg(wxWindow *parent, PWScore &core, CItemData *shortcut)
 : m_Core(core), m_Shortcut(shortcut)
 {
   ASSERT(m_Shortcut != nullptr);
-  Init();
-  Create(parent);
-}
+  wxASSERT(!parent || parent->IsTopLevel());
 
-/*!
- * EditShortcutDlg destructor
- */
-
-EditShortcutDlg::~EditShortcutDlg()
-{
-}
-
-/*!
- * EditShortcutDlg creator
- */
-
-bool EditShortcutDlg::Create(wxWindow* parent)
-{
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create(parent, wxID_ANY, _("Edit Shortcut"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
@@ -92,7 +76,12 @@ bool EditShortcutDlg::Create(wxWindow* parent)
   SetValidators();
   UpdateControls();
   ItemFieldsToDialog();
-  return true;
+
+}
+
+EditShortcutDlg* EditShortcutDlg::Create(wxWindow *parent, PWScore &core, CItemData *shortcut)
+{
+  return new EditShortcutDlg(parent, core, shortcut);
 }
 
 void EditShortcutDlg::ItemFieldsToDialog()
@@ -224,24 +213,6 @@ void EditShortcutDlg::UpdateControls()
     m_TextCtrlShortcutTitle->Disable();
     m_TextCtrlShortcutUsername->Disable();
   }
-}
-
-/*!
- * Member initialisation
- */
-
-void EditShortcutDlg::Init()
-{
-  m_ComboBoxShortcutGroup = nullptr;
-  m_TextCtrlShortcutTitle = nullptr;
-  m_TextCtrlShortcutUsername = nullptr;
-  m_StaticTextShortcutCreated = nullptr;
-  m_StaticTextShortcutChanged = nullptr;
-  m_StaticTextShortcutAccessed = nullptr;
-  m_StaticTextShortcutAnyChange = nullptr;
-  m_StaticTextBaseEntryGroup = nullptr;
-  m_StaticTextBaseEntryTitle = nullptr;
-  m_StaticTextBaseEntryUsername = nullptr;
 }
 
 /*!

--- a/src/ui/wxWidgets/EditShortcutDlg.h
+++ b/src/ui/wxWidgets/EditShortcutDlg.h
@@ -43,17 +43,15 @@ class EditShortcutDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
-  /// Constructors
-  EditShortcutDlg(wxWindow* parent, PWScore &core, CItemData *shortcut);
+
+  static EditShortcutDlg* Create(wxWindow *parent, PWScore &core, CItemData *shortcut);
 
   /// Destructor
-  virtual ~EditShortcutDlg();
+  virtual ~EditShortcutDlg() = default;
 
-  /// Creation
-  bool Create(wxWindow* parent);
-
-  /// Initialises member variables
-  void Init();
+protected:
+  /// Constructors
+  EditShortcutDlg(wxWindow *parent, PWScore &core, CItemData *shortcut);
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -92,18 +90,18 @@ private:
   //*)
 
   //(*Declarations(EditShortcutDlgDialog)
-  wxComboBox* m_ComboBoxShortcutGroup;
-  wxTextCtrl* m_TextCtrlShortcutTitle;
-  wxTextCtrl* m_TextCtrlShortcutUsername;
+  wxComboBox* m_ComboBoxShortcutGroup = nullptr;
+  wxTextCtrl* m_TextCtrlShortcutTitle = nullptr;
+  wxTextCtrl* m_TextCtrlShortcutUsername = nullptr;
 
-  wxStaticText* m_StaticTextShortcutCreated;
-  wxStaticText* m_StaticTextShortcutChanged;
-  wxStaticText* m_StaticTextShortcutAccessed;
-  wxStaticText* m_StaticTextShortcutAnyChange;
+  wxStaticText* m_StaticTextShortcutCreated = nullptr;
+  wxStaticText* m_StaticTextShortcutChanged = nullptr;
+  wxStaticText* m_StaticTextShortcutAccessed = nullptr;
+  wxStaticText* m_StaticTextShortcutAnyChange = nullptr;
 
-  wxStaticText* m_StaticTextBaseEntryGroup;
-  wxStaticText* m_StaticTextBaseEntryTitle;
-  wxStaticText* m_StaticTextBaseEntryUsername;
+  wxStaticText* m_StaticTextBaseEntryGroup = nullptr;
+  wxStaticText* m_StaticTextBaseEntryTitle = nullptr;
+  wxStaticText* m_StaticTextBaseEntryUsername = nullptr;
   //*)
 
   wxString m_ShortcutGroup;
@@ -120,7 +118,7 @@ private:
   wxString m_BaseEntryUsername;
 
   PWScore &m_Core;
-  CItemData *m_Shortcut;
+  CItemData *m_Shortcut = nullptr;
 };
 
 #endif // _EDITSHORTCUTDLG_H_

--- a/src/ui/wxWidgets/EditShortcutDlg.h
+++ b/src/ui/wxWidgets/EditShortcutDlg.h
@@ -18,13 +18,13 @@
  */
 
 #include <wx/combobox.h>
-#include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
 
 #include "core/ItemData.h"
 #include "core/PWScore.h"
+#include "QueryCancelDlg.h"
 
 /*!
  * Forward declarations
@@ -37,7 +37,7 @@
  * EditShortcutDlg class declaration
  */
 
-class EditShortcutDlg : public wxDialog
+class EditShortcutDlg : public QueryCancelDlg
 {
   DECLARE_CLASS(EditShortcutDlg)
   DECLARE_EVENT_TABLE()
@@ -72,8 +72,19 @@ private:
   void ItemFieldsToDialog();
   void SetValidators();
   void UpdateControls();
+  bool SyncAndQueryCancel(bool showDialog) override;
 
-  //(*Handlers(CreateShortcutDlg)
+  enum Changes : uint32_t {
+    None = 0,
+    Group = 1u,
+    Title = 1u << 1,
+    User = 1u << 2,
+  };
+  
+  uint32_t GetChanges() const;  
+  bool IsChanged() const override;
+
+  //(*Handlers(EditShortcutDlgDialog)
   void OnOk(wxCommandEvent& event);
   //*)
 

--- a/src/ui/wxWidgets/ExportTextWarningDlg.cpp
+++ b/src/ui/wxWidgets/ExportTextWarningDlg.cpp
@@ -46,11 +46,13 @@ BEGIN_EVENT_TABLE( ExportTextWarningDlgBase, wxDialog )
 #endif
 END_EVENT_TABLE()
 
-ExportTextWarningDlgBase::ExportTextWarningDlgBase(wxWindow* parent) : wxDialog(parent, wxID_ANY, wxEmptyString,
+ExportTextWarningDlgBase::ExportTextWarningDlgBase(wxWindow *parent) : wxDialog(parent, wxID_ANY, wxEmptyString,
                       wxDefaultPosition, wxDefaultSize,
                       wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER),
   selCriteria(new SelectionCriteria), m_combinationEntry(nullptr), m_pollingTimer(nullptr)
 {
+  wxASSERT(!parent || parent->IsTopLevel());
+
   auto mainSizer = new wxBoxSizer(wxVERTICAL);
   mainSizer->AddSpacer(TopMargin);
 
@@ -170,7 +172,7 @@ ExportTextWarningDlgBase::~ExportTextWarningDlgBase()
 void ExportTextWarningDlgBase::OnAdvancedSelection( wxCommandEvent& evt )
 {
   UNREFERENCED_PARAMETER(evt);
-  DoAdvancedSelection();
+  CallAfter(&ExportTextWarningDlgBase::DoAdvancedSelection);
 }
 
 #ifndef NO_YUBI

--- a/src/ui/wxWidgets/ExportTextWarningDlg.h
+++ b/src/ui/wxWidgets/ExportTextWarningDlg.h
@@ -32,18 +32,17 @@ class ExportTextWarningDlgBase : public wxDialog
 
   DECLARE_CLASS( ExportTextWarningDlgBase )
   DECLARE_EVENT_TABLE()
-
 public:
-  ExportTextWarningDlgBase(wxWindow* parent);
+  SelectionCriteria* selCriteria;
+  StringX           passKey;
+  wxString          delimiter;
+protected:
+  explicit ExportTextWarningDlgBase(wxWindow *parent);
   ~ExportTextWarningDlgBase();
 
   void OnAdvancedSelection( wxCommandEvent& evt );
 
   virtual void DoAdvancedSelection() = 0;
-
-  SelectionCriteria* selCriteria;
-  StringX           passKey;
-  wxString          delimiter;
 private:
 #ifndef NO_YUBI
   void OnYubibtnClick( wxCommandEvent& event );
@@ -58,14 +57,17 @@ template <class DlgType>
 class ExportTextWarningDlg : public ExportTextWarningDlgBase
 {
 public:
-  ExportTextWarningDlg(wxWindow* parent) : ExportTextWarningDlgBase(parent)
+  static ExportTextWarningDlg* Create(wxWindow *parent) {
+    return new ExportTextWarningDlg(parent);
+  }
+protected:
+  explicit ExportTextWarningDlg(wxWindow *parent) : ExportTextWarningDlgBase(parent)
   {
     SetTitle(DlgType::GetTitle());
   }
 
   virtual void DoAdvancedSelection() {
-    AdvancedSelectionDlg<DlgType> dlg(this, selCriteria);
-    dlg.ShowModal();
+    ShowModalAndGetResult<AdvancedSelectionDlg<DlgType>>(this, selCriteria);
   }
 };
 

--- a/src/ui/wxWidgets/FieldSelectionDlg.cpp
+++ b/src/ui/wxWidgets/FieldSelectionDlg.cpp
@@ -47,18 +47,19 @@ BEGIN_EVENT_TABLE( FieldSelectionDlg, wxDialog )
   EVT_COMMAND(wxID_ANY, EVT_RELAYOUT_DLG, FieldSelectionDlg::OnRelayoutDlg)
 END_EVENT_TABLE()
 
-FieldSelectionDlg::FieldSelectionDlg(wxWindow* parent,
-                                     const CItemData::FieldType* available, size_t navail,
+FieldSelectionDlg::FieldSelectionDlg(wxWindow *parent, const CItemData::FieldType* available, size_t navail,
                                      const CItemData::FieldType* mandatory, size_t nmandatory,
                                      FieldSet& userSelection,
                                      const wxString& operation,
-                                     const wxString& dlgtitle/* = wxEmptyString*/,
-                                     const wxString& dlgText/* = wxEmptyString*/,
-                                     const wxString& vMsg/* = wxEmptyString*/, 
-                                     const wxString& vTitle/* = wxEmptyString*/)
+                                     const wxString& dlgtitle,
+                                     const wxString& dlgText,
+                                     const wxString& vMsg, 
+                                     const wxString& vTitle)
                                       :wxDialog(parent, wxID_ANY, FieldSelTitle(dlgtitle, operation),
                                                 wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER)
 {
+  wxASSERT(!parent || parent->IsTopLevel());
+
   wxBoxSizer* dlgSizer = new wxBoxSizer(wxVERTICAL);
   
   dlgSizer->AddSpacer(TopMargin);
@@ -80,6 +81,16 @@ FieldSelectionDlg::FieldSelectionDlg(wxWindow* parent,
     dlgSizer->Add(btnSizer, wxSizerFlags(0).Expand().Border(wxLEFT|wxRIGHT, SideMargin));
   dlgSizer->AddSpacer(BottomMargin);
   SetSizer(dlgSizer);
+}
+
+FieldSelectionDlg* FieldSelectionDlg::Create(wxWindow *parent, const CItemData::FieldType* available, size_t navail,
+                                     const CItemData::FieldType* mandatory, size_t nmandatory,
+                                     FieldSet& userSelection, const wxString& operation,
+                                     const wxString& dlgtitle, const wxString& dlgText, 
+                                     const wxString& vMsg, const wxString& vTitle)
+{
+  return new FieldSelectionDlg(parent, available, navail, mandatory, nmandatory,
+                              userSelection, operation, dlgtitle, dlgText, vMsg, vTitle);
 }
 
 void FieldSelectionDlg::OnInitDialog(wxInitDialogEvent& evt)

--- a/src/ui/wxWidgets/FieldSelectionDlg.h
+++ b/src/ui/wxWidgets/FieldSelectionDlg.h
@@ -25,10 +25,8 @@
 class FieldSelectionDlg : public wxDialog
 {
   DECLARE_EVENT_TABLE()
-
 public:
-  FieldSelectionDlg(wxWindow* parent,
-                    const CItemData::FieldType* available, size_t navail,
+  static FieldSelectionDlg* Create(wxWindow *parent, const CItemData::FieldType* available, size_t navail,
                     const CItemData::FieldType* mandatory, size_t nmandatory,
                     FieldSet& userSelection,
                     const wxString& operation,  //something like "search", or "merge" or "compare"
@@ -37,6 +35,17 @@ public:
                     const wxString& validationTitle = wxEmptyString,
                     const wxString& title = wxEmptyString,
                     const wxString& staticText = wxEmptyString);
+
+protected:
+  FieldSelectionDlg(wxWindow *parent, const CItemData::FieldType* available, size_t navail,
+                    const CItemData::FieldType* mandatory, size_t nmandatory,
+                    FieldSet& userSelection,
+                    const wxString& operation,  //something like "search", or "merge" or "compare"
+                    // These would be constructed from 'operation' if not provided explicitly
+                    const wxString& validationMessage, 
+                    const wxString& validationTitle,
+                    const wxString& title,
+                    const wxString& staticText);
   
   void OnInitDialog(wxInitDialogEvent& evt);
   void OnRelayoutDlg(wxCommandEvent& evt);  

--- a/src/ui/wxWidgets/ImportTextDlg.cpp
+++ b/src/ui/wxWidgets/ImportTextDlg.cpp
@@ -72,7 +72,7 @@ ImportTextDlg::ImportTextDlg(wxWindow *parent, const wxString& filename) :  wxDi
 
   //since the controls aren't direct children of the dialog but instead are
   //parented by wxCollipsiblePane, we need to validate recursively
-  SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY);
+  SetExtraStyle(GetExtraStyle() | wxWS_EX_VALIDATE_RECURSIVELY);
   CreateControls();
 }
 

--- a/src/ui/wxWidgets/ImportTextDlg.cpp
+++ b/src/ui/wxWidgets/ImportTextDlg.cpp
@@ -52,7 +52,7 @@ IMPLEMENT_CLASS( ImportTextDlg, wxDialog )
 BEGIN_EVENT_TABLE( ImportTextDlg, wxDialog )
 END_EVENT_TABLE()
 
-ImportTextDlg::ImportTextDlg(wxWindow* parent, const wxString filename) :  wxDialog(parent,
+ImportTextDlg::ImportTextDlg(wxWindow *parent, const wxString& filename) :  wxDialog(parent,
                                                             wxID_ANY,
                                                             _("Import Text Settings"),
                                                             wxDefaultPosition,
@@ -68,16 +68,19 @@ ImportTextDlg::ImportTextDlg(wxWindow* parent, const wxString filename) :  wxDia
                                                     importUnderGroup(false),
                                                     importPasswordsOnly(false)
 {
+  wxASSERT(!parent || parent->IsTopLevel());
+
   //since the controls aren't direct children of the dialog but instead are
   //parented by wxCollipsiblePane, we need to validate recursively
   SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY);
   CreateControls();
 }
 
-ImportTextDlg::~ImportTextDlg()
+ImportTextDlg* ImportTextDlg::Create(wxWindow *parent, const wxString& filename)
 {
+  return new ImportTextDlg(parent, filename);
 }
-
+                                                                  
 wxCollapsiblePane* ImportTextDlg::CreateImportOptionsPane(wxBoxSizer* dlgSizer)
 {
   const wxSizerFlags Left = wxSizerFlags().Proportion(0).Border(wxLEFT, SideMargin);

--- a/src/ui/wxWidgets/ImportTextDlg.h
+++ b/src/ui/wxWidgets/ImportTextDlg.h
@@ -30,11 +30,12 @@ class ImportTextDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
-  ImportTextDlg(wxWindow* parent, const wxString filename = "");
-  virtual ~ImportTextDlg();
-
+  static ImportTextDlg* Create(wxWindow *parent, const wxString& filename = wxEmptyString);
+  virtual ~ImportTextDlg() = default;
+protected:
+  ImportTextDlg(wxWindow *parent, const wxString& filename);
   void CreateControls();
-
+public:
   wxString filepath;
   
   bool delimiterComma;
@@ -51,7 +52,6 @@ public:
   bool importPasswordsOnly;
   
   TCHAR FieldSeparator() const;
-  
 private:
   wxCollapsiblePane* CreateParsingOptionsPane(wxBoxSizer* dlgSizer);
   wxCollapsiblePane* CreateImportOptionsPane(wxBoxSizer* dlgSizer);

--- a/src/ui/wxWidgets/ImportXmlDlg.cpp
+++ b/src/ui/wxWidgets/ImportXmlDlg.cpp
@@ -28,11 +28,13 @@
 
 IMPLEMENT_CLASS( ImportXmlDlg, wxDialog )
 
-ImportXmlDlg::ImportXmlDlg(wxWindow* parent, const wxString filename) : wxDialog(parent, wxID_ANY, wxString(_("Import XML Settings"))),
+ImportXmlDlg::ImportXmlDlg(wxWindow *parent, const wxString& filename) : wxDialog(parent, wxID_ANY, wxString(_("Import XML Settings"))),
                                                   importUnderGroup(false), 
                                                   importPasswordsOnly(false),
                                                   filepath(filename)
 {
+  wxASSERT(!parent || parent->IsTopLevel());
+
   enum { TopMargin = 20, BottomMargin = 20, SideMargin = 30, RowSeparation = 10, ColSeparation = 20};
   
   wxSizerFlags borderFlags = wxSizerFlags().Border(wxLEFT|wxRIGHT, SideMargin).Expand();
@@ -73,6 +75,11 @@ ImportXmlDlg::ImportXmlDlg(wxWindow* parent, const wxString filename) : wxDialog
   dlgSizer->AddSpacer(BottomMargin);
   
   SetSizerAndFit(dlgSizer);
+}
+
+ImportXmlDlg* ImportXmlDlg::Create(wxWindow *parent, const wxString& filename)
+{
+  return new ImportXmlDlg(parent, filename);
 }
 
 wxCheckBox* ImportXmlDlg::CheckBox(const wxString& label, bool* validatorTarget)

--- a/src/ui/wxWidgets/ImportXmlDlg.h
+++ b/src/ui/wxWidgets/ImportXmlDlg.h
@@ -22,10 +22,12 @@ class ImportXmlDlg : public wxDialog
 {
   DECLARE_CLASS( ImportXmlDlg )
   
-public:
-  ImportXmlDlg(wxWindow* parent, const wxString filename = "");
+protected:
+  ImportXmlDlg(wxWindow *parent, const wxString& filename);
 
 public:
+  static ImportXmlDlg* Create(wxWindow *parent, const wxString& filename);
+
   bool importUnderGroup;
   wxString groupName;
   

--- a/src/ui/wxWidgets/ManageFiltersDlg.cpp
+++ b/src/ui/wxWidgets/ManageFiltersDlg.cpp
@@ -219,22 +219,7 @@ END_EVENT_TABLE()
  * ManageFiltersDlg constructors
  */
 
-ManageFiltersDlg::ManageFiltersDlg() :
-                                 m_pMapAllFilters(nullptr),
-                                 m_pCurrentFilters(nullptr),
-                                 m_bCanHaveAttachments(false),
-                                 m_psMediaTypes(nullptr),
-                                 m_bReadOnly(true),
-                                 m_core(nullptr),
-                                 m_pActiveFilterPool(nullptr),
-                                 m_pActiveFilterName(nullptr),
-                                 m_pbFilterActive(nullptr)
-{
-  Init();
-}
-
-ManageFiltersDlg::ManageFiltersDlg(wxWindow* parent,
-                                   PWScore *core,
+ManageFiltersDlg::ManageFiltersDlg(wxWindow *parent, PWScore *core,
                                    PWSFilters &MapFilters,
                                    st_filters *currentFilters,
                                    FilterPool *activefilterpool,
@@ -261,16 +246,7 @@ ManageFiltersDlg::ManageFiltersDlg(wxWindow* parent,
                                             m_pActiveFilterName(activefiltername),
                                             m_pbFilterActive(bFilterActive)
 {
-  Init();
-  Create(parent, id, caption, pos, size, style);
-}
-
-/*!
- * ManageFiltersDlg creator
- */
-
-bool ManageFiltersDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
+  wxASSERT(!parent || parent->IsTopLevel());
 ////@begin ManageFiltersDlg creation
   SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY|wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create( parent, id, caption, pos, size, style );
@@ -282,39 +258,29 @@ bool ManageFiltersDlg::Create( wxWindow* parent, wxWindowID id, const wxString& 
   }
   Centre();
 ////@end ManageFiltersDlg creation
-  return true;
 }
 
 
-/*!
- * ManageFiltersDlg destructor
- */
-
-ManageFiltersDlg::~ManageFiltersDlg()
+ManageFiltersDlg* ManageFiltersDlg::Create(wxWindow *parent, PWScore *core,
+                                   PWSFilters &MapFilters,
+                                   st_filters *currentFilters,
+                                   FilterPool *activefilterpool,
+                                   stringT *activefiltername,
+                                   bool *bFilterActive,
+                                   const bool bCanHaveAttachments,
+                                   const std::set<StringX> *psMediaTypes,
+                                   bool readOnly,
+                                   wxWindowID id, const wxString& caption,
+                                   const wxPoint& pos,
+                                   const wxSize& size,
+                                   long style )
 {
-////@begin ManageFiltersDlg destruction
-////@end ManageFiltersDlg destruction
+  return new ManageFiltersDlg(parent, core, MapFilters, currentFilters,
+                              activefilterpool, activefiltername,
+                              bFilterActive, bCanHaveAttachments,
+                              psMediaTypes, readOnly,
+                              id, caption, pos, size, style);
 }
-
-
-/*!
- * Member initialisation
- */
-
-void ManageFiltersDlg::Init()
-{
-////@begin ManageFiltersDlg member initialisation
-  m_MapFiltersGrid = nullptr;
-  m_FontHeight = 15;
-  m_SelectedFilterPool = FPOOL_LAST;
-  m_SelectedFilterName = L"";
-  m_num_to_copy = 0;
-  m_num_to_export = 0;
-  m_bDBFiltersChanged = false;
-  windowSize.Set(0, 0);
-////@end ManageFiltersDlg member initialisation
-}
-
 
 /*!
  * Control creation for ManageFiltersDlg
@@ -771,7 +737,12 @@ void ManageFiltersDlg::OnCellLeftClick( wxGridEvent& event )
  * wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_NEW
  */
 
-void ManageFiltersDlg::OnNewClick( wxCommandEvent& event )
+void ManageFiltersDlg::OnNewClick(wxCommandEvent&)
+{
+  CallAfter(&ManageFiltersDlg::DoNewClick);
+}
+
+void ManageFiltersDlg::DoNewClick()
 {
   st_filters filters; // New filter is empty
   bool bActiveFilter = m_MapFilterData.IsFilterActive();
@@ -781,8 +752,7 @@ void ManageFiltersDlg::OnNewClick( wxCommandEvent& event )
   while(bDoEdit) {
     bDoEdit = false; // In formal case we run only one time in the loop; but when removal of double entry is requested we avoid goto
 
-    SetFiltersDlg dlg(GetParent(), &filters, m_pCurrentFilters, &bAppliedCalled, DFTYPE_MAIN, FPOOL_SESSION, m_bCanHaveAttachments, m_psMediaTypes);
-    int rc = dlg.ShowModal();
+    int rc = ShowModalAndGetResult<SetFiltersDlg>(this, &filters, m_pCurrentFilters, &bAppliedCalled, DFTYPE_MAIN, FPOOL_SESSION, m_bCanHaveAttachments, m_psMediaTypes);
     
     if(bActiveFilter && ! *m_pbFilterActive) {
       // On filter active before and now no filter active take back usage flag
@@ -853,7 +823,12 @@ void ManageFiltersDlg::OnNewClick( wxCommandEvent& event )
  * wxEVT_COMMAND_BUTTON_CLICKED event handler for ID_EDIT
  */
 
-void ManageFiltersDlg::OnEditClick( wxCommandEvent& event )
+void ManageFiltersDlg::OnEditClick(wxCommandEvent&)
+{
+  CallAfter(&ManageFiltersDlg::DoEditClick);
+}
+
+void ManageFiltersDlg::DoEditClick()
 {
   st_Filterkey fk;
   st_filters filters; // New filter is empty
@@ -877,8 +852,7 @@ void ManageFiltersDlg::OnEditClick( wxCommandEvent& event )
   while(bDoEdit) { // Loop to avoid goto
     bDoEdit = false;  // In formal case we run only one time in the loop; but when removal of double entry is requested we avoid goto
 
-    SetFiltersDlg dlg(GetParent(), &filters, m_pCurrentFilters, &bAppliedCalled, DFTYPE_MAIN, fk.fpool, m_bCanHaveAttachments, m_psMediaTypes);
-    int rc = dlg.ShowModal();
+    int rc = ShowModalAndGetResult<SetFiltersDlg>(this, &filters, m_pCurrentFilters, &bAppliedCalled, DFTYPE_MAIN, fk.fpool, m_bCanHaveAttachments, m_psMediaTypes);
     
     if(bActiveFilter && ! *m_pbFilterActive) {
       // On filter active before and now no filter active take back usage flag

--- a/src/ui/wxWidgets/ManageFiltersDlg.cpp
+++ b/src/ui/wxWidgets/ManageFiltersDlg.cpp
@@ -794,7 +794,7 @@ void ManageFiltersDlg::OnNewClick( wxCommandEvent& event )
       bActiveFilter = false;
     }
   
-    if(rc == wxID_OK || (rc == wxID_CANCEL && bAppliedCalled)) {
+    if(rc == wxID_OK || (rc == wxID_CANCEL && bAppliedCalled && !IsCloseInProgress())) {
       if(rc != wxID_OK) {
         // Overtake last applied filter
         filters = *m_pCurrentFilters;
@@ -890,7 +890,7 @@ void ManageFiltersDlg::OnEditClick( wxCommandEvent& event )
       bActiveFilter = false;
     }
   
-    if (rc == wxID_OK || (rc == wxID_CANCEL && bAppliedCalled)) {
+    if (rc == wxID_OK || (rc == wxID_CANCEL && bAppliedCalled && !IsCloseInProgress())) {
       if(rc != wxID_OK) {
         // Overtake last applied filter
         filters = *m_pCurrentFilters;

--- a/src/ui/wxWidgets/ManageFiltersDlg.h
+++ b/src/ui/wxWidgets/ManageFiltersDlg.h
@@ -115,18 +115,14 @@ class ManageFiltersDlg: public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
-  /// Constructors
-  ManageFiltersDlg();
-  ManageFiltersDlg( wxWindow* parent, PWScore *core, PWSFilters &MapFilters, st_filters *currentFilters, FilterPool *activefilterpool, stringT *activefiltername, bool *bFilterActive, const bool bCanHaveAttachments = false, const std::set<StringX> *psMediaTypes = NULL, bool readOnly = true, wxWindowID id = SYMBOL_MANAGEFILTERS_IDNAME, const wxString& caption = SYMBOL_MANAGEFILTERS_TITLE, const wxPoint& pos = SYMBOL_MANAGEFILTERS_POSITION, const wxSize& size = SYMBOL_MANAGEFILTERS_SIZE, long style = SYMBOL_MANAGEFILTERS_STYLE );
-
-  /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_MANAGEFILTERS_IDNAME, const wxString& caption = SYMBOL_MANAGEFILTERS_TITLE, const wxPoint& pos = SYMBOL_MANAGEFILTERS_POSITION, const wxSize& size = SYMBOL_MANAGEFILTERS_SIZE, long style = SYMBOL_MANAGEFILTERS_STYLE );
+  static ManageFiltersDlg* Create(wxWindow *parent, PWScore *core, PWSFilters &MapFilters, st_filters *currentFilters, FilterPool *activefilterpool, stringT *activefiltername, bool *bFilterActive, const bool bCanHaveAttachments = false, const std::set<StringX> *psMediaTypes = nullptr, bool readOnly = true, wxWindowID id = SYMBOL_MANAGEFILTERS_IDNAME, const wxString& caption = SYMBOL_MANAGEFILTERS_TITLE, const wxPoint& pos = SYMBOL_MANAGEFILTERS_POSITION, const wxSize& size = SYMBOL_MANAGEFILTERS_SIZE, long style = SYMBOL_MANAGEFILTERS_STYLE );
 
   /// Destructor
-  ~ManageFiltersDlg();
-
-  /// Initialises member variables
-  void Init();
+  ~ManageFiltersDlg() = default;
+protected:
+  /// Constructors
+  ManageFiltersDlg() = default;
+  ManageFiltersDlg(wxWindow *parent, PWScore *core, PWSFilters &MapFilters, st_filters *currentFilters, FilterPool *activefilterpool, stringT *activefiltername, bool *bFilterActive, const bool bCanHaveAttachments, const std::set<StringX> *psMediaTypes, bool readOnly, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style);
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -201,37 +197,41 @@ private:
   void SetGridColLeftAligned(int col);
   wxSize ExtendColSize(int col, int extend = 30);
   
+  void DoNewClick();
+  void DoEditClick();
+  
+  
   ////@begin ManageFiltersDlg member variables
-  PWSFilters *m_pMapAllFilters;  // The map of all present filters
-  st_filters *m_pCurrentFilters; // Pointer to the currect active (or de-activated) filter
-  const bool m_bCanHaveAttachments;
-  const std::set<StringX> *m_psMediaTypes;
-  const bool m_bReadOnly;
-  PWScore   *m_core;
+  PWSFilters *m_pMapAllFilters = nullptr;  // The map of all present filters
+  st_filters *m_pCurrentFilters = nullptr; // Pointer to the currect active (or de-activated) filter
+  const bool m_bCanHaveAttachments = false;
+  const std::set<StringX> *m_psMediaTypes = nullptr;
+  const bool m_bReadOnly = false;
+  PWScore   *m_core = nullptr;
   
   // Active filter is shown on the pwSafe main windows
-  FilterPool *m_pActiveFilterPool;
-  stringT *m_pActiveFilterName;
-  bool    *m_pbFilterActive;
+  FilterPool *m_pActiveFilterPool = nullptr;
+  stringT *m_pActiveFilterName = nullptr;
+  bool    *m_pbFilterActive = nullptr;
   
-  ManageFiltersGrid *m_MapFiltersGrid;     // Grid to show all filters
-  wxStaticText      *m_SelectedFilterText; // Dialog item to be updated with the shown filters name
-  pwFiltersGrid     *m_filterGrid;         // Grid to show the filters content
+  ManageFiltersGrid *m_MapFiltersGrid = nullptr;     // Grid to show all filters
+  wxStaticText      *m_SelectedFilterText = nullptr; // Dialog item to be updated with the shown filters name
+  pwFiltersGrid     *m_filterGrid = nullptr;         // Grid to show the filters content
   
   // The slected filter is marked in the list of filters and the content is shown in the lower grid
-  FilterPool m_SelectedFilterPool;
+  FilterPool m_SelectedFilterPool = FPOOL_LAST;
   stringT    m_SelectedFilterName;
   st_filters m_SelectedFilter;
   
-  int m_num_to_copy;    // Number of selected entries in copy to DB column
-  int m_num_to_export;  // Number of selected entries for export operation
+  int m_num_to_copy = 0;    // Number of selected entries in copy to DB column
+  int m_num_to_export = 0;  // Number of selected entries for export operation
   
   pwSortedManageFilters m_MapFilterData;   // Map to handle sorting for filter in the filters grid
   
-  bool m_bDBFiltersChanged;
+  bool m_bDBFiltersChanged = false;
 
   // Height of used font
-  int m_FontHeight;
+  int m_FontHeight = 15;
   
   // Old window size to determine change when resize is called
   wxSize windowSize;

--- a/src/ui/wxWidgets/ManagePasswordPoliciesDlg.cpp
+++ b/src/ui/wxWidgets/ManagePasswordPoliciesDlg.cpp
@@ -85,7 +85,7 @@ END_EVENT_TABLE()
  * ManagePasswordPoliciesDlg constructor
  */
 
-ManagePasswordPoliciesDlg::ManagePasswordPoliciesDlg( wxWindow* parent,  PWScore &core, wxWindowID id,
+ManagePasswordPoliciesDlg::ManagePasswordPoliciesDlg(wxWindow *parent, PWScore &core, wxWindowID id,
               const wxString& caption, const wxPoint& pos,
               const wxSize& size, long style )
 : m_core(core), m_curPolRow(-1),
@@ -93,16 +93,10 @@ ManagePasswordPoliciesDlg::ManagePasswordPoliciesDlg( wxWindow* parent,  PWScore
   m_bSortNamesAscending(true), m_bSortEntriesAscending(true), m_bViewPolicy(true),
   m_bShowPolicyEntriesInitially(true)
 {
-  Init();
-  Create(parent, id, caption, pos, size, style);
-}
+  wxASSERT(!parent || parent->IsTopLevel());
 
-/*!
- * ManagePasswordPoliciesDlg creator
- */
+  m_PolicyManager = std::unique_ptr<PolicyManager>(new PolicyManager(m_core));
 
-bool ManagePasswordPoliciesDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
 ////@begin ManagePasswordPoliciesDlg creation
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create( parent, id, caption, pos, size, style );
@@ -114,34 +108,13 @@ bool ManagePasswordPoliciesDlg::Create( wxWindow* parent, wxWindowID id, const w
   }
   Centre();
 ////@end ManagePasswordPoliciesDlg creation
-  return true;
 }
 
-/*!
- * ManagePasswordPoliciesDlg destructor
- */
-
-ManagePasswordPoliciesDlg::~ManagePasswordPoliciesDlg()
+ManagePasswordPoliciesDlg* ManagePasswordPoliciesDlg::Create(wxWindow *parent, PWScore &core, wxWindowID id,
+              const wxString& caption, const wxPoint& pos,
+              const wxSize& size, long style)
 {
-////@begin ManagePasswordPoliciesDlg destruction
-////@end ManagePasswordPoliciesDlg destruction
-}
-
-/*!
- * Member initialisation
- */
-
-void ManagePasswordPoliciesDlg::Init()
-{
-////@begin ManagePasswordPoliciesDlg member initialisation
-  m_PolicyNames = nullptr;
-  m_passwordCtrl = nullptr;
-  m_lowerTableDesc = nullptr;
-  m_PolicyDetails = nullptr;
-  m_PolicyEntries = nullptr;
-////@end ManagePasswordPoliciesDlg member initialisation
-
-  m_PolicyManager = std::unique_ptr<PolicyManager>(new PolicyManager(m_core));
+  return new ManagePasswordPoliciesDlg(parent, core, id, caption, pos, size, style);
 }
 
 /*!
@@ -595,16 +568,21 @@ void ManagePasswordPoliciesDlg::ResizeGridColumns()
 
 void ManagePasswordPoliciesDlg::OnNewClick( wxCommandEvent& )
 {
+  CallAfter(&ManagePasswordPoliciesDlg::DoNewClick);
+}
+
+void ManagePasswordPoliciesDlg::DoNewClick()
+{
   auto policies = m_PolicyManager->GetPolicies();
   auto policy   = m_PolicyManager->GetDefaultPolicy();
 
-  PasswordPolicyDlg ppdlg(this, m_core, policies);
-  ppdlg.SetPolicyData(wxEmptyString, policy);
+  DestroyWrapper<PasswordPolicyDlg> ppdlg(this, m_core, policies);
+  ppdlg.Get()->SetPolicyData(wxEmptyString, policy);
 
-  if (ppdlg.ShowModal() == wxID_OK) {
+  if (ppdlg.Get()->ShowModal() == wxID_OK) {
     wxString policyname;
 
-    ppdlg.GetPolicyData(policyname, policy);
+    ppdlg.Get()->GetPolicyData(policyname, policy);
 
     m_PolicyManager->PolicyAdded(policyname.ToStdWstring(), policy);
 
@@ -619,6 +597,11 @@ void ManagePasswordPoliciesDlg::OnNewClick( wxCommandEvent& )
  */
 
 void ManagePasswordPoliciesDlg::OnEditClick( wxCommandEvent& )
+{
+  CallAfter(&ManagePasswordPoliciesDlg::DoEditClick);
+}
+
+void ManagePasswordPoliciesDlg::DoEditClick()
 {
   int row = GetSelectedRow();
 
@@ -650,13 +633,13 @@ void ManagePasswordPoliciesDlg::OnEditClick( wxCommandEvent& )
     originalPolicy     = m_PolicyManager->GetPolicy(originalPolicyname.ToStdWstring());
   }
 
-  PasswordPolicyDlg ppdlg(this, m_core, policies);
+  DestroyWrapper<PasswordPolicyDlg> ppdlg(this, m_core, policies);
 
-  ppdlg.SetPolicyData(originalPolicyname, originalPolicy);
+  ppdlg.Get()->SetPolicyData(originalPolicyname, originalPolicy);
 
-  if (ppdlg.ShowModal() == wxID_OK) {
+  if (ppdlg.Get()->ShowModal() == wxID_OK) {
 
-    ppdlg.GetPolicyData(modifiedPolicyname, modifiedPolicy);
+    ppdlg.Get()->GetPolicyData(modifiedPolicyname, modifiedPolicy);
 
     if (originalPolicyname != modifiedPolicyname) {
 

--- a/src/ui/wxWidgets/ManagePasswordPoliciesDlg.h
+++ b/src/ui/wxWidgets/ManagePasswordPoliciesDlg.h
@@ -25,7 +25,7 @@
 #include "core/StringX.h"
 #include "core/PWScore.h"
 #include "core/PolicyManager.h"
-
+#include "QueryCancelDlg.h"
 #include <vector>
 
 /*!
@@ -65,7 +65,7 @@ class wxGrid;
  * ManagePasswordPoliciesDlg class declaration
  */
 
-class ManagePasswordPoliciesDlg: public wxDialog
+class ManagePasswordPoliciesDlg: public QueryCancelDlg
 {
   DECLARE_DYNAMIC_CLASS( ManagePasswordPoliciesDlg )
   DECLARE_EVENT_TABLE()
@@ -166,6 +166,16 @@ protected:
   PWPolicy GetSelectedPolicy() const;
   int GetSelectedRow() const;
   void ResizeGridColumns();
+
+  enum Changes : uint32_t {
+    None = 0,
+    DefaultPolicy = 1u,
+    NamedPolices = 1u << 1,
+  };
+
+  uint32_t GetChanges() const;
+  bool SyncAndQueryCancel(bool showDialog) override;
+  bool IsChanged() const override;
 
   PWScore &m_core;
 

--- a/src/ui/wxWidgets/ManagePasswordPoliciesDlg.h
+++ b/src/ui/wxWidgets/ManagePasswordPoliciesDlg.h
@@ -71,22 +71,17 @@ class ManagePasswordPoliciesDlg: public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
-  /// Constructors
-  ManagePasswordPoliciesDlg( wxWindow* parent,  PWScore &core,
-         wxWindowID id = SYMBOL_MANAGEPASSWORDPOLICIESDLG_IDNAME,
-         const wxString& caption = SYMBOL_MANAGEPASSWORDPOLICIESDLG_TITLE,
-         const wxPoint& pos = SYMBOL_MANAGEPASSWORDPOLICIESDLG_POSITION,
-         const wxSize& size = SYMBOL_MANAGEPASSWORDPOLICIESDLG_SIZE,
-         long style = SYMBOL_MANAGEPASSWORDPOLICIESDLG_STYLE );
-
   /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_MANAGEPASSWORDPOLICIESDLG_IDNAME, const wxString& caption = SYMBOL_MANAGEPASSWORDPOLICIESDLG_TITLE, const wxPoint& pos = SYMBOL_MANAGEPASSWORDPOLICIESDLG_POSITION, const wxSize& size = SYMBOL_MANAGEPASSWORDPOLICIESDLG_SIZE, long style = SYMBOL_MANAGEPASSWORDPOLICIESDLG_STYLE );
+  static ManagePasswordPoliciesDlg* Create(wxWindow *parent, PWScore &core, wxWindowID id = SYMBOL_MANAGEPASSWORDPOLICIESDLG_IDNAME, const wxString& caption = SYMBOL_MANAGEPASSWORDPOLICIESDLG_TITLE, const wxPoint& pos = SYMBOL_MANAGEPASSWORDPOLICIESDLG_POSITION, const wxSize& size = SYMBOL_MANAGEPASSWORDPOLICIESDLG_SIZE, long style = SYMBOL_MANAGEPASSWORDPOLICIESDLG_STYLE );
 
   /// Destructor
-  ~ManagePasswordPoliciesDlg();
+  ~ManagePasswordPoliciesDlg() = default;
 
-  /// Initialises member variables
-  void Init();
+protected:
+  /// Constructors
+  ManagePasswordPoliciesDlg(wxWindow *parent, PWScore &core,
+         wxWindowID id, const wxString& caption, const wxPoint& pos,
+         const wxSize& size,long style);
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -149,13 +144,16 @@ public:
 
   // Overridden virtuals
   virtual bool Show(bool show = true);
+  
+  void DoNewClick();
+  void DoEditClick();
 
 ////@begin ManagePasswordPoliciesDlg member variables
-  wxGrid* m_PolicyNames;
-  wxTextCtrl* m_passwordCtrl;
-  wxStaticText* m_lowerTableDesc;
-  wxGrid* m_PolicyDetails;
-  wxGrid* m_PolicyEntries;
+  wxGrid* m_PolicyNames = nullptr;
+  wxTextCtrl* m_passwordCtrl = nullptr;
+  wxStaticText* m_lowerTableDesc = nullptr;
+  wxGrid* m_PolicyDetails = nullptr;
+  wxGrid* m_PolicyEntries = nullptr;
 ////@end ManagePasswordPoliciesDlg member variables
  private:
   void UpdateNames();

--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -249,35 +249,7 @@ void PasswordSafeFrame::OnOpenClick(wxCommandEvent& WXUNUSED(evt))
 
 void PasswordSafeFrame::OnCloseClick(wxCommandEvent& WXUNUSED(evt))
 {
-  PWSprefs *prefs = PWSprefs::GetInstance();
-
-  // Save Application related preferences
-  prefs->SaveApplicationPreferences();
-  if( m_core.IsDbOpen() ) {
-    int rc = SaveIfChanged();
-    if (rc != PWScore::SUCCESS)
-      return;
-
-    m_core.SafeUnlockCurFile();
-    m_core.SetCurFile(wxEmptyString);
-
-    // Reset core and clear ALL associated data
-    m_core.ReInit();
-
-    // clear the application data before ending
-    ClearAppData();
-    
-    // Force close all active dialogs
-    CloseAllWindows(&TimedTaskChain::CreateTaskChain([](){}), static_cast<CloseFlags>(CloseFlags::CLOSE_FORCED|CloseFlags::LEAVE_MAIN));
-    
-    SetTitle(wxEmptyString);
-    m_sysTray->SetTrayStatus(SystemTray::TrayStatus::CLOSED);
-    wxCommandEvent dummyEv;
-    m_search->OnSearchClose(dummyEv); // fix github issue 375
-    m_core.SetReadOnly(false);
-    UpdateStatusBar();
-    UpdateMenuBar();
-  }
+  CloseDB(nullptr);
 }
 
 void PasswordSafeFrame::OnLockSafe(wxCommandEvent&)
@@ -1397,6 +1369,6 @@ void PasswordSafeFrame::DoPropertiesClick()
 
 void PasswordSafeFrame::OnExitClick(wxCommandEvent& WXUNUSED(evt))
 {
-  CloseAllWindows(&TimedTaskChain::CreateTaskChain([](){}), CloseFlags::CLOSE_NORMAL);
+  CloseAllWindows(&TimedTaskChain::CreateTaskChain([](){}), CloseFlags::CLOSE_NORMAL, nullptr);
 }
 

--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -1371,6 +1371,10 @@ void PasswordSafeFrame::DoPropertiesClick()
 
 void PasswordSafeFrame::OnExitClick(wxCommandEvent& WXUNUSED(evt))
 {
-  CloseAllWindows(&TimedTaskChain::CreateTaskChain([](){}), CloseFlags::CLOSE_NORMAL, nullptr);
+  CloseAllWindows(&TimedTaskChain::CreateTaskChain([](){}), CloseFlags::CLOSE_NORMAL, [this](bool success) {
+    if (!success) {
+      // `this` should be valid here, because we haven't closed DB
+      wxMessageBox(_("Can't close database. There are unsaved changes in opened dialogs."), wxTheApp->GetAppName(), wxOK | wxICON_WARNING, this);
+    }
+  });
 }
-

--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -1306,19 +1306,21 @@ void PasswordSafeFrame::DoSynchronize(wxString filename)
                 wxT("Synchronize menu enabled for empty or read-only database!"));
 
   SyncWizard wiz(this, &m_core, filename);
-  wiz.RunWizard(wiz.GetFirstPage());
-
-  if (wiz.GetNumUpdated() > 0)
-    UpdateStatusBar();
-
+  if (wiz.RunWizard(wiz.GetFirstPage())) {
+    if (wiz.GetNumUpdated() > 0 && wiz.GetSyncCommands()) {
+      m_core.Execute(wiz.GetSyncCommands());
+      UpdateStatusBar();
+    }
 #ifdef NOT_YET
-  ChangeOkUpdate();
+    ChangeOkUpdate();
 #endif
 
-  RefreshViews();
+    RefreshViews();
 
-  if (wiz.ShowReport())
-    ViewReport(*wiz.GetReport());
+    if (wiz.ShowReport()) {
+      ViewReport(*wiz.GetReport());
+    }
+  }
 }
 
 void PasswordSafeFrame::OnPropertiesClick(wxCommandEvent& WXUNUSED(evt))

--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -1351,8 +1351,6 @@ void PasswordSafeFrame::OnPropertiesClick(wxCommandEvent& WXUNUSED(evt))
 
 void PasswordSafeFrame::OnExitClick(wxCommandEvent& WXUNUSED(evt))
 {
-  m_exitFromMenu = true;
-
-  Close();
+  CloseAllWindows(&TimedTaskChain::CreateTaskChain([](){}), CloseFlags::CLOSE_NORMAL);
 }
 

--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -80,7 +80,7 @@ void PasswordSafeFrame::DisplayFileWriteError(int rc, const StringX &fname)
 
 void PasswordSafeFrame::OnNewClick(wxCommandEvent& WXUNUSED(evt))
 {
-  New();
+  CallAfter([&](){PasswordSafeFrame::New();});
 }
 
 int PasswordSafeFrame::New()
@@ -167,8 +167,9 @@ int PasswordSafeFrame::NewFile(StringX &fname)
     } else
       return PWScore::USER_CANCEL;
 
-    SafeCombinationSetupDlg dbox_pksetup(this);
-    rc = dbox_pksetup.ShowModal();
+    DestroyWrapper<SafeCombinationSetupDlg> dbox_pksetupWrapper(this);
+    SafeCombinationSetupDlg* dbox_pksetup = dbox_pksetupWrapper.Get();
+    rc = dbox_pksetup->ShowModal();
 
     if (rc == wxID_CANCEL)
       return PWScore::USER_CANCEL;  //User cancelled password entry
@@ -220,7 +221,7 @@ int PasswordSafeFrame::NewFile(StringX &fname)
     m_core.SetCurFile(fname);
 
     m_core.SetReadOnly(false); // new file can't be read-only...
-    m_core.NewFile(tostringx(dbox_pksetup.GetPassword()));
+    m_core.NewFile(tostringx(dbox_pksetup->GetPassword()));
 #ifdef notyet
     startLockCheckTimer();
 #endif
@@ -265,7 +266,10 @@ void PasswordSafeFrame::OnCloseClick(wxCommandEvent& WXUNUSED(evt))
 
     // clear the application data before ending
     ClearAppData();
-
+    
+    // Force close all active dialogs
+    CloseAllWindows(&TimedTaskChain::CreateTaskChain([](){}), static_cast<CloseFlags>(CloseFlags::CLOSE_FORCED|CloseFlags::LEAVE_MAIN));
+    
     SetTitle(wxEmptyString);
     m_sysTray->SetTrayStatus(SystemTray::TrayStatus::CLOSED);
     wxCommandEvent dummyEv;
@@ -283,7 +287,7 @@ void PasswordSafeFrame::OnLockSafe(wxCommandEvent&)
 
 void PasswordSafeFrame::OnUnlockSafe(wxCommandEvent&)
 {
-  UnlockSafe(true, true);
+  CallAfter(&PasswordSafeFrame::UnlockSafe, true, true);
 }
 
 /*!
@@ -757,13 +761,13 @@ void PasswordSafeFrame::OnExportVx(wxCommandEvent& evt)
 void PasswordSafeFrame::OnExportPlainText(wxCommandEvent& evt)
 {
   UNREFERENCED_PARAMETER(evt);
-  DoExportText<ExportFullText>();
+  CallAfter(&PasswordSafeFrame::DoExportText<ExportFullText>);
 }
 
 void PasswordSafeFrame::OnExportXml(wxCommandEvent& evt)
 {
   UNREFERENCED_PARAMETER(evt);
-  DoExportText<ExportFullXml>();
+  CallAfter(&PasswordSafeFrame::DoExportText<ExportFullXml>);
 }
 
 IMPLEMENT_CLASS_TEMPLATE( AdvancedSelectionDlg, wxDialog, ExportFullXml )
@@ -784,18 +788,20 @@ void PasswordSafeFrame::DoExportText()
     return;
   }
 
-  ExportTextWarningDlg<ExportType> et(this);
-  if (et.ShowModal() != wxID_OK)
+  DestroyWrapper<ExportTextWarningDlg<ExportType>> etWrapper(this);
+  auto *et = etWrapper.Get(); 
+  if (et->ShowModal() != wxID_OK) {
     return;
+  }
 
   StringX newfile;
-  StringX pw(et.passKey);
+  StringX pw(et->passKey);
   if (m_core.CheckPasskey(sx_temp, pw) == PWScore::SUCCESS) {
-    const CItemData::FieldBits bsExport = et.selCriteria->GetSelectedFields();
-    const std::wstring subgroup_name = tostdstring(et.selCriteria->SubgroupSearchText());
-    const int subgroup_object = et.selCriteria->SubgroupObject();
-    const int subgroup_function = et.selCriteria->SubgroupFunctionWithCase();
-    wchar_t delimiter = et.delimiter.IsEmpty()? wxT('\xbb') : et.delimiter[0];
+    const CItemData::FieldBits bsExport = et->selCriteria->GetSelectedFields();
+    const std::wstring subgroup_name = tostdstring(et->selCriteria->SubgroupSearchText());
+    const int subgroup_object = et->selCriteria->SubgroupObject();
+    const int subgroup_function = et->selCriteria->SubgroupFunctionWithCase();
+    wchar_t delimiter = et->delimiter.IsEmpty()? wxT('\xbb') : et->delimiter[0];
 
     // Note: MakeOrderedItemList gets its members by walking the
     // tree therefore, if a filter is active, it will ONLY export
@@ -870,6 +876,11 @@ void PasswordSafeFrame::DoExportText()
 
 void PasswordSafeFrame::OnImportText(wxCommandEvent& evt)
 {
+  CallAfter(&PasswordSafeFrame::DoImportText, evt.GetString());
+}
+
+void PasswordSafeFrame::DoImportText(wxString filename)
+{
   if (m_core.IsReadOnly()) {// disable in read-only mode
     wxMessageBox(_("The current database was opened in read-only mode.  You cannot import into it."),
                   _("Import text"), wxOK | wxICON_EXCLAMATION, this);
@@ -887,18 +898,19 @@ void PasswordSafeFrame::OnImportText(wxCommandEvent& evt)
     return;
   }
 
-  ImportTextDlg dlg(this, evt.GetString());
-  if (dlg.ShowModal() != wxID_OK)
+  DestroyWrapper<ImportTextDlg> dlgWrapper(this, filename);
+  ImportTextDlg *dlg = dlgWrapper.Get();
+  if (dlg->ShowModal() != wxID_OK)
     return;
 
-  StringX ImportedPrefix(dlg.groupName.c_str());
-  TCHAR fieldSeparator = dlg.FieldSeparator();
+  StringX ImportedPrefix(dlg->groupName.c_str());
+  TCHAR fieldSeparator = dlg->FieldSeparator();
 
   std::wstring strError;
-  wxString TxtFileName = dlg.filepath;
+  wxString TxtFileName = dlg->filepath;
   int numImported(0), numSkipped(0), numPWHErrors(0), numRenamed(0), numNoPolicyNames(0);
-  wchar_t delimiter = dlg.strDelimiterLine[0];
-  bool bImportPSWDsOnly = dlg.importPasswordsOnly;
+  wchar_t delimiter = dlg->strDelimiterLine[0];
+  bool bImportPSWDsOnly = dlg->importPasswordsOnly;
 
   /* Create report as we go */
   CReport rpt;
@@ -987,6 +999,11 @@ void PasswordSafeFrame::OnImportText(wxCommandEvent& evt)
 
 void PasswordSafeFrame::OnImportXML(wxCommandEvent& evt)
 {
+  CallAfter(&PasswordSafeFrame::DoImportXML, evt.GetString());
+}
+
+void PasswordSafeFrame::DoImportXML(wxString filename)
+{
   if (m_core.IsReadOnly()) // disable in read-only mode
     return;
 
@@ -1011,17 +1028,19 @@ void PasswordSafeFrame::OnImportXML(wxCommandEvent& evt)
   }
 #endif
 
-  ImportXmlDlg dlg(this, evt.GetString());
-  if (dlg.ShowModal() != wxID_OK)
+  DestroyWrapper<ImportXmlDlg> dlgWrapper(this, filename);
+  ImportXmlDlg *dlg = dlgWrapper.Get();
+  if (dlg->ShowModal() != wxID_OK) {
     return;
+  }
 
-  std::wstring ImportedPrefix(tostdstring(dlg.groupName));
+  std::wstring ImportedPrefix(tostdstring(dlg->groupName));
   std::wstring strXMLErrors, strSkippedList, strPWHErrorList, strRenameList;
-  wxString XMLFilename = dlg.filepath;
+  wxString XMLFilename = dlg->filepath;
   int numValidated, numImported, numSkipped, numRenamed, numPWHErrors;
   int numRenamedPolicies, numNoPolicy;
   int numShortcutsRemoved, numEmptyGroupsImported;
-  bool bImportPSWDsOnly = dlg.importPasswordsOnly;
+  bool bImportPSWDsOnly = dlg->importPasswordsOnly;
 
   wxBeginBusyCursor();  // This may take a while!
 
@@ -1033,7 +1052,7 @@ void PasswordSafeFrame::OnImportXML(wxCommandEvent& evt)
   std::vector<StringX> vgroups;
   Command *pcmd = nullptr;
 
-  int rc = m_core.ImportXMLFile(ImportedPrefix, std::wstring(XMLFilename),
+  int rc = m_core.ImportXMLFile(ImportedPrefix, tostdstring(XMLFilename),
                             tostdstring(XSDFilename.GetFullPath()), bImportPSWDsOnly,
                             strXMLErrors, strSkippedList, strPWHErrorList, strRenameList,
                             numValidated, numImported, numSkipped, numPWHErrors, numRenamed,
@@ -1049,12 +1068,12 @@ void PasswordSafeFrame::OnImportXML(wxCommandEvent& evt)
   switch (rc) {
     case PWScore::XML_FAILED_VALIDATION:
       cs_temp = wxString::Format(_("File: %ls failed validation against XML Schema:\n\n%ls"),
-                                        dlg.filepath.c_str(), strXMLErrors.c_str());
+                                        dlg->filepath.c_str(), strXMLErrors.c_str());
       delete pcmd;
       break;
     case PWScore::XML_FAILED_IMPORT:
       cs_temp = wxString::Format(_("File: %ls passed Validation but had the following errors during import:\n\n%ls"),
-                              dlg.filepath.c_str(), strXMLErrors.c_str());
+                              dlg->filepath.c_str(), strXMLErrors.c_str());
       delete pcmd;
       break;
     case PWScore::SUCCESS:
@@ -1096,7 +1115,7 @@ void PasswordSafeFrame::OnImportXML(wxCommandEvent& evt)
         }
 
         cs_temp.Printf(_("File: %ls was imported (entries validated %d / imported %d%ls%ls%ls). See report for details."),
-                       dlg.filepath.c_str(), numValidated, numImported,
+                       dlg->filepath.c_str(), numValidated, numImported,
                        cs_skipped.c_str(), cs_renamed.c_str(), cs_PWHErrors.c_str());
         // TODO -Tell user if any empty groups imported
       } else {
@@ -1131,14 +1150,19 @@ void PasswordSafeFrame::OnImportXML(wxCommandEvent& evt)
 
 void PasswordSafeFrame::OnImportKeePass(wxCommandEvent& evt)
 {
+  CallAfter(&PasswordSafeFrame::DoImportKeePass, evt.GetString());
+}
+
+void PasswordSafeFrame::DoImportKeePass(wxString filename)
+{
   if (m_core.IsReadOnly()) // disable in read-only mode
     return;
 
   wxString KPsFileName;
   
-  if(evt.GetString().IsEmpty()) {
+  if(filename.IsEmpty()) {
     wxFileDialog fd(this, _("Please Choose a KeePass Text File to Import"),
-                  wxEmptyString, evt.GetString(),
+                  wxEmptyString, filename,
                   _("Text files (*.txt)|*.txt|CSV files (*.csv)|*.csv|All files (*.*; *)|*.*;*"),
                   (wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_PREVIEW));
 
@@ -1148,7 +1172,7 @@ void PasswordSafeFrame::OnImportKeePass(wxCommandEvent& evt)
     KPsFileName = fd.GetPath();
   }
   else {
-    KPsFileName = evt.GetString();
+    KPsFileName = filename;
   }
   CReport rpt;
 
@@ -1227,8 +1251,15 @@ void PasswordSafeFrame::OnImportKeePass(wxCommandEvent& evt)
 
 void PasswordSafeFrame::OnMergeAnotherSafe(wxCommandEvent& evt)
 {
-  MergeDlg dlg(this, &m_core, evt.GetString());
-  if (dlg.ShowModal() == wxID_OK) {
+  CallAfter(&PasswordSafeFrame::DoMergeAnotherSafe, evt.GetString());
+}
+
+void PasswordSafeFrame::DoMergeAnotherSafe(wxString filename)
+{
+  DestroyWrapper<MergeDlg> dlgWrapper(this, &m_core, filename);
+  MergeDlg* dlg = dlgWrapper.Get();
+
+  if (dlg->ShowModal() == wxID_OK) {
     PWScore othercore; // NOT PWSAuxCore, as we handle db prefs explicitly
     // Reading a new file changes the preferences as they are instance dependent
     // not core dependent
@@ -1240,14 +1271,14 @@ void PasswordSafeFrame::OnMergeAnotherSafe(wxCommandEvent& evt)
     // 'other' default Password Policy when needed in Compare, Merge & Sync
     prefs->SetupCopyPrefs();
 
-    int rc = ReadCore(othercore, dlg.GetOtherSafePath(),
-                      dlg.GetOtherSafeCombination(), true, this);
+    int rc = ReadCore(othercore, dlg->GetOtherSafePath(),
+                      dlg->GetOtherSafeCombination(), true, this);
 
     // Reset database preferences - first to defaults then add saved changes!
     prefs->Load(sxSavePrefString);
 
     if (rc == PWScore::SUCCESS) {
-        Merge(tostringx(dlg.GetOtherSafePath()), &othercore, dlg.GetSelectionCriteria());
+        Merge(tostringx(dlg->GetOtherSafePath()), &othercore, dlg->GetSelectionCriteria());
     }
   }
 }
@@ -1283,17 +1314,26 @@ void PasswordSafeFrame::Merge(const StringX &sx_Filename2, PWScore *pothercore, 
 
 void PasswordSafeFrame::OnCompare(wxCommandEvent& WXUNUSED(evt))
 {
-  CompareDlg dlg(this, &m_core);
-  dlg.ShowModal();
+  CallAfter(&PasswordSafeFrame::DoCompare);
+}
+
+void PasswordSafeFrame::DoCompare()
+{
+  ShowModalAndGetResult<CompareDlg>(this, &m_core);
 }
 
 void PasswordSafeFrame::OnSynchronize(wxCommandEvent& evt)
+{
+  CallAfter(&PasswordSafeFrame::DoSynchronize, evt.GetString());
+}
+
+void PasswordSafeFrame::DoSynchronize(wxString filename)
 {
   // disable in read-only mode or empty
   wxCHECK_RET(!m_core.IsReadOnly() && m_core.IsDbOpen() && m_core.GetNumEntries() != 0,
                 wxT("Synchronize menu enabled for empty or read-only database!"));
 
-  SyncWizard wiz(this, &m_core, evt.GetString());
+  SyncWizard wiz(this, &m_core, filename);
   wiz.RunWizard(wiz.GetFirstPage());
 
   if (wiz.GetNumUpdated() > 0)
@@ -1311,27 +1351,33 @@ void PasswordSafeFrame::OnSynchronize(wxCommandEvent& evt)
 
 void PasswordSafeFrame::OnPropertiesClick(wxCommandEvent& WXUNUSED(evt))
 {
-  PropertiesDlg propsDialog(this, m_core);
-  propsDialog.ShowModal();
+  CallAfter(&PasswordSafeFrame::DoPropertiesClick);
+}
 
-  if (propsDialog.HasDbNameChanged() || propsDialog.HasDbDescriptionChanged()) {
+void PasswordSafeFrame::DoPropertiesClick()
+{
+  DestroyWrapper<PropertiesDlg> dlgWrapper(this, m_core);
+  PropertiesDlg* propsDialog = dlgWrapper.Get();
+  propsDialog->ShowModal();
+
+  if (propsDialog->HasDbNameChanged() || propsDialog->HasDbDescriptionChanged()) {
 
     auto multiCommands = MultiCommands::Create(&m_core);
 
-    if (propsDialog.HasDbNameChanged()) {
+    if (propsDialog->HasDbNameChanged()) {
 
       multiCommands->Add(
         ChangeDBHeaderCommand::Create(
-          &m_core, propsDialog.GetNewDbName(), PWSfile::HDR_DBNAME
+          &m_core, propsDialog->GetNewDbName(), PWSfile::HDR_DBNAME
         )
       );
     }
 
-    if (propsDialog.HasDbDescriptionChanged()) {
+    if (propsDialog->HasDbDescriptionChanged()) {
 
       multiCommands->Add(
         ChangeDBHeaderCommand::Create(
-          &m_core, propsDialog.GetNewDbDescription(), PWSfile::HDR_DBDESC
+          &m_core, propsDialog->GetNewDbDescription(), PWSfile::HDR_DBDESC
         )
       );
     }

--- a/src/ui/wxWidgets/MenuManageHandlers.cpp
+++ b/src/ui/wxWidgets/MenuManageHandlers.cpp
@@ -49,7 +49,13 @@
 
 void PasswordSafeFrame::OnChangePasswordClick(wxCommandEvent& WXUNUSED(evt))
 {
-  auto window = new SafeCombinationChangeDlg(this, m_core);
+  CallAfter(&PasswordSafeFrame::DoChangePassword);
+}
+
+void PasswordSafeFrame::DoChangePassword()
+{
+  DestroyWrapper<SafeCombinationChangeDlg> windowWrapper(this, m_core);
+  SafeCombinationChangeDlg* window = windowWrapper.Get();
   int returnValue = window->ShowModal();
   if (returnValue == wxID_OK) {
     m_core.ChangePasskey(window->GetNewpasswd());
@@ -57,9 +63,7 @@ void PasswordSafeFrame::OnChangePasswordClick(wxCommandEvent& WXUNUSED(evt))
   if (!window->IsYubiProtected())
     m_core.SetYubiSK(nullptr); // erase YubiSK, as it's no longer protected by Yuibkey
 #endif
-
   }
-  window->Destroy();
 }
 
 /*!
@@ -68,12 +72,18 @@ void PasswordSafeFrame::OnChangePasswordClick(wxCommandEvent& WXUNUSED(evt))
 
 void PasswordSafeFrame::OnPreferencesClick(wxCommandEvent& WXUNUSED(evt))
 {
+  CallAfter(&PasswordSafeFrame::DoPreferencesClick);
+}
+
+void PasswordSafeFrame::DoPreferencesClick()
+{
   PWSprefs* prefs = PWSprefs::GetInstance();
   bool showMenuSeprator = prefs->GetPref(PWSprefs::ShowMenuSeparator);
   bool autoAdjColWidth = prefs->GetPref(PWSprefs::AutoAdjColWidth);
   bool toolbarShowText = prefs->GetPref(PWSprefs::ToolbarShowText);
   const StringX sxOldDBPrefsString(prefs->Store());
-  OptionsPropertySheetDlg *window = new OptionsPropertySheetDlg(this, m_core);
+  DestroyWrapper<OptionsPropertySheetDlg> windowWrapper(this, m_core);
+  OptionsPropertySheetDlg* window = windowWrapper.Get();
 
   if (window->ShowModal() == wxID_OK) {
     if(showMenuSeprator != prefs->GetPref(PWSprefs::ShowMenuSeparator)) {
@@ -122,7 +132,6 @@ void PasswordSafeFrame::OnPreferencesClick(wxCommandEvent& WXUNUSED(evt))
     }
   }
   if (!IsCloseInProgress()) {
-    window->Destroy();
     SetFocus();
   }
 }
@@ -176,6 +185,11 @@ void PasswordSafeFrame::OnBackupSafe(wxCommandEvent& WXUNUSED(evt))
 
 void PasswordSafeFrame::OnRestoreSafe(wxCommandEvent& WXUNUSED(evt))
 {
+  CallAfter(&PasswordSafeFrame::DoRestoreSafe);
+}
+
+void PasswordSafeFrame::DoRestoreSafe()
+{
   if (SaveIfChanged() != PWScore::SUCCESS)
     return;
 
@@ -200,9 +214,9 @@ void PasswordSafeFrame::OnRestoreSafe(wxCommandEvent& WXUNUSED(evt))
   if (wxbf.empty())
     return;
 
-  SafeCombinationPromptDlg pwdprompt(this, m_core, wxbf, false);
-  if (pwdprompt.ShowModal() == wxID_OK) {
-    const StringX passkey = pwdprompt.GetPassword();
+  DestroyWrapper<SafeCombinationPromptDlg> pwdprompt(this, m_core, wxbf, false);
+  if (pwdprompt.Get()->ShowModal() == wxID_OK) {
+    const StringX passkey = pwdprompt.Get()->GetPassword();
     // unlock the file we're leaving
     m_core.SafeUnlockCurFile();
 
@@ -241,8 +255,12 @@ void PasswordSafeFrame::OnRestoreSafe(wxCommandEvent& WXUNUSED(evt))
 
 void PasswordSafeFrame::OnPwdPolsMClick( wxCommandEvent&  )
 {
-  ManagePasswordPoliciesDlg ppols(this, m_core);
-  ppols.ShowModal();
+  CallAfter(&PasswordSafeFrame::DoPwdPolsMClick);
+}
+
+void PasswordSafeFrame::DoPwdPolsMClick()
+{
+  ShowModalAndGetResult<ManagePasswordPoliciesDlg>(this, m_core);
 }
 
 /*!
@@ -251,6 +269,11 @@ void PasswordSafeFrame::OnPwdPolsMClick( wxCommandEvent&  )
 
 void PasswordSafeFrame::OnGeneratePassword(wxCommandEvent& WXUNUSED(event))
 {
+  CallAfter(&PasswordSafeFrame::DoGeneratePassword);
+}
+
+void PasswordSafeFrame::DoGeneratePassword()
+{
   PolicyManager policyManager(m_core);
   auto customPolicies = policyManager.GetPolicies();
   auto defaultPolicy  = policyManager.GetDefaultPolicy();
@@ -258,10 +281,10 @@ void PasswordSafeFrame::OnGeneratePassword(wxCommandEvent& WXUNUSED(event))
 
   customPolicies[std2stringx(defaultName)] = defaultPolicy;
 
-  PasswordPolicyDlg ppdlg(this, m_core, customPolicies, PasswordPolicyDlg::DialogType::GENERATOR);
-  ppdlg.SetPolicyData(defaultName, defaultPolicy);
+  DestroyWrapper<PasswordPolicyDlg> ppdlg(this, m_core, customPolicies, PasswordPolicyDlg::DialogType::GENERATOR);
+  ppdlg.Get()->SetPolicyData(defaultName, defaultPolicy);
 
-  ppdlg.ShowModal();
+  ppdlg.Get()->ShowModal();
 }
 
 #ifndef NO_YUBI
@@ -271,8 +294,12 @@ void PasswordSafeFrame::OnGeneratePassword(wxCommandEvent& WXUNUSED(event))
 
 void PasswordSafeFrame::OnYubikeyMngClick(wxCommandEvent& WXUNUSED(event))
 {
-  YubiCfgDlg ykCfg(this, m_core);
-  ykCfg.ShowModal();
+  CallAfter(&PasswordSafeFrame::DoYubikeyMngClick);
+}
+
+void PasswordSafeFrame::DoYubikeyMngClick()
+{
+  ShowModalAndGetResult<YubiCfgDlg>(this, m_core);
 }
 #endif
 
@@ -327,7 +354,12 @@ void PasswordSafeFrame::OnLanguageClick(wxCommandEvent& evt)
  * wxEVT_COMMAND_MENU_SELECTED event handler for ID_CHANGEMODE
  */
 
-void PasswordSafeFrame::OnChangeMode(wxCommandEvent& evt)
+void PasswordSafeFrame::OnChangeMode(wxCommandEvent&)
+{
+  CallAfter(&PasswordSafeFrame::DoChangeMode);
+}
+
+void PasswordSafeFrame::DoChangeMode()
 {
   // Don't bother doing anything if DB is read-only on disk
   bool bFileIsReadOnly;
@@ -378,9 +410,9 @@ bool PasswordSafeFrame::ChangeMode(bool promptUser)
   } else if (promptUser) { // R-O -> R/W
     // Taken from GetAndCheckPassword.
     // We don't want all the other processing that GetAndCheckPassword does
-    SafeCombinationPromptDlg scp(nullptr, m_core, towxstring(m_core.GetCurFile()), false);
+    int rc = ShowModalAndGetResult<SafeCombinationPromptDlg>(this, m_core, towxstring(m_core.GetCurFile()), false);
 
-    if(scp.ShowModal() != wxID_OK)
+    if(rc != wxID_OK)
       return false;
   } // R-O -> R/W
 

--- a/src/ui/wxWidgets/MenuManageHandlers.cpp
+++ b/src/ui/wxWidgets/MenuManageHandlers.cpp
@@ -121,8 +121,10 @@ void PasswordSafeFrame::OnPreferencesClick(wxCommandEvent& WXUNUSED(evt))
       }
     }
   }
-  window->Destroy();
-  SetFocus();
+  if (!IsCloseInProgress()) {
+    window->Destroy();
+    SetFocus();
+  }
 }
 
 /*

--- a/src/ui/wxWidgets/MenuViewHandlers.cpp
+++ b/src/ui/wxWidgets/MenuViewHandlers.cpp
@@ -400,7 +400,7 @@ void PasswordSafeFrame::DoEditFilter()
   st_filters filters(CurrentFilter());
   bool bCanHaveAttachments = m_core.GetNumAtts() > 0;
   const std::set<StringX> sMediaTypes = m_core.GetAllMediaTypes();
-  bool bAppliedCalled;
+  bool bAppliedCalled = false;
   stringT oldName = CurrentFilter().fname;
   st_Filterkey fk;
   bool bDoEdit = true;

--- a/src/ui/wxWidgets/MenuViewHandlers.cpp
+++ b/src/ui/wxWidgets/MenuViewHandlers.cpp
@@ -407,7 +407,7 @@ void PasswordSafeFrame::OnEditFilter(wxCommandEvent& )
     SetFiltersDlg dlg(this, &filters, &CurrentFilter(), &bAppliedCalled, DFTYPE_MAIN, FPOOL_SESSION, bCanHaveAttachments, &sMediaTypes);
     int rc = dlg.ShowModal();
   
-    if (rc == wxID_OK || (rc == wxID_CANCEL && bAppliedCalled)) {
+    if (rc == wxID_OK || (rc == wxID_CANCEL && bAppliedCalled && !IsCloseInProgress())) {
       // User can apply the filter in SetFiltersDlg and then press Cancel button
       // and afterwards process changes, update only on OK button and continue with actualized version
       if(rc == wxID_OK) {

--- a/src/ui/wxWidgets/MenuViewHandlers.cpp
+++ b/src/ui/wxWidgets/MenuViewHandlers.cpp
@@ -222,8 +222,7 @@ void PasswordSafeFrame::RunShowReport(int iAction)
   CReport rpt;
   rpt.StartReport(iAction, m_core.GetCurFile().c_str(), false);
   if(rpt.ReadFromDisk()) {
-    ViewReportDlg dlg(this, &rpt, true);
-    dlg.ShowModal();
+    ShowModalAndGetResult<ViewReportDlg>(this, &rpt, true);
   }
   else {
     wxString tcAction = CReport::ReportNames.find(iAction)->second;
@@ -233,62 +232,62 @@ void PasswordSafeFrame::RunShowReport(int iAction)
 
 void PasswordSafeFrame::OnShowReportSynchronize(wxCommandEvent& WXUNUSED(evt))
 {
-  RunShowReport(IDSC_RPTSYNCH);
+  CallAfter(&PasswordSafeFrame::RunShowReport, IDSC_RPTSYNCH);
 }
 
 void PasswordSafeFrame::OnShowReportCompare(wxCommandEvent& WXUNUSED(evt))
 {
-  RunShowReport(IDSC_RPTCOMPARE);
+  CallAfter(&PasswordSafeFrame::RunShowReport, IDSC_RPTCOMPARE);
 }
 
 void PasswordSafeFrame::OnShowReportMerge(wxCommandEvent& WXUNUSED(evt))
 {
-  RunShowReport(IDSC_RPTMERGE);
+  CallAfter(&PasswordSafeFrame::RunShowReport, IDSC_RPTMERGE);
 }
 
 void PasswordSafeFrame::OnShowReportImportText(wxCommandEvent& WXUNUSED(evt))
 {
-  RunShowReport(IDSC_RPTIMPORTTEXT);
+  CallAfter(&PasswordSafeFrame::RunShowReport, IDSC_RPTIMPORTTEXT);
 }
 
 void PasswordSafeFrame::OnShowReportImportXML(wxCommandEvent& WXUNUSED(evt))
 {
-  RunShowReport(IDSC_RPTIMPORTXML);
+  CallAfter(&PasswordSafeFrame::RunShowReport, IDSC_RPTIMPORTXML);
 }
 
 void PasswordSafeFrame::OnShowReportImportKeePassV1_TXT(wxCommandEvent& WXUNUSED(evt))
 {
-  RunShowReport(IDSC_RPTIMPORTKPV1TXT);
+  CallAfter(&PasswordSafeFrame::RunShowReport, IDSC_RPTIMPORTKPV1TXT);
 }
 
 void PasswordSafeFrame::OnShowReportImportKeePassV1_CSV(wxCommandEvent& WXUNUSED(evt))
 {
-  RunShowReport(IDSC_RPTIMPORTKPV1CSV);
+  CallAfter(&PasswordSafeFrame::RunShowReport, IDSC_RPTIMPORTKPV1CSV);
 }
 
 void PasswordSafeFrame::OnShowReportExportText(wxCommandEvent& WXUNUSED(evt))
 {
-  RunShowReport(IDSC_RPTEXPORTTEXT);
+  CallAfter(&PasswordSafeFrame::RunShowReport, IDSC_RPTEXPORTTEXT);
 }
 
 void PasswordSafeFrame::OnShowReportExportXML(wxCommandEvent& WXUNUSED(evt))
 {
-  RunShowReport(IDSC_RPTEXPORTXML);
+  CallAfter(&PasswordSafeFrame::RunShowReport, IDSC_RPTEXPORTXML);
 }
 
 void PasswordSafeFrame::OnShowReportExportDB(wxCommandEvent& WXUNUSED(evt))
 {
-  RunShowReport(IDSC_RPTEXPORTDB);
+  CallAfter(&PasswordSafeFrame::RunShowReport, IDSC_RPTEXPORTDB);
 }
 
 void PasswordSafeFrame::OnShowReportFind(wxCommandEvent& WXUNUSED(evt))
 {
-  RunShowReport(IDSC_RPTFIND);
+  CallAfter(&PasswordSafeFrame::RunShowReport, IDSC_RPTFIND);
 }
 
 void PasswordSafeFrame::OnShowReportValidate(wxCommandEvent& WXUNUSED(evt))
 {
-  RunShowReport(IDSC_RPTVALIDATE);
+  CallAfter(&PasswordSafeFrame::RunShowReport, IDSC_RPTVALIDATE);
 }
 
 void PasswordSafeFrame::OnShowHideToolBar(wxCommandEvent& evt)
@@ -393,6 +392,11 @@ void PasswordSafeFrame::ApplyFilters()
 
 void PasswordSafeFrame::OnEditFilter(wxCommandEvent& )
 {
+  CallAfter(&PasswordSafeFrame::DoEditFilter);
+}
+
+void PasswordSafeFrame::DoEditFilter()
+{
   st_filters filters(CurrentFilter());
   bool bCanHaveAttachments = m_core.GetNumAtts() > 0;
   const std::set<StringX> sMediaTypes = m_core.GetAllMediaTypes();
@@ -404,8 +408,7 @@ void PasswordSafeFrame::OnEditFilter(wxCommandEvent& )
   while(bDoEdit) {
     bDoEdit = false; // In formal case we run only one time in the loop; but when removal of double entry is requested we avoid goto
 
-    SetFiltersDlg dlg(this, &filters, &CurrentFilter(), &bAppliedCalled, DFTYPE_MAIN, FPOOL_SESSION, bCanHaveAttachments, &sMediaTypes);
-    int rc = dlg.ShowModal();
+    int rc = ShowModalAndGetResult<SetFiltersDlg>(this, &filters, &CurrentFilter(), &bAppliedCalled, DFTYPE_MAIN, FPOOL_SESSION, bCanHaveAttachments, &sMediaTypes);;
   
     if (rc == wxID_OK || (rc == wxID_CANCEL && bAppliedCalled && !IsCloseInProgress())) {
       // User can apply the filter in SetFiltersDlg and then press Cancel button
@@ -536,6 +539,11 @@ private:
 
 void PasswordSafeFrame::OnManageFilters(wxCommandEvent& )
 {
+  CallAfter(&PasswordSafeFrame::DoManageFilters);
+}
+
+void PasswordSafeFrame::DoManageFilters()
+{
   st_Filterkey fkl, fku;
   PWSFilters::iterator mf_iter, mf_lower_iter, mf_upper_iter;
   
@@ -565,12 +573,11 @@ void PasswordSafeFrame::OnManageFilters(wxCommandEvent& )
       mf_iter != core_filters.end(); mf_iter++) {
     m_MapAllFilters.insert(PWSFilters::Pair(mf_iter->first, mf_iter->second));
   }
-  
+
   bool bCanHaveAttachments = m_core.GetNumAtts() > 0;
   const std::set<StringX> sMediaTypes = m_core.GetAllMediaTypes();
-  
-  ManageFiltersDlg dlg(this, &m_core, m_MapAllFilters, &CurrentFilter(), &m_currentfilterpool, &m_selectedfiltername, &m_bFilterActive, bCanHaveAttachments, &sMediaTypes, m_core.IsReadOnly());
-  int rc = dlg.ShowModal();
+
+  int rc = ShowModalAndGetResult<ManageFiltersDlg>(this, &m_core, m_MapAllFilters, &CurrentFilter(), &m_currentfilterpool, &m_selectedfiltername, &m_bFilterActive, bCanHaveAttachments, &sMediaTypes, m_core.IsReadOnly());;
   
   // No change in DB filter when return ID_CANCEL
   if(rc == wxID_CANCEL)

--- a/src/ui/wxWidgets/MergeDlg.cpp
+++ b/src/ui/wxWidgets/MergeDlg.cpp
@@ -39,10 +39,12 @@ BEGIN_EVENT_TABLE( MergeDlg, wxDialog )
   EVT_BUTTON( ID_ADVANCED,  MergeDlg::OnAdvancedSelection )
 END_EVENT_TABLE()
 
-MergeDlg::MergeDlg(wxWindow* parent, PWScore* core, const wxString filename) :
+MergeDlg::MergeDlg(wxWindow *parent, PWScore* core, const wxString& filename) :
                       wxDialog(parent, wxID_ANY, wxString(_("Merge Another Database"))),
                       m_core(core), m_selection(new SelectionCriteria), m_dbPanel(nullptr)
 {
+  wxASSERT(!parent || parent->IsTopLevel());
+
   const wxString filePrompt(wxString(_("Choose Database to Merge into \"")) <<
                                           towxstring(m_core->GetCurFile()) << wxT("\""));
   const wxString filePickerCtrlTitle(_("Please Choose a Database to Merge into current database"));
@@ -69,6 +71,11 @@ MergeDlg::MergeDlg(wxWindow* parent, PWScore* core, const wxString filename) :
   dlgSizer->AddSpacer(BottomMargin);
 
   SetSizerAndFit(dlgSizer);
+}
+
+MergeDlg* MergeDlg::Create(wxWindow *parent, PWScore* core, const wxString& filename)
+{
+  return new MergeDlg(parent, core, filename);
 }
 
 MergeDlg::~MergeDlg()
@@ -113,8 +120,12 @@ IMPLEMENT_CLASS_TEMPLATE( AdvancedSelectionDlg, wxDialog, AdvancedMergeOptions )
 
 void MergeDlg::OnAdvancedSelection(wxCommandEvent& )
 {
-  AdvancedSelectionDlg<AdvancedMergeOptions> dlg(this, m_selection);
-  dlg.ShowModal();
+  CallAfter(&MergeDlg::DoAdvancedSelection);
+}
+
+void MergeDlg::DoAdvancedSelection()
+{
+  ShowModalAndGetResult<AdvancedSelectionDlg<AdvancedMergeOptions>>(this, m_selection);
 }
 
 wxString MergeDlg::GetOtherSafePath() const

--- a/src/ui/wxWidgets/MergeDlg.h
+++ b/src/ui/wxWidgets/MergeDlg.h
@@ -26,19 +26,21 @@ class MergeDlg : public wxDialog
   DECLARE_EVENT_TABLE()
   
 public:
-  MergeDlg(wxWindow* parent, PWScore* core, const wxString filename = "");
+  static MergeDlg* Create(wxWindow *parent, PWScore* core, const wxString &filename = wxEmptyString);
   ~MergeDlg();
-
+protected:
+  MergeDlg(wxWindow *parent, PWScore* core, const wxString &filename);
   void OnAdvancedSelection( wxCommandEvent& evt );
-
+public:
   wxString GetOtherSafePath() const;
   StringX GetOtherSafeCombination() const;
   SelectionCriteria GetSelectionCriteria() const;
   
 private:
-  PWScore* m_core;
-  SelectionCriteria* m_selection;
-  DbSelectionPanel* m_dbPanel;
+  void DoAdvancedSelection();
+  PWScore* m_core = nullptr;
+  SelectionCriteria* m_selection = nullptr;
+  DbSelectionPanel* m_dbPanel = nullptr;
 };
 
 #endif // _MERGEDLG_H_

--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -144,25 +144,20 @@ const wxString DCAStrings[] = {
 /*!
  * OptionsPropertySheetDlg constructors
  */
-
-OptionsPropertySheetDlg::OptionsPropertySheetDlg(PWScore &core) : m_core(core)
-{
-  Init();
-}
-
-OptionsPropertySheetDlg::OptionsPropertySheetDlg( wxWindow* parent, PWScore &core, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
+OptionsPropertySheetDlg::OptionsPropertySheetDlg(wxWindow *parent, PWScore &core, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
   : m_core(core)
 {
-  Init();
-  Create(parent, id, caption, pos, size, style);
-}
+  const wxSize imageSize(64, 64);
 
-/*!
- * OptionsPropertySheetDlg creator
- */
+  m_ImageList = new wxImageList(imageSize.GetWidth(), imageSize.GetHeight());
+  m_ImageList->Add(wxIcon(backups_xpm));        // https://www.pngrepo.com/svg/224774/database
+  m_ImageList->Add(wxIcon(display_xpm));        // https://www.pngrepo.com/svg/131986/computer
+  m_ImageList->Add(wxIcon(miscellaneous_xpm));  // https://www.pngrepo.com/svg/230756/test
+  m_ImageList->Add(wxIcon(history_xpm));        // https://www.pngrepo.com/svg/95031/file
+  m_ImageList->Add(wxIcon(security_xpm));       // https://www.pngrepo.com/svg/219291/security-shield
+  m_ImageList->Add(wxIcon(shortcuts_xpm));      // https://www.pngrepo.com/svg/153991/keyboard
+  m_ImageList->Add(wxIcon(system_xpm));         // https://www.pngrepo.com/svg/230728/settings-gear
 
-bool OptionsPropertySheetDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
 ////@begin OptionsPropertySheetDlg creation
   SetSheetStyle(wxPROPSHEET_LISTBOOK);
   SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY|wxWS_EX_BLOCK_EVENTS);
@@ -176,7 +171,11 @@ bool OptionsPropertySheetDlg::Create( wxWindow* parent, wxWindowID id, const wxS
 ////@end OptionsPropertySheetDlg creation
   wxCommandEvent dummyEv;
   OnSuffixCBSet(dummyEv);
-  return true;
+}
+
+OptionsPropertySheetDlg* OptionsPropertySheetDlg::Create(wxWindow *parent, PWScore &core, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style)
+{
+  return new OptionsPropertySheetDlg(parent, core, id, caption, pos, size, style);
 }
 
 /*!
@@ -188,72 +187,6 @@ OptionsPropertySheetDlg::~OptionsPropertySheetDlg()
 ////@begin OptionsPropertySheetDlg destruction
 ////@end OptionsPropertySheetDlg destruction
   delete m_ImageList;
-}
-
-/*!
- * Member initialisation
- */
-
-void OptionsPropertySheetDlg::Init()
-{
-////@begin OptionsPropertySheetDlg member initialisation
-  m_Backups_Panel = nullptr;
-  m_Backups_DefaultPrefixRB = nullptr;
-  m_Backups_UserPrefixRB = nullptr;
-  m_Backups_UserPrefixTXT = nullptr;
-  m_Backups_SuffixCB = nullptr;
-  m_Backups_MaxIncrSB = nullptr;
-  m_Backups_SuffixExampleST = nullptr;
-  m_Backups_DefaultDirRB = nullptr;
-  m_Backups_UserDirRB = nullptr;
-  m_Backups_UserDirTXT = nullptr;
-  m_Backups_DirBN = nullptr;
-
-  m_Display_Panel = nullptr;
-  m_Display_ShowPasswordInTreeCB = nullptr;
-  m_Display_PreExpiryWarnCB = nullptr;
-  m_Display_PreExpiryWarnDaysSB = nullptr;
-
-  m_Misc_Panel = nullptr;
-  m_Misc_DoubleClickActionCB = nullptr;
-  m_Misc_ShiftDoubleClickActionCB = nullptr;
-  m_Misc_DefaultUsernameTXT = nullptr;
-  m_Misc_DefaultUsernameLBL = nullptr;
-
-  m_PasswordHistory_Panel = nullptr;
-  m_PasswordHistory_SaveCB = nullptr;
-  m_PasswordHistory_NumDefaultSB = nullptr;
-  m_PasswordHistory_DefaultExpiryDaysSB = nullptr;
-  m_PasswordHistory_ApplyBN = nullptr;
-  m_PasswordHistory_NoChangeRB = nullptr;
-  m_PasswordHistory_StopRB = nullptr;
-  m_PasswordHistory_StartRB = nullptr;
-  m_PasswordHistory_SetMaxRB = nullptr;
-  m_PasswordHistory_ClearRB = nullptr;
-  m_PasswordHistory_Apply2ProtectedCB = nullptr;
-
-  m_Security_Panel = nullptr;
-  m_Security_LockOnIdleTimeoutCB = nullptr;
-  m_Security_IdleTimeoutSB = nullptr;
-
-  m_Shortcuts_Panel = nullptr;
-
-  m_System_Panel = nullptr;
-  m_System_UseSystemTrayCB = nullptr;
-  m_System_MaxREItemsSB = nullptr;
-  m_System_SystemTrayWarningST = nullptr;
-////@end OptionsPropertySheetDlg member initialisation
-
-  const wxSize imageSize(64, 64);
-
-  m_ImageList = new wxImageList(imageSize.GetWidth(), imageSize.GetHeight());
-  m_ImageList->Add(wxIcon(backups_xpm));        // https://www.pngrepo.com/svg/224774/database
-  m_ImageList->Add(wxIcon(display_xpm));        // https://www.pngrepo.com/svg/131986/computer
-  m_ImageList->Add(wxIcon(miscellaneous_xpm));  // https://www.pngrepo.com/svg/230756/test
-  m_ImageList->Add(wxIcon(history_xpm));        // https://www.pngrepo.com/svg/95031/file
-  m_ImageList->Add(wxIcon(security_xpm));       // https://www.pngrepo.com/svg/219291/security-shield
-  m_ImageList->Add(wxIcon(shortcuts_xpm));      // https://www.pngrepo.com/svg/153991/keyboard
-  m_ImageList->Add(wxIcon(system_xpm));         // https://www.pngrepo.com/svg/230728/settings-gear
 }
 
 /*!

--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.h
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.h
@@ -150,17 +150,13 @@ class OptionsPropertySheetDlg : public wxPropertySheetDialog
 
 public:
   /// Constructors
-  OptionsPropertySheetDlg(PWScore &core);
-  OptionsPropertySheetDlg( wxWindow* parent, PWScore &core, wxWindowID id = SYMBOL_COPTIONS_IDNAME, const wxString& caption = SYMBOL_COPTIONS_TITLE, const wxPoint& pos = SYMBOL_COPTIONS_POSITION, const wxSize& size = SYMBOL_COPTIONS_SIZE, long style = SYMBOL_COPTIONS_STYLE );
-
-  /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_COPTIONS_IDNAME, const wxString& caption = SYMBOL_COPTIONS_TITLE, const wxPoint& pos = SYMBOL_COPTIONS_POSITION, const wxSize& size = SYMBOL_COPTIONS_SIZE, long style = SYMBOL_COPTIONS_STYLE );
+  static OptionsPropertySheetDlg* Create(wxWindow *parent, PWScore &core, wxWindowID id = SYMBOL_COPTIONS_IDNAME, const wxString& caption = SYMBOL_COPTIONS_TITLE, const wxPoint& pos = SYMBOL_COPTIONS_POSITION, const wxSize& size = SYMBOL_COPTIONS_SIZE, long style = SYMBOL_COPTIONS_STYLE );
 
   /// Destructor
   ~OptionsPropertySheetDlg();
-
-  /// Initialises member variables
-  void Init();
+protected:
+  /// Constructors
+  OptionsPropertySheetDlg(wxWindow *parent, PWScore &core, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style);
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -200,11 +196,12 @@ public:
   /// wxEVT_UPDATE_UI event handler for all command ids
   void OnUpdateUI(wxUpdateUIEvent& evt);
 
+  void OnOk(wxCommandEvent& evt);
 ////@end OptionsPropertySheetDlg event handler declarations
 
   /// wxEVT_COMMAND_BOOKCTRL_PAGE_CHANGING event handler for all pages (wxID_ANY)
   void OnPageChanging(wxBookCtrlEvent& evt);
-
+public:
 ////@begin OptionsPropertySheetDlg member function declarations
   uint32 GetHashItersValue() const { return m_hashIterValue; }
 
@@ -214,11 +211,8 @@ public:
   /// Retrieves icon resources
   wxIcon GetIconResource( const wxString& name );
 ////@end OptionsPropertySheetDlg member function declarations
-  void OnOk(wxCommandEvent& evt);
   /// Should we show tooltips?
   static bool ShowToolTips();
-
-
 private:
   void PrefsToPropSheet();
   void PropSheetToPrefs();
@@ -236,61 +230,61 @@ private:
 ////@begin OptionsPropertySheetDlg member variables
 private:
   // Tab Icons
-  wxImageList*    m_ImageList;
+  wxImageList*    m_ImageList = nullptr;
 
   // Tab: "Backups"
-  wxPanel*        m_Backups_Panel;
-  wxRadioButton*  m_Backups_DefaultPrefixRB;
-  wxRadioButton*  m_Backups_UserPrefixRB;
-  wxTextCtrl*     m_Backups_UserPrefixTXT;
-  wxComboBox*     m_Backups_SuffixCB;
-  wxSpinCtrl*     m_Backups_MaxIncrSB;
-  wxStaticText*   m_Backups_SuffixExampleST;
-  wxRadioButton*  m_Backups_DefaultDirRB;
-  wxRadioButton*  m_Backups_UserDirRB;
-  wxTextCtrl*     m_Backups_UserDirTXT;
-  wxButton*       m_Backups_DirBN;
+  wxPanel*        m_Backups_Panel = nullptr;
+  wxRadioButton*  m_Backups_DefaultPrefixRB = nullptr;
+  wxRadioButton*  m_Backups_UserPrefixRB = nullptr;
+  wxTextCtrl*     m_Backups_UserPrefixTXT = nullptr;
+  wxComboBox*     m_Backups_SuffixCB = nullptr;
+  wxSpinCtrl*     m_Backups_MaxIncrSB = nullptr;
+  wxStaticText*   m_Backups_SuffixExampleST = nullptr;
+  wxRadioButton*  m_Backups_DefaultDirRB = nullptr;
+  wxRadioButton*  m_Backups_UserDirRB = nullptr;
+  wxTextCtrl*     m_Backups_UserDirTXT = nullptr;
+  wxButton*       m_Backups_DirBN = nullptr;
 
   // Tab: "Display"
-  wxPanel*        m_Display_Panel;
-  wxCheckBox*     m_Display_ShowPasswordInTreeCB;
-  wxCheckBox*     m_Display_PreExpiryWarnCB;
-  wxSpinCtrl*     m_Display_PreExpiryWarnDaysSB;
+  wxPanel*        m_Display_Panel = nullptr;
+  wxCheckBox*     m_Display_ShowPasswordInTreeCB = nullptr;
+  wxCheckBox*     m_Display_PreExpiryWarnCB = nullptr;
+  wxSpinCtrl*     m_Display_PreExpiryWarnDaysSB = nullptr;
 
   // Tab: "Miscellaneous"
-  wxPanel*        m_Misc_Panel;
-  wxComboBox*     m_Misc_DoubleClickActionCB;
-  wxComboBox*     m_Misc_ShiftDoubleClickActionCB;
-  wxTextCtrl*     m_Misc_DefaultUsernameTXT;
-  wxStaticText*   m_Misc_DefaultUsernameLBL;
+  wxPanel*        m_Misc_Panel = nullptr;
+  wxComboBox*     m_Misc_DoubleClickActionCB = nullptr;
+  wxComboBox*     m_Misc_ShiftDoubleClickActionCB = nullptr;
+  wxTextCtrl*     m_Misc_DefaultUsernameTXT = nullptr;
+  wxStaticText*   m_Misc_DefaultUsernameLBL = nullptr;
   wxString        m_Misc_OtherBrowserLocationparams;
 
   // Tab: "Password History"
-  wxPanel*        m_PasswordHistory_Panel;
-  wxCheckBox*     m_PasswordHistory_SaveCB;
-  wxSpinCtrl*     m_PasswordHistory_NumDefaultSB;
-  wxSpinCtrl*     m_PasswordHistory_DefaultExpiryDaysSB;
-  wxRadioButton*  m_PasswordHistory_NoChangeRB;
-  wxRadioButton*  m_PasswordHistory_StopRB;
-  wxRadioButton*  m_PasswordHistory_StartRB;
-  wxRadioButton*  m_PasswordHistory_SetMaxRB;
-  wxRadioButton*  m_PasswordHistory_ClearRB;
-  wxButton*       m_PasswordHistory_ApplyBN;
-  wxCheckBox*     m_PasswordHistory_Apply2ProtectedCB;
+  wxPanel*        m_PasswordHistory_Panel = nullptr;
+  wxCheckBox*     m_PasswordHistory_SaveCB = nullptr;
+  wxSpinCtrl*     m_PasswordHistory_NumDefaultSB = nullptr;
+  wxSpinCtrl*     m_PasswordHistory_DefaultExpiryDaysSB = nullptr;
+  wxRadioButton*  m_PasswordHistory_NoChangeRB = nullptr;
+  wxRadioButton*  m_PasswordHistory_StopRB = nullptr;
+  wxRadioButton*  m_PasswordHistory_StartRB = nullptr;
+  wxRadioButton*  m_PasswordHistory_SetMaxRB = nullptr;
+  wxRadioButton*  m_PasswordHistory_ClearRB = nullptr;
+  wxButton*       m_PasswordHistory_ApplyBN = nullptr;
+  wxCheckBox*     m_PasswordHistory_Apply2ProtectedCB = nullptr;
 
   // Tab: "Security"
-  wxPanel*        m_Security_Panel;
-  wxCheckBox*     m_Security_LockOnIdleTimeoutCB;
-  wxSpinCtrl*     m_Security_IdleTimeoutSB;
+  wxPanel*        m_Security_Panel = nullptr;
+  wxCheckBox*     m_Security_LockOnIdleTimeoutCB = nullptr;
+  wxSpinCtrl*     m_Security_IdleTimeoutSB = nullptr;
 
   // Tab: "Shortcuts"
-  wxPanel*        m_Shortcuts_Panel;
+  wxPanel*        m_Shortcuts_Panel = nullptr;
 
   // Tab: "System"
-  wxPanel*        m_System_Panel;
-  wxCheckBox*     m_System_UseSystemTrayCB;
-  wxSpinCtrl*     m_System_MaxREItemsSB;
-  wxStaticText*   m_System_SystemTrayWarningST;
+  wxPanel*        m_System_Panel = nullptr;
+  wxCheckBox*     m_System_UseSystemTrayCB = nullptr;
+  wxSpinCtrl*     m_System_MaxREItemsSB = nullptr;
+  wxStaticText*   m_System_SystemTrayWarningST = nullptr;
 
   uint32 m_hashIterValue;
   int m_DoubleClickAction;

--- a/src/ui/wxWidgets/PWFiltersBoolDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersBoolDlg.cpp
@@ -51,6 +51,8 @@ BEGIN_EVENT_TABLE( pwFiltersBoolDlg, wxDialog )
 
   EVT_BUTTON( wxID_OK, pwFiltersBoolDlg::OnOk )
   EVT_COMBOBOX( ID_COMBOBOX53, pwFiltersBoolDlg::OnSelectionChange )
+  EVT_BUTTON( wxID_CANCEL, pwFiltersBoolDlg::OnCancelClick )
+  EVT_CLOSE( pwFiltersBoolDlg::OnClose )
 
 END_EVENT_TABLE()
 
@@ -298,4 +300,15 @@ void pwFiltersBoolDlg::OnOk(wxCommandEvent& WXUNUSED(event))
     }
   }
   EndModal(wxID_OK);
+}
+
+bool pwFiltersBoolDlg::IsChanged() const {
+  switch (m_ComboBoxBool->GetSelection()) {
+    case 0:
+      return *m_prule != m_pmrx[0];
+    case 1:
+      return *m_prule != m_pmrx[1];
+    default:
+      return *m_prule != PWSMatch::MR_INVALID;
+  }
 }

--- a/src/ui/wxWidgets/PWFiltersBoolDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersBoolDlg.cpp
@@ -58,29 +58,13 @@ END_EVENT_TABLE()
  * pwFiltersBoolDlg constructors
  */
 
-pwFiltersBoolDlg::pwFiltersBoolDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule)
-: m_ftype(ftype)
+pwFiltersBoolDlg::pwFiltersBoolDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule)
+: m_ftype(ftype), m_prule(rule)
 {
-  m_prule = &rule;
+  wxASSERT(!parent || parent->IsTopLevel());
 
-  Init();
-  Create(parent);
-}
-
-/*!
- * pwFiltersBoolDlg destructor
- */
-
-pwFiltersBoolDlg::~pwFiltersBoolDlg()
-{
-}
-
-/*!
- * pwFiltersBoolDlg creator
- */
-
-bool pwFiltersBoolDlg::Create(wxWindow* parent)
-{
+  m_btype = ConvertType(m_ftype);
+  
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create(parent, wxID_ANY, _("Display Filter Boolean Value"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
@@ -91,7 +75,11 @@ bool pwFiltersBoolDlg::Create(wxWindow* parent)
   Centre();
 
   SetValidators();
-  return true;
+}
+
+pwFiltersBoolDlg* pwFiltersBoolDlg::Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule)
+{
+  return new pwFiltersBoolDlg(parent, ftype, rule);
 }
 
 /*!
@@ -177,42 +165,30 @@ void pwFiltersBoolDlg::SetValidators()
  * Member initialisation
  */
 
-void pwFiltersBoolDlg::Init()
+pwFiltersBoolDlg::BoolType pwFiltersBoolDlg::ConvertType(FieldType ftype)
 {
-  m_ComboBoxBool = nullptr;
-  m_idx = -1;
-  m_pmrx = nullptr;
-  
-  switch (m_ftype) {
+  switch (ftype) {
     case FT_PROTECTED:
-      m_btype = BT_IS;
-      break;
+      return BT_IS;
     case FT_KBSHORTCUT:
-      m_btype = BT_PRESENT;
-      break;
+      return BT_PRESENT;
     case FT_UNKNOWNFIELDS:
-      m_btype = BT_PRESENT;
-      break;
+      return BT_PRESENT;
     case HT_PRESENT:
-      m_btype = BT_PRESENT;
-      break;
+      return BT_PRESENT;
     case HT_ACTIVE:
-      m_btype = BT_ACTIVE;
-      break;
+      return BT_ACTIVE;
     case PT_PRESENT:
-      m_btype = BT_PRESENT;
-      break;
+      return BT_PRESENT;
     case PT_EASYVISION:
     case PT_PRONOUNCEABLE:
     case PT_HEXADECIMAL:
-      m_btype = BT_SET;
-      break;
+      return BT_SET;
     case AT_PRESENT:
-      m_btype = BT_PRESENT;
-      break;
+      return BT_PRESENT;
     default:
       wxASSERT(false);
-      m_btype = BT_IS;
+      return BT_IS;
   }
 }
 

--- a/src/ui/wxWidgets/PWFiltersBoolDlg.h
+++ b/src/ui/wxWidgets/PWFiltersBoolDlg.h
@@ -18,11 +18,11 @@
  */
 
 #include <wx/choice.h>
-#include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
 #include "core/PWSFilters.h"
+#include "QueryCancelDlg.h"
 
 /*!
  * Forward declarations
@@ -45,7 +45,7 @@
  * pwFiltersBoolDlg class declaration
  */
 
-class pwFiltersBoolDlg : public wxDialog
+class pwFiltersBoolDlg : public QueryCancelDlg
 {
   DECLARE_CLASS(pwFiltersBoolDlg)
   DECLARE_EVENT_TABLE()
@@ -83,6 +83,8 @@ private:
   void OnOk(wxCommandEvent& event);
   void OnSelectionChange(wxCommandEvent& event);
   //*)
+
+  bool IsChanged() const override;
 
   //(*Declarations(pwFiltersBoolDlg)
   wxComboBox* m_ComboBoxBool = nullptr;

--- a/src/ui/wxWidgets/PWFiltersBoolDlg.h
+++ b/src/ui/wxWidgets/PWFiltersBoolDlg.h
@@ -51,19 +51,15 @@ class pwFiltersBoolDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
+  static pwFiltersBoolDlg* Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule);
+protected:
   enum BoolType {BT_PRESENT, BT_ACTIVE, BT_SET, BT_IS};
 
   /// Constructors
-  pwFiltersBoolDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule);
+  pwFiltersBoolDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule);
 
   /// Destructor
-  virtual ~pwFiltersBoolDlg();
-
-  /// Creation
-  bool Create(wxWindow* parent);
-
-  /// Initialises member variables
-  void Init();
+  virtual ~pwFiltersBoolDlg() = default;
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -77,6 +73,7 @@ public:
   /// Should we show tooltips?
   static bool ShowToolTips();
 
+  static BoolType ConvertType(FieldType ftype);
 private:
 
   void InitDialog();
@@ -88,15 +85,15 @@ private:
   //*)
 
   //(*Declarations(pwFiltersBoolDlg)
-  wxComboBox* m_ComboBoxBool;
+  wxComboBox* m_ComboBoxBool = nullptr;
   //*)
 
   const FieldType m_ftype;
   BoolType m_btype;   // Boolean Type is set depending from field type
-  int m_idx;
-  PWSMatch::MatchRule *m_prule; // Pointer to the buffer with result
+  int m_idx = -1;
+  PWSMatch::MatchRule *m_prule = nullptr; // Pointer to the buffer with result
   
-  const PWSMatch::MatchRule *m_pmrx; // Pointer to one of the arrays below, depending from boolean type
+  const PWSMatch::MatchRule *m_pmrx = nullptr; // Pointer to one of the arrays below, depending from boolean type
   
   static const PWSMatch::MatchRule m_mrxp[PW_NUM_BOOL_ENUM];
   static const PWSMatch::MatchRule m_mrxa[PW_NUM_BOOL_ENUM];

--- a/src/ui/wxWidgets/PWFiltersDCADlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersDCADlg.cpp
@@ -65,6 +65,8 @@ BEGIN_EVENT_TABLE( pwFiltersDCADlg, wxDialog )
   EVT_BUTTON( wxID_OK, pwFiltersDCADlg::OnOk )
   EVT_COMBOBOX( ID_COMBOBOX55, pwFiltersDCADlg::OnSelectionChangeRule )
   EVT_COMBOBOX( ID_COMBOBOX56, pwFiltersDCADlg::OnSelectionChangeDCA )
+  EVT_BUTTON( wxID_CANCEL, pwFiltersDCADlg::OnCancelClick )
+  EVT_CLOSE( pwFiltersDCADlg::OnClose )
 
 END_EVENT_TABLE()
 
@@ -392,4 +394,31 @@ void pwFiltersDCADlg::OnOk(wxCommandEvent& WXUNUSED(event))
     }
   }
   EndModal(wxID_OK);
+}
+
+bool pwFiltersDCADlg::IsChanged() const {
+  const auto idx = m_ComboBoxRule->GetSelection();
+  if(idx >= 0 && idx < PW_NUM_DCA_RULE_ENUM) {
+    if (*m_prule != m_mrx[idx]) {
+      return true;
+    }
+  }
+  else if (*m_prule != PWSMatch::MR_INVALID) {
+    return true;
+  }
+
+  const auto idx_dca = m_ComboBoxDCA->GetSelection();
+
+  if(idx_dca >= 0 && idx_dca < PW_NUM_DCA_ENUM) {
+    if (*m_pfdca != m_mdca[idx_dca].dcaValue) {
+      return true;
+    }
+  }
+  else if(idx > 1) { // is not MR_PRESENT or MR_NOTPRESENT
+    if (*m_prule != PWSMatch::MR_INVALID) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/ui/wxWidgets/PWFiltersDCADlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersDCADlg.cpp
@@ -72,30 +72,14 @@ END_EVENT_TABLE()
  * pwFiltersDCADlg constructors
  */
 
-pwFiltersDCADlg::pwFiltersDCADlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, short &fdca)
+pwFiltersDCADlg::pwFiltersDCADlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, short *fdca)
 : m_ftype(ftype)
 {
-  m_prule = &rule;
-  m_pfdca = &fdca;
+  wxASSERT(!parent || parent->IsTopLevel());
 
-  Init();
-  Create(parent);
-}
+  m_prule = rule;
+  m_pfdca = fdca;
 
-/*!
- * pwFiltersDCADlg destructor
- */
-
-pwFiltersDCADlg::~pwFiltersDCADlg()
-{
-}
-
-/*!
- * pwFiltersDCADlg creator
- */
-
-bool pwFiltersDCADlg::Create(wxWindow* parent)
-{
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create(parent, wxID_ANY, _("Display Filter DCA Value"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
@@ -106,7 +90,11 @@ bool pwFiltersDCADlg::Create(wxWindow* parent)
   Centre();
 
   SetValidators();
-  return true;
+}
+
+pwFiltersDCADlg* pwFiltersDCADlg::Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, short *fdca)
+{
+  return new pwFiltersDCADlg(parent, ftype, rule, fdca);
 }
 
 /*!
@@ -217,7 +205,7 @@ void pwFiltersDCADlg::InitDialog()
   m_idx_dca = -1;
   if(m_idx != -1) {
     for(int i = 0; i < PW_NUM_DCA_ENUM; i++) {
-      if(m_fdca == m_mdca[i].dcaValue) {
+      if(*m_pfdca == m_mdca[i].dcaValue) {
         m_idx_dca = i;
         break;
       }
@@ -257,19 +245,6 @@ void pwFiltersDCADlg::SetValidators()
 {
   m_ComboBoxRule->SetValidator(wxGenericValidator(&m_idx));
   m_ComboBoxDCA->SetValidator(wxGenericValidator(&m_idx_dca));
-}
-
-/*!
- * Member initialisation
- */
-
-void pwFiltersDCADlg::Init()
-{
-  m_ComboBoxRule = nullptr;
-  m_ComboBoxDCA = nullptr;
-  m_idx = -1;
-  m_idx_dca = -1;
-  m_fdca = *m_pfdca;
 }
 
 /*!

--- a/src/ui/wxWidgets/PWFiltersDCADlg.h
+++ b/src/ui/wxWidgets/PWFiltersDCADlg.h
@@ -18,12 +18,12 @@
  */
 
 #include <wx/choice.h>
-#include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
 #include "core/PWSFilters.h"
 #include "core/PWSprefs.h"
+#include "QueryCancelDlg.h"
 
 /*!
  * Forward declarations
@@ -48,7 +48,7 @@
  * pwFiltersDCADlg class declaration
  */
 
-class pwFiltersDCADlg : public wxDialog
+class pwFiltersDCADlg : public QueryCancelDlg
 {
   DECLARE_CLASS(pwFiltersDCADlg)
   DECLARE_EVENT_TABLE()
@@ -86,6 +86,8 @@ private:
   void OnSelectionChangeRule(wxCommandEvent& event);
   void OnSelectionChangeDCA(wxCommandEvent& event);
   //*)
+
+  bool IsChanged() const override;
 
   //(*Declarations(pwFiltersDCADlg)
   wxComboBox* m_ComboBoxRule = nullptr;

--- a/src/ui/wxWidgets/PWFiltersDCADlg.h
+++ b/src/ui/wxWidgets/PWFiltersDCADlg.h
@@ -54,17 +54,13 @@ class pwFiltersDCADlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
+  static pwFiltersDCADlg* Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, short *fdca);
+protected:
   /// Constructors
-  pwFiltersDCADlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, short &fdca);
+  pwFiltersDCADlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, short *fdca);
 
   /// Destructor
-  virtual ~pwFiltersDCADlg();
-
-  /// Creation
-  bool Create(wxWindow* parent);
-
-  /// Initialises member variables
-  void Init();
+  virtual ~pwFiltersDCADlg() = default;
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -92,17 +88,17 @@ private:
   //*)
 
   //(*Declarations(pwFiltersDCADlg)
-  wxComboBox* m_ComboBoxRule;
-  wxComboBox* m_ComboBoxDCA;
+  wxComboBox* m_ComboBoxRule = nullptr;
+  wxComboBox* m_ComboBoxDCA = nullptr;
   //*)
 
   const FieldType m_ftype;
-  int m_idx;
-  int m_idx_dca;
-  short m_fdca;
+  int m_idx = -1;
+  int m_idx_dca = -1;
+
   // Result parameter
-  PWSMatch::MatchRule *m_prule;
-  short *m_pfdca;
+  PWSMatch::MatchRule *m_prule = nullptr;
+  short *m_pfdca = nullptr;
 
   typedef struct dcaMapItem {
     int msgText;

--- a/src/ui/wxWidgets/PWFiltersDateDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersDateDlg.cpp
@@ -59,6 +59,8 @@ BEGIN_EVENT_TABLE( pwFiltersDateDlg, wxDialog )
   EVT_SPINCTRL( ID_SPINCTRL68, pwFiltersDateDlg::OnFNum2Change )
   EVT_RADIOBUTTON(  ID_RADIO_BT_ON, pwFiltersDateDlg::OnRadiobuttonOnSelected )
   EVT_RADIOBUTTON(  ID_RADIO_BT_IN, pwFiltersDateDlg::OnRadiobuttonInSelected )
+  EVT_BUTTON( wxID_CANCEL, pwFiltersDateDlg::OnCancelClick )
+  EVT_CLOSE( pwFiltersDateDlg::OnClose )
 
 END_EVENT_TABLE()
 
@@ -458,45 +460,14 @@ void pwFiltersDateDlg::CheckControls()
 }
 
 /*!
- * isRuleSelected Check if given rule is the selected one (this one marked by m_idx)
+ * isRuleSelected Check if given rule is the selected one
  */
 
-bool pwFiltersDateDlg::isRuleSelected(PWSMatch::MatchRule rule)
+bool pwFiltersDateDlg::isRuleSelected(int idx, PWSMatch::MatchRule rule) const
 {
-  return (m_idx >= 0) &&
-         ((m_add_present && (m_idx < (PW_NUM_PRESENT_ENUM + PW_NUM_DATE_CRITERIA_ENUM)) && (m_idx >= PW_NUM_PRESENT_ENUM) && (m_mrcrit[m_idx - PW_NUM_PRESENT_ENUM] == rule)) ||
-          (! m_add_present && (m_idx < PW_NUM_DATE_CRITERIA_ENUM) && (m_mrcrit[m_idx] == rule)));
-}
-
-/*!
- * CheckBetween Check if given rule is the BETWEEN and if both numbers are in right order or lower value is below maximum
- * Optional give hint to the user
- */
-
-bool pwFiltersDateDlg::CheckBetween(bool showMessage)
-{
-  if(isRuleSelected(PWSMatch::MR_BETWEEN)) {
-    if(m_fdatetype == PW_DATE_REL) {
-      if(m_fnum1 >= m_fnum2) {
-        if(showMessage)
-          wxMessageBox(_("Please correct numeric values."), _("Second number must be greater than first"), wxOK|wxICON_ERROR);
-        return false;
-      }
-      else if(m_fnum1 == m_max) {
-        if(showMessage)
-          wxMessageBox(_("Please correct numeric values."), _("Maximum value for first number and 'Between' rule"), wxOK|wxICON_ERROR);
-        return false;
-      }
-    }
-    else {
-      if(m_fdate1 >= m_fdate2) {
-        if(showMessage)
-          wxMessageBox(_("Please correct date values."), _("Second date must be later than first"), wxOK|wxICON_ERROR);
-        return false;
-      }
-    }
-  }
-  return true;
+  return (idx >= 0) &&
+         ((m_add_present && (idx < (PW_NUM_PRESENT_ENUM + PW_NUM_DATE_CRITERIA_ENUM)) && (idx >= PW_NUM_PRESENT_ENUM) && (m_mrcrit[idx - PW_NUM_PRESENT_ENUM] == rule)) ||
+          (! m_add_present && (idx < PW_NUM_DATE_CRITERIA_ENUM) && (m_mrcrit[idx] == rule)));
 }
 
 /*!
@@ -557,6 +528,75 @@ void pwFiltersDateDlg::OnRadiobuttonInSelected(wxCommandEvent& WXUNUSED(event))
   CheckControls();
 }
 
+bool pwFiltersDateDlg::IsValid(bool showMessage) const {
+  const auto idx = m_ComboBox->GetSelection();
+  const auto fnum1 = m_FNum1Ctrl->GetValue();
+  const auto fnum2 = m_FNum2Ctrl->GetValue();
+  const auto fdate1 = m_ExpDate1Ctrl->GetValue();
+  const auto fdate2 = m_ExpDate2Ctrl->GetValue();
+
+  // CheckBetween Check if given rule is the BETWEEN and if both numbers are in right order or lower value is below maximum
+  if (isRuleSelected(idx, PWSMatch::MR_BETWEEN)) {
+    if (m_fdatetype == PW_DATE_REL) {
+      if (fnum1 >= fnum2) {
+        if(showMessage) {
+          wxMessageBox(_("Please correct numeric values."), _("Second number must be greater than first"), wxOK|wxICON_ERROR);
+        }
+        return false;
+      }
+      else if(fnum1 == m_max) {
+        if (showMessage) {
+          wxMessageBox(_("Please correct numeric values."), _("Maximum value for first number and 'Between' rule"), wxOK|wxICON_ERROR);
+        }
+        return false;
+      }
+    }
+    else {
+      if (fdate1 >= fdate2) {
+        if (showMessage) {
+          wxMessageBox(_("Please correct date values."), _("Second date must be later than first"), wxOK|wxICON_ERROR);
+        }
+        return false;
+      }
+    }
+  }
+
+  if (m_fdatetype == PW_DATE_REL) {
+    if (isRuleSelected(idx, PWSMatch::MR_BEFORE) && (fnum1 == m_min)) {
+      if (showMessage) {
+        wxMessageBox(_("Please correct numeric values."), _("Number is set to the minimum value. 'Less than' is not allowed."), wxOK|wxICON_ERROR);
+      }
+      return false;
+    }
+
+    if (isRuleSelected(idx, PWSMatch::MR_AFTER) && (fnum1 == m_max)) {
+      if (showMessage) {
+        wxMessageBox(_("Please correct numeric values."), _("Number is set to the maximum value. 'Greater than' is not allowed."), wxOK|wxICON_ERROR);
+      }
+      return false;
+    }
+    if (m_ftype != FT_XTIME) {
+      // All dates, except History must be located in the history
+      if ((fnum1 > 0) || (isRuleSelected(idx, PWSMatch::MR_BETWEEN) && (fnum2 > 0))) {
+        if (showMessage) {
+          wxMessageBox(_("Please correct numeric values."), _("A future date is not valid for this field"), wxOK|wxICON_ERROR);
+        }
+        return false;
+      }
+    }
+  }
+  else if (m_ftype != FT_XTIME) {
+    // All dates, except History must be located in the history
+    if ((fdate1 > wxDateTime::Now()) || (isRuleSelected(idx, PWSMatch::MR_BETWEEN) && (fdate2 > wxDateTime::Now()))) {
+      if (showMessage) {
+        wxMessageBox(_("Please correct date values."), _("A future date is not valid for this field"), wxOK|wxICON_ERROR);
+      }
+      return false;
+    }
+  }
+  return true;
+}
+
 /*!
  * wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_OK
  */
@@ -570,41 +610,16 @@ void pwFiltersDateDlg::OnOk(wxCommandEvent& WXUNUSED(event))
       EndModal(wxID_CANCEL);
       return;
     }
+
+    if (!IsValid(true)) {
+      return;
+    }
     
     m_fdate1 = m_ExpDate1Ctrl->GetValue();
     m_fdate2 = m_ExpDate2Ctrl->GetValue();
     m_fnum1 = m_FNum1Ctrl->GetValue();
     m_fnum2 = m_FNum2Ctrl->GetValue();
 
-    if(! CheckBetween(true))
-      return;
-    
-    if(m_fdatetype == PW_DATE_REL) {
-      if(isRuleSelected(PWSMatch::MR_BEFORE) && (m_fnum1 == m_min)) {
-        wxMessageBox(_("Please correct numeric values."), _("Number is set to the minimum value. 'Less than' is not allowed."), wxOK|wxICON_ERROR);
-        return;
-      }
-    
-      if(isRuleSelected(PWSMatch::MR_AFTER) && (m_fnum1 == m_max)) {
-        wxMessageBox(_("Please correct numeric values."), _("Number is set to the maximum value. 'Greater than' is not allowed."), wxOK|wxICON_ERROR);
-        return;
-      }
-      if(m_ftype != FT_XTIME) {
-        // All dates, except History must be located in the history
-        if((m_fnum1 > 0) || (isRuleSelected(PWSMatch::MR_BETWEEN) && (m_fnum2 > 0))) {
-          wxMessageBox(_("Please correct numeric values."), _("A future date is not valid for this field"), wxOK|wxICON_ERROR);
-          return;
-        }
-      }
-    }
-    else if(m_ftype != FT_XTIME) {
-      // All dates, except History must be located in the history
-      if((m_fdate1 > wxDateTime::Now()) || (isRuleSelected(PWSMatch::MR_BETWEEN) && (m_fdate2 > wxDateTime::Now()))) {
-        wxMessageBox(_("Please correct date values."), _("A future date is not valid for this field"), wxOK|wxICON_ERROR);
-        return;
-      }
-    }
-    
     if(m_add_present) {
       if((m_idx >= 0) && (m_idx < PW_NUM_PRESENT_ENUM)) {
         *m_prule = m_mrpres[m_idx];
@@ -636,7 +651,7 @@ void pwFiltersDateDlg::OnOk(wxCommandEvent& WXUNUSED(event))
     else {
       if(m_fdatetype == PW_DATE_REL) {
         *m_pfnum1 = m_fnum1;
-        if(isRuleSelected(PWSMatch::MR_BETWEEN))
+        if(isRuleSelected(m_idx, PWSMatch::MR_BETWEEN))
           *m_pfnum2 = m_fnum2;
         else
           *m_pfnum2 = 0;
@@ -645,7 +660,7 @@ void pwFiltersDateDlg::OnOk(wxCommandEvent& WXUNUSED(event))
       }
       else {
         *m_pfdate1 = m_fdate1.GetTicks();
-        if(isRuleSelected(PWSMatch::MR_BETWEEN))
+        if(isRuleSelected(m_idx, PWSMatch::MR_BETWEEN))
           *m_pfdate2 = m_fdate2.GetTicks();
         else
           *m_pfdate2 = static_cast<time_t>(0);
@@ -655,4 +670,78 @@ void pwFiltersDateDlg::OnOk(wxCommandEvent& WXUNUSED(event))
     }
   }
   EndModal(wxID_OK);
+}
+
+bool pwFiltersDateDlg::IsChanged() const {
+  const auto idx = m_ComboBox->GetSelection();
+  if (idx < 0) {
+    return false;
+  }
+
+  if (!IsValid(false)) {
+    return true;
+  }
+
+  if (m_add_present) {
+    if (idx >= 0 && idx < PW_NUM_PRESENT_ENUM) {
+      if (*m_prule != m_mrpres[idx]) {
+        return true;
+      }
+    }
+    else {
+      const auto tmpIdx = idx - PW_NUM_PRESENT_ENUM;
+      if (tmpIdx < PW_NUM_DATE_CRITERIA_ENUM) {
+        if (*m_prule != m_mrcrit[tmpIdx]) {
+          return true;
+        }
+      }
+      else if (*m_prule != PWSMatch::MR_INVALID) {
+        return true;
+      }
+    }
+  }
+  else {
+    if (idx < PW_NUM_DATE_CRITERIA_ENUM) {
+      if (*m_prule != m_mrcrit[idx]) {
+        return true;
+      }
+    }
+    else if (*m_prule != PWSMatch::MR_INVALID) {
+      return true;
+    }
+  }
+
+  if (*m_pfdatetype != m_fdatetype) {
+    return true;
+  }
+
+  if (*m_prule != PWSMatch::MR_PRESENT && *m_prule != PWSMatch::MR_NOTPRESENT) {
+    const auto fnum1 = m_FNum1Ctrl->GetValue();
+    const auto fnum2 = m_FNum2Ctrl->GetValue();
+
+    if (m_fdatetype == PW_DATE_REL) {
+      if (*m_pfnum1 != fnum1) {
+        return true;
+      }
+      if (isRuleSelected(idx, PWSMatch::MR_BETWEEN)) {
+        if (*m_pfnum2 != fnum2) {
+          return true;
+        }
+      }
+    }
+    else {
+      const auto fdate1 = m_ExpDate1Ctrl->GetValue();
+      const auto fdate2 = m_ExpDate2Ctrl->GetValue();
+
+      if (*m_pfdate1 != fdate1.GetTicks()) {
+        return true;
+      }
+      if (isRuleSelected(idx, PWSMatch::MR_BETWEEN)) {
+        if (*m_pfdate2 != fdate2.GetTicks()) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
 }

--- a/src/ui/wxWidgets/PWFiltersDateDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersDateDlg.cpp
@@ -66,34 +66,16 @@ END_EVENT_TABLE()
  * pwFiltersDateDlg constructors
  */
 
-pwFiltersDateDlg::pwFiltersDateDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, time_t &fdate1, time_t &fdate2, int &fnum1, int &fnum2, int &fdatetype)
-: m_ftype(ftype), m_add_present(false), m_min(-1), m_max(-1)
+pwFiltersDateDlg::pwFiltersDateDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, time_t *fdate1, time_t *fdate2, int *fnum1, int *fnum2, int *fdatetype)
+: m_ftype(ftype), m_add_present(false), m_min(-1), m_max(-1),
+  m_prule(rule), m_pfdate1(fdate1), m_pfdate2(fdate2), 
+  m_pfnum1(fnum1), m_pfnum2(fnum2),
+  m_pfdatetype(fdatetype)
 {
-  m_prule = &rule;
-  m_pfdate1 = &fdate1;
-  m_pfdate2 = &fdate2;
-  m_pfnum1 = &fnum1;
-  m_pfnum2 = &fnum2;
-  m_pfdatetype = &fdatetype;
+  wxASSERT(!parent || parent->IsTopLevel());
 
   Init();
-  Create(parent);
-}
 
-/*!
- * pwFiltersDateDlg destructor
- */
-
-pwFiltersDateDlg::~pwFiltersDateDlg()
-{
-}
-
-/*!
- * pwFiltersDateDlg creator
- */
-
-bool pwFiltersDateDlg::Create(wxWindow* parent)
-{
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create(parent, wxID_ANY, _("Display Filter Date Value"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
@@ -104,7 +86,11 @@ bool pwFiltersDateDlg::Create(wxWindow* parent)
   Centre();
 
   SetValidators();
-  return true;
+}
+
+pwFiltersDateDlg* pwFiltersDateDlg::Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, time_t *fdate1, time_t *fdate2, int *fnum1, int *fnum2, int *fdatetype)
+{
+  return new pwFiltersDateDlg(parent, ftype, rule, fdate1, fdate2, fnum1, fnum2, fdatetype);
 }
 
 /*!
@@ -207,15 +193,6 @@ void pwFiltersDateDlg::SetValidators()
 
 void pwFiltersDateDlg::Init()
 {
-  m_ComboBox = nullptr;
-  m_ExpDate1Ctrl = nullptr;
-  m_ExpDate2Ctrl = nullptr;
-  m_FNum1Ctrl = nullptr;
-  m_FNum2Ctrl = nullptr;
-  m_OnCtrl = nullptr;
-  m_InCtrl = nullptr;
-  m_idx = -1;
-
   switch (m_ftype) {
     case FT_CTIME:
     case FT_PMTIME:

--- a/src/ui/wxWidgets/PWFiltersDateDlg.h
+++ b/src/ui/wxWidgets/PWFiltersDateDlg.h
@@ -18,7 +18,6 @@
  */
 
 #include <wx/choice.h>
-#include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 #include <wx/spinctrl.h>
@@ -27,6 +26,7 @@
 #include <wx/datectrl.h>
 
 #include "core/PWSFilters.h"
+#include "QueryCancelDlg.h"
 
 /*!
  * Forward declarations
@@ -56,7 +56,7 @@
  * pwFiltersDateDlg class declaration
  */
 
-class pwFiltersDateDlg : public wxDialog
+class pwFiltersDateDlg : public QueryCancelDlg
 {
   DECLARE_CLASS(pwFiltersDateDlg)
   DECLARE_EVENT_TABLE()
@@ -106,9 +106,11 @@ private:
   //*)
   
   void CheckControls();
-  bool CheckBetween(bool showMessage);
-  bool isRuleSelected(PWSMatch::MatchRule rule);
+  bool isRuleSelected(int idx, PWSMatch::MatchRule rule) const;
   void UpdateUnitSelection();
+
+  bool IsChanged() const override;
+  bool IsValid(bool showMessage) const;
 
   //(*Declarations(pwFiltersDateDlg)
   wxComboBox* m_ComboBox = nullptr;

--- a/src/ui/wxWidgets/PWFiltersDateDlg.h
+++ b/src/ui/wxWidgets/PWFiltersDateDlg.h
@@ -62,11 +62,14 @@ class pwFiltersDateDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
+  static pwFiltersDateDlg* Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, time_t *fdate1, time_t *fdate2, int *fnum1, int *fnum2, int *fdatetype);
+
+protected:
   /// Constructors
-  pwFiltersDateDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, time_t &fdate1, time_t &fdate2, int &fnum1, int &fnum2, int &fdatetype);
+  pwFiltersDateDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, time_t *fdate1, time_t *fdate2, int *fnum1, int *fnum2, int *fdatetype);
 
   /// Destructor
-  virtual ~pwFiltersDateDlg();
+  virtual ~pwFiltersDateDlg() = default;
 
   /// Creation
   bool Create(wxWindow* parent);
@@ -108,13 +111,13 @@ private:
   void UpdateUnitSelection();
 
   //(*Declarations(pwFiltersDateDlg)
-  wxComboBox* m_ComboBox;
-  wxDatePickerCtrl* m_ExpDate1Ctrl;
-  wxDatePickerCtrl* m_ExpDate2Ctrl;
-  wxSpinCtrl* m_FNum1Ctrl;
-  wxSpinCtrl* m_FNum2Ctrl;
-  wxRadioButton* m_OnCtrl;
-  wxRadioButton* m_InCtrl;
+  wxComboBox* m_ComboBox = nullptr;
+  wxDatePickerCtrl* m_ExpDate1Ctrl = nullptr;
+  wxDatePickerCtrl* m_ExpDate2Ctrl = nullptr;
+  wxSpinCtrl* m_FNum1Ctrl = nullptr;
+  wxSpinCtrl* m_FNum2Ctrl = nullptr;
+  wxRadioButton* m_OnCtrl = nullptr;
+  wxRadioButton* m_InCtrl = nullptr;
   //*)
 
   enum { PW_DATE_ABS = 0, PW_DATE_REL = 1 }; // values for int m_fdatetype
@@ -122,7 +125,7 @@ private:
   const FieldType m_ftype;
   bool m_add_present;
   
-  int m_idx;
+  int m_idx = -1;
   wxDateTime m_fdate1;
   wxDateTime m_fdate2;
   int m_fnum1;

--- a/src/ui/wxWidgets/PWFiltersGrid.cpp
+++ b/src/ui/wxWidgets/PWFiltersGrid.cpp
@@ -859,6 +859,7 @@ bool pwFiltersGrid::GetCriterion(int row)
         FilterRow(row).fnum1 = fnum1;
         return true;
       }
+      break;
     }
     case PWSMatch::MT_INTEGER:
     {

--- a/src/ui/wxWidgets/PWFiltersGrid.cpp
+++ b/src/ui/wxWidgets/PWFiltersGrid.cpp
@@ -532,20 +532,27 @@ void pwFiltersGrid::OnCellLeftClick(wxGridEvent& event)
         }
       }
       else if(col == FLC_CRITERIA_TEXT) {
-        GetCriterion(row); // Call editor on criteria field
-        RefreshCell(row, FLC_CRITERIA_TEXT);
-        DoCheckFilterIsComplete(row);
-        
-        // Increase size if needed
-        wxClientDC dc(GetGridWindow());
-        dc.SetFont(GetDefaultCellFont());
-        wxSize size = dc.GetTextExtent(GetTable()->GetValue(row, FLC_CRITERIA_TEXT));
-        if(size.GetWidth() > GetColSize(FLC_CRITERIA_TEXT))
-          SetColSize(FLC_CRITERIA_TEXT, size.GetWidth() + 6);
+        CallAfter(&pwFiltersGrid::DoEditCriteria, row);
       }
     }
   }
   event.Skip();
+}
+void pwFiltersGrid::DoEditCriteria(int row)
+{
+  // Call editor on criteria field
+  if (GetCriterion(row)) { 
+    RefreshCell(row, FLC_CRITERIA_TEXT);
+    DoCheckFilterIsComplete(row);
+
+    // Increase size if needed
+    wxClientDC dc(GetGridWindow());
+    dc.SetFont(GetDefaultCellFont());
+    wxSize size = dc.GetTextExtent(GetTable()->GetValue(row, FLC_CRITERIA_TEXT));
+    if(size.GetWidth() > GetColSize(FLC_CRITERIA_TEXT)) {
+      SetColSize(FLC_CRITERIA_TEXT, size.GetWidth() + 6);
+    }
+  }
 }
 
 /*!
@@ -809,30 +816,30 @@ void pwFiltersGrid::UpdateMatchType(int row)
 
 /*!
  * GetCriterion calls the related editor dialog to fetch the parameter depending on the matching type
+ * @return true, if dialog wasn't canceled
  */
 
-void pwFiltersGrid::GetCriterion(int row)
+bool pwFiltersGrid::GetCriterion(int row)
 {
   FieldType ft = RowFieldType(row);
   PWSMatch::MatchType mt(RowMatchType(row));
   
   if(ft == FT_INVALID) {
     // Do nothing as long field type is not set (also no message dialog)
-    return;
+    return false;
   }
-  
+  int rc = wxID_CANCEL;
   switch(mt) {
     case PWSMatch::MT_STRING:
     {
       PWSMatch::MatchRule value = RowMatchRule(row);
-      wxString string = towxstring(FilterRow(row).fstring);
+      wxString fstring = towxstring(FilterRow(row).fstring);
       bool fcase = FilterRow(row).fcase;
       // Call Dialog
-      pwFiltersStringDlg dlg(this, RowFieldType(row), value, string, fcase);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<pwFiltersStringDlg>(wxGetTopLevelParent(this), RowFieldType(row), &value, &fstring, &fcase);
       if(rc == wxID_OK) {
         SetRowMatchRule(row, value);
-        FilterRow(row).fstring = tostringx(string);
+        FilterRow(row).fstring = tostringx(fstring);
         FilterRow(row).fcase = fcase;
       }
       break;
@@ -840,19 +847,18 @@ void pwFiltersGrid::GetCriterion(int row)
     case PWSMatch::MT_PASSWORD:
     {
       PWSMatch::MatchRule value = RowMatchRule(row);
-      wxString string = towxstring(FilterRow(row).fstring);
+      wxString fstring = towxstring(FilterRow(row).fstring);
       bool fcase = FilterRow(row).fcase;
       int fnum1 = FilterRow(row).fnum1;
       // Call Dialog
-      pwFiltersPasswordDlg dlg(this, RowFieldType(row), value, string, fcase, fnum1);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<pwFiltersPasswordDlg>(wxGetTopLevelParent(this), RowFieldType(row), &value, &fstring, &fcase, &fnum1);
       if(rc == wxID_OK) {
         SetRowMatchRule(row, value);
-        FilterRow(row).fstring = tostringx(string);
+        FilterRow(row).fstring = tostringx(fstring);
         FilterRow(row).fcase = fcase;
         FilterRow(row).fnum1 = fnum1;
+        return true;
       }
-      break;
     }
     case PWSMatch::MT_INTEGER:
     {
@@ -860,8 +866,7 @@ void pwFiltersGrid::GetCriterion(int row)
       int fnum1 = FilterRow(row).fnum1;
       int fnum2 = FilterRow(row).fnum2;
       // Call Dialog
-      pwFiltersIntegerDlg dlg(this, RowFieldType(row), value, fnum1, fnum2);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<pwFiltersIntegerDlg>(wxGetTopLevelParent(this), RowFieldType(row), &value, &fnum1, &fnum2);
       if(rc == wxID_OK) {
         SetRowMatchRule(row, value);
         FilterRow(row).fnum1 = fnum1;
@@ -878,8 +883,7 @@ void pwFiltersGrid::GetCriterion(int row)
       time_t fdate2 = FilterRow(row).fdate2;
       int fdatetype = FilterRow(row).fdatetype;
       // Call Dialog
-      pwFiltersDateDlg dlg(this, RowFieldType(row), value, fdate1, fdate2, fnum1, fnum2, fdatetype);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<pwFiltersDateDlg>(wxGetTopLevelParent(this), RowFieldType(row), &value, &fdate1, &fdate2, &fnum1, &fnum2, &fdatetype);
       if(rc == wxID_OK) {
         SetRowMatchRule(row, value);
         FilterRow(row).fnum1 = fnum1;
@@ -894,8 +898,7 @@ void pwFiltersGrid::GetCriterion(int row)
     {
       PWSMatch::MatchRule value = RowMatchRule(row);
       // Call Dialog
-      pwFiltersBoolDlg dlg(this, RowFieldType(row), value);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<pwFiltersBoolDlg>(wxGetTopLevelParent(this), RowFieldType(row), &value);
       if(rc == wxID_OK) {
         SetRowMatchRule(row, value);
       }
@@ -910,8 +913,7 @@ void pwFiltersGrid::GetCriterion(int row)
       // Set filter Name to current value
       filters.fname = static_cast<wxTextCtrl *>(GetParent()->FindWindow(ID_FILTERNAME))->GetValue().c_str();
       // Call Dialog
-      SetFiltersDlg dlg(this, &filters, nullptr, &bAppliedCalled, DFTYPE_PWHISTORY, m_filterpool, false, m_psMediaTypes);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<SetFiltersDlg>(wxGetTopLevelParent(this), &filters, nullptr, &bAppliedCalled, DFTYPE_PWHISTORY, m_filterpool, false, m_psMediaTypes);
       if(rc == wxID_OK) {
         m_pfilters->vHfldata = filters.vHfldata;
         m_pfilters->num_Hactive = filters.num_Hactive;
@@ -928,8 +930,7 @@ void pwFiltersGrid::GetCriterion(int row)
       // Set filter Name to current value
       filters.fname = static_cast<wxTextCtrl *>(GetParent()->FindWindow(ID_FILTERNAME))->GetValue().c_str();
       // Call Dialog
-      SetFiltersDlg dlg(this, &filters, nullptr, &bAppliedCalled, DFTYPE_PWPOLICY, m_filterpool, false, m_psMediaTypes);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<SetFiltersDlg>(wxGetTopLevelParent(this), &filters, nullptr, &bAppliedCalled, DFTYPE_PWPOLICY, m_filterpool, false, m_psMediaTypes);
       if(rc == wxID_OK) {
         m_pfilters->vPfldata = filters.vPfldata;
         m_pfilters->num_Pactive = filters.num_Pactive;
@@ -942,8 +943,7 @@ void pwFiltersGrid::GetCriterion(int row)
       PWSMatch::MatchRule value = RowMatchRule(row);
       CItemData::EntryType etype = FilterRow(row).etype;
       // Call Dialog
-      pwFiltersTypeDlg dlg(this, RowFieldType(row), value, etype);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<pwFiltersTypeDlg>(wxGetTopLevelParent(this), RowFieldType(row), &value, &etype);
       if(rc == wxID_OK) {
         SetRowMatchRule(row, value);
         FilterRow(row).etype = etype;
@@ -956,8 +956,7 @@ void pwFiltersGrid::GetCriterion(int row)
       PWSMatch::MatchRule value = RowMatchRule(row);
       short fdca = FilterRow(row).fdca;
       // Call Dialog
-      pwFiltersDCADlg dlg(this, RowFieldType(row), value, fdca);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<pwFiltersDCADlg>(wxGetTopLevelParent(this), RowFieldType(row), &value, &fdca);
       if(rc == wxID_OK) {
         SetRowMatchRule(row, value);
         FilterRow(row).fdca = fdca;
@@ -969,8 +968,7 @@ void pwFiltersGrid::GetCriterion(int row)
       PWSMatch::MatchRule value = RowMatchRule(row);
       CItemData::EntryStatus estatus = FilterRow(row).estatus;
       // Call Dialog
-      pwFiltersStatusDlg dlg(this, RowFieldType(row), value, estatus);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<pwFiltersStatusDlg>(wxGetTopLevelParent(this), RowFieldType(row), &value, &estatus);
       if(rc == wxID_OK) {
         SetRowMatchRule(row, value);
         FilterRow(row).estatus = estatus;
@@ -984,8 +982,7 @@ void pwFiltersGrid::GetCriterion(int row)
       int fnum2 = FilterRow(row).fnum2;
       int funit = FilterRow(row).funit;
       // Call Dialog
-      pwFiltersIntegerDlg dlg(this, RowFieldType(row), value, fnum1, fnum2, &funit);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<pwFiltersIntegerDlg>(wxGetTopLevelParent(this), RowFieldType(row), &value, &fnum1, &fnum2, &funit);
       if(rc == wxID_OK) {
         SetRowMatchRule(row, value);
         FilterRow(row).fnum1 = fnum1;
@@ -1003,8 +1000,7 @@ void pwFiltersGrid::GetCriterion(int row)
       // Set filter Name to current value
       filters.fname = static_cast<wxTextCtrl *>(GetParent()->FindWindow(ID_FILTERNAME))->GetValue().c_str();
       // Call Dialog
-      SetFiltersDlg dlg(this, &filters, nullptr, &bAppliedCalled, DFTYPE_ATTACHMENT, m_filterpool, false, m_psMediaTypes);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<SetFiltersDlg>(wxGetTopLevelParent(this), &filters, nullptr, &bAppliedCalled, DFTYPE_ATTACHMENT, m_filterpool, false, m_psMediaTypes);
       if(rc == wxID_OK) {
         m_pfilters->vAfldata = filters.vAfldata;
         m_pfilters->num_Aactive = filters.num_Aactive;
@@ -1015,14 +1011,13 @@ void pwFiltersGrid::GetCriterion(int row)
     case PWSMatch::MT_MEDIATYPE:
     {
       PWSMatch::MatchRule value = RowMatchRule(row);
-      wxString string = towxstring(FilterRow(row).fstring);
+      wxString fstring = towxstring(FilterRow(row).fstring);
       bool fcase = FilterRow(row).fcase;
       // Call Dialog
-      pwFiltersMediaTypesDlg dlg(this, RowFieldType(row), value, string, fcase, m_psMediaTypes);
-      int rc = dlg.ShowModal();
+      rc = ShowModalAndGetResult<pwFiltersMediaTypesDlg>(wxGetTopLevelParent(this), RowFieldType(row), &value, &fstring, &fcase, m_psMediaTypes);
       if(rc == wxID_OK) {
         SetRowMatchRule(row, value);
-        FilterRow(row).fstring = tostringx(string);
+        FilterRow(row).fstring = tostringx(fstring);
         FilterRow(row).fcase = fcase;
       }
       break;
@@ -1030,6 +1025,7 @@ void pwFiltersGrid::GetCriterion(int row)
     default:
       break;
   }
+  return rc == wxID_OK;
 }
 
 /*!

--- a/src/ui/wxWidgets/PWFiltersGrid.h
+++ b/src/ui/wxWidgets/PWFiltersGrid.h
@@ -156,6 +156,7 @@ public:
   
   // Helper function for the grid
   void DoCheckFilterIsComplete(int row);
+  void DoEditCriteria(int row);
   
   bool IsSameAsDefault(int row);
   void ClearIfEmpty();
@@ -186,7 +187,7 @@ private:
   void SetGridColFormat(int col, wxGridCellRenderer *renderer, wxGridCellEditor *editor = nullptr);
   void SetGridColReadOnly(int col);
   void UpdateMatchType(int row);
-  void GetCriterion(int row);
+  bool GetCriterion(int row);
   
   st_filters *m_pfilters; // Pointer to the handled filter
   const bool m_bCanHaveAttachments;

--- a/src/ui/wxWidgets/PWFiltersIntegerDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersIntegerDlg.cpp
@@ -79,32 +79,13 @@ END_EVENT_TABLE()
  * pwFiltersIntegerDlg constructors
  */
 
-pwFiltersIntegerDlg::pwFiltersIntegerDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, int &fnum1, int &fnum2, int *funit)
-: m_ftype(ftype), m_add_present(false), m_min(-1), m_max(-1), m_funit(-1)
+pwFiltersIntegerDlg::pwFiltersIntegerDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, int *fnum1, int *fnum2, int *funit)
+: m_ftype(ftype), m_prule(rule), m_pfnum1(fnum1), m_pfnum2(fnum2), m_pfunit(funit)
 {
-  m_prule = &rule;
-  m_pfnum1 = &fnum1;
-  m_pfnum2 = &fnum2;
-  m_pfunit = funit;
+  wxASSERT(!parent || parent->IsTopLevel());
 
   Init();
-  Create(parent);
-}
 
-/*!
- * pwFiltersIntegerDlg destructor
- */
-
-pwFiltersIntegerDlg::~pwFiltersIntegerDlg()
-{
-}
-
-/*!
- * pwFiltersIntegerDlg creator
- */
-
-bool pwFiltersIntegerDlg::Create(wxWindow* parent)
-{
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create(parent, wxID_ANY, _("Display Filter Integer Value"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
@@ -115,7 +96,11 @@ bool pwFiltersIntegerDlg::Create(wxWindow* parent)
   Centre();
 
   SetValidators();
-  return true;
+}
+
+pwFiltersIntegerDlg* pwFiltersIntegerDlg::Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, int *fnum1, int *fnum2, int *funit)
+{
+  return new pwFiltersIntegerDlg(parent, ftype, rule, fnum1, fnum2, funit);
 }
 
 /*!
@@ -214,11 +199,6 @@ void pwFiltersIntegerDlg::SetValidators()
 
 void pwFiltersIntegerDlg::Init()
 {
-  m_ComboBox = nullptr;
-  m_FNum1Ctrl = nullptr;
-  m_FNum2Ctrl = nullptr;
-  m_idx = -1;
-
   switch (m_ftype) {
     case FT_PASSWORDLEN:
       wxASSERT(m_pfunit == nullptr);

--- a/src/ui/wxWidgets/PWFiltersIntegerDlg.h
+++ b/src/ui/wxWidgets/PWFiltersIntegerDlg.h
@@ -18,12 +18,12 @@
  */
 
 #include <wx/choice.h>
-#include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 #include <wx/spinctrl.h>
 
 #include "core/PWSFilters.h"
+#include "QueryCancelDlg.h"
 
 /*!
  * Forward declarations
@@ -52,7 +52,7 @@
  * pwFiltersIntegerDlg class declaration
  */
 
-class pwFiltersIntegerDlg : public wxDialog
+class pwFiltersIntegerDlg : public QueryCancelDlg
 {
   DECLARE_CLASS(pwFiltersIntegerDlg)
   DECLARE_EVENT_TABLE()
@@ -99,9 +99,11 @@ private:
   //*)
   
   void CheckControls();
-  bool CheckBetween(bool showMessage);
-  bool isRuleSelected(PWSMatch::MatchRule rule);
+  bool isRuleSelected(int idx, PWSMatch::MatchRule rule) const;
   void UpdateUnitSelection();
+
+  bool IsChanged() const override;
+  bool IsValid(bool showMessage) const;
 
   //(*Declarations(pwFiltersIntegerDlg)
   wxComboBox* m_ComboBox = nullptr;

--- a/src/ui/wxWidgets/PWFiltersIntegerDlg.h
+++ b/src/ui/wxWidgets/PWFiltersIntegerDlg.h
@@ -56,13 +56,14 @@ class pwFiltersIntegerDlg : public wxDialog
 {
   DECLARE_CLASS(pwFiltersIntegerDlg)
   DECLARE_EVENT_TABLE()
-
 public:
+  static pwFiltersIntegerDlg* Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, int *fnum1, int *fnum2, int *funit = nullptr);
+protected:
   /// Constructors
-  pwFiltersIntegerDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, int &fnum1, int &fnum2, int *funit = NULL);
+  pwFiltersIntegerDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, int *fnum1, int *fnum2, int *funit);
 
   /// Destructor
-  virtual ~pwFiltersIntegerDlg();
+  virtual ~pwFiltersIntegerDlg() = default;
 
   /// Creation
   bool Create(wxWindow* parent);
@@ -103,32 +104,32 @@ private:
   void UpdateUnitSelection();
 
   //(*Declarations(pwFiltersIntegerDlg)
-  wxComboBox* m_ComboBox;
-  wxSpinCtrl* m_FNum1Ctrl;
-  wxSpinCtrl* m_FNum2Ctrl;
-  wxRadioButton* m_UnitByteCtrl;
-  wxRadioButton* m_UnitKByteCtrl;
-  wxRadioButton* m_UnitMByteCtrl;
-  wxStaticText*  m_IntervalTextCtrl;
+  wxComboBox* m_ComboBox = nullptr;
+  wxSpinCtrl* m_FNum1Ctrl = nullptr;
+  wxSpinCtrl* m_FNum2Ctrl = nullptr;
+  wxRadioButton* m_UnitByteCtrl = nullptr;
+  wxRadioButton* m_UnitKByteCtrl = nullptr;
+  wxRadioButton* m_UnitMByteCtrl = nullptr;
+  wxStaticText*  m_IntervalTextCtrl = nullptr;
   //*)
   
   wxString infoFmtStr; // Format string for information text
 
   const FieldType m_ftype;
-  bool m_add_present;
+  bool m_add_present = false;
   
-  int m_idx;
-  int m_fnum1;
-  int m_fnum2;
-  int m_min;
-  int m_max;
-  int m_funit;
+  int m_idx = -1;
+  int m_fnum1 = -1;
+  int m_fnum2 = -1;
+  int m_min = -1;
+  int m_max = -1;
+  int m_funit = -1;
   
   // Result parameter
-  PWSMatch::MatchRule *m_prule;
-  int                 *m_pfnum1;
-  int                 *m_pfnum2;
-  int                 *m_pfunit;
+  PWSMatch::MatchRule *m_prule = nullptr;
+  int                 *m_pfnum1 = nullptr;
+  int                 *m_pfnum2 = nullptr;
+  int                 *m_pfunit = nullptr;
   
   static const PWSMatch::MatchRule m_mrpres[PW_NUM_PRESENT_ENUM];
   static const PWSMatch::MatchRule m_mrcrit[PW_NUM_INT_CRITERIA_ENUM];

--- a/src/ui/wxWidgets/PWFiltersMediaDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersMediaDlg.cpp
@@ -57,6 +57,8 @@ BEGIN_EVENT_TABLE( pwFiltersMediaTypesDlg, wxDialog )
   EVT_COMBOBOX( ID_COMBOBOX69, pwFiltersMediaTypesDlg::OnSelectionChange )
   EVT_COMBOBOX( ID_COMBOBOX70, pwFiltersMediaTypesDlg::OnMediaTypeChange )
   EVT_TEXT( ID_COMBOBOX70, pwFiltersMediaTypesDlg::OnMediaTypeChange )
+  EVT_BUTTON( wxID_CANCEL, pwFiltersMediaTypesDlg::OnCancelClick )
+  EVT_CLOSE( pwFiltersMediaTypesDlg::OnClose )
 
 END_EVENT_TABLE()
 
@@ -415,4 +417,51 @@ void pwFiltersMediaTypesDlg::OnOk(wxCommandEvent& WXUNUSED(event))
     *m_pfcase = m_fcase;
   }
   EndModal(wxID_OK);
+}
+
+bool pwFiltersMediaTypesDlg::IsChanged() const {
+  const auto idx = m_ComboBox->GetSelection();
+
+  if (idx < 0) {
+    return false;
+  }
+
+  if (m_add_present) {
+    if (idx >= 0 && idx < PW_NUM_PRESENT_ENUM) {
+      if (*m_prule != m_mrpres[idx]) {
+        return true;
+      }
+    }
+    else {
+      const auto tmpIdx = idx - PW_NUM_PRESENT_ENUM;
+      if(tmpIdx < PW_NUM_MEDIA_TYPES_CRITERIA_ENUM) {
+        if (*m_prule != m_mrcrit[tmpIdx]) {
+          return true;
+        }
+      }
+      else if (*m_prule != PWSMatch::MR_INVALID) {
+        return true;
+      }
+    }
+  }
+  else {
+    if(idx < PW_NUM_MEDIA_TYPES_CRITERIA_ENUM) {
+      if (*m_prule != m_mrcrit[idx]) {
+        return true;
+      }
+    }
+    else if (*m_prule != PWSMatch::MR_INVALID) {
+      return true;
+    }
+  }
+
+  if (*m_pvalue != m_MediaTypes->GetValue()) {
+    return true;
+  }
+
+  if (*m_pfcase != m_CheckBoxFCase->GetValue()) {
+    return true;
+  }
+
+  return false;
 }

--- a/src/ui/wxWidgets/PWFiltersMediaDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersMediaDlg.cpp
@@ -64,31 +64,14 @@ END_EVENT_TABLE()
  * pwFiltersMediaTypesDlg constructors
  */
 
-pwFiltersMediaTypesDlg::pwFiltersMediaTypesDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, wxString &value, bool &fcase, const std::set<StringX> *psMediaTypes)
-: m_ftype(ftype), m_psMediaTypes(psMediaTypes), m_add_present(false)
+pwFiltersMediaTypesDlg::pwFiltersMediaTypesDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, wxString *value, bool *fcase, const std::set<StringX> *psMediaTypes)
+: m_ftype(ftype), m_psMediaTypes(psMediaTypes),
+  m_prule(rule), m_pvalue(value), m_pfcase(fcase)
 {
-  m_prule = &rule;
-  m_pvalue = &value;
-  m_pfcase = &fcase;
+  wxASSERT(!parent || parent->IsTopLevel());
 
   Init();
-  Create(parent);
-}
-
-/*!
- * pwFiltersMediaTypesDlg destructor
- */
-
-pwFiltersMediaTypesDlg::~pwFiltersMediaTypesDlg()
-{
-}
-
-/*!
- * pwFiltersMediaTypesDlg creator
- */
-
-bool pwFiltersMediaTypesDlg::Create(wxWindow* parent)
-{
+  
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create(parent, wxID_ANY, _("Display Filter Media Types Value"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
@@ -99,7 +82,11 @@ bool pwFiltersMediaTypesDlg::Create(wxWindow* parent)
   Centre();
 
   SetValidators();
-  return true;
+}
+
+pwFiltersMediaTypesDlg* pwFiltersMediaTypesDlg::Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, wxString *value, bool *fcase, const std::set<StringX> *psMediaTypes)
+{
+  return new pwFiltersMediaTypesDlg(parent, ftype, rule, value, fcase, psMediaTypes);
 }
 
 /*!
@@ -235,10 +222,6 @@ void pwFiltersMediaTypesDlg::SetValidators()
 
 void pwFiltersMediaTypesDlg::Init()
 {
-  m_ComboBox = nullptr;
-  m_MediaTypes = nullptr;
-  m_idx = -1;
-  
   switch (m_ftype) {
     case AT_MEDIATYPE:
       m_add_present = false;

--- a/src/ui/wxWidgets/PWFiltersMediaDlg.h
+++ b/src/ui/wxWidgets/PWFiltersMediaDlg.h
@@ -20,11 +20,11 @@
 #include <set>
 
 #include <wx/choice.h>
-#include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
 #include "core/PWSFilters.h"
+#include "QueryCancelDlg.h"
 
 /*!
  * Forward declarations
@@ -50,7 +50,7 @@
  * pwFiltersMediaTypesDlg class declaration
  */
 
-class pwFiltersMediaTypesDlg : public wxDialog
+class pwFiltersMediaTypesDlg : public QueryCancelDlg
 {
   DECLARE_CLASS(pwFiltersMediaTypesDlg)
   DECLARE_EVENT_TABLE()
@@ -92,6 +92,8 @@ private:
   void OnSelectionChange(wxCommandEvent& event);
   void OnMediaTypeChange(wxCommandEvent& event);
   //*)
+
+  bool IsChanged() const override;
 
   //(*Declarations(pwFiltersMediaTypesDlg)
   wxComboBox* m_ComboBox;

--- a/src/ui/wxWidgets/PWFiltersMediaDlg.h
+++ b/src/ui/wxWidgets/PWFiltersMediaDlg.h
@@ -56,11 +56,13 @@ class pwFiltersMediaTypesDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
+  static pwFiltersMediaTypesDlg* Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, wxString *value, bool *fcase, const std::set<StringX> *psMediaTypes);
+protected:
   /// Constructors
-  pwFiltersMediaTypesDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, wxString &value, bool &fcase, const std::set<StringX> *psMediaTypes);
+  pwFiltersMediaTypesDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, wxString *value, bool *fcase, const std::set<StringX> *psMediaTypes);
 
   /// Destructor
-  virtual ~pwFiltersMediaTypesDlg();
+  virtual ~pwFiltersMediaTypesDlg() = default;
 
   /// Creation
   bool Create(wxWindow* parent);
@@ -103,12 +105,12 @@ private:
   bool m_fcase;
 
   const FieldType m_ftype;
-  const std::set<StringX> *m_psMediaTypes;
-  bool m_add_present;
+  const std::set<StringX> *m_psMediaTypes = nullptr;
+  bool m_add_present = false;
   // Result parameter
-  PWSMatch::MatchRule *m_prule;
-  wxString            *m_pvalue;
-  bool                *m_pfcase;
+  PWSMatch::MatchRule *m_prule = nullptr;
+  wxString            *m_pvalue = nullptr;
+  bool                *m_pfcase = nullptr;
   
   static const PWSMatch::MatchRule m_mrpres[PW_NUM_PRESENT_ENUM];
   static const PWSMatch::MatchRule m_mrcrit[PW_NUM_MEDIA_TYPES_CRITERIA_ENUM];

--- a/src/ui/wxWidgets/PWFiltersPasswordDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersPasswordDlg.cpp
@@ -59,6 +59,8 @@ BEGIN_EVENT_TABLE( pwFiltersPasswordDlg, wxDialog )
   EVT_COMBOBOX( ID_COMBOBOX72, pwFiltersPasswordDlg::OnSelectionChange )
   EVT_TEXT( ID_TEXTCTRL73, pwFiltersPasswordDlg::OnTextChange )
   EVT_SPINCTRL( ID_SPINCTRL75, pwFiltersPasswordDlg::OnFNum1Change )
+  EVT_BUTTON( wxID_CANCEL, pwFiltersPasswordDlg::OnCancelClick )
+  EVT_CLOSE( pwFiltersPasswordDlg::OnClose )
 
 END_EVENT_TABLE()
 
@@ -359,6 +361,9 @@ void pwFiltersPasswordDlg::OnOk(wxCommandEvent& WXUNUSED(event))
     else
       *m_prule = PWSMatch::MR_INVALID;
 
+
+    m_string = m_TextCtrlValueString->GetValue();
+
     if(*m_prule != PWSMatch::MR_EXPIRED &&
        *m_prule != PWSMatch::MR_WILLEXPIRE &&
        m_string.IsEmpty()) {
@@ -366,7 +371,6 @@ void pwFiltersPasswordDlg::OnOk(wxCommandEvent& WXUNUSED(event))
       return;
     }
     
-    m_string = m_TextCtrlValueString->GetValue();
     m_fcase = m_CheckBoxFCase->GetValue();
     m_fnum1 = m_FNum1Ctrl->GetValue();
 
@@ -384,4 +388,50 @@ void pwFiltersPasswordDlg::OnOk(wxCommandEvent& WXUNUSED(event))
     *m_pfnum1 = m_fnum1;
   }
   EndModal(wxID_OK);
+}
+
+bool pwFiltersPasswordDlg::IsChanged() const {
+  const auto idx = m_ComboBox->GetSelection();
+
+  if (idx < 0) {
+    return false;
+  }
+
+  if (idx < PW_NUM_PASSWORD_CRITERIA_ENUM) {
+    if (*m_prule != m_mrcrit[idx]) {
+      return true;
+    }
+  }
+  else if (*m_prule != PWSMatch::MR_INVALID) {
+    return true;
+  }
+
+  const auto str = m_TextCtrlValueString->GetValue();
+  if(*m_prule != PWSMatch::MR_EXPIRED && *m_prule != PWSMatch::MR_WILLEXPIRE && str.IsEmpty()) {
+    return true;
+  }
+
+  if (*m_pvalue != str) {
+    return true;
+  }
+
+  if(*m_prule != PWSMatch::MR_EXPIRED && *m_prule != PWSMatch::MR_WILLEXPIRE && *m_pfcase != m_CheckBoxFCase->GetValue()) {
+    return true;
+  }
+
+  auto fnum1 = m_FNum1Ctrl->GetValue();
+  if (*m_prule == PWSMatch::MR_WILLEXPIRE) {
+    if (fnum1 < 1) {
+      fnum1 = 1;
+    }
+  }
+  else {
+    fnum1 = 0;
+  }
+
+  if (*m_pfnum1 != fnum1) {
+    return true;
+  }
+
+  return false;
 }

--- a/src/ui/wxWidgets/PWFiltersPasswordDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersPasswordDlg.cpp
@@ -65,33 +65,14 @@ END_EVENT_TABLE()
 /*!
  * pwFiltersPasswordDlg constructors
  */
-
-pwFiltersPasswordDlg::pwFiltersPasswordDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, wxString &value, bool &fcase, int &fnum1)
-: m_ftype(ftype)
+pwFiltersPasswordDlg::pwFiltersPasswordDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, wxString *value, bool *fcase, int *fnum1)
+: m_ftype(ftype),
+ m_prule(rule), m_pvalue(value), m_pfcase(fcase), m_pfnum1(fnum1)
 {
-  m_prule = &rule;
-  m_pvalue = &value;
-  m_pfcase = &fcase;
-  m_pfnum1 = &fnum1;
+  wxASSERT(!parent || parent->IsTopLevel());
 
   Init();
-  Create(parent);
-}
 
-/*!
- * pwFiltersPasswordDlg destructor
- */
-
-pwFiltersPasswordDlg::~pwFiltersPasswordDlg()
-{
-}
-
-/*!
- * pwFiltersPasswordDlg creator
- */
-
-bool pwFiltersPasswordDlg::Create(wxWindow* parent)
-{
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create(parent, wxID_ANY, _("Display Filter Password Value"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
@@ -102,7 +83,11 @@ bool pwFiltersPasswordDlg::Create(wxWindow* parent)
   Centre();
 
   SetValidators();
-  return true;
+}
+
+pwFiltersPasswordDlg* pwFiltersPasswordDlg::Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, wxString *value, bool *fcase, int *fnum1)
+{
+  return new pwFiltersPasswordDlg(parent, ftype, rule, value, fcase, fnum1);
 }
 
 /*!
@@ -174,10 +159,6 @@ void pwFiltersPasswordDlg::SetValidators()
 
 void pwFiltersPasswordDlg::Init()
 {
-  m_ComboBox = nullptr;
-  m_TextCtrlValueString = nullptr;
-  m_idx = -1;
-  
   m_string = *m_pvalue;
   m_fcase = *m_pfcase;
   m_fnum1 = *m_pfnum1;

--- a/src/ui/wxWidgets/PWFiltersPasswordDlg.h
+++ b/src/ui/wxWidgets/PWFiltersPasswordDlg.h
@@ -18,12 +18,12 @@
  */
 
 #include <wx/choice.h>
-#include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 #include <wx/spinctrl.h>
 
 #include "core/PWSFilters.h"
+#include "QueryCancelDlg.h"
 
 /*!
  * Forward declarations
@@ -49,7 +49,7 @@
  * pwFiltersPasswordDlg class declaration
  */
 
-class pwFiltersPasswordDlg : public wxDialog
+class pwFiltersPasswordDlg : public QueryCancelDlg
 {
   DECLARE_CLASS(pwFiltersPasswordDlg)
   DECLARE_EVENT_TABLE()
@@ -94,6 +94,8 @@ private:
   void OnTextChange(wxCommandEvent& event);
   void OnFNum1Change(wxSpinEvent& event);
   //*)
+
+  bool IsChanged() const override;
 
   //(*Declarations(pwFiltersPasswordDlg)
   wxComboBox* m_ComboBox = nullptr;

--- a/src/ui/wxWidgets/PWFiltersPasswordDlg.h
+++ b/src/ui/wxWidgets/PWFiltersPasswordDlg.h
@@ -56,10 +56,14 @@ class pwFiltersPasswordDlg : public wxDialog
 
 public:
   /// Constructors
-  pwFiltersPasswordDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, wxString &value, bool &fcase, int &fnum1);
+  static pwFiltersPasswordDlg* Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, wxString *value, bool *fcase, int *fnum1);
+
+protected:
+  /// Constructors
+  pwFiltersPasswordDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, wxString *value, bool *fcase, int *fnum1);
 
   /// Destructor
-  virtual ~pwFiltersPasswordDlg();
+  virtual ~pwFiltersPasswordDlg() = default;
 
   /// Creation
   bool Create(wxWindow* parent);
@@ -92,13 +96,13 @@ private:
   //*)
 
   //(*Declarations(pwFiltersPasswordDlg)
-  wxComboBox* m_ComboBox;
-  wxTextCtrl* m_TextCtrlValueString;
-  wxCheckBox* m_CheckBoxFCase;
-  wxSpinCtrl* m_FNum1Ctrl;
+  wxComboBox* m_ComboBox = nullptr;
+  wxTextCtrl* m_TextCtrlValueString = nullptr;
+  wxCheckBox* m_CheckBoxFCase = nullptr;
+  wxSpinCtrl* m_FNum1Ctrl = nullptr;
   //*)
 
-  int m_idx;
+  int m_idx = -1;
   wxString m_string;
   bool m_fcase;
   int m_fnum1;
@@ -109,10 +113,10 @@ private:
 
   const FieldType m_ftype;
   // Result parameter
-  PWSMatch::MatchRule *m_prule;
-  wxString            *m_pvalue;
-  bool                *m_pfcase;
-  int                 *m_pfnum1;
+  PWSMatch::MatchRule *m_prule = nullptr;
+  wxString            *m_pvalue = nullptr;
+  bool                *m_pfcase = nullptr;
+  int                 *m_pfnum1 = nullptr;
   
   static const PWSMatch::MatchRule m_mrcrit[PW_NUM_PASSWORD_CRITERIA_ENUM];
 };

--- a/src/ui/wxWidgets/PWFiltersStatusDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersStatusDlg.cpp
@@ -56,6 +56,8 @@ BEGIN_EVENT_TABLE( pwFiltersStatusDlg, wxDialog )
   EVT_BUTTON( wxID_OK, pwFiltersStatusDlg::OnOk )
   EVT_COMBOBOX( ID_COMBOBOX60, pwFiltersStatusDlg::OnSelectionChangeRule )
   EVT_COMBOBOX( ID_COMBOBOX61, pwFiltersStatusDlg::OnSelectionChangeStatus )
+  EVT_BUTTON( wxID_CANCEL, pwFiltersStatusDlg::OnCancelClick )
+  EVT_CLOSE( pwFiltersStatusDlg::OnClose )
 
 END_EVENT_TABLE()
 
@@ -327,4 +329,28 @@ void pwFiltersStatusDlg::OnOk(wxCommandEvent& WXUNUSED(event))
     }
   }
   EndModal(wxID_OK);
+}
+
+bool pwFiltersStatusDlg::IsChanged() const {
+  const auto idx = m_ComboBoxRule->GetSelection();
+  if (idx >= 0 && idx < PW_NUM_STATUS_RULE_ENUM) {
+    if (*m_prule != m_mrx[idx]) {
+      return true;
+    }
+  }
+  else if (*m_prule != PWSMatch::MR_INVALID) {
+    return true;
+  }
+
+  const auto idx_status = m_ComboBoxStatus->GetSelection();
+  if(idx_status >= 0 && idx_status < PW_NUM_STATUS_ENUM) {
+    if (*m_pestatus != m_mstatus[idx_status].statusValue) {
+      return true;
+    }
+  }
+  else if (*m_prule != PWSMatch::MR_INVALID) {
+    return true;
+  }
+
+  return false;
 }

--- a/src/ui/wxWidgets/PWFiltersStatusDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersStatusDlg.cpp
@@ -63,30 +63,13 @@ END_EVENT_TABLE()
  * pwFiltersStatusDlg constructors
  */
 
-pwFiltersStatusDlg::pwFiltersStatusDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, CItemData::EntryStatus &estatus)
-: m_ftype(ftype)
+pwFiltersStatusDlg::pwFiltersStatusDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, CItemData::EntryStatus *estatus)
+: m_ftype(ftype), m_prule(rule), m_pestatus(estatus)
 {
-  m_prule = &rule;
-  m_pestatus = &estatus;
+  wxASSERT(!parent || parent->IsTopLevel());
 
-  Init();
-  Create(parent);
-}
+  m_estatus = *m_pestatus;
 
-/*!
- * pwFiltersStatusDlg destructor
- */
-
-pwFiltersStatusDlg::~pwFiltersStatusDlg()
-{
-}
-
-/*!
- * pwFiltersStatusDlg creator
- */
-
-bool pwFiltersStatusDlg::Create(wxWindow* parent)
-{
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create(parent, wxID_ANY, _("Display Filter Entry Status Value"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
@@ -97,7 +80,11 @@ bool pwFiltersStatusDlg::Create(wxWindow* parent)
   Centre();
 
   SetValidators();
-  return true;
+}
+
+pwFiltersStatusDlg* pwFiltersStatusDlg::Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, CItemData::EntryStatus *estatus)
+{
+  return new pwFiltersStatusDlg(parent, ftype, rule, estatus);
 }
 
 /*!
@@ -205,19 +192,6 @@ void pwFiltersStatusDlg::SetValidators()
 {
   m_ComboBoxRule->SetValidator(wxGenericValidator(&m_idx));
   m_ComboBoxStatus->SetValidator(wxGenericValidator(&m_idx_status));
-}
-
-/*!
- * Member initialisation
- */
-
-void pwFiltersStatusDlg::Init()
-{
-  m_ComboBoxRule = nullptr;
-  m_ComboBoxStatus = nullptr;
-  m_idx = -1;
-  m_idx_status = -1;
-  m_estatus = *m_pestatus;
 }
 
 /*!

--- a/src/ui/wxWidgets/PWFiltersStatusDlg.h
+++ b/src/ui/wxWidgets/PWFiltersStatusDlg.h
@@ -18,12 +18,12 @@
  */
 
 #include <wx/choice.h>
-#include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
 #include "core/PWSFilters.h"
 #include "core/PWSprefs.h"
+#include "QueryCancelDlg.h"
 
 /*!
  * Forward declarations
@@ -48,7 +48,7 @@
  * pwFiltersStatusDlg class declaration
  */
 
-class pwFiltersStatusDlg : public wxDialog
+class pwFiltersStatusDlg : public QueryCancelDlg
 {
   DECLARE_CLASS(pwFiltersStatusDlg)
   DECLARE_EVENT_TABLE()
@@ -90,6 +90,8 @@ private:
   void OnSelectionChangeRule(wxCommandEvent& event);
   void OnSelectionChangeStatus(wxCommandEvent& event);
   //*)
+
+  bool IsChanged() const override;
 
   //(*Declarations(pwFiltersStatusDlg)
   wxComboBox* m_ComboBoxRule = nullptr;

--- a/src/ui/wxWidgets/PWFiltersStatusDlg.h
+++ b/src/ui/wxWidgets/PWFiltersStatusDlg.h
@@ -54,11 +54,13 @@ class pwFiltersStatusDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
+  static pwFiltersStatusDlg* Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, CItemData::EntryStatus *estatus);
+protected:
   /// Constructors
-  pwFiltersStatusDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, CItemData::EntryStatus &estatus);
+  pwFiltersStatusDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, CItemData::EntryStatus *estatus);
 
   /// Destructor
-  virtual ~pwFiltersStatusDlg();
+  virtual ~pwFiltersStatusDlg() = default;
 
   /// Creation
   bool Create(wxWindow* parent);
@@ -90,17 +92,17 @@ private:
   //*)
 
   //(*Declarations(pwFiltersStatusDlg)
-  wxComboBox* m_ComboBoxRule;
-  wxComboBox* m_ComboBoxStatus;
+  wxComboBox* m_ComboBoxRule = nullptr;
+  wxComboBox* m_ComboBoxStatus = nullptr;
   //*)
 
   const FieldType m_ftype;
-  int m_idx;
-  int m_idx_status;
+  int m_idx = -1;
+  int m_idx_status = -1;
   CItemData::EntryStatus m_estatus;
   // Result parameter
-  PWSMatch::MatchRule *m_prule;
-  CItemData::EntryStatus *m_pestatus;
+  PWSMatch::MatchRule *m_prule = nullptr;
+  CItemData::EntryStatus *m_pestatus = nullptr;
 
   typedef struct estatusMapItem {
     int msgText;

--- a/src/ui/wxWidgets/PWFiltersStringDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersStringDlg.cpp
@@ -56,6 +56,8 @@ BEGIN_EVENT_TABLE( pwFiltersStringDlg, wxDialog )
   EVT_BUTTON( wxID_OK, pwFiltersStringDlg::OnOk )
   EVT_COMBOBOX( ID_COMBOBOX51, pwFiltersStringDlg::OnSelectionChange )
   EVT_TEXT( ID_TEXTCTRL52, pwFiltersStringDlg::OnTextChange )
+  EVT_BUTTON( wxID_CANCEL, pwFiltersStringDlg::OnCancelClick )
+  EVT_CLOSE( pwFiltersStringDlg::OnClose )
 
 END_EVENT_TABLE()
 
@@ -399,4 +401,51 @@ void pwFiltersStringDlg::OnOk(wxCommandEvent& WXUNUSED(event))
     *m_pfcase = m_fcase;
   }
   EndModal(wxID_OK);
+}
+
+bool pwFiltersStringDlg::IsChanged() const {
+  const auto idx = m_ComboBox->GetSelection();
+
+  if (idx < 0) {
+    return false;
+  }
+
+  if (m_add_present) {
+    if (idx >= 0 && idx < PW_NUM_PRESENT_ENUM) {
+      if (*m_prule != m_mrpres[idx]) {
+        return true;
+      }
+    }
+    else {
+      const auto tmpIdx = idx - PW_NUM_PRESENT_ENUM;
+      if (tmpIdx < PW_NUM_STR_CRITERIA_ENUM) {
+        if (*m_prule != m_mrcrit[tmpIdx]) {
+          return true;
+        }
+      }
+      else if (*m_prule != PWSMatch::MR_INVALID) {
+        return true;
+      }
+    }
+  }
+  else {
+    if (idx < PW_NUM_STR_CRITERIA_ENUM) {
+      if (*m_prule != m_mrcrit[idx]) {
+        return true;
+      }
+    }
+    else if (*m_prule != PWSMatch::MR_INVALID) {
+      return true;
+    }
+  }
+
+  if (*m_pvalue != m_TextCtrlValueString->GetValue()) {
+    return true;
+  }
+
+  if (*m_pfcase != m_CheckBoxFCase->GetValue()) {
+    return true;
+  }
+
+  return false;
 }

--- a/src/ui/wxWidgets/PWFiltersStringDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersStringDlg.cpp
@@ -64,7 +64,7 @@ END_EVENT_TABLE()
  */
 
 pwFiltersStringDlg::pwFiltersStringDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, wxString &value, bool &fcase)
-: m_ftype(ftype), m_add_present(false)
+: m_ftype(ftype), m_add_present(false), m_controlsReady(false)
 {
   m_prule = &rule;
   m_pvalue = &value;
@@ -286,6 +286,7 @@ void pwFiltersStringDlg::CreateControls()
   BoxSizer1->Fit(this);
   BoxSizer1->SetSizeHints(this);
   //*)
+  m_controlsReady = true;
 }
 
 /*!
@@ -323,6 +324,9 @@ wxIcon pwFiltersStringDlg::GetIconResource(const wxString& WXUNUSED(name))
 
 void pwFiltersStringDlg::OnSelectionChange(wxCommandEvent& WXUNUSED(event))
 {
+  if (!m_controlsReady) {
+    return;
+  }
   int idx = m_ComboBox->GetSelection();
 
   if(m_add_present) {
@@ -358,6 +362,9 @@ void pwFiltersStringDlg::OnSelectionChange(wxCommandEvent& WXUNUSED(event))
 
 void pwFiltersStringDlg::OnTextChange(wxCommandEvent& WXUNUSED(event))
 {
+  if (!m_controlsReady) {
+    return;
+  }
   if(m_TextCtrlValueString && m_TextCtrlValueString->GetLineLength(0)) {
     FindWindow(wxID_OK)->Enable();
   }

--- a/src/ui/wxWidgets/PWFiltersStringDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersStringDlg.cpp
@@ -63,31 +63,14 @@ END_EVENT_TABLE()
  * pwFiltersStringDlg constructors
  */
 
-pwFiltersStringDlg::pwFiltersStringDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, wxString &value, bool &fcase)
-: m_ftype(ftype), m_add_present(false), m_controlsReady(false)
+pwFiltersStringDlg::pwFiltersStringDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, wxString *value, bool *fcase)
+: m_ftype(ftype), 
+  m_prule(rule), m_pvalue(value), m_pfcase(fcase)
 {
-  m_prule = &rule;
-  m_pvalue = &value;
-  m_pfcase = &fcase;
+  wxASSERT(!parent || parent->IsTopLevel());
 
   Init();
-  Create(parent);
-}
 
-/*!
- * pwFiltersStringDlg destructor
- */
-
-pwFiltersStringDlg::~pwFiltersStringDlg()
-{
-}
-
-/*!
- * pwFiltersStringDlg creator
- */
-
-bool pwFiltersStringDlg::Create(wxWindow* parent)
-{
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create(parent, wxID_ANY, _("Display Filter String Value"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
@@ -98,9 +81,12 @@ bool pwFiltersStringDlg::Create(wxWindow* parent)
   Centre();
 
   SetValidators();
-  return true;
 }
 
+pwFiltersStringDlg* pwFiltersStringDlg::Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, wxString *value, bool *fcase)
+{
+  return new pwFiltersStringDlg(parent, ftype, rule, value, fcase);
+}
 /*!
  * InitDialog set selection in choice list and optimize window size
  */
@@ -194,10 +180,6 @@ void pwFiltersStringDlg::SetValidators()
 
 void pwFiltersStringDlg::Init()
 {
-  m_ComboBox = nullptr;
-  m_TextCtrlValueString = nullptr;
-  m_idx = -1;
-  
   switch (m_ftype) {
     case FT_GROUPTITLE:
     case FT_TITLE:

--- a/src/ui/wxWidgets/PWFiltersStringDlg.h
+++ b/src/ui/wxWidgets/PWFiltersStringDlg.h
@@ -101,6 +101,7 @@ private:
 
   const FieldType m_ftype;
   bool m_add_present;
+  bool m_controlsReady;
   // Result parameter
   PWSMatch::MatchRule *m_prule;
   wxString            *m_pvalue;

--- a/src/ui/wxWidgets/PWFiltersStringDlg.h
+++ b/src/ui/wxWidgets/PWFiltersStringDlg.h
@@ -18,11 +18,11 @@
  */
 
 #include <wx/choice.h>
-#include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
 #include "core/PWSFilters.h"
+#include "QueryCancelDlg.h"
 
 /*!
  * Forward declarations
@@ -48,7 +48,7 @@
  * pwFiltersStringDlg class declaration
  */
 
-class pwFiltersStringDlg : public wxDialog
+class pwFiltersStringDlg : public QueryCancelDlg
 {
   DECLARE_CLASS(pwFiltersStringDlg)
   DECLARE_EVENT_TABLE()
@@ -90,6 +90,8 @@ private:
   void OnSelectionChange(wxCommandEvent& event);
   void OnTextChange(wxCommandEvent& event);
   //*)
+
+  bool IsChanged() const override;
 
   //(*Declarations(pwFiltersStringDlg)
   wxComboBox* m_ComboBox = nullptr;

--- a/src/ui/wxWidgets/PWFiltersStringDlg.h
+++ b/src/ui/wxWidgets/PWFiltersStringDlg.h
@@ -54,11 +54,13 @@ class pwFiltersStringDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
+  static pwFiltersStringDlg* Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, wxString *value, bool *fcase);
+protected:
   /// Constructors
-  pwFiltersStringDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, wxString &value, bool &fcase);
+  pwFiltersStringDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, wxString *value, bool *fcase);
 
   /// Destructor
-  virtual ~pwFiltersStringDlg();
+  virtual ~pwFiltersStringDlg() = default;
 
   /// Creation
   bool Create(wxWindow* parent);
@@ -90,22 +92,22 @@ private:
   //*)
 
   //(*Declarations(pwFiltersStringDlg)
-  wxComboBox* m_ComboBox;
-  wxTextCtrl* m_TextCtrlValueString;
-  wxCheckBox* m_CheckBoxFCase;
+  wxComboBox* m_ComboBox = nullptr;
+  wxTextCtrl* m_TextCtrlValueString = nullptr;
+  wxCheckBox* m_CheckBoxFCase = nullptr;
   //*)
 
-  int m_idx;
+  int m_idx = -1;
   wxString m_string;
   bool m_fcase;
 
   const FieldType m_ftype;
-  bool m_add_present;
-  bool m_controlsReady;
+  bool m_add_present = false;
+  bool m_controlsReady = false;
   // Result parameter
-  PWSMatch::MatchRule *m_prule;
-  wxString            *m_pvalue;
-  bool                *m_pfcase;
+  PWSMatch::MatchRule *m_prule = nullptr;
+  wxString            *m_pvalue = nullptr;
+  bool                *m_pfcase = nullptr;
   
   static const PWSMatch::MatchRule m_mrpres[PW_NUM_PRESENT_ENUM];
   static const PWSMatch::MatchRule m_mrcrit[PW_NUM_STR_CRITERIA_ENUM];

--- a/src/ui/wxWidgets/PWFiltersTypeDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersTypeDlg.cpp
@@ -58,6 +58,8 @@ BEGIN_EVENT_TABLE( pwFiltersTypeDlg, wxDialog )
   EVT_BUTTON( wxID_OK, pwFiltersTypeDlg::OnOk )
   EVT_COMBOBOX( ID_COMBOBOX62, pwFiltersTypeDlg::OnSelectionChangeRule )
   EVT_COMBOBOX( ID_COMBOBOX63, pwFiltersTypeDlg::OnSelectionChangeType )
+  EVT_BUTTON( wxID_CANCEL, pwFiltersTypeDlg::OnCancelClick )
+  EVT_CLOSE( pwFiltersTypeDlg::OnClose )
 
 END_EVENT_TABLE()
 
@@ -329,4 +331,28 @@ void pwFiltersTypeDlg::OnOk(wxCommandEvent& WXUNUSED(event))
     }
   }
   EndModal(wxID_OK);
+}
+
+bool pwFiltersTypeDlg::IsChanged() const {
+  const auto idx = m_ComboBoxRule->GetSelection();
+
+  if(idx >= 0 && idx < PW_NUM_TYPE_RULE_ENUM) {
+    if (*m_prule != m_mrx[idx]) {
+      return true;
+    }
+  }
+  else if (*m_prule != PWSMatch::MR_INVALID) {
+    return true;
+  }
+
+  const auto idx_type = m_ComboBoxType->GetSelection();
+  if(idx_type >= 0 && idx_type < PW_NUM_TYPE_ENUM) {
+    if (*m_petype != m_mtype[idx_type].typeValue) {
+      return true;
+    }
+  }
+  else if (*m_prule != PWSMatch::MR_INVALID) {
+    return true;
+  }
+  return false;
 }

--- a/src/ui/wxWidgets/PWFiltersTypeDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersTypeDlg.cpp
@@ -65,30 +65,13 @@ END_EVENT_TABLE()
  * pwFiltersTypeDlg constructors
  */
 
-pwFiltersTypeDlg::pwFiltersTypeDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, CItemData::EntryType &etype)
-: m_ftype(ftype)
+pwFiltersTypeDlg::pwFiltersTypeDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, CItemData::EntryType *etype)
+: m_ftype(ftype), m_prule(rule), m_petype(etype)
 {
-  m_prule = &rule;
-  m_petype = &etype;
+  wxASSERT(!parent || parent->IsTopLevel());
 
-  Init();
-  Create(parent);
-}
+  m_etype = *m_petype;
 
-/*!
- * pwFiltersTypeDlg destructor
- */
-
-pwFiltersTypeDlg::~pwFiltersTypeDlg()
-{
-}
-
-/*!
- * pwFiltersTypeDlg creator
- */
-
-bool pwFiltersTypeDlg::Create(wxWindow* parent)
-{
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create(parent, wxID_ANY, _("Display Filter Entry Type Value"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
 
@@ -99,7 +82,11 @@ bool pwFiltersTypeDlg::Create(wxWindow* parent)
   Centre();
 
   SetValidators();
-  return true;
+}
+
+pwFiltersTypeDlg* pwFiltersTypeDlg::Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, CItemData::EntryType *etype)
+{
+  return new pwFiltersTypeDlg(parent, ftype, rule, etype);
 }
 
 /*!
@@ -207,19 +194,6 @@ void pwFiltersTypeDlg::SetValidators()
 {
   m_ComboBoxRule->SetValidator(wxGenericValidator(&m_idx));
   m_ComboBoxType->SetValidator(wxGenericValidator(&m_idx_type));
-}
-
-/*!
- * Member initialisation
- */
-
-void pwFiltersTypeDlg::Init()
-{
-  m_ComboBoxRule = nullptr;
-  m_ComboBoxType = nullptr;
-  m_idx = -1;
-  m_idx_type = -1;
-  m_etype = *m_petype;
 }
 
 /*!

--- a/src/ui/wxWidgets/PWFiltersTypeDlg.h
+++ b/src/ui/wxWidgets/PWFiltersTypeDlg.h
@@ -18,12 +18,12 @@
  */
 
 #include <wx/choice.h>
-#include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
 #include "core/PWSFilters.h"
 #include "core/PWSprefs.h"
+#include "QueryCancelDlg.h"
 
 /*!
  * Forward declarations
@@ -48,7 +48,7 @@
  * pwFiltersTypeDlg class declaration
  */
 
-class pwFiltersTypeDlg : public wxDialog
+class pwFiltersTypeDlg : public QueryCancelDlg
 {
   DECLARE_CLASS(pwFiltersTypeDlg)
   DECLARE_EVENT_TABLE()
@@ -90,6 +90,8 @@ private:
   void OnSelectionChangeRule(wxCommandEvent& event);
   void OnSelectionChangeType(wxCommandEvent& event);
   //*)
+
+  bool IsChanged() const override;
 
   //(*Declarations(pwFiltersTypeDlg)
   wxComboBox* m_ComboBoxRule = nullptr;

--- a/src/ui/wxWidgets/PWFiltersTypeDlg.h
+++ b/src/ui/wxWidgets/PWFiltersTypeDlg.h
@@ -54,11 +54,13 @@ class pwFiltersTypeDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
+  static pwFiltersTypeDlg* Create(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, CItemData::EntryType *etype);
+protected:
   /// Constructors
-  pwFiltersTypeDlg(wxWindow* parent, FieldType ftype, PWSMatch::MatchRule &rule, CItemData::EntryType &etype);
+  pwFiltersTypeDlg(wxWindow *parent, FieldType ftype, PWSMatch::MatchRule *rule, CItemData::EntryType *etype);
 
   /// Destructor
-  virtual ~pwFiltersTypeDlg();
+  virtual ~pwFiltersTypeDlg() = default;
 
   /// Creation
   bool Create(wxWindow* parent);
@@ -90,17 +92,17 @@ private:
   //*)
 
   //(*Declarations(pwFiltersTypeDlg)
-  wxComboBox* m_ComboBoxRule;
-  wxComboBox* m_ComboBoxType;
+  wxComboBox* m_ComboBoxRule = nullptr;
+  wxComboBox* m_ComboBoxType = nullptr;
   //*)
 
   const FieldType m_ftype;
-  int m_idx;
-  int m_idx_type;
+  int m_idx = -1;
+  int m_idx_type = -1;
   CItemData::EntryType m_etype;
   // Result parameter
-  PWSMatch::MatchRule *m_prule;
-  CItemData::EntryType *m_petype;
+  PWSMatch::MatchRule *m_prule = nullptr;
+  CItemData::EntryType *m_petype = nullptr;;
 
   typedef struct etypeMapItem {
     int msgText;

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -723,10 +723,10 @@ void PWSafeApp::ConfigureIdleTimer()
 void PWSafeApp::OnIdleTimer(wxTimerEvent &evt)
 {
   if (evt.GetId() == IDLE_TIMER_ID && PWSprefs::GetInstance()->GetPref(PWSprefs::LockDBOnIdleTimeout)) {
-    if (m_frame != nullptr && !m_frame->GetCurrentSafe().IsEmpty()) {
+    if (m_frame != nullptr && !m_frame->IsClosed() && !m_frame->IsLocked()) {
       m_idleTimer->Stop(); // Stop as with modal dialog a dialog will stay open
       m_frame->IconizeOrHideAndLock();
-      if(!m_frame->GetCurrentSafe().IsEmpty()) // If restored start timer again
+      if(!m_frame->IsLocked()) // If not locked, start timer again
         ConfigureIdleTimer();
     }
   }

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -547,6 +547,8 @@ bool PWSafeApp::OnInit()
   }
   if (PWSprefs::GetInstance()->GetPref(PWSprefs::UseSystemTray))
     m_frame->ShowTrayIcon();
+
+  m_frame->Register(); // register modal dialog hook
   return true;
 }
 

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -900,7 +900,7 @@ void PWSafeApp::OnHelp(wxCommandEvent& evt)
     StringToStringMap& helpmap = GetHelpMap();
     StringToStringMap::iterator itr = helpmap.find(keyName);
     if (itr != helpmap.end()) {
-      wxHtmlModalHelp help(wxGetApp().GetTopWindow(), helpFileNamePath, itr->second, wxHF_DEFAULT_STYLE);
+      wxHtmlModalHelp help(window, helpFileNamePath, itr->second, wxHF_DEFAULT_STYLE);
     }
     else {
 #ifdef __WXDEBUG__

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -483,10 +483,9 @@ bool PWSafeApp::OnInit()
   if (!cmd_closed && !cmd_silent && !cmd_minimized) {
     // Get the file, r/w mode and password from user
     // Note that file may be new
-    SafeCombinationEntryDlg* initWindow = new SafeCombinationEntryDlg(nullptr, m_core);
+    DestroyWrapper<SafeCombinationEntryDlg> initWindowWrapper(nullptr, m_core);
+    SafeCombinationEntryDlg *initWindow = initWindowWrapper.Get();
     int returnValue = initWindow->ShowModal();
-
-    initWindow->Destroy();
 
     if (returnValue != wxID_OK) {
       return false;
@@ -943,4 +942,8 @@ void PWSafeApp::RestartIdleTimer()
     m_idleTimer->Stop();
     m_idleTimer->Start(interval, wxTIMER_CONTINUOUS);
   }
+}
+
+bool PWSafeApp::IsCloseInProgress() const {
+  return m_frame->IsCloseInProgress();
 }

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -98,6 +98,7 @@ public:
 
   wxIconBundle GetAppIcons() const { return m_appIcons; }
 
+  bool IsCloseInProgress() const;
 private:
   PWScore m_core;
   wxTimer *m_idleTimer;

--- a/src/ui/wxWidgets/PasswordPolicyDlg.cpp
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.cpp
@@ -64,22 +64,19 @@ END_EVENT_TABLE()
  * PasswordPolicyDlg constructor
  */
 
-PasswordPolicyDlg::PasswordPolicyDlg( wxWindow* parent, PWScore &core,
+PasswordPolicyDlg::PasswordPolicyDlg(wxWindow *parent, PWScore &core,
                                   const PSWDPolicyMap &polmap, DialogType type,
                                   wxWindowID id, const wxString& caption,
                                   const wxPoint& pos, const wxSize& size, long style )
 : m_core(core), m_MapPSWDPLC(polmap), m_DialogType(type)
 {
-  Init();
-  Create(parent, type, id, caption, pos, size, style);
-}
+  wxASSERT(!parent || parent->IsTopLevel());
 
-/*!
- * PasswordPolicyDlg creator
- */
-
-bool PasswordPolicyDlg::Create( wxWindow* parent, DialogType type, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
+  // Collect all policy names to display in combobox control
+  for (auto& policy : m_MapPSWDPLC) {
+    m_Policynames.Add(stringx2std(policy.first));
+  }
+  
 ////@begin PasswordPolicyDlg creation
   m_DialogType = type;
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
@@ -92,7 +89,14 @@ bool PasswordPolicyDlg::Create( wxWindow* parent, DialogType type, wxWindowID id
   }
   Centre();
 ////@end PasswordPolicyDlg creation
-  return true;
+}
+
+PasswordPolicyDlg* PasswordPolicyDlg::Create(wxWindow *parent, PWScore &core,
+                                  const PSWDPolicyMap &polmap, DialogType type,
+                                  wxWindowID id, const wxString& caption,
+                                  const wxPoint& pos, const wxSize& size, long style)
+{
+  return new PasswordPolicyDlg(parent, core, polmap, type, id, caption, pos, size, style);
 }
 
 void PasswordPolicyDlg::SetDefaultSymbolDisplay(bool restore_defaults)
@@ -109,54 +113,6 @@ void PasswordPolicyDlg::SetDefaultSymbolDisplay(bool restore_defaults)
   }
   m_Symbols = symset.c_str();
   m_OwnSymbols->SetValue(m_Symbols);
-}
-
-/*!
- * PasswordPolicyDlg destructor
- */
-
-PasswordPolicyDlg::~PasswordPolicyDlg()
-{
-////@begin PasswordPolicyDlg destruction
-////@end PasswordPolicyDlg destruction
-}
-
-/*!
- * Member initialisation
- */
-
-void PasswordPolicyDlg::Init()
-{
-////@begin PasswordPolicyDlg member initialisation
-  m_pwpLenCtrl = nullptr;
-  m_pwMinsGSzr = nullptr;
-  m_pwpUseLowerCtrl = nullptr;
-  m_pwNumLCbox = nullptr;
-  m_pwpLCSpin = nullptr;
-  m_pwpUseUpperCtrl = nullptr;
-  m_pwNumUCbox = nullptr;
-  m_pwpUCSpin = nullptr;
-  m_pwpUseDigitsCtrl = nullptr;
-  m_pwNumDigbox = nullptr;
-  m_pwpDigSpin = nullptr;
-  m_pwpSymCtrl = nullptr;
-  m_pwNumSymbox = nullptr;
-  m_pwpSymSpin = nullptr;
-  m_OwnSymbols = nullptr;
-  m_pwpEasyCtrl = nullptr;
-  m_pwpPronounceCtrl = nullptr;
-  m_pwpHexCtrl = nullptr;
-
-  m_UseDatabasePolicyCtrl = nullptr;
-  m_PoliciesSelectionCtrl = nullptr;
-  m_passwordCtrl = nullptr;
-  m_itemStaticBoxSizer6 = nullptr;
-////@end PasswordPolicyDlg member initialisation
-
-  // Collect all policy names to display in combobox control
-  for (auto& policy : m_MapPSWDPLC) {
-    m_Policynames.Add(stringx2std(policy.first));
-  }
 }
 
 /*!

--- a/src/ui/wxWidgets/PasswordPolicyDlg.h
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.h
@@ -24,6 +24,7 @@
 #include "core/coredefs.h"
 #include "core/PWPolicy.h"
 #include "core/PWScore.h"
+#include "QueryCancelDlg.h"
 
 /*!
  * Forward declarations
@@ -76,7 +77,7 @@ class wxSpinCtrl;
  * PasswordPolicyDlg class declaration
  */
 
-class PasswordPolicyDlg : public wxDialog
+class PasswordPolicyDlg : public QueryCancelDlg
 {
   DECLARE_EVENT_TABLE()
 
@@ -131,9 +132,6 @@ protected:
 
   /// wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_OK
   void OnOkClick( wxCommandEvent& event );
-
-  /// wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_CANCEL
-  void OnCancelClick( wxCommandEvent& event );
 
   /// wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_HELP
   void OnHelpClick( wxCommandEvent& event );
@@ -217,6 +215,23 @@ public:
 private:
   void EnableSizerChildren(wxSizer* sizer, bool state);
 
+  bool SyncAndQueryCancel(bool showDialog) override;
+
+  enum Changes : uint32_t {
+    None = 0,
+    Flags = 1u,
+    Length = 1u << 1,
+    DigitMinLength = 1u << 2,
+    LowerMinLength = 1u << 3,
+    SymbolMinLength = 1u << 4,
+    UpperMinLength = 1u << 5,
+    Symbols = 1u << 6,
+    Name = 1u << 7
+  };
+
+  uint32_t GetChanges() const;
+  bool IsChanged() const override;
+
 ////@begin PasswordPolicyDlg member variables
   /* Controls for DialogType EDITOR */
   wxSpinCtrl* m_pwpLenCtrl = nullptr;
@@ -264,6 +279,7 @@ private:
   void CBox2Spin(wxCheckBox *cb, wxSpinCtrl *sp);
   bool UpdatePolicy();
   bool Verify();
+  PWPolicy ReadPolicy() const;
 
   PWScore &m_core;
   const PSWDPolicyMap &m_MapPSWDPLC; // used to detect existing name

--- a/src/ui/wxWidgets/PasswordPolicyDlg.h
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.h
@@ -82,22 +82,23 @@ class PasswordPolicyDlg : public wxDialog
 
 public:
   enum class DialogType { EDITOR, GENERATOR };
-
-  /// Constructors
-  PasswordPolicyDlg( wxWindow* parent, PWScore &core,
+  static PasswordPolicyDlg* Create(wxWindow *parent, PWScore &core,
                    const PSWDPolicyMap &polmap,
                    DialogType type = DialogType::EDITOR,
                    wxWindowID id = SYMBOL_PASSWORDPOLICYDLG_IDNAME,
                    const wxString& caption = SYMBOL_PASSWORDPOLICYDLG_TITLE,
                    const wxPoint& pos = SYMBOL_PASSWORDPOLICYDLG_POSITION,
                    const wxSize& size = SYMBOL_PASSWORDPOLICYDLG_SIZE,
-                   long style = SYMBOL_PASSWORDPOLICYDLG_STYLE );
-
-  /// Creation
-  bool Create( wxWindow* parent, DialogType type = DialogType::EDITOR, wxWindowID id = SYMBOL_PASSWORDPOLICYDLG_IDNAME, const wxString& caption = SYMBOL_PASSWORDPOLICYDLG_TITLE, const wxPoint& pos = SYMBOL_PASSWORDPOLICYDLG_POSITION, const wxSize& size = SYMBOL_PASSWORDPOLICYDLG_SIZE, long style = SYMBOL_PASSWORDPOLICYDLG_STYLE );
-
+                   long style = SYMBOL_PASSWORDPOLICYDLG_STYLE);
+                   
   /// Destructor
-  ~PasswordPolicyDlg();
+  ~PasswordPolicyDlg() = default;
+protected:
+  /// Constructors
+  PasswordPolicyDlg(wxWindow *parent, PWScore &core,
+                   const PSWDPolicyMap &polmap,
+                   DialogType type, wxWindowID id,
+                   const wxString& caption, const wxPoint& pos, const wxSize& size, long style);
 
   /// Initialises member variables
   void Init();
@@ -154,6 +155,7 @@ public:
 
 ////@end PasswordPolicyDlg event handler declarations
 
+public:
 ////@begin PasswordPolicyDlg member function declarations
 
   wxString GetSymbols() const { return m_Symbols ; }
@@ -203,6 +205,7 @@ public:
 
   /// Retrieves icon resources
   wxIcon GetIconResource( const wxString& name );
+
 ////@end PasswordPolicyDlg member function declarations
   void SetPolicyData(const wxString &polname, const PWPolicy &pol);
   void GetPolicyData(wxString &polname, PWPolicy &pol)
@@ -216,31 +219,31 @@ private:
 
 ////@begin PasswordPolicyDlg member variables
   /* Controls for DialogType EDITOR */
-  wxSpinCtrl* m_pwpLenCtrl;
-  wxGridSizer* m_pwMinsGSzr;
-  wxCheckBox* m_pwpUseLowerCtrl;
-  wxBoxSizer* m_pwNumLCbox;
-  wxSpinCtrl* m_pwpLCSpin;
-  wxCheckBox* m_pwpUseUpperCtrl;
-  wxBoxSizer* m_pwNumUCbox;
-  wxSpinCtrl* m_pwpUCSpin;
-  wxCheckBox* m_pwpUseDigitsCtrl;
-  wxBoxSizer* m_pwNumDigbox;
-  wxSpinCtrl* m_pwpDigSpin;
-  wxCheckBox* m_pwpSymCtrl;
-  wxBoxSizer* m_pwNumSymbox;
-  wxSpinCtrl* m_pwpSymSpin;
-  wxTextCtrl* m_OwnSymbols;
-  wxCheckBox* m_pwpEasyCtrl;
-  wxCheckBox* m_pwpPronounceCtrl;
-  wxCheckBox* m_pwpHexCtrl;
+  wxSpinCtrl* m_pwpLenCtrl = nullptr;
+  wxGridSizer* m_pwMinsGSzr = nullptr;
+  wxCheckBox* m_pwpUseLowerCtrl = nullptr;
+  wxBoxSizer* m_pwNumLCbox = nullptr;
+  wxSpinCtrl* m_pwpLCSpin = nullptr;
+  wxCheckBox* m_pwpUseUpperCtrl = nullptr;
+  wxBoxSizer* m_pwNumUCbox = nullptr;
+  wxSpinCtrl* m_pwpUCSpin = nullptr;
+  wxCheckBox* m_pwpUseDigitsCtrl = nullptr;
+  wxBoxSizer* m_pwNumDigbox = nullptr;
+  wxSpinCtrl* m_pwpDigSpin = nullptr;
+  wxCheckBox* m_pwpSymCtrl = nullptr;
+  wxBoxSizer* m_pwNumSymbox = nullptr;
+  wxSpinCtrl* m_pwpSymSpin = nullptr;
+  wxTextCtrl* m_OwnSymbols = nullptr;
+  wxCheckBox* m_pwpEasyCtrl = nullptr;
+  wxCheckBox* m_pwpPronounceCtrl = nullptr;
+  wxCheckBox* m_pwpHexCtrl = nullptr;
 
   /* Additional controls for DialogType GENERATOR */
-  wxCheckBox* m_UseDatabasePolicyCtrl;
-  wxComboBox* m_PoliciesSelectionCtrl;
-  wxTextCtrl* m_passwordCtrl;
+  wxCheckBox* m_UseDatabasePolicyCtrl = nullptr;
+  wxComboBox* m_PoliciesSelectionCtrl = nullptr;
+  wxTextCtrl* m_passwordCtrl = nullptr;
   wxArrayString m_Policynames;
-  wxStaticBoxSizer* m_itemStaticBoxSizer6;
+  wxStaticBoxSizer* m_itemStaticBoxSizer6  = nullptr;;
 
   wxString m_Symbols;
   wxString m_polname;

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -2399,10 +2399,10 @@ void PasswordSafeFrame::CleanupAfterReloadFailure(bool tellUser)
 /**
  * Unlock database
  * @param restoreUI restore opened windows after unlock
- * @param iconizeOnFailure will iconize if this parameters set to true and
- *   VerifySafeCombination() failed
+ * @param iconizeOnCancel will iconize if this parameters set to true and
+ *   user canceled dialog
 */
-void PasswordSafeFrame::UnlockSafe(bool restoreUI, bool iconizeOnFailure)
+void PasswordSafeFrame::UnlockSafe(bool restoreUI, bool iconizeOnCancel)
 {
   wxMutexTryLocker unlockMutex(m_dblockMutex);
   if (!unlockMutex.IsAcquired()){
@@ -2461,12 +2461,12 @@ void PasswordSafeFrame::UnlockSafe(bool restoreUI, bool iconizeOnFailure)
           wxPostEvent(this, event);
           return;
         }
-        default:
+        case (wxID_CANCEL):
         {
-          if (!IsIconized() && iconizeOnFailure)
+          if (!IsIconized() && iconizeOnCancel) {
             Iconize();
-          if(restoreUI && iconizeOnFailure)
-            return;
+          }
+          return; // allow to cancel dialog and left locked in any case
         }
       }
     } while(bModalOpen && PWSprefs::GetInstance()->GetPref(PWSprefs::UseSystemTray));

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -2927,7 +2927,7 @@ void PasswordSafeFrame::CloseAllWindows(TimedTaskChain* taskChain, CloseFlags fl
 
   if (!m_closeDisabler) {
     m_closeDisabler = new wxWindowDisabler();
-    m_penginCloseWindow = nullptr;
+    m_pengingCloseWindow = nullptr;
     if (delayClose) {
       // some windows (such as wxHtmlHelpDialog need more cycles for activation), delay close processing after show
       taskChain->then([taskChain, flags, onFinish, this]{
@@ -2946,7 +2946,7 @@ void PasswordSafeFrame::CloseAllWindows(TimedTaskChain* taskChain, CloseFlags fl
     wxTopLevelWindow* win = *itr;
     if (win) {
       if (win->IsShown()) {
-        if (win == m_penginCloseWindow) { // close already sheduled, but still not done
+        if (win == m_pengingCloseWindow) { // close already sheduled, but still not done
           pws_os::Trace(L"Waiting for window close <%ls> (%ls), flags=%d\n", ToStr(win->GetTitle()), ToStr(win->GetName()), flags);
           taskChain->then([taskChain, flags, onFinish, this]{
             CloseAllWindows(taskChain, flags, onFinish);
@@ -2955,7 +2955,7 @@ void PasswordSafeFrame::CloseAllWindows(TimedTaskChain* taskChain, CloseFlags fl
         }
 
         pws_os::Trace(L"Closing <%ls> (%ls), flags=%d\n", ToStr(win->GetTitle()), ToStr(win->GetName()), flags);
-        m_penginCloseWindow = win;
+        m_pengingCloseWindow = win;
         if (win->Close((flags & CloseFlags::CLOSE_FORCED) == CloseFlags::CLOSE_FORCED)) {
           if (itr == lastWindowItr) {
             // main windows closed, no need to schedule new check
@@ -2983,7 +2983,7 @@ void PasswordSafeFrame::CloseAllWindows(TimedTaskChain* taskChain, CloseFlags fl
   }
   delete m_closeDisabler;
   m_closeDisabler = nullptr;
-  m_penginCloseWindow = nullptr;
+  m_pengingCloseWindow = nullptr;
   
   if (vetoed && (flags & CloseFlags::HIDE_ON_VETO) == CloseFlags::HIDE_ON_VETO) {
     HideTopLevelWindows();
@@ -3070,6 +3070,7 @@ std::vector<wxTopLevelWindow*> PasswordSafeFrame::GetTopLevelWindowsList() const
       // wxMessageDialog don't set needed m_shown and m_modalShowing flags in ShowModal, so just log it
       // (we even can't close them, because m_modalShowing isn't set and Close event isn't processed)
       pws_os::Trace(L"Message dialog <%ls> (%ls) can't be hidden/closed\n", ToStr(dialog->GetTitle()), ToStr(dialog->GetName()));
+      continue;
     }
 #endif
     if (shown) {

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -2479,7 +2479,7 @@ void PasswordSafeFrame::UnlockSafe(bool restoreUI, bool iconizeOnFailure)
 
   if (restoreUI) {
     if (!IsShown()) {
-      ShowWindowRecursively(this);
+      ShowWindowRecursively(hiddenWindows);
     }
     if (IsIconized()) {
       Iconize(false);
@@ -2589,7 +2589,7 @@ void PasswordSafeFrame::HideUI(bool lock)
     //We should not have to show up the icon manually if m_sysTray
     //can be notified of changes to PWSprefs::UseSystemTray
     m_sysTray->ShowIcon();
-    HideWindowRecursively(this);
+    hiddenWindows = HideWindowRecursively();
   }
 }
 

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -2457,6 +2457,9 @@ void PasswordSafeFrame::UnlockSafe(bool restoreUI, bool iconizeOnCancel)
         }
         return; // allow to cancel dialog and left locked in any case
       }
+      default:
+        wxASSERT_MSG(false, wxT("Unexpected SafeCombinationPromptDlg result"));
+        break;
     }
 
     if (m_savedDBPrefs != wxEmptyString) {

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -2230,6 +2230,11 @@ bool PasswordSafeFrame::IsClosed() const
           !m_core.HasDBChanged() && !m_core.AnyToUndo() && !m_core.AnyToRedo());
 }
 
+bool PasswordSafeFrame::IsLocked() const
+{
+  return m_sysTray->IsLocked();
+}
+
 void PasswordSafeFrame::RebuildGUI(const int iView /*= iBothViews*/)
 {
   // assumption: the view get updated on switching between each other,
@@ -2598,8 +2603,10 @@ void PasswordSafeFrame::IconizeOrHideAndLock()
   bool bModalOpen = false;
   
   if (PWSprefs::GetInstance()->GetPref(PWSprefs::UseSystemTray)) {
-    bModalOpen = (CountTopLevelWindowRecursively(this) > 1);
-    HideUI(true);
+    if (!m_sysTray->IsLocked()) {
+      bModalOpen = (CountTopLevelWindowRecursively(this) > 1);
+      HideUI(true);
+    }
   }
   else {
     TryIconize();

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -2907,7 +2907,7 @@ void PasswordSafeFrame::ResetFilters()
  
  @param taskChain chain to use when closing multiple dialogs
  @param flags close options
- @param onSuccess if set, will be called after closing all windows
+ @param onFinish if set, will be called after closing all windows
  
  Here we have to use taskChain, because when closing multiple dialogs, 
  CallAfter is not enough to allow dialog to finish result processing and break event loop
@@ -2936,8 +2936,8 @@ void PasswordSafeFrame::CloseAllWindows(TimedTaskChain* taskChain, CloseFlags fl
   
   auto tlvList = GetTopLevelWindowsList();
   auto itr = tlvList.rbegin();
-  auto endItr = ((flags & CloseFlags::LEAVE_MAIN) == CloseFlags::LEAVE_MAIN) ? --tlvList.rend() : tlvList.rend();
-  auto lastWindowItr = --tlvList.rend();
+  const auto endItr = ((flags & CloseFlags::LEAVE_MAIN) == CloseFlags::LEAVE_MAIN) ? --tlvList.rend() : tlvList.rend();
+  const auto lastWindowItr = --tlvList.rend();
   bool vetoed = false;
   while (itr != endItr) {
     wxTopLevelWindow* win = *itr;

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -2416,7 +2416,7 @@ void PasswordSafeFrame::UnlockSafe(bool restoreUI, bool iconizeOnFailure)
     int noTopLevelWindow = CountTopLevelWindowRecursively(this);
     
     bModalOpen = (noTopLevelWindow > 1); // More than one Top Level Window, the second one is modal
-#if (__WXOSX__)
+#if defined(__WXOSX__)
     const int TopLevelWindowLimit = 2; // OSX allow exit with one modal window open only
 #else
 # if (wxVERSION_NUMBER >= 3104)

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -2494,6 +2494,8 @@ void PasswordSafeFrame::UnlockSafe(bool restoreUI, bool iconizeOnCancel)
     // Without this, modal dialogs like msgboxes lose focus and we end up in a different message loop than theirs.
     // See https://sourceforge.net/tracker/?func=detail&aid=3537985&group_id=41019&atid=429579
     wxSafeYield();
+    // for some reason, we have to restore main frame's position after Yeild, otherwise it could be restored at wrong position when window was moved before lock
+    wxGetApp().RestoreFrameCoords();
   }
   else if (IsShown()) { /* if it is somehow visible, show it correctly */
     Show(true);

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -610,6 +610,7 @@ public:
   void HideSearchBar();
 
   bool IsClosed() const;
+  bool IsLocked() const;
   
   static void DisplayFileWriteError(int rc, const StringX &fname);
 

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -229,6 +229,7 @@ public:
 
   ItemList::size_type GetNumEntries() const {return m_core.GetNumEntries();}
 
+  bool CanCloseDialogs() const;
   void CloseDB(std::function<void(bool)> callback);
   
   /* Observer Interface Implementation */

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -616,7 +616,8 @@ public:
 
   bool IsClosed() const;
   bool IsLocked() const;
-  
+  /// Get top dialog (shown or hidden)
+  wxTopLevelWindow* GetTopWindow() const;
   static void DisplayFileWriteError(int rc, const StringX &fname);
 
 ////@begin PasswordSafeFrame member variables

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -228,6 +228,8 @@ public:
 
   ItemList::size_type GetNumEntries() const {return m_core.GetNumEntries();}
 
+  void CloseDB(std::function<void(bool)> callback);
+  
   /* Observer Interface Implementation */
 
   /// Implements Observer::DatabaseModified(bool)
@@ -722,7 +724,7 @@ private:
   void ChangeFontPreference(const PWSprefs::StringPrefs fontPreference);
   
   enum CloseFlags { CLOSE_NORMAL = 0, CLOSE_FORCED = 1, LEAVE_MAIN = 2, HIDE_ON_VETO = 4 };
-  void CloseAllWindows(TimedTaskChain* taskChain, CloseFlags flags);
+  void CloseAllWindows(TimedTaskChain* taskChain, CloseFlags flags, std::function<void(bool success)> onFinish);
   bool IsCloseInProgress() const;
 
   void SaveLayoutPreferences();

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -778,6 +778,9 @@ private:
   wxAuiManager m_AuiManager;
   wxAuiToolBar* m_Toolbar;
   DragBarCtrl* m_Dragbar;
+
+  // top-level windows that we hid while locking the UI
+  wxWindowList hiddenWindows;
 };
 
 BEGIN_DECLARE_EVENT_TYPES()

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -25,6 +25,7 @@
 #include <wx/statusbr.h>
 #include <wx/treebase.h> // for wxTreeItemId
 #include <wx/settings.h>
+#include <wx/modalhook.h>
 
 #include "core/PWScore.h"
 #include "core/PWSFilters.h"
@@ -200,7 +201,7 @@ enum {
  * PasswordSafeFrame class declaration
  */
 
-class PasswordSafeFrame : public wxFrame, public Observer
+class PasswordSafeFrame : public wxFrame, public Observer, public wxModalDialogHook
 {
     DECLARE_CLASS( PasswordSafeFrame )
     DECLARE_EVENT_TABLE()
@@ -788,6 +789,13 @@ private:
   st_filters &CurrentFilter() {return m_FilterManager.m_currentfilter;}
   void ResetFilters();
   
+  virtual int Enter(wxDialog* dialog) override;
+  virtual void Exit(wxDialog* dialog) override;
+  
+  std::vector<wxTopLevelWindow*> GetTopLevelWindowsList() const;
+  void HideTopLevelWindows();
+  void ShowHiddenWindows();
+  
   // Global Filters
   PWSFilters m_MapAllFilters;     // Includes DB and temporary (added, imported, autoloaded etc.)
   FilterPool m_currentfilterpool; // Filter pool of the current active filter
@@ -812,8 +820,9 @@ private:
   wxAuiToolBar* m_Toolbar;
   DragBarCtrl* m_Dragbar;
 
-  // top-level windows that we hid while locking the UI
-  wxWindowList m_hiddenWindows;
+  // top-level windows that we hide while locking the UI
+  std::vector<wxTopLevelWindow*> m_hiddenWindows;
+  std::vector<wxDialog*> m_shownDialogs;
   wxWindowDisabler* m_closeDisabler = nullptr; // disable all windows while waiting for close
 };
 

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -697,7 +697,8 @@ private:
   void DoBrowse(CItemData &item, bool bAutotype);
   void DoRun(CItemData &item);
   void DoEmail(CItemData &item);
-  void DoPasswordSubset(CItemData &item);
+  void DoPasswordSubset(CItemData *item);
+  void DoEditBase();
 
   // These 3 fns are called via wxEvtHandler::CallAfter in sequence for autotyping
   void MinimizeOrHideBeforeAutotyping();
@@ -726,6 +727,30 @@ private:
 
   void SaveLayoutPreferences();
   bool LoadLayoutPreferences();
+
+    void DoCreateShortcut(CItemData* item);
+  void DoDeleteItems(bool askConfirmation, int num_children);
+  void DoImportXML(wxString filename);
+  void DoImportText(wxString filename);
+  void DoImportKeePass(wxString filename);
+  void DoManageFilters();
+  void DoPwdPolsMClick();
+  void DoEditFilter();
+  void DoGeneratePassword();
+  void DoChangePassword();
+  void DoPasswordQRCode(CItemData* item);
+  void DoPropertiesClick();
+  void DoMergeAnotherSafe(wxString filename);
+  void DoRestoreSafe();
+  void DoChangeMode();
+  void DoPreferencesClick();
+  void DoSynchronize(wxString filename);
+  void DoCompare();
+  void DoViewAttachment(CItemData* item);
+
+#ifndef NO_YUBI
+  void DoYubikeyMngClick();
+#endif /* NO_YUBI */  
 
   PWScore &m_core;
   ViewType m_currentView;

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -35,6 +35,7 @@
 #include "wxUtilities.h"
 #include "DnDFile.h"
 #include "DragBarCtrl.h"
+#include "TimedTaskChain.h"
 
 #include <tuple>
 #include <vector>
@@ -718,6 +719,10 @@ private:
   void UpdateLastClipboardAction(const CItemData::FieldType field);
 
   void ChangeFontPreference(const PWSprefs::StringPrefs fontPreference);
+  
+  enum CloseFlags { CLOSE_NORMAL = 0, CLOSE_FORCED = 1, LEAVE_MAIN = 2, HIDE_ON_VETO = 4 };
+  void CloseAllWindows(TimedTaskChain* taskChain, CloseFlags flags);
+  bool IsCloseInProgress() const;
 
   void SaveLayoutPreferences();
   bool LoadLayoutPreferences();
@@ -727,12 +732,12 @@ private:
   TreeSortType m_currentSort;
   PasswordSafeSearch* m_search;
   SystemTray* m_sysTray;
-  bool m_exitFromMenu;
   bool m_bRestoredDBUnsaved;
   CRUEList m_RUEList;
   GuiInfo* m_guiInfo;
   bool m_bTSUpdated;
   wxString m_savedDBPrefs;
+
   enum {iListOnly = 1, iTreeOnly = 2, iBothViews = 3};
 
   /*
@@ -781,7 +786,8 @@ private:
   DragBarCtrl* m_Dragbar;
 
   // top-level windows that we hid while locking the UI
-  wxWindowList hiddenWindows;
+  wxWindowList m_hiddenWindows;
+  wxWindowDisabler* m_closeDisabler = nullptr; // disable all windows while waiting for close
 };
 
 BEGIN_DECLARE_EVENT_TYPES()

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -826,7 +826,7 @@ private:
   std::vector<wxTopLevelWindow*> m_hiddenWindows;
   std::vector<wxDialog*> m_shownDialogs;
   wxWindowDisabler* m_closeDisabler = nullptr; // disable all windows while waiting for close
-  wxTopLevelWindow* m_penginCloseWindow = nullptr; // current window that processing close event
+  wxTopLevelWindow* m_pengingCloseWindow = nullptr; // current window that processing close event
 };
 
 BEGIN_DECLARE_EVENT_TYPES()

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -794,7 +794,7 @@ private:
   
   std::vector<wxTopLevelWindow*> GetTopLevelWindowsList() const;
   void HideTopLevelWindows();
-  void ShowHiddenWindows();
+  void ShowHiddenWindows(bool raise);
   
   // Global Filters
   PWSFilters m_MapAllFilters;     // Includes DB and temporary (added, imported, autoloaded etc.)
@@ -824,6 +824,7 @@ private:
   std::vector<wxTopLevelWindow*> m_hiddenWindows;
   std::vector<wxDialog*> m_shownDialogs;
   wxWindowDisabler* m_closeDisabler = nullptr; // disable all windows while waiting for close
+  wxTopLevelWindow* m_penginCloseWindow = nullptr; // current window that processing close event
 };
 
 BEGIN_DECLARE_EVENT_TYPES()

--- a/src/ui/wxWidgets/PasswordSafeSearch.h
+++ b/src/ui/wxWidgets/PasswordSafeSearch.h
@@ -125,6 +125,9 @@ private:
   void CalculateToolsWidth();
   wxSize CalculateSearchWidth();
   void UpdateStatusAreaWidth();
+  void DoToolBarFindReport(int controlId);
+  
+  void GetAdvancedSearchOptions(int cointrolId);
 
   void SetModified(bool modified) { m_modified = modified; }
   bool IsModified() const { return m_modified; }

--- a/src/ui/wxWidgets/PasswordSubsetDlg.cpp
+++ b/src/ui/wxWidgets/PasswordSubsetDlg.cpp
@@ -54,27 +54,11 @@ END_EVENT_TABLE()
 /*!
  * PasswordSubsetDlg constructors
  */
-
-PasswordSubsetDlg::PasswordSubsetDlg()
-: m_password(wxEmptyString)
-{
-  Init();
-}
-
-PasswordSubsetDlg::PasswordSubsetDlg( wxWindow* parent, const StringX &password,
+PasswordSubsetDlg::PasswordSubsetDlg(wxWindow *parent, const StringX &password,
                                   wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
   : m_password(password)
 {
-  Init();
-  Create(parent, id, caption, pos, size, style);
-}
-
-/*!
- * PasswordSubsetDlg creator
- */
-
-bool PasswordSubsetDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
+  wxASSERT(!parent || parent->IsTopLevel());
 ////@begin PasswordSubsetDlg creation
   SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY|wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create( parent, id, caption, pos, size, style );
@@ -86,31 +70,12 @@ bool PasswordSubsetDlg::Create( wxWindow* parent, wxWindowID id, const wxString&
   }
   Centre();
 ////@end PasswordSubsetDlg creation
-  return true;
 }
 
-/*!
- * PasswordSubsetDlg destructor
- */
-
-PasswordSubsetDlg::~PasswordSubsetDlg()
+PasswordSubsetDlg* PasswordSubsetDlg::Create(wxWindow *parent, const StringX &password,
+  wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style)
 {
-////@begin PasswordSubsetDlg destruction
-////@end PasswordSubsetDlg destruction
-}
-
-/*!
- * Member initialisation
- */
-
-void PasswordSubsetDlg::Init()
-{
-////@begin PasswordSubsetDlg member initialisation
-  m_pos = nullptr;
-  m_vals = nullptr;
-  m_error = nullptr;
-  m_copyBtn = nullptr;
-////@end PasswordSubsetDlg member initialisation
+  return new PasswordSubsetDlg(parent, password, id, caption, pos, size, style);
 }
 
 /*!

--- a/src/ui/wxWidgets/PasswordSubsetDlg.h
+++ b/src/ui/wxWidgets/PasswordSubsetDlg.h
@@ -58,19 +58,15 @@ class PasswordSubsetDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
-  /// Constructors
-  PasswordSubsetDlg();
-  PasswordSubsetDlg( wxWindow* parent, const StringX &password,
+   static PasswordSubsetDlg* Create(wxWindow *parent, const StringX &password,
                    wxWindowID id = SYMBOL_PASSWORDSUBSETDLG_IDNAME, const wxString& caption = SYMBOL_PASSWORDSUBSETDLG_TITLE, const wxPoint& pos = SYMBOL_PASSWORDSUBSETDLG_POSITION, const wxSize& size = SYMBOL_PASSWORDSUBSETDLG_SIZE, long style = SYMBOL_PASSWORDSUBSETDLG_STYLE );
-
-  /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_PASSWORDSUBSETDLG_IDNAME, const wxString& caption = SYMBOL_PASSWORDSUBSETDLG_TITLE, const wxPoint& pos = SYMBOL_PASSWORDSUBSETDLG_POSITION, const wxSize& size = SYMBOL_PASSWORDSUBSETDLG_SIZE, long style = SYMBOL_PASSWORDSUBSETDLG_STYLE );
-
   /// Destructor
-  ~PasswordSubsetDlg();
+  ~PasswordSubsetDlg() = default;
 
-  /// Initialises member variables
-  void Init();
+protected:
+  /// Constructors
+  PasswordSubsetDlg() = default;
+  PasswordSubsetDlg(wxWindow *parent, const StringX &password, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style);
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -106,10 +102,10 @@ private:
   bool GetSubsetString(const wxString& subset, bool with_delims, StringX& result) const;
   const StringX m_password;
 ////@begin PasswordSubsetDlg member variables
-  wxTextCtrl* m_pos;
-  wxTextCtrl* m_vals;
-  wxStaticText* m_error;
-  wxBitmapButton* m_copyBtn;
+  wxTextCtrl* m_pos = nullptr;
+  wxTextCtrl* m_vals = nullptr;
+  wxStaticText* m_error = nullptr;
+  wxBitmapButton* m_copyBtn = nullptr;
 ////@end PasswordSubsetDlg member variables
 };
 

--- a/src/ui/wxWidgets/PropertiesDlg.cpp
+++ b/src/ui/wxWidgets/PropertiesDlg.cpp
@@ -431,14 +431,16 @@ void PropertiesDlg::OnOkClick( wxCommandEvent& WXUNUSED(evt) )
  */
 void PropertiesDlg::OnEditName( wxCommandEvent& WXUNUSED(evt) )
 {
-  wxTextEntryDialog textInputDialog(
-    this, _("Name:"), _("Please enter the new database name"), m_NewDbName.c_str(), wxOK|wxCANCEL
-  );
+  CallAfter(&PropertiesDlg::DoEditName);
+}
 
-  textInputDialog.SetSize(550, -1);
+void PropertiesDlg::DoEditName() {
+  auto* inputDialog = new wxTextEntryDialog(this, _("Name:"), _("Please enter the new database name"), m_NewDbName.c_str(), wxOK|wxCANCEL);
 
-  if (textInputDialog.ShowModal() == wxID_OK) {
-    auto newDbName = textInputDialog.GetValue();
+  inputDialog->SetSize(550, -1);
+
+  if (inputDialog->ShowModal() == wxID_OK) {
+    auto newDbName = inputDialog->GetValue();
 
     if (newDbName.IsEmpty()) {
       m_DbName  = _("N/A");     // Show 'N/A' on the UI in case of an empty string,
@@ -452,6 +454,8 @@ void PropertiesDlg::OnEditName( wxCommandEvent& WXUNUSED(evt) )
       m_NewDbName = tostringx(newDbName);
     }
   }
+
+  inputDialog->Destroy();
 }
 
 /*!
@@ -459,14 +463,16 @@ void PropertiesDlg::OnEditName( wxCommandEvent& WXUNUSED(evt) )
  */
 void PropertiesDlg::OnEditDescription( wxCommandEvent& WXUNUSED(evt) )
 {
-  wxTextEntryDialog textInputDialog(
-    this, _("Description:"), _("Please enter the new database description"), m_NewDbDescription.c_str(), wxOK|wxCANCEL|wxTE_MULTILINE
-  );
+  CallAfter(&PropertiesDlg::DoEditDescription);
+}
 
-  textInputDialog.SetSize(550, 300);
+void PropertiesDlg::DoEditDescription() {
+  auto* inputDialog = new wxTextEntryDialog(this, _("Description:"), _("Please enter the new database description"), m_NewDbDescription.c_str(), wxOK|wxCANCEL|wxTE_MULTILINE);
 
-  if (textInputDialog.ShowModal() == wxID_OK) {
-    auto newDbDescription = textInputDialog.GetValue();
+  inputDialog->SetSize(550, 300);
+
+  if (inputDialog->ShowModal() == wxID_OK) {
+    auto newDbDescription = inputDialog->GetValue();
 
     if (newDbDescription.IsEmpty()) {
       m_DbDescription = _("N/A");     // Show 'N/A' on the UI in case of an empty string,
@@ -480,4 +486,6 @@ void PropertiesDlg::OnEditDescription( wxCommandEvent& WXUNUSED(evt) )
       m_NewDbDescription = tostringx(newDbDescription);
     }
   }
+
+  inputDialog->Destroy();
 }

--- a/src/ui/wxWidgets/PropertiesDlg.cpp
+++ b/src/ui/wxWidgets/PropertiesDlg.cpp
@@ -59,21 +59,15 @@ END_EVENT_TABLE()
  * PropertiesDlg constructors
  */
 
-PropertiesDlg::PropertiesDlg(wxWindow* parent, const PWScore &core,
+PropertiesDlg::PropertiesDlg(wxWindow *parent, const PWScore &core,
                          wxWindowID id, const wxString& caption,
                          const wxPoint& pos, const wxSize& size, long style)
   : m_core(core)
 {
+  wxASSERT(!parent || parent->IsTopLevel());
+
   Init();
-  Create(parent, id, caption, pos, size, style);
-}
 
-/*!
- * PropertiesDlg creator
- */
-
-bool PropertiesDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
 ////@begin PropertiesDlg creation
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create( parent, id, caption, pos, size, style );
@@ -85,17 +79,13 @@ bool PropertiesDlg::Create( wxWindow* parent, wxWindowID id, const wxString& cap
   }
   Centre();
 ////@end PropertiesDlg creation
-  return true;
 }
 
-/*!
- * PropertiesDlg destructor
- */
-
-PropertiesDlg::~PropertiesDlg()
+PropertiesDlg* PropertiesDlg::Create(wxWindow *parent, const PWScore &core,
+                         wxWindowID id, const wxString& caption,
+                         const wxPoint& pos, const wxSize& size, long style)
 {
-////@begin PropertiesDlg destruction
-////@end PropertiesDlg destruction
+  return new PropertiesDlg(parent, core, id, caption, pos, size, style);
 }
 
 /*!

--- a/src/ui/wxWidgets/PropertiesDlg.h
+++ b/src/ui/wxWidgets/PropertiesDlg.h
@@ -169,6 +169,9 @@ private:
   StringX m_NewDbName;
   StringX m_NewDbDescription;
   const PWScore &m_core;
+  
+  void DoEditName();
+  void DoEditDescription();
 };
 
 #endif // _PROPERTIESDLG_H_

--- a/src/ui/wxWidgets/PropertiesDlg.h
+++ b/src/ui/wxWidgets/PropertiesDlg.h
@@ -71,19 +71,20 @@ class PropertiesDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
-  /// Constructors
-  PropertiesDlg(wxWindow* parent, const PWScore &core,
+  
+  static PropertiesDlg* Create(wxWindow *parent, const PWScore &core,
               wxWindowID id = SYMBOL_PROPERTIESDLG_IDNAME,
               const wxString& caption = SYMBOL_PROPERTIESDLG_TITLE,
               const wxPoint& pos = SYMBOL_PROPERTIESDLG_POSITION,
               const wxSize& size = SYMBOL_PROPERTIESDLG_SIZE,
               long style = SYMBOL_PROPERTIESDLG_STYLE );
-
-  /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_PROPERTIESDLG_IDNAME, const wxString& caption = SYMBOL_PROPERTIESDLG_TITLE, const wxPoint& pos = SYMBOL_PROPERTIESDLG_POSITION, const wxSize& size = SYMBOL_PROPERTIESDLG_SIZE, long style = SYMBOL_PROPERTIESDLG_STYLE );
-
   /// Destructor
-  ~PropertiesDlg();
+  ~PropertiesDlg() = default;
+protected:
+  /// Constructors
+  PropertiesDlg(wxWindow *parent, const PWScore &core,
+              wxWindowID id, const wxString& caption,
+              const wxPoint& pos, const wxSize& size, long style);
 
   /// Initialises member variables
   void Init();
@@ -103,7 +104,7 @@ public:
   void OnEditDescription(wxCommandEvent& evt);
 
 ////@end PropertiesDlg event handler declarations
-
+public:
 ////@begin PropertiesDlg member function declarations
 
   wxString GetDatabase() const { return m_database ; }

--- a/src/ui/wxWidgets/QRCodeDlg.cpp
+++ b/src/ui/wxWidgets/QRCodeDlg.cpp
@@ -39,8 +39,7 @@ BEGIN_EVENT_TABLE(QRCodeDlg, wxDialog)
   EVT_TIMER(wxID_ANY, QRCodeDlg::OnTimer)
 END_EVENT_TABLE()
 
-QRCodeDlg::QRCodeDlg(wxWindow *parent,
-                     const StringX &data,
+QRCodeDlg::QRCodeDlg(wxWindow *parent, const StringX &data,
                      const wxString &dlgTitle,
                      const int seconds,
                      const wxPoint &pos,
@@ -48,7 +47,16 @@ QRCodeDlg::QRCodeDlg(wxWindow *parent,
                      long style,
                      const wxString &name) : wxDialog(parent, wxID_ANY, dlgTitle, pos, size, style, name), timer(this), secondsRemaining(seconds)
 {
+  wxASSERT(!parent || parent->IsTopLevel());
+
   CreateControls(data);
+}
+
+QRCodeDlg* QRCodeDlg::Create(wxWindow *parent, const StringX &data, const wxString &dlgTitle,
+                     const int seconds, const wxPoint &pos,
+                     const wxSize &size, long style, const wxString &name)
+{
+  return new QRCodeDlg(parent, data, dlgTitle, seconds, pos, size, style, name);
 }
 
 void QRCodeDlg::CreateControls(const StringX &data)
@@ -148,8 +156,7 @@ public:
     }
     else
     {
-      QRCodeDlg dlg(nullptr, StringX(argv[1]), "Scan this QR Code and comapre with the program argument");
-      dlg.ShowModal();
+      ShowModalAndGetResult<QRCodeDlg>(this, StringX(argv[1]), "Scan this QR Code and comapre with the program argument");
       // Normall we return true here
       return false;
     }

--- a/src/ui/wxWidgets/QRCodeDlg.h
+++ b/src/ui/wxWidgets/QRCodeDlg.h
@@ -35,7 +35,7 @@ class QRCodeDlg : public wxDialog
   void UpdateTimeRemaining();
 
 public:
-  QRCodeDlg(wxWindow* parent,
+  static QRCodeDlg* Create(wxWindow *parent, 
             const StringX &data,
             const wxString& title,
             const int seconds = 15,
@@ -45,7 +45,11 @@ public:
             const wxString &name=wxDialogNameStr);
 
   ~QRCodeDlg() = default;
-
+protected:
+  QRCodeDlg(wxWindow *parent, const StringX &data, const wxString& title,
+            const int seconds, 
+            const wxPoint &pos, const wxSize &size, long style,
+            const wxString &name);
   //void OnInitDialog(wxInitDialogEvent& evt)  override;
   //void OnRelayoutDlg(wxCommandEvent& evt)  override;  
   void CreateControls(const StringX &data);

--- a/src/ui/wxWidgets/QueryCancelDlg.cpp
+++ b/src/ui/wxWidgets/QueryCancelDlg.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2003-2021 Rony Shapiro <ronys@pwsafe.org>.
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+
+/** \file pwFiltersBoolDlg.cpp
+*
+*/
+
+// For compilers that support precompilation, includes "wx/wx.h".
+#include "wx/wxprec.h"
+
+#ifndef WX_PRECOMP
+#include "wx/wx.h"
+#endif
+
+#include "QueryCancelDlg.h"
+#include "wxUtilities.h"
+
+void QueryCancelDlg::OnClose(wxCloseEvent &event) {
+  if (event.CanVeto()) {
+    // when trying to closing app/db, don't ask questions when data changed
+    if (!SyncAndQueryCancel(!IsCloseInProgress())) {
+      event.Veto();
+      return;
+    }
+  }
+  EndDialog(wxID_CANCEL); // cancel directly (if we skip event, OnCancel will be called and ask one more time)
+}
+
+void QueryCancelDlg::OnCancelClick(wxCommandEvent& /*event*/) {
+  if (SyncAndQueryCancel(true)) {
+    EndModal(wxID_CANCEL);
+  }
+}
+
+/**
+ * Check if something changes and ask to discard changes
+ @return true, if cancel allowed
+*/
+bool QueryCancelDlg::SyncAndQueryCancel(bool showDialog) {
+  if (!(Validate() && TransferDataFromWindow()) || IsChanged()) {
+    if (showDialog) {
+      auto res = wxMessageDialog(
+        nullptr,
+        _("One or more preferences have been changed. Are you sure you wish to cancel?"), wxEmptyString,
+        wxYES_NO | wxNO_DEFAULT | wxICON_EXCLAMATION
+      ).ShowModal();
+      if (res == wxID_YES) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return true;
+}
+

--- a/src/ui/wxWidgets/QueryCancelDlg.cpp
+++ b/src/ui/wxWidgets/QueryCancelDlg.cpp
@@ -46,7 +46,7 @@ bool QueryCancelDlg::SyncAndQueryCancel(bool showDialog) {
     if (showDialog) {
       auto res = wxMessageDialog(
         nullptr,
-        _("One or more preferences have been changed. Are you sure you wish to cancel?"), wxEmptyString,
+        _("Unsaved changes have been made. Are you sure you wish to cancel?"), wxEmptyString,
         wxYES_NO | wxNO_DEFAULT | wxICON_EXCLAMATION
       ).ShowModal();
       if (res == wxID_YES) {

--- a/src/ui/wxWidgets/QueryCancelDlg.h
+++ b/src/ui/wxWidgets/QueryCancelDlg.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2003-2021 Rony Shapiro <ronys@pwsafe.org>.
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+
+/** \file QueryCancelDlg.h
+*/
+
+#ifndef _QUERYCANCELDLG_H_
+#define _QUERYCANCELDLG_H_
+
+/*!
+ * Includes
+ */
+
+#include <wx/dialog.h>
+
+/*!
+ * QueryCancelDlg class declaration
+ */
+
+class QueryCancelDlg : public wxDialog
+{
+public:
+  virtual void OnCancelClick(wxCommandEvent& event);
+  virtual void OnClose(wxCloseEvent& event);
+  virtual bool SyncAndQueryCancel(bool showDialog);
+  virtual bool IsChanged() const = 0;
+};
+
+#endif // _QUERYCANCELDLG_H_

--- a/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
@@ -66,22 +66,13 @@ END_EVENT_TABLE()
  * SafeCombinationChangeDlg constructors
  */
 
-SafeCombinationChangeDlg::SafeCombinationChangeDlg(wxWindow* parent, PWScore &core,
+SafeCombinationChangeDlg::SafeCombinationChangeDlg(wxWindow *parent, PWScore &core,
                                                wxWindowID id, const wxString& caption,
                                                const wxPoint& pos,
                                                const wxSize& size, long style)
 : m_core(core)
 {
-  Init();
-  Create(parent, id, caption, pos, size, style);
-}
-
-/*!
- * SafeCombinationChangeDlg creator
- */
-
-bool SafeCombinationChangeDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
+  wxASSERT(!parent || parent->IsTopLevel());
 ////@begin SafeCombinationChangeDlg creation
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create( parent, id, caption, pos, size, style );
@@ -103,7 +94,13 @@ bool SafeCombinationChangeDlg::Create( wxWindow* parent, wxWindowID id, const wx
   m_pollingTimer = new wxTimer(this, YubiMixin::POLLING_TIMER_ID);
   m_pollingTimer->Start(2*YubiMixin::POLLING_INTERVAL); // 2 controls
 #endif
-  return true;
+}
+
+
+SafeCombinationChangeDlg* SafeCombinationChangeDlg::Create(wxWindow *parent, PWScore &core,
+  wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style)
+{
+  return new SafeCombinationChangeDlg(parent, core, id, caption, pos, size, style);
 }
 
 /*!
@@ -117,24 +114,6 @@ SafeCombinationChangeDlg::~SafeCombinationChangeDlg()
 #ifndef NO_YUBI
   delete m_pollingTimer;
 #endif
-}
-
-/*!
- * Member initialisation
- */
-
-void SafeCombinationChangeDlg::Init()
-{
-////@begin SafeCombinationChangeDlg member initialisation
-  m_oldPasswdEntry = nullptr;
-  m_newPasswdEntry = nullptr;
-  m_confirmEntry = nullptr;
-#ifndef NO_YUBI
-  m_YubiBtn = nullptr;
-  m_YubiBtn2 = nullptr;
-  m_yubiStatusCtrl = nullptr;
-#endif
-////@end SafeCombinationChangeDlg member initialisation
 }
 
 /*!

--- a/src/ui/wxWidgets/SafeCombinationChangeDlg.h
+++ b/src/ui/wxWidgets/SafeCombinationChangeDlg.h
@@ -69,17 +69,13 @@ class SafeCombinationChangeDlg : public wxDialog
 
 public:
   /// Constructors
-  SafeCombinationChangeDlg(wxWindow* parent, PWScore &core,
+  static SafeCombinationChangeDlg* Create(wxWindow *parent, PWScore &core,
                          wxWindowID id = SYMBOL_SAFECOMBINATIONCHANGEDLG_IDNAME, const wxString& caption = SYMBOL_SAFECOMBINATIONCHANGEDLG_TITLE, const wxPoint& pos = SYMBOL_SAFECOMBINATIONCHANGEDLG_POSITION, const wxSize& size = SYMBOL_SAFECOMBINATIONCHANGEDLG_SIZE, long style = SYMBOL_SAFECOMBINATIONCHANGEDLG_STYLE );
-
-  /// Creation
-  bool Create(wxWindow* parent, wxWindowID id = SYMBOL_SAFECOMBINATIONCHANGEDLG_IDNAME, const wxString& caption = SYMBOL_SAFECOMBINATIONCHANGEDLG_TITLE, const wxPoint& pos = SYMBOL_SAFECOMBINATIONCHANGEDLG_POSITION, const wxSize& size = SYMBOL_SAFECOMBINATIONCHANGEDLG_SIZE, long style = SYMBOL_SAFECOMBINATIONCHANGEDLG_STYLE );
-
   /// Destructor
   ~SafeCombinationChangeDlg();
-
-  /// Initialises member variables
-  void Init();
+protected:
+  /// Constructors
+  SafeCombinationChangeDlg(wxWindow *parent, PWScore &core, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style);
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -92,8 +88,7 @@ public:
 
   /// wxEVT_COMMAND_BUTTON_CLICKED event handler for ID_YUBIBTN2
   void OnYubibtn2Click( wxCommandEvent& event );
-  bool IsYubiProtected() const {return m_IsYubiProtected;}
-#endif
+#endif // NO_YUBI
 
   /// wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_OK
   void OnOkClick( wxCommandEvent& event );
@@ -105,7 +100,7 @@ public:
   void OnPollingTimer(wxTimerEvent& timerEvent);
 
 ////@begin SafeCombinationChangeDlg member function declarations
-
+public:
   StringX GetConfirm() const { return m_confirm ; }
   void SetConfirm(StringX value) { m_confirm = value ; }
 
@@ -124,16 +119,21 @@ public:
 
   /// Should we show tooltips?
   static bool ShowToolTips();
-
-////@begin SafeCombinationChangeDlg member variables
-  SafeCombinationCtrl* m_oldPasswdEntry;
-  SafeCombinationCtrl* m_newPasswdEntry;
+  
 #ifndef NO_YUBI
-  wxBitmapButton* m_YubiBtn;
-  wxBitmapButton* m_YubiBtn2;
-  wxStaticText* m_yubiStatusCtrl;
+  bool IsYubiProtected() const {return m_IsYubiProtected;}
 #endif
-  SafeCombinationCtrl* m_confirmEntry;
+
+private:
+////@begin SafeCombinationChangeDlg member variables
+  SafeCombinationCtrl* m_oldPasswdEntry = nullptr;
+  SafeCombinationCtrl* m_newPasswdEntry = nullptr;
+#ifndef NO_YUBI
+  wxBitmapButton* m_YubiBtn = nullptr;
+  wxBitmapButton* m_YubiBtn2 = nullptr;
+  wxStaticText* m_yubiStatusCtrl = nullptr;
+#endif
+  SafeCombinationCtrl* m_confirmEntry = nullptr;
 private:
   StringX m_confirm;
   StringX m_newpasswd;
@@ -147,7 +147,7 @@ private:
 #ifndef NO_YUBI
   // try having 2 mixin objects to handle things:
   YubiMixin m_yubiMixin1, m_yubiMixin2;
-  wxTimer* m_pollingTimer; // for Yubi
+  wxTimer* m_pollingTimer = nullptr; // for Yubi
   bool m_IsYubiProtected = false; // set if 2nd Yubi button clicked. Clear YubiSK on OK if false.
 #endif
 };

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.h
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.h
@@ -75,18 +75,18 @@ class SafeCombinationEntryDlg: public wxDialog
 
 public:
   /// Constructors
-  SafeCombinationEntryDlg(PWScore &core);
-  SafeCombinationEntryDlg(wxWindow* parent, PWScore &core,
-                          wxWindowID id = SYMBOL_SAFECOMBINATIONENTRYDLG_IDNAME, const wxString& caption = SYMBOL_SAFECOMBINATIONENTRYDLG_TITLE, const wxPoint& pos = SYMBOL_SAFECOMBINATIONENTRYDLG_POSITION, const wxSize& size = SYMBOL_SAFECOMBINATIONENTRYDLG_SIZE, long style = SYMBOL_SAFECOMBINATIONENTRYDLG_STYLE );
-
-  /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_SAFECOMBINATIONENTRYDLG_IDNAME, const wxString& caption = SYMBOL_SAFECOMBINATIONENTRYDLG_TITLE, const wxPoint& pos = SYMBOL_SAFECOMBINATIONENTRYDLG_POSITION, const wxSize& size = SYMBOL_SAFECOMBINATIONENTRYDLG_SIZE, long style = SYMBOL_SAFECOMBINATIONENTRYDLG_STYLE );
+  static SafeCombinationEntryDlg* Create(wxWindow *parent, PWScore &core,
+    wxWindowID id = SYMBOL_SAFECOMBINATIONENTRYDLG_IDNAME, 
+    const wxString& caption = SYMBOL_SAFECOMBINATIONENTRYDLG_TITLE, 
+    const wxPoint& pos = SYMBOL_SAFECOMBINATIONENTRYDLG_POSITION, 
+    const wxSize& size = SYMBOL_SAFECOMBINATIONENTRYDLG_SIZE, 
+    long style = SYMBOL_SAFECOMBINATIONENTRYDLG_STYLE);
 
   /// Destructor
   ~SafeCombinationEntryDlg();
-
-  /// Initialises member variables
-  void Init();
+protected:
+  SafeCombinationEntryDlg(wxWindow *parent, PWScore &core,
+    wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style);
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -127,7 +127,7 @@ public:
   void OnDBSelectionChange( wxCommandEvent& event );
 
 ////@begin SafeCombinationEntryDlg member function declarations
-
+public:
   StringX GetPassword() const { return m_password ; }
   void SetPassword(StringX value) { m_password = value ; }
 
@@ -140,27 +140,29 @@ public:
 
   /// Should we show tooltips?
   static bool ShowToolTips();
-
-  wxStaticText* m_version;
-  wxComboBox* m_filenameCB;
-  SafeCombinationCtrl* m_combinationEntry;
+protected:
+  void DoNewDbClick();
+  
+  wxStaticText* m_version = nullptr;
+  wxComboBox* m_filenameCB = nullptr;
+  SafeCombinationCtrl* m_combinationEntry = nullptr;
 
 #ifndef NO_YUBI
-  wxBitmapButton* m_YubiBtn;
-  wxStaticText* m_yubiStatusCtrl;
+  wxBitmapButton* m_YubiBtn = nullptr;
+  wxStaticText* m_yubiStatusCtrl = nullptr;
 #endif
 
 private:
   StringX m_password;
   wxString m_filename;
-  wxString m_ellipsizedFilename;
+  wxString m_ellipsizedFilename = wxEmptyString;
   bool m_readOnly;
   PWScore &m_core;
-  unsigned m_tries;
-  bool m_postInitDone;
+  unsigned m_tries = 0;
+  bool m_postInitDone = false;
 
 #ifndef NO_YUBI
-  wxTimer* m_pollingTimer; // for Yubi, but can't go into mixin :-(
+  wxTimer* m_pollingTimer = nullptr; // for Yubi, but can't go into mixin :-(
   // Not strictly yubi, but refactored to work with it:
 #endif
   void ProcessPhrase();

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -69,7 +69,7 @@ END_EVENT_TABLE()
  * SafeCombinationPromptDlg constructors
  */
 
-SafeCombinationPromptDlg::SafeCombinationPromptDlg(wxWindow* parent, PWScore &core,
+SafeCombinationPromptDlg::SafeCombinationPromptDlg(wxWindow *parent, PWScore &core,
                                                const wxString &fname, const bool allowExit,
                                                wxWindowID id,
                                                const wxString& caption,
@@ -77,16 +77,7 @@ SafeCombinationPromptDlg::SafeCombinationPromptDlg(wxWindow* parent, PWScore &co
                                                const wxSize& size, long style)
 : m_core(core), m_filename(fname), m_tries(0), m_allowExit(allowExit)
 {
-  Init();
-  Create(parent, id, caption, pos, size, style);
-}
-
-/*!
- * SafeCombinationPromptDlg creator
- */
-
-bool SafeCombinationPromptDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
+  wxASSERT(!parent || parent->IsTopLevel());
 ////@begin SafeCombinationPromptDlg creation
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create( parent, id, caption, pos, size, style );
@@ -105,7 +96,17 @@ bool SafeCombinationPromptDlg::Create( wxWindow* parent, wxWindowID id, const wx
   m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
   m_pollingTimer->Start(YubiMixin::POLLING_INTERVAL);
 #endif
-  return true;
+}
+
+
+SafeCombinationPromptDlg* SafeCombinationPromptDlg::Create(wxWindow *parent, PWScore &core,
+                                               const wxString &fname, const bool allowExit,
+                                               wxWindowID id,
+                                               const wxString& caption,
+                                               const wxPoint& pos,
+                                               const wxSize& size, long style)
+{
+  return new SafeCombinationPromptDlg(parent, core, fname, allowExit, id, caption, pos, size, style);
 }
 
 /*!
@@ -119,22 +120,6 @@ SafeCombinationPromptDlg::~SafeCombinationPromptDlg()
 #ifndef NO_YUBI
   delete m_pollingTimer;
 #endif
-}
-
-/*!
- * Member initialisation
- */
-
-void SafeCombinationPromptDlg::Init()
-{
-////@begin SafeCombinationPromptDlg member initialisation
-  m_scctrl = nullptr;
-#ifndef NO_YUBI
-  m_YubiBtn = nullptr;
-  m_yubiStatusCtrl = nullptr;
-#endif
-
-////@end SafeCombinationPromptDlg member initialisation
 }
 
 /*!

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.h
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.h
@@ -69,24 +69,21 @@ class SafeCombinationPromptDlg : public wxDialog
   DECLARE_CLASS( SafeCombinationPromptDlg )
   DECLARE_EVENT_TABLE()
 
+
 public:
-  /// Constructors
-  SafeCombinationPromptDlg(wxWindow* parent, PWScore &core, const wxString &fname, const bool allowExit = true,
+  static SafeCombinationPromptDlg* Create(wxWindow *parent, PWScore &core, const wxString &fname, const bool allowExit = true,
                          wxWindowID id = SYMBOL_SAFECOMBINATIONPROMPTDLG_IDNAME, const wxString& caption = SYMBOL_SAFECOMBINATIONPROMPTDLG_TITLE, const wxPoint& pos = SYMBOL_SAFECOMBINATIONPROMPTDLG_POSITION, const wxSize& size = SYMBOL_SAFECOMBINATIONPROMPTDLG_SIZE, long style = SYMBOL_SAFECOMBINATIONPROMPTDLG_STYLE );
+   /// Destructor
+~SafeCombinationPromptDlg();
 
-  /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_SAFECOMBINATIONPROMPTDLG_IDNAME, const wxString& caption = SYMBOL_SAFECOMBINATIONPROMPTDLG_TITLE, const wxPoint& pos = SYMBOL_SAFECOMBINATIONPROMPTDLG_POSITION, const wxSize& size = SYMBOL_SAFECOMBINATIONPROMPTDLG_SIZE, long style = SYMBOL_SAFECOMBINATIONPROMPTDLG_STYLE );
-
-  /// Destructor
-  ~SafeCombinationPromptDlg();
-
-  /// Initialises member variables
-  void Init();
+  StringX GetPassword() const {return m_password;}
+protected:
+  /// Constructors
+  SafeCombinationPromptDlg(wxWindow *parent, PWScore &core, const wxString &fname, const bool allowExit,
+    wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style);
 
   /// Creates the controls and sizers
   void CreateControls();
-
-  StringX GetPassword() const {return m_password;}
 
 ////@begin SafeCombinationPromptDlg event handler declarations
 
@@ -123,7 +120,7 @@ public:
   static bool ShowToolTips();
 
 ////@begin SafeCombinationPromptDlg member variables
-  SafeCombinationCtrl* m_scctrl;
+  SafeCombinationCtrl* m_scctrl = nullptr;
 ////@end SafeCombinationPromptDlg member variables
   PWScore &m_core;
   wxString m_filename;
@@ -133,9 +130,9 @@ public:
   bool m_allowExit;
   
 #ifndef NO_YUBI
-  wxBitmapButton* m_YubiBtn;
-  wxStaticText* m_yubiStatusCtrl;
-  wxTimer* m_pollingTimer; // for Yubi, but can't go into mixin :-(
+  wxBitmapButton* m_YubiBtn = nullptr;
+  wxStaticText* m_yubiStatusCtrl = nullptr;
+  wxTimer* m_pollingTimer = nullptr; // for Yubi, but can't go into mixin :-(
 #endif
 
   void ProcessPhrase();

--- a/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
@@ -67,24 +67,9 @@ END_EVENT_TABLE()
 /*!
  * SafeCombinationSetupDlg constructors
  */
-
-SafeCombinationSetupDlg::SafeCombinationSetupDlg()
+SafeCombinationSetupDlg::SafeCombinationSetupDlg(wxWindow *parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
 {
-  Init();
-}
-
-SafeCombinationSetupDlg::SafeCombinationSetupDlg( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
-  Init();
-  Create(parent, id, caption, pos, size, style);
-}
-
-/*!
- * SafeCombinationSetupDlg creator
- */
-
-bool SafeCombinationSetupDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
+  wxASSERT(!parent || parent->IsTopLevel());
 ////@begin SafeCombinationSetupDlg creation
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create( parent, id, caption, pos, size, style );
@@ -101,7 +86,11 @@ bool SafeCombinationSetupDlg::Create( wxWindow* parent, wxWindowID id, const wxS
   m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
   m_pollingTimer->Start(YubiMixin::POLLING_INTERVAL);
 #endif
-  return true;
+}
+
+SafeCombinationSetupDlg* SafeCombinationSetupDlg::Create(wxWindow *parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
+{
+  return new SafeCombinationSetupDlg(parent, id, caption, pos, size, style);
 }
 
 /*!
@@ -115,20 +104,6 @@ SafeCombinationSetupDlg::~SafeCombinationSetupDlg()
 #ifndef NO_YUBI
   delete m_pollingTimer;
 #endif
-}
-
-/*!
- * Member initialisation
- */
-
-void SafeCombinationSetupDlg::Init()
-{
-////@begin SafeCombinationSetupDlg member initialisation
-#ifndef NO_YUBI
-  m_YubiBtn = nullptr;
-  m_yubiStatusCtrl = nullptr;
-#endif
-////@end SafeCombinationSetupDlg member initialisation
 }
 
 /*!

--- a/src/ui/wxWidgets/SafeCombinationSetupDlg.h
+++ b/src/ui/wxWidgets/SafeCombinationSetupDlg.h
@@ -70,23 +70,18 @@ class SafeCombinationSetupDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
-  /// Constructors
-  SafeCombinationSetupDlg();
-  SafeCombinationSetupDlg( wxWindow* parent, wxWindowID id = SYMBOL_SAFECOMBINATIONSETUPDLG_IDNAME, const wxString& caption = SYMBOL_SAFECOMBINATIONSETUPDLG_TITLE, const wxPoint& pos = SYMBOL_SAFECOMBINATIONSETUPDLG_POSITION, const wxSize& size = SYMBOL_SAFECOMBINATIONSETUPDLG_SIZE, long style = SYMBOL_SAFECOMBINATIONSETUPDLG_STYLE );
-
-  /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_SAFECOMBINATIONSETUPDLG_IDNAME, const wxString& caption = SYMBOL_SAFECOMBINATIONSETUPDLG_TITLE, const wxPoint& pos = SYMBOL_SAFECOMBINATIONSETUPDLG_POSITION, const wxSize& size = SYMBOL_SAFECOMBINATIONSETUPDLG_SIZE, long style = SYMBOL_SAFECOMBINATIONSETUPDLG_STYLE );
+  static SafeCombinationSetupDlg* Create(wxWindow *parent, wxWindowID id = SYMBOL_SAFECOMBINATIONSETUPDLG_IDNAME, const wxString& caption = SYMBOL_SAFECOMBINATIONSETUPDLG_TITLE, const wxPoint& pos = SYMBOL_SAFECOMBINATIONSETUPDLG_POSITION, const wxSize& size = SYMBOL_SAFECOMBINATIONSETUPDLG_SIZE, long style = SYMBOL_SAFECOMBINATIONSETUPDLG_STYLE );
 
   /// Destructor
   ~SafeCombinationSetupDlg();
-
-  /// Initialises member variables
-  void Init();
+  wxString GetPassword() const {return m_password;}
+protected:
+  /// Constructors
+  SafeCombinationSetupDlg(wxWindow *parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style);
+  SafeCombinationSetupDlg() = default;
 
   /// Creates the controls and sizers
   void CreateControls();
-
-  wxString GetPassword() const {return m_password;}
 
   ////@begin SafeCombinationSetupDlg event handler declarations
 
@@ -116,14 +111,14 @@ public:
 
 ////@begin SafeCombinationSetupDlg member variables
 #ifndef NO_YUBI
-  wxBitmapButton* m_YubiBtn;
-  wxStaticText* m_yubiStatusCtrl;
+  wxBitmapButton* m_YubiBtn = nullptr;
+  wxStaticText* m_yubiStatusCtrl = nullptr;
 #endif
 ////@end SafeCombinationSetupDlg member variables
  private:
 
 #ifndef NO_YUBI
-  wxTimer* m_pollingTimer; // for Yubi, but can't go into mixin :-(
+  wxTimer* m_pollingTimer = nullptr; // for Yubi, but can't go into mixin :-(
 #endif
   wxString m_password;
   wxString m_verify;

--- a/src/ui/wxWidgets/SelectAliasDlg.cpp
+++ b/src/ui/wxWidgets/SelectAliasDlg.cpp
@@ -213,14 +213,7 @@ void SelectTreeCtrl::OnMouseRightClick(wxMouseEvent& event)
  * SelectAliasDlg constructors
  */
 
-
-SelectAliasDlg::SelectAliasDlg() : m_Core(nullptr), m_Item(nullptr), m_BaseItem(nullptr)
-{
-  Init();
-}
-
-SelectAliasDlg::SelectAliasDlg(wxWindow* parent,
-                             PWScore *core,
+SelectAliasDlg::SelectAliasDlg(wxWindow *parent, PWScore *core,
                              CItemData *item,
                              CItemData **pbci,
                              wxWindowID id, const wxString& caption,
@@ -229,53 +222,8 @@ SelectAliasDlg::SelectAliasDlg(wxWindow* parent,
                                             m_Item(item),
                                             m_BaseItem(pbci)
 {
-  Init();
-  Create(parent, id, caption, pos, size, style);
-}
+  wxASSERT(!parent || parent->IsTopLevel());
 
-
-/*!
- * SelectAliasDlg creator
- */
-
-bool SelectAliasDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
-////@begin SelectAliasDlg creation
-  SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY|wxWS_EX_BLOCK_EVENTS);
-  wxDialog::Create( parent, id, caption, pos, size, style );
-
-  CreateControls();
-  if (GetSizer())
-  {
-    GetSizer()->SetSizeHints(this);
-  }
-  Centre();
-////@end SelectAliasDlg creation
-  return true;
-}
-
-
-/*!
- * SelectAliasDlg destructor
- */
-
-SelectAliasDlg::~SelectAliasDlg()
-{
-////@begin SelectAliasDlg destruction
-////@end SelectAliasDlg destruction
-}
-
-
-/*!
- * Member initialisation
- */
-
-void SelectAliasDlg::Init()
-{
-////@begin SelectAliasDlg member initialisation
-  m_AliasName = _T("");
-  m_Tree = nullptr;
-  m_AliasBaseTextCtrl = nullptr;
   if(m_Core && m_Item && m_BaseItem) {
     CItemData *pbci = m_Core->GetBaseEntry(m_Item);
     if(pbci) {
@@ -287,9 +235,28 @@ void SelectAliasDlg::Init()
       *m_BaseItem = pbci;
     }
   }
-////@end SelectAliasDlg member initialisation
+  ////@begin SelectAliasDlg creation
+  SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY|wxWS_EX_BLOCK_EVENTS);
+  wxDialog::Create( parent, id, caption, pos, size, style );
+
+  CreateControls();
+  if (GetSizer())
+  {
+    GetSizer()->SetSizeHints(this);
+  }
+  Centre();
+////@end SelectAliasDlg creation
 }
 
+SelectAliasDlg* SelectAliasDlg::Create(wxWindow *parent, PWScore *core,
+                             CItemData *item,
+                             CItemData **pbci,
+                             wxWindowID id, const wxString& caption,
+                             const wxPoint& pos, const wxSize& size,
+                             long style)
+{
+  return new SelectAliasDlg(parent, core, item, pbci, id, caption, pos, size, style);
+}
 
 /*!
  * Control creation for SelectAliasDlg
@@ -579,16 +546,16 @@ void SelectTreeCtrl::OnCollapseAll(wxCommandEvent& evt)
   }
 }
 
-void SelectTreeCtrl::OnViewClick(wxCommandEvent& evt)
+void SelectTreeCtrl::OnViewClick(wxCommandEvent&)
+{
+  CallAfter(&SelectTreeCtrl::DoViewClick);
+}
+
+void SelectTreeCtrl::DoViewClick()
 {
   if(m_menu_item) {
     CItemData item = *m_menu_item;
     item.SetProtected(true);
-    AddEditPropSheetDlg dialog(
-      this, m_core,
-      AddEditPropSheetDlg::SheetType::VIEW,
-      &item
-    );
-    (void) dialog.ShowModal();
+    ShowModalAndGetResult<AddEditPropSheetDlg>(this, m_core, AddEditPropSheetDlg::SheetType::VIEW, &item);
   }
 }

--- a/src/ui/wxWidgets/SelectAliasDlg.h
+++ b/src/ui/wxWidgets/SelectAliasDlg.h
@@ -99,6 +99,7 @@ public:
   
   void SetCurrentMenuItem(const CItemData *pci) { m_menu_item = pci; };
 
+  void DoViewClick();
 private:
   const CItemData* m_menu_item;
 };
@@ -113,19 +114,19 @@ class SelectAliasDlg : public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
-  /// Constructors
-  SelectAliasDlg();
-  SelectAliasDlg( wxWindow* parent, PWScore *core, CItemData *item, CItemData **pbci,
-                  wxWindowID id = SYMBOL_SELECTALIAS_IDNAME, const wxString& caption = SYMBOL_SELECTALIAS_TITLE, const wxPoint& pos = SYMBOL_SELECTALIAS_POSITION, const wxSize& size = SYMBOL_SELECTALIAS_SIZE, long style = SYMBOL_SELECTALIAS_STYLE );
-
-  /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_SELECTALIAS_IDNAME, const wxString& caption = SYMBOL_SELECTALIAS_TITLE, const wxPoint& pos = SYMBOL_SELECTALIAS_POSITION, const wxSize& size = SYMBOL_SELECTALIAS_SIZE, long style = SYMBOL_SELECTALIAS_STYLE );
+  static SelectAliasDlg* Create(wxWindow *parent, PWScore *core, CItemData *item, CItemData **pbci,
+    wxWindowID id = SYMBOL_SELECTALIAS_IDNAME, const wxString& caption = SYMBOL_SELECTALIAS_TITLE, const wxPoint& pos = SYMBOL_SELECTALIAS_POSITION, const wxSize& size = SYMBOL_SELECTALIAS_SIZE, long style = SYMBOL_SELECTALIAS_STYLE );
 
   /// Destructor
-  ~SelectAliasDlg();
-
-  /// Initialises member variables
-  void Init();
+  ~SelectAliasDlg() = default;
+  void UpdateSelChanged(CItemData *pci);
+    /// Centralized handling of right click in the grid or the tree view
+  void OnContextMenu(const CItemData* item);
+protected:
+  /// Constructors
+  SelectAliasDlg() = default;
+  SelectAliasDlg(wxWindow *parent, PWScore *core, CItemData *item, CItemData **pbci,
+    wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style);
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -156,25 +157,20 @@ public:
 
   /// Should we show tooltips?
   static bool ShowToolTips();
-  
-  void UpdateSelChanged(CItemData *pci);
-  /// Centralized handling of right click in the grid or the tree view
-  void OnContextMenu(const CItemData* item);
-  
 ////@end SelectAliasDlg member function declarations
 
 ////@begin SelectAliasDlg member variables
 private:
   void InitDialog();
   
-  PWScore *m_Core;
-  CItemData *m_Item;
-  CItemData **m_BaseItem;
+  PWScore *m_Core = nullptr;
+  CItemData *m_Item = nullptr;
+  CItemData **m_BaseItem = nullptr;
 
   wxString m_AliasName;
-  wxTextCtrl *m_AliasBaseTextCtrl;
+  wxTextCtrl *m_AliasBaseTextCtrl = nullptr;
 
-  SelectTreeCtrl *m_Tree;
+  SelectTreeCtrl *m_Tree = nullptr;
 ////@end SelectAliasDlg member variables
 };
 

--- a/src/ui/wxWidgets/SetFiltersDlg.cpp
+++ b/src/ui/wxWidgets/SetFiltersDlg.cpp
@@ -65,23 +65,10 @@ END_EVENT_TABLE()
 /*!
  * SetFiltersDlg constructors
  */
-
-SetFiltersDlg::SetFiltersDlg() : m_pfilters(nullptr),
-                                 m_currentFilters(nullptr),
-                                 m_bCanHaveAttachments(false),
-                                 m_psMediaTypes(nullptr),
-                                 m_filtertype(DFTYPE_INVALID),
-                                 m_filterpool(FPOOL_LAST),
-                                 m_AppliedCalled(nullptr)
-{
-  Init();
-}
-
-SetFiltersDlg::SetFiltersDlg(wxWindow* parent,
-                             st_filters *pfilters,
+SetFiltersDlg::SetFiltersDlg(wxWindow *parent, st_filters *pfilters,
                              st_filters *currentFilters,
                              bool *appliedCalled,
-                             const FilterType &filtertype,
+                             const FilterType filtertype,
                              const FilterPool filterpool,
                              const bool bCanHaveAttachments,
                              const std::set<StringX> *psMediaTypes,
@@ -97,9 +84,13 @@ SetFiltersDlg::SetFiltersDlg(wxWindow* parent,
                                             m_filterpool(filterpool),
                                             m_AppliedCalled(appliedCalled)
 {
+  wxASSERT(!parent || parent->IsTopLevel());
+
   wxString heading(caption);
   
-  Init();
+  ASSERT(m_pfilters);
+  m_filterName = towxstring(m_pfilters->fname);
+  
   switch(filtertype) {
     case DFTYPE_PWHISTORY:
       heading = SYMBOL_SETFILTERS_PWHIST_TITLE;
@@ -117,16 +108,7 @@ SetFiltersDlg::SetFiltersDlg(wxWindow* parent,
         heading = SYMBOL_SETFILTERS_TITLE;
       break;
   }
-  Create(parent, id, heading, pos, size, style);
-}
 
-
-/*!
- * SetFiltersDlg creator
- */
-
-bool SetFiltersDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
 ////@begin SetFiltersDlg creation
   SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY|wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create( parent, id, caption, pos, size, style );
@@ -147,34 +129,16 @@ bool SetFiltersDlg::Create( wxWindow* parent, wxWindowID id, const wxString& cap
     Move(x + SET_FILTER_WINDOW_OFFSET, y + SET_FILTER_WINDOW_OFFSET);
   }
 ////@end SetFiltersDlg creation
-  return true;
 }
 
-
-/*!
- * SetFiltersDlg destructor
- */
-
-SetFiltersDlg::~SetFiltersDlg()
+SetFiltersDlg* SetFiltersDlg::Create(wxWindow *parent, st_filters *pfilters, st_filters *currentFilters, 
+  bool *appliedCalled, const FilterType filtertype, FilterPool filterpool, 
+  const bool bCanHaveAttachments, const std::set<StringX> *psMediaTypes, wxWindowID id, 
+  const wxString& caption, const wxPoint& pos, const wxSize& size, long style)
 {
-////@begin SetFiltersDlg destruction
-////@end SetFiltersDlg destruction
+  return new SetFiltersDlg(parent, pfilters, currentFilters, appliedCalled, filtertype, filterpool, 
+                           bCanHaveAttachments, psMediaTypes, id, caption, pos, size, style);
 }
-
-
-/*!
- * Member initialisation
- */
-
-void SetFiltersDlg::Init()
-{
-////@begin SetFiltersDlg member initialisation
-  m_filterGrid = NULL;
-  ASSERT(m_pfilters);
-  m_filterName = towxstring(m_pfilters->fname);
-////@end SetFiltersDlg member initialisation
-}
-
 
 /*!
  * Control creation for SetFiltersDlg

--- a/src/ui/wxWidgets/SetFiltersDlg.h
+++ b/src/ui/wxWidgets/SetFiltersDlg.h
@@ -24,6 +24,7 @@
 #include "core/core.h"
 
 #include "PWFiltersGrid.h"
+#include "QueryCancelDlg.h"
 ////@end includes
 
 /*!
@@ -58,7 +59,7 @@ class pwFiltersGrid;
  * SetFiltersDlg class declaration
  */
 
-class SetFiltersDlg: public wxDialog
+class SetFiltersDlg: public QueryCancelDlg
 {    
   DECLARE_DYNAMIC_CLASS( SetFilters )
   DECLARE_EVENT_TABLE()
@@ -86,12 +87,8 @@ public:
   /// wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_OK
   void OnOkClick( wxCommandEvent& event );
 
-  /// wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_CANCEL
-  void OnCancelClick( wxCommandEvent& event );
-
   /// wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_HELP
   void OnHelpClick( wxCommandEvent& event );
-
 ////@end SetFiltersDlg event handler declarations
 
 ////@begin SetFiltersDlg member function declarations
@@ -116,8 +113,11 @@ public:
   
 private:
   bool VerifyFilters();
+  bool SyncAndQueryCancel(bool showDialog) override;
+  bool IsChanged() const override;
    
   st_filters *m_pfilters = nullptr;           // The filter to change
+  st_filters m_origFilters;                   // Copy of filter to detect changes
   st_filters *m_currentFilters = nullptr;     // The filter to be set for Apply
   const bool m_bCanHaveAttachments = false; // Version V4 includes attachments
   const std::set<StringX> *m_psMediaTypes = nullptr;  // Attachement media types, present in current data base

--- a/src/ui/wxWidgets/SetFiltersDlg.h
+++ b/src/ui/wxWidgets/SetFiltersDlg.h
@@ -64,19 +64,16 @@ class SetFiltersDlg: public wxDialog
   DECLARE_EVENT_TABLE()
 
 public:
-  /// Constructors
-  SetFiltersDlg();
-  SetFiltersDlg( wxWindow* parent, st_filters *pfilters, st_filters *currentFilters, bool *appliedCalled,
-                const FilterType &filtertype = DFTYPE_MAIN, FilterPool filterpool = FPOOL_LAST, const bool bCanHaveAttachments = false, const std::set<StringX> *psMediaTypes = NULL, wxWindowID id = SYMBOL_SETFILTERS_IDNAME, const wxString& caption = SYMBOL_SETFILTERS_TITLE, const wxPoint& pos = SYMBOL_SETFILTERS_POSITION, const wxSize& size = SYMBOL_SETFILTERS_SIZE, long style = SYMBOL_SETFILTERS_STYLE );
-
-  /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_SETFILTERS_IDNAME, const wxString& caption = SYMBOL_SETFILTERS_TITLE, const wxPoint& pos = SYMBOL_SETFILTERS_POSITION, const wxSize& size = SYMBOL_SETFILTERS_SIZE, long style = SYMBOL_SETFILTERS_STYLE );
+  static SetFiltersDlg* Create(wxWindow *parent, st_filters *pfilters, st_filters *currentFilters, bool *appliedCalled,
+    const FilterType filtertype = DFTYPE_MAIN, FilterPool filterpool = FPOOL_LAST, const bool bCanHaveAttachments = false, const std::set<StringX> *psMediaTypes = nullptr, wxWindowID id = SYMBOL_SETFILTERS_IDNAME, const wxString& caption = SYMBOL_SETFILTERS_TITLE, const wxPoint& pos = SYMBOL_SETFILTERS_POSITION, const wxSize& size = SYMBOL_SETFILTERS_SIZE, long style = SYMBOL_SETFILTERS_STYLE );
 
   /// Destructor
-  ~SetFiltersDlg();
-
-  /// Initialises member variables
-  void Init();
+  ~SetFiltersDlg() = default;
+public:
+  /// Constructors
+  SetFiltersDlg() = default;
+  SetFiltersDlg(wxWindow *parent, st_filters *pfilters, st_filters *currentFilters, bool *appliedCalled,
+                const FilterType filtertype, FilterPool filterpool, const bool bCanHaveAttachments, const std::set<StringX> *psMediaTypes, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style);
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -115,18 +112,18 @@ public:
 ////@end SetFiltersDlg member function declarations
 
 ////@begin SetFiltersDlg member variables
-  pwFiltersGrid* m_filterGrid;
+  pwFiltersGrid* m_filterGrid = nullptr;
   
 private:
   bool VerifyFilters();
    
-  st_filters *m_pfilters;           // The filter to change
-  st_filters *m_currentFilters;     // The filter to be set for Apply
-  const bool m_bCanHaveAttachments; // Version V4 includes attachments
-  const std::set<StringX> *m_psMediaTypes;  // Attachement media types, present in current data base
-  const FilterType m_filtertype;    // Type of filter
-  const FilterPool m_filterpool;    // Filter pool
-  bool  *m_AppliedCalled;           // Mark, when Applied had been called and currentFilters is filled with actual one
+  st_filters *m_pfilters = nullptr;           // The filter to change
+  st_filters *m_currentFilters = nullptr;     // The filter to be set for Apply
+  const bool m_bCanHaveAttachments = false; // Version V4 includes attachments
+  const std::set<StringX> *m_psMediaTypes = nullptr;  // Attachement media types, present in current data base
+  const FilterType m_filtertype = DFTYPE_INVALID;    // Type of filter
+  const FilterPool m_filterpool = FPOOL_LAST;    // Filter pool
+  bool  *m_AppliedCalled = nullptr;           // Mark, when Applied had been called and currentFilters is filled with actual one
   
   wxString m_filterName;
 ////@end SetFiltersDlg member variables

--- a/src/ui/wxWidgets/SyncWizard.cpp
+++ b/src/ui/wxWidgets/SyncWizard.cpp
@@ -48,10 +48,11 @@ struct SyncData {
   SelectionCriteria selCriteria;
   wxFileName        otherDB;
   StringX           combination;
-  PWScore*          core;
+  PWScore*          core = nullptr;
   size_t            numUpdated;
-  CReport           syncReport;
+  std::unique_ptr<CReport> syncReport = std::unique_ptr<CReport>(new CReport());
   bool              showReport;
+  MultiCommands*    syncCmds = nullptr;
 };
 
 /*!
@@ -202,7 +203,6 @@ class SyncStatusPage: public SyncWizardPage
   void Synchronize(PWScore* currentCore, const PWScore* otherCore);
   void ReportAdvancedOptions(CReport* rpt, const wxString& operation);
   void OnSyncStartEvent(wxCommandEvent& evt);
-
 public:
   SyncStatusPage(wxWizard* parent, SyncData* data);
 
@@ -215,6 +215,8 @@ public:
 //
 BEGIN_EVENT_TABLE(SyncWizard, wxWizard)
   EVT_WIZARD_PAGE_CHANGING(wxID_ANY, SyncWizard::OnWizardPageChanging)
+  EVT_CLOSE( SyncWizard::OnClose )
+  EVT_WIZARD_CANCEL(wxID_ANY, SyncWizard::OnWizardCancel)
 END_EVENT_TABLE()
 
 SyncWizard::SyncWizard(wxWindow* parent, PWScore* core, const wxString filename):
@@ -286,7 +288,59 @@ bool SyncWizard::ShowReport() const {
 }
 
 CReport* SyncWizard::GetReport() const {
-  return &m_syncData->syncReport;
+  return m_syncData->syncReport.get();
+}
+
+MultiCommands* SyncWizard::GetSyncCommands() const {
+  return m_syncData->syncCmds;
+}
+
+bool SyncWizard::QueryCancel(bool showDialog) {
+  if (m_syncData->numUpdated > 0) {
+    if (showDialog) {
+      auto res = wxMessageDialog(
+        nullptr,
+        _("One or more items have been changed. Are you sure you wish to cancel?"), wxEmptyString,
+        wxYES_NO | wxNO_DEFAULT | wxICON_EXCLAMATION
+      ).ShowModal();
+      if (res == wxID_YES) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return true;
+}
+
+void SyncWizard::ResetSyncData() {
+  // reset info about changes
+  m_syncData->numUpdated = 0;
+  m_syncData->showReport = false;
+  m_syncData->syncReport = std::unique_ptr<CReport>(new CReport());
+  if (m_syncData->syncCmds) {
+    delete m_syncData->syncCmds;
+  }
+  m_syncData->syncCmds = nullptr;
+}
+
+void SyncWizard::OnClose(wxCloseEvent &event) {
+  if (event.CanVeto()) {
+    // when trying to closing app/db, don't ask questions when data changed
+    if (!QueryCancel(!IsCloseInProgress())) {
+      event.Veto();
+      return;
+    }
+  }
+  EndDialog(wxID_CANCEL); // cancel directly (if we skip event, OnCancel will be called and ask one more time)
+}
+
+void SyncWizard::OnWizardCancel(wxWizardEvent& event) {
+  if (QueryCancel(true)) {
+    event.Skip();
+  }
+  else {
+    event.Veto();
+  }
 }
 
 ////////////////////////////////////////////
@@ -635,7 +689,7 @@ Foreach entry in otherCore
 */
 void SyncStatusPage::Synchronize(PWScore* currentCore, const PWScore *otherCore)
 {
-  CReport& rpt = m_syncData->syncReport;
+  CReport& rpt = *m_syncData->syncReport;
 
   rpt.StartReport(IDSC_RPTSYNCH, currentCore->GetCurFile().c_str());
   wxString line = wxString::Format(_("Synchronizing from database: %ls\n"), otherCore->GetCurFile().c_str());
@@ -742,7 +796,7 @@ void SyncStatusPage::Synchronize(PWScore* currentCore, const PWScore *otherCore)
   Command *pcmd2 = UpdateGUICommand::Create(currentCore, UpdateGUICommand::WN_REDO,
                                             UpdateGUICommand::GUI_REDO_MERGESYNC);
   pmulticmds->Add(pcmd2);
-  currentCore->Execute(pmulticmds);
+  m_syncData->syncCmds = pmulticmds; // will execute later
 
   /* tell the user we're done & provide short merge report */
   const wxString cs_entries = (numUpdated == 1 ? _("entry") : _("entries"));

--- a/src/ui/wxWidgets/SyncWizard.h
+++ b/src/ui/wxWidgets/SyncWizard.h
@@ -31,7 +31,10 @@ class SyncWizard : public wxWizard
 {
   wxWizardPageSimple* m_page1;
   SyncData* m_syncData;
-
+  bool QueryCancel(bool showDialog);
+  void OnWizardCancel(wxWizardEvent& event);
+  void OnClose(wxCloseEvent &event);
+  void ResetSyncData();
 public:
   SyncWizard(wxWindow* parent, PWScore* core, const wxString filename = "");
   ~SyncWizard();
@@ -42,7 +45,8 @@ public:
 
   size_t GetNumUpdated() const;
   bool   ShowReport() const;
-  CReport*   GetReport() const;
+  CReport* GetReport() const;
+  MultiCommands* GetSyncCommands() const;
   void OnWizardPageChanging(wxWizardEvent& evt);
 
   DECLARE_EVENT_TABLE()

--- a/src/ui/wxWidgets/SystemTray.cpp
+++ b/src/ui/wxWidgets/SystemTray.cpp
@@ -135,6 +135,7 @@ wxMenu* SystemTray::CreatePopupMenu()
   if (m_status != TrayStatus::CLOSED) {
     menu->AppendSeparator();
     menu->Append(wxID_CLOSE, _("&Close"))->SetBitmap(wxBitmap(close_xpm));
+    menu->Enable(wxID_CLOSE, m_frame->CanCloseDialogs());
     menu->AppendSubMenu(GetRecentHistory(), _("&Recent Entries History"));
   }
 
@@ -146,7 +147,7 @@ wxMenu* SystemTray::CreatePopupMenu()
   menu->Append(wxID_ABOUT,         _("&About Password Safe..."))->SetBitmap(wxBitmap(about_xpm));
   menu->AppendSeparator();
   menu->Append(wxID_EXIT, _("&Exit"))->SetBitmap(wxBitmap(exit_xpm));
-
+  menu->Enable(wxID_EXIT, m_frame->CanCloseDialogs());
   //let the user iconize even if its already iconized
   if (!m_frame->IsShown())
     menu->Enable(wxID_ICONIZE_FRAME, false);

--- a/src/ui/wxWidgets/SystemTray.cpp
+++ b/src/ui/wxWidgets/SystemTray.cpp
@@ -230,51 +230,53 @@ void SystemTray::OnSysTrayMenuItem(wxCommandEvent& evt)
     else {
       wxCommandEvent cmd(evt.GetEventType(), GetFrameCommandId(opn));
       cmd.SetExtraLong(id);
-#if wxCHECK_VERSION(2,9,0)
       m_frame->GetEventHandler()->ProcessEvent(cmd);
-#else
-      m_frame->ProcessEvent(cmd);
-#endif
     }
   }
   else {
     switch(id) {
-
-      case ID_SYSTRAY_RESTORE:
-        m_frame->UnlockSafe(true, false); // true => restore UI
-        break;
-
-      case ID_SYSTRAY_LOCK:
-        m_frame->HideUI(true);
-        break;
-
-      case ID_SYSTRAY_UNLOCK:
-        m_frame->UnlockSafe(false, false); // false => don't restore UI
-        break;
-
-      case ID_SYSTRAY_CLEAR_RUE:
-        m_frame->ClearRUEList();
-        break;
-
       case wxID_EXIT:
       case ID_CLEARCLIPBOARD:
       case wxID_ABOUT:
       case wxID_CLOSE:
         m_frame->GetEventHandler()->ProcessEvent(evt);
         break;
-
-      case wxID_ICONIZE_FRAME:
-        m_frame->Iconize();
-        break;
-
       default:
+        wxTheApp->CallAfter([this, id](){ ProcessSysTrayMenuItem(id); });
         break;
     }
   }
 }
 
+void SystemTray::ProcessSysTrayMenuItem(int itemId)
+{
+  switch(itemId) {
+    case ID_SYSTRAY_RESTORE:
+      m_frame->UnlockSafe(true, false); // true => restore UI
+      break;
+
+    case ID_SYSTRAY_LOCK:
+      m_frame->HideUI(true);
+      break;
+
+    case ID_SYSTRAY_UNLOCK:
+      m_frame->UnlockSafe(false, false); // false => don't restore UI
+      break;
+
+    case ID_SYSTRAY_CLEAR_RUE:
+      m_frame->ClearRUEList();
+      break;
+
+    case wxID_ICONIZE_FRAME:
+      m_frame->Iconize();
+      break;
+
+    default:
+      break;
+  }
+}
+
 void SystemTray::OnTaskBarLeftDoubleClick(wxTaskBarIconEvent& WXUNUSED(evt))
 {
-  EventHandlerDisabler ehd(this);
-  m_frame->UnlockSafe(true, false); //true => restore UI
+  wxTheApp->CallAfter([this](){ ProcessSysTrayMenuItem(ID_SYSTRAY_RESTORE); });
 }

--- a/src/ui/wxWidgets/SystemTray.cpp
+++ b/src/ui/wxWidgets/SystemTray.cpp
@@ -152,6 +152,14 @@ wxMenu* SystemTray::CreatePopupMenu()
   if (!m_frame->IsShown())
     menu->Enable(wxID_ICONIZE_FRAME, false);
 
+  // whe there are active modal dialogs, we need to reparent menu, so it could process context menu events
+  // "fix" for https://github.com/wxWidgets/wxWidgets/blob/v3.0.5/src/gtk/menu.cpp#L49
+  wxTopLevelWindow *parent = m_frame->GetTopWindow();
+  if (parent) {
+    menu->SetEventHandler(this);
+    parent->PopupMenu(menu, wxPoint(-1, -1));
+    return nullptr;
+  }
   return menu;
 }
 

--- a/src/ui/wxWidgets/SystemTray.h
+++ b/src/ui/wxWidgets/SystemTray.h
@@ -41,6 +41,7 @@ class SystemTray : protected wxTaskBarIcon
   protected:
     //overridden from wxTaskBarIcon, called by framework on r-click
     virtual wxMenu* CreatePopupMenu();
+    void ProcessSysTrayMenuItem(int itemId);
 
   private:
     wxMenu* GetRecentHistory();

--- a/src/ui/wxWidgets/ViewAttachmentDlg.cpp
+++ b/src/ui/wxWidgets/ViewAttachmentDlg.cpp
@@ -31,10 +31,11 @@ BEGIN_EVENT_TABLE(ViewAttachmentDlg, wxDialog)
   //*)
 END_EVENT_TABLE()
 
-ViewAttachmentDlg::ViewAttachmentDlg(wxWindow* parent, wxWindowID id)
+ViewAttachmentDlg::ViewAttachmentDlg(wxWindow *parent, wxWindowID id)
 {
+  wxASSERT(!parent || parent->IsTopLevel());
   //(*Initialize(ViewAttachmentDlg)
-  Create(parent, id, _("View Attachment"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE, _T("ID_VIEWATTACHMENT"));
+  wxDialog::Create(parent, id, _("View Attachment"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE, _T("ID_VIEWATTACHMENT"));
   SetMinSize(wxSize(300,400));
 
   auto *panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
@@ -57,10 +58,9 @@ ViewAttachmentDlg::ViewAttachmentDlg(wxWindow* parent, wxWindowID id)
   //*)
 }
 
-ViewAttachmentDlg::~ViewAttachmentDlg()
+ViewAttachmentDlg* ViewAttachmentDlg::Create(wxWindow *parent, wxWindowID id)
 {
-  //(*Destroy(ViewAttachmentDlg)
-  //*)
+  return new ViewAttachmentDlg(parent, id);
 }
 
 /**

--- a/src/ui/wxWidgets/ViewAttachmentDlg.h
+++ b/src/ui/wxWidgets/ViewAttachmentDlg.h
@@ -29,13 +29,13 @@
 
 class ViewAttachmentDlg: public wxDialog
 {
-  public:
-
-    ViewAttachmentDlg(wxWindow* parent, wxWindowID id = -1);
-    virtual ~ViewAttachmentDlg();
+public:
+    static ViewAttachmentDlg* Create(wxWindow *parent, wxWindowID id = -1);
+    virtual ~ViewAttachmentDlg() = default;
 
     bool LoadImage(const CItemAtt &itemAttachment);
-
+protected:
+    ViewAttachmentDlg(wxWindow *parent, wxWindowID id);
 private:
 
     //(*Handlers(ViewAttachmentDlg)

--- a/src/ui/wxWidgets/ViewReportDlg.cpp
+++ b/src/ui/wxWidgets/ViewReportDlg.cpp
@@ -28,11 +28,12 @@
 #include "ViewReportDlg.h"
 #include "wxUtilities.h"
 
-ViewReportDlg::ViewReportDlg(wxWindow* parent, CReport* pRpt, bool fromFile) :
+ViewReportDlg::ViewReportDlg(wxWindow *parent, CReport* pRpt, bool fromFile) :
                 wxDialog(parent, wxID_ANY, _("View Report"), wxDefaultPosition, wxDefaultSize,
                       wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER),  m_pRpt(pRpt)
 {
   wxASSERT(pRpt);
+  wxASSERT(!parent || parent->IsTopLevel());
 
   wxBoxSizer* dlgSizer = new wxBoxSizer(wxVERTICAL);
 
@@ -69,8 +70,9 @@ ViewReportDlg::ViewReportDlg(wxWindow* parent, CReport* pRpt, bool fromFile) :
   SetSizerAndFit(dlgSizer);
 }
 
-ViewReportDlg::~ViewReportDlg()
+ViewReportDlg* ViewReportDlg::Create(wxWindow *parent, CReport* pRpt, bool fromFile)
 {
+  return new ViewReportDlg(parent, pRpt, fromFile);
 }
 
 void ViewReportDlg::OnSave(wxCommandEvent& evt)

--- a/src/ui/wxWidgets/ViewReportDlg.h
+++ b/src/ui/wxWidgets/ViewReportDlg.h
@@ -22,9 +22,10 @@ class ViewReportDlg : public wxDialog {
   CReport* m_pRpt;
   
 public:
-  ViewReportDlg(wxWindow* pParent, CReport* pRpt, bool fromFile = false);
-  ~ViewReportDlg();
-
+  static ViewReportDlg* Create(wxWindow *parent, CReport* pRpt, bool fromFile = false);
+  ~ViewReportDlg() = default;
+protected:
+  ViewReportDlg(wxWindow *parent, CReport* pRpt, bool fromFile);
   void OnSave(wxCommandEvent& event);
   void OnRemove(wxCommandEvent& event);
   void OnClose(wxCommandEvent& event);

--- a/src/ui/wxWidgets/YubiCfgDlg.cpp
+++ b/src/ui/wxWidgets/YubiCfgDlg.cpp
@@ -67,19 +67,12 @@ END_EVENT_TABLE()
  * YubiCfgDlg constructors
  */
 
-YubiCfgDlg::YubiCfgDlg( wxWindow* parent, PWScore &core, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
+YubiCfgDlg::YubiCfgDlg(wxWindow *parent, PWScore &core, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
 : m_core(core)
 {
+  wxASSERT(!parent || parent->IsTopLevel());
+
   Init();
-  Create(parent, id, caption, pos, size, style);
-}
-
-/*!
- * YubiCfgDlg creator
- */
-
-bool YubiCfgDlg::Create( wxWindow* parent, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-{
 ////@begin YubiCfgDlg creation
   SetExtraStyle(wxWS_EX_BLOCK_EVENTS);
   wxDialog::Create( parent, id, caption, pos, size, style );
@@ -92,7 +85,11 @@ bool YubiCfgDlg::Create( wxWindow* parent, wxWindowID id, const wxString& captio
   Centre();
 ////@end YubiCfgDlg creation
   HideSK();
-  return true;
+}
+
+YubiCfgDlg* YubiCfgDlg::Create(wxWindow *parent, PWScore &core, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
+{
+  return new YubiCfgDlg(parent, core, id, caption, pos, size, style);
 }
 
 /*!
@@ -112,11 +109,6 @@ YubiCfgDlg::~YubiCfgDlg()
 
 void YubiCfgDlg::Init()
 {
-////@begin YubiCfgDlg member initialisation
-  m_SKSizer = nullptr;
-  m_SKCtrl = nullptr;
-  m_ykstatus = nullptr;
-////@end YubiCfgDlg member initialisation
   m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
   m_present = !IsYubiInserted(); // lie to trigger correct actions in timer even
   m_yksernum = m_yksk = wxEmptyString;

--- a/src/ui/wxWidgets/YubiCfgDlg.h
+++ b/src/ui/wxWidgets/YubiCfgDlg.h
@@ -64,13 +64,13 @@ class YubiCfgDlg : public wxDialog
 
 public:
   /// Constructors
-  YubiCfgDlg( wxWindow* parent, PWScore &core, wxWindowID id = SYMBOL_YUBICFGDLG_IDNAME, const wxString& caption = SYMBOL_YUBICFGDLG_TITLE, const wxPoint& pos = SYMBOL_YUBICFGDLG_POSITION, const wxSize& size = SYMBOL_YUBICFGDLG_SIZE, long style = SYMBOL_YUBICFGDLG_STYLE );
-
-  /// Creation
-  bool Create( wxWindow* parent, wxWindowID id = SYMBOL_YUBICFGDLG_IDNAME, const wxString& caption = SYMBOL_YUBICFGDLG_TITLE, const wxPoint& pos = SYMBOL_YUBICFGDLG_POSITION, const wxSize& size = SYMBOL_YUBICFGDLG_SIZE, long style = SYMBOL_YUBICFGDLG_STYLE );
+  static YubiCfgDlg* Create(wxWindow *parent, PWScore &core, wxWindowID id = SYMBOL_YUBICFGDLG_IDNAME, const wxString& caption = SYMBOL_YUBICFGDLG_TITLE, const wxPoint& pos = SYMBOL_YUBICFGDLG_POSITION, const wxSize& size = SYMBOL_YUBICFGDLG_SIZE, long style = SYMBOL_YUBICFGDLG_STYLE );
 
   /// Destructor
   ~YubiCfgDlg();
+protected:
+  /// Constructors
+  YubiCfgDlg(wxWindow *parent, PWScore &core, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style);
 
   /// Initialises member variables
   void Init();
@@ -111,9 +111,9 @@ public:
   static bool ShowToolTips();
 
 ////@begin YubiCfgDlg member variables
-  wxStaticBoxSizer* m_SKSizer;
-  wxTextCtrl* m_SKCtrl;
-  wxStaticText* m_ykstatus;
+  wxStaticBoxSizer* m_SKSizer = nullptr;
+  wxTextCtrl* m_SKCtrl = nullptr;
+  wxStaticText* m_ykstatus = nullptr;
 private:
   wxString m_yksernum; // Device's serial number
   wxString m_yksk; // Device's secret key
@@ -127,7 +127,7 @@ private:
   void HideSK();
 
   enum { POLLING_TIMER_ID = 66 } ; 
-  wxTimer* m_pollingTimer;
+  wxTimer* m_pollingTimer = nullptr;
   bool m_present; // key present?
   bool m_isSKHidden;
   mutable wxMutex m_mutex; // protect against race conditions when calling Yubi API

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -28,6 +28,7 @@
 #include <wx/versioninfo.h>
 
 #include "core/PWScore.h"
+#include "PWSafeApp.h"
 
 #include "wxUtilities.h"
 
@@ -608,4 +609,9 @@ void ImagePanel::DrawBitmapCentered(wxDC &dc, const wxSize &drawAreaSize, const 
   int yCenterPosition = (drawAreaSize.GetHeight() - imageSize.GetHeight()) / 2;
 
   dc.DrawBitmap(m_Bitmap, xCenterPosition, yCenterPosition, false);
+}
+
+bool IsCloseInProgress()
+{
+  return wxGetApp().IsCloseInProgress();
 }

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -76,42 +76,6 @@ int ReadCore(PWScore& othercore, const wxString& file, const StringX& combinatio
   return rc;
 }
 
-wxWindowList HideTopLevelWindows()
-{
-  wxWindowList hiddenWindows;
-  // wxTopLevelWindows is global exported list of top level windows
-  for (wxWindowList::iterator itr = wxTopLevelWindows.begin(); itr != hiddenWindows.end(); ++itr) {
-    wxTopLevelWindow* win = wxDynamicCast(*itr, wxTopLevelWindow);
-    if (win && win->IsShown()) {
-      // we need to remember hidden windows to show later only them
-      // (also don't close while iterating over global list to prevent any side effects)
-      hiddenWindows.Append(win);
-    }
-  }
-  // hiding windows in reverse order
-  for (wxWindowList::reverse_iterator itr = hiddenWindows.rbegin(); itr != hiddenWindows.rend(); ++itr) {
-      wxWindow* win = *itr;
-      //Don't call Hide() here, which just calls Show(false), which is overridden in
-      //derived classes, and wxDialog actually cancels the modal loop and closes the window
-      pws_os::Trace(L"Hide window %ls\n", ToStr(wxDynamicCast(win, wxTopLevelWindow)->GetTitle()));
-      win->ClearBackground();
-      win->wxWindow::Show(false);
-  }
-  return hiddenWindows;
-}
-        
-void ShowWindows(wxWindowList& hiddenWindows)
-{
-  for(wxWindowList::iterator itr = hiddenWindows.begin(); itr != hiddenWindows.end(); ++itr) {
-    wxWindow* win = *itr;
-    pws_os::Trace(L"Show window %ls\n", ToStr(wxDynamicCast(win, wxTopLevelWindow)->GetTitle()));
-    win->wxWindow::Show(true);
-    win->Raise();
-    win->Update();
-  }
-  hiddenWindows.clear();
-}
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // MultiCheckboxValidator implementation
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -75,37 +75,7 @@ int ReadCore(PWScore& othercore, const wxString& file, const StringX& combinatio
   return rc;
 }
 
-int CountTopLevelWindowRecursively(wxTopLevelWindow* win)
-{
-  if (!win)
-    return 0;
-  int count = 1;
-  wxWindowList& children = win->GetChildren();
-  for(wxWindowList::iterator itr = children.begin(); itr != children.end(); ++itr) {
-    if ((*itr)->IsTopLevel()) {
-      count += CountTopLevelWindowRecursively(wxDynamicCast(*itr, wxTopLevelWindow));
-    }
-  }
-  return count;
-}
-
-void CloseChildWindowRecursively(wxTopLevelWindow* win, wxTopLevelWindow* top)
-{
-  if (!win)
-    return;
-  wxWindowList& children = win->GetChildren();
-  for(wxWindowList::iterator itr = children.begin(); itr != children.end(); ++itr) {
-    if ((*itr)->IsTopLevel()) {
-      CloseChildWindowRecursively(wxDynamicCast(*itr, wxTopLevelWindow), top);
-    }
-  }
-  if(win != top) {
-    wxCommandEvent evt(wxEVT_CLOSE_WINDOW);
-    wxPostEvent(win, evt);
-  }
-}
-
-wxWindowList HideWindowRecursively()
+wxWindowList HideTopLevelWindows()
 {
   wxWindowList hiddenWindows;
   // wxTopLevelWindows is global exported list of top level windows
@@ -129,7 +99,7 @@ wxWindowList HideWindowRecursively()
   return hiddenWindows;
 }
         
-void ShowWindowRecursively(wxWindowList& hiddenWindows)
+void ShowWindows(wxWindowList& hiddenWindows)
 {
   for(wxWindowList::iterator itr = hiddenWindows.begin(); itr != hiddenWindows.end(); ++itr) {
     wxWindow* win = *itr;

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -176,9 +176,6 @@ inline const wxChar* ToStr(bool b) {
   return b? wxT("True"): wxT("False");
 }
 
-wxWindowList HideTopLevelWindows();
-void ShowWindows(wxWindowList& hiddenWindows);
-
 // Workaround for wxTE_PASSWORD being immutable:
 void ShowHideText(wxTextCtrl *&txtCtrl, const wxString &text,
                   wxSizer *sizer, bool show);

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -176,8 +176,9 @@ inline const wxChar* ToStr(bool b) {
   return b? wxT("True"): wxT("False");
 }
 
-void HideWindowRecursively(wxTopLevelWindow* win);
-void ShowWindowRecursively(wxTopLevelWindow* win);
+wxWindowList HideWindowRecursively();
+void ShowWindowRecursively(wxWindowList& hiddenWindows);
+
 int CountTopLevelWindowRecursively(wxTopLevelWindow* win);
 void CloseChildWindowRecursively(wxTopLevelWindow* win, wxTopLevelWindow* top);
 

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -176,11 +176,8 @@ inline const wxChar* ToStr(bool b) {
   return b? wxT("True"): wxT("False");
 }
 
-wxWindowList HideWindowRecursively();
-void ShowWindowRecursively(wxWindowList& hiddenWindows);
-
-int CountTopLevelWindowRecursively(wxTopLevelWindow* win);
-void CloseChildWindowRecursively(wxTopLevelWindow* win, wxTopLevelWindow* top);
+wxWindowList HideTopLevelWindows();
+void ShowWindows(wxWindowList& hiddenWindows);
 
 // Workaround for wxTE_PASSWORD being immutable:
 void ShowHideText(wxTextCtrl *&txtCtrl, const wxString &text,

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -401,4 +401,32 @@ private:
   wxBitmap m_Bitmap;          // The possibly scaled bitmap representation of the image.
 };
 
+bool IsCloseInProgress();
+
+template <class Dlg, typename... Args> int ShowModalAndGetResult(Args&&... args) {
+  Dlg* ptr = Dlg::Create(std::forward<Args>(args)...);
+  int result = ptr->ShowModal();
+  ptr->Destroy();
+  return result;
+}
+
+template<class T> class DestroyWrapper {
+public:
+  template<typename... Args>
+  DestroyWrapper(Args&&... args) : m_ptr(T::Create(std::forward<Args>(args)...)) {
+  }
+
+  ~DestroyWrapper() {
+    if (m_ptr) {
+      m_ptr->Destroy();
+    }
+  }
+
+  T* Get() {
+    return m_ptr;
+  }
+private:
+  T *m_ptr;
+};
+
 #endif // _WXUTILITIES_H_


### PR DESCRIPTION
Few weeks ago I've updated pwsafe on my Linux workstation and found some issues with show/hide functions:
- after unlocking container, some "strange" window at left top corner was shown too
- password dialog shown immediately after locking DB
- password dialog for locked DB can't be canceled

First 4 commit I've tested for two weeks in everyday usage and there were no problems in my configuration, last two I've added today (without fixing parents for dialogs, 3rd level modal window in filters dialogs were not hidden)

@KaiZin2018, could you please check, if this fix don't break your fixes from 9e140eb5? 
I've reproduced the crash when trying to "autoclose" 3rd level filter dialog today (but haven't found main reason for it, maybe will try once more on the next weekend), but I haven't any problems with restoring multiple modal dialogs without showing unlock dialog immediately after lock (https://github.com/pwsafe/pwsafe/commit/9e140eb52b265b75914eddb12d7ae81665a3859f#diff-4c6e9ddec6b3289b3913013306741bb7ac4527d3a85875401f7484a89b8cff65R2486).

cfg: slackware64-current, wxWidgests 3.0.5, xfce 4.16

Creating this as draft, because some changes may be needed.