### PR TITLE
[cpack] Update definition of CPACK_PACKAGE_FILE_NAME

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,11 +495,12 @@ if (NOT WIN32)
 
       if (NOT DPKG_EXECUTABLE)
         # if we can't find dpkg, we don't really care, as this variable won't be used in this run.
-        set (CPACK_DEBIAN_PACKAGE_ARCHITECTURE i386)
+        set (PACKAGE_ARCHITECTURE "")
       else ()
         execute_process(COMMAND "${DPKG_EXECUTABLE}" --print-architecture
                         OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
+        set (PACKAGE_ARCHITECTURE "-${CPACK_DEBIAN_PACKAGE_ARCHITECTURE")
       endif ()
     endif ()
 endif (NOT WIN32)
@@ -563,7 +564,7 @@ endif ()
 #
 # Build name of package file (e.g. passwordsafe-ubuntu18-1.08.1-BETA-amd64.deb)
 #
-set (CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${DISTRO_NAME}${DISTRO_MAJOR_VERSION}-${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_ARCHITECTURE})
+set (CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${DISTRO_NAME}${DISTRO_MAJOR_VERSION}-${CPACK_PACKAGE_VERSION}${PACKAGE_ARCHITECTURE})
 
 if (EXISTS "/etc/debian_version")
 ## we are on a debian based distro, but we can't make assumptions about which

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,7 +529,7 @@ else(LSB_RELEASE_EXECUTABLE) # look for /etc/os-release
     file ( STRINGS ${OS_RELEASE_FILE} OS_RELEASE_LIST )
     foreach ( OS_RELEASE_ITEM IN ITEMS ${OS_RELEASE_LIST} )
       string (REGEX REPLACE "\;" "" OS_RELEASE_ITEM ${OS_RELEASE_ITEM})
-      if (${OS_RELEASE_ITEM} MATCHES "^[ ]*NAME[ ]*=[ ]*(.+)")
+      if (${OS_RELEASE_ITEM} MATCHES "^[ ]*ID[ ]*=[ ]*(.+)")
         string (REGEX REPLACE ".*=[ ]*(.+)" "\\1"
           RELEASE_ID_SHORT ${OS_RELEASE_ITEM})
       elseif (${OS_RELEASE_ITEM} MATCHES "^[ ]*VERSION_ID[ ]*=[ ]*([0-9]+)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,7 +500,7 @@ if (NOT WIN32)
         execute_process(COMMAND "${DPKG_EXECUTABLE}" --print-architecture
                         OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set (PACKAGE_ARCHITECTURE "-${CPACK_DEBIAN_PACKAGE_ARCHITECTURE")
+        set (PACKAGE_ARCHITECTURE "-${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
       endif ()
     endif ()
 endif (NOT WIN32)


### PR DESCRIPTION
This PR makes two changes to how the CPack variable `CPACK_PACKAGE_FILE_NAME` is defined - neither change should affect the definition for `dpkg`-based systems.

The first change simply removes the architecture tag from the file name when `dpkg` is not present (rather than adding "i386" regardless of how the package was actually built).

The second change fixes an unsanitized use of the `NAME` variable from os-release which is permitted to contain whitespace.  This led CPack to interpret the filename as a list on Fedora 35 (value is "Fedora Linux") and error out during RPM generation.  This corrects that behavior by using `ID` from os-release which is guaranteed by spec (`man 5 os-release`) to contain no whitespace.