### PR TITLE
Add support for installing dependencies on Pop! OS

### DIFF
--- a/Misc/setup-linux-dev-env.sh
+++ b/Misc/setup-linux-dev-env.sh
@@ -63,10 +63,9 @@ fi
 # We have distro and release, let's get to work
 
 case "$DISTRO" in
-    debian|ubuntu|linuxmint|raspbian)
-        if test \( "$DISTRO" = "ubuntu" -a "$RELEASE" -ge 20 \) -o \
-         \( "$DISTRO" = "debian" -a  \( "$RELEASE" -eq 0 -o "$RELEASE" -ge 11 \) \) -o \
-         \( "$DISTRO" = "linuxmint" -a "$RELEASE" -ge 20 \) ; then
+    debian|ubuntu|linuxmint|pop|raspbian)
+        if test \( \( "$DISTRO" = "ubuntu" -o "$DISTRO" = "pop" -o "$DISTRO" = "linuxmint" \) -a "$RELEASE" -ge 20 \) -o \
+         \( "$DISTRO" = "debian" -a \( "$RELEASE" -eq 0 -o "$RELEASE" -ge 11 \) \) ; then
             LIBWXDEV="libwxgtk3.0-gtk3-dev"
         else
             LIBWXDEV="libwxgtk3.0-dev"


### PR DESCRIPTION
It's based on Ubuntu and follows the same versioning scheme, so should
be using the same dependency versions.

Building works fine otherwise.