### PR TITLE
[wx] Update to English text in SelectionCriteria

### DIFF
--- a/src/ui/wxWidgets/PasswordSafeSearch.cpp
+++ b/src/ui/wxWidgets/PasswordSafeSearch.cpp
@@ -472,7 +472,7 @@ void PasswordSafeSearch::OnToolBarFindReport(wxCommandEvent& event)
   report.StartReport(IDSC_RPTFIND, m_parentFrame->GetCurrentFile().c_str());
   
   if(m_criteria) {
-    m_criteria->ReportAdvancedOptions(&report, _("Find"), m_parentFrame->GetCurrentFile().c_str());
+    m_criteria->ReportAdvancedOptions(&report, _("found"), m_parentFrame->GetCurrentFile().c_str());
   }
   
   stringT line, searchT(searchText.c_str()), searchCaseT(GetToolToggled(ID_FIND_IGNORE_CASE) ? _("(case-sensitive)"): _("(not case-sensitive)"));

--- a/src/ui/wxWidgets/SelectionCriteria.cpp
+++ b/src/ui/wxWidgets/SelectionCriteria.cpp
@@ -118,7 +118,7 @@ void SelectionCriteria::ReportAdvancedOptions(CReport* rpt, const wxString& oper
   wxArrayString fieldsSelected, fieldsNotSelected;
   const bool allSelected = GetFieldSelection(fieldsSelected, fieldsNotSelected);
   if (allSelected) {
-    line.Printf(_("\tAll fields in matching entries were %ls"), operation);
+    line.Printf(_("\tAll fields in matching entries from %ls"), operation);
     rpt->WriteLine(line.c_str());
   }
   else {

--- a/src/ui/wxWidgets/SelectionCriteria.cpp
+++ b/src/ui/wxWidgets/SelectionCriteria.cpp
@@ -110,7 +110,7 @@ wxString SelectionCriteria::GetGroupSelectionDescription() const
 void SelectionCriteria::ReportAdvancedOptions(CReport* rpt, const wxString& operation, const wxString& fullPath)
 {
   wxString line = GetGroupSelectionDescription();
-  line << _(" from ") << operation << _(" with corresponding entries from \"")
+  line << _(" were ") << operation << _(" with corresponding entries from \"")
               << fullPath << wxT('"');
   rpt->WriteLine(line.c_str());
   rpt->WriteLine();
@@ -118,7 +118,7 @@ void SelectionCriteria::ReportAdvancedOptions(CReport* rpt, const wxString& oper
   wxArrayString fieldsSelected, fieldsNotSelected;
   const bool allSelected = GetFieldSelection(fieldsSelected, fieldsNotSelected);
   if (allSelected) {
-    line.Printf(_("\tAll fields in matching entries from %ls"), operation);
+    line.Printf(_("\tAll fields in matching entries were %ls"), operation);
     rpt->WriteLine(line.c_str());
   }
   else {

--- a/src/ui/wxWidgets/SelectionCriteria.cpp
+++ b/src/ui/wxWidgets/SelectionCriteria.cpp
@@ -110,7 +110,7 @@ wxString SelectionCriteria::GetGroupSelectionDescription() const
 void SelectionCriteria::ReportAdvancedOptions(CReport* rpt, const wxString& operation, const wxString& fullPath)
 {
   wxString line = GetGroupSelectionDescription();
-  line << _(" were ") << operation << _(" with corresponding entries from \"")
+  line << _(" from ") << operation << _(" with corresponding entries from \"")
               << fullPath << wxT('"');
   rpt->WriteLine(line.c_str());
   rpt->WriteLine();


### PR DESCRIPTION
During translation updates for German at this line (separate PR), the following strange English translation came up. Maybe in the past it only stated "were:" but now the operation is also given. I would replace the "were" with _from_ <operation> or with _with_.

Current report looks like this where the text is used
```
...
All entries were Find with corresponding entries from "/path/test.psafe3"

All fields in matching entries were Find
...
```