### PR TITLE
Fix xml install path on Unix platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,7 @@ install (TARGETS pwsafe RUNTIME DESTINATION "bin")
 
 
 if (NOT WIN32)
-  install (DIRECTORY xml DESTINATION "share/passwordsafe/")
+  install (DIRECTORY xml DESTINATION "share/passwordsafe")
   ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_BINARY_DIR}/pwsafe.1.gz
                      COMMAND ${GZIP} ARGS -9 -n -c ${PROJECT_SOURCE_DIR}/docs/pwsafe.1 > pwsafe.1.gz
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
Mostly cosmetic but there is currently double slashes in XML install path on Linux.

For example an excerpt of a Nix build:

```
-- Installing: /nix/store/f2j49p6l23hds07irqzpn7d39rgp04i9-pwsafe-1.14.0/share/passwordsafe//xml
-- Installing: /nix/store/f2j49p6l23hds07irqzpn7d39rgp04i9-pwsafe-1.14.0/share/passwordsafe//xml/pwsafe.xsl
-- Installing: /nix/store/f2j49p6l23hds07irqzpn7d39rgp04i9-pwsafe-1.14.0/share/passwordsafe//xml/pwsafe_filter.xsd
-- Installing: /nix/store/f2j49p6l23hds07irqzpn7d39rgp04i9-pwsafe-1.14.0/share/passwordsafe//xml/pwsafe.xsd
```

With the proposed change:

```
-- Installing: /nix/store/privbg5myn9xzgaff5pwvcr5bl2m71pb-pwsafe-1.14.0/share/passwordsafe/xml
-- Installing: /nix/store/privbg5myn9xzgaff5pwvcr5bl2m71pb-pwsafe-1.14.0/share/passwordsafe/xml/pwsafe.xsl
-- Installing: /nix/store/privbg5myn9xzgaff5pwvcr5bl2m71pb-pwsafe-1.14.0/share/passwordsafe/xml/pwsafe_filter.xsd
-- Installing: /nix/store/privbg5myn9xzgaff5pwvcr5bl2m71pb-pwsafe-1.14.0/share/passwordsafe/xml/pwsafe.xsd
```
