### PR TITLE
[wx] Fix file path name for Yubi

### DIFF
--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -633,6 +633,9 @@ void SafeCombinationEntryDlg::OnYubibtnClick(wxCommandEvent& WXUNUSED(event))
 {
   m_combinationEntry->AllowEmptyCombinationOnce();  // Allow blank password when Yubi's used
 
+  // For the validation process, put the full file path name back into the combo box.
+  m_filenameCB->ChangeValue(m_filename);
+
   if (Validate() && TransferDataFromWindow()) {
     if (!pws_os::FileExists(tostdstring(m_filename))) {
       wxMessageDialog err(this, _("File or path not found."),


### PR DESCRIPTION
This is an attempt to fix the reported issue [1548](https://sourceforge.net/p/passwordsafe/bugs/1548/) on SourceForge.
It's untested because I don't have a Yubikey. 