### PR TITLE
Fix build on big-endian architectures

### DIFF
--- a/src/core/ItemData.cpp
+++ b/src/core/ItemData.cpp
@@ -1949,8 +1949,9 @@ bool CItemData::DeSerializePlainText(const std::vector<char> &v)
     }
 
 #ifdef PWS_BIG_ENDIAN
-    unsigned char buf[len] = {0};
-
+    unsigned char buf[len];
+    memset(buf, 0, len*sizeof(char));
+	  
     switch(type) {
       case CTIME:
       case PMTIME:

--- a/src/core/ItemData.cpp
+++ b/src/core/ItemData.cpp
@@ -1950,7 +1950,7 @@ bool CItemData::DeSerializePlainText(const std::vector<char> &v)
 
 #ifdef PWS_BIG_ENDIAN
     unsigned char buf[len];
-    memset(buf, 0, len*sizeof(char));
+    memset(buf, 0, len*sizeof(buf[0]));
 	  
     switch(type) {
       case CTIME:


### PR DESCRIPTION
```
ItemData.cpp:1942:23: error: variable-sized object may not be initialized
    unsigned char buf[len] = {0};
```