### PR TITLE
[SF1545] Restore maximized status of the window on program start

### DIFF
--- a/src/ui/Windows/MainFile.cpp
+++ b/src/ui/Windows/MainFile.cpp
@@ -257,13 +257,14 @@ BOOL DboxMain::OpenOnInit()
   PWSprefs::GetInstance()->GetPrefRect(rect.top, rect.bottom, rect.left, rect.right);
 
   HRGN hrgnWork = WinUtil::GetWorkAreaRegion();
-  // also check that window will be visible
-  if ((rect.top == -1 && rect.bottom == -1 && rect.left == -1 && rect.right == -1) ||
-    !RectInRegion(hrgnWork, rect)) {
+  
+  // Check if windows was maximized first, otherwise !RectInRegion() below always wins.
+  if (rect.top == 0 && rect.bottom == 0 && rect.left == 0 && rect.right == 0) {
+      ShowWindow(SW_SHOWMAXIMIZED);
+  } else if ((rect.top == -1 && rect.bottom == -1 && rect.left == -1 && rect.right == -1) ||
+      !RectInRegion(hrgnWork, rect)) { // also check that window will be visible
     GetWindowRect(&rect);
     SendMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(rect.Width(), rect.Height()));
-  } else if (rect.top == 0 && rect.bottom == 0 && rect.left == 0 && rect.right == 0) { // marks maximized window
-    ShowWindow(SW_SHOWMAXIMIZED);
   } else {
     PlaceWindow(this, &rect, SW_HIDE);
   }


### PR DESCRIPTION
Since commit 103134a6e, the maximized window is saved in the prefs
as an empty rect (0, 0, 0, 0). So do the maximized check first.
Previously, the visibility check (RectInRegion) would always win and
ignore the empty rect thus not restoring the maximized state.

The fix is not complete. The following situation is still not right:
1. Place Window in the middle of the screen.
   Normally, if you close the program and open it again, the window
   is shown in the same place.
2. Click Maximize button and close the program.
   Windows position is saved as (0, 0, 0, 0).
3. Open the program again. Window is shown as Maximized.
   This didn't work. This commit fixes it.
4. Click Restore button.
   Window is restored to the top-left corner with some default size.
   Expectation: Windows is restored to its previous state from 1.