### PR TITLE
Fix build with GCC 12 (missing <time.h> include)

### DIFF
--- a/src/os/unix/pws_time.h
+++ b/src/os/unix/pws_time.h
@@ -10,9 +10,7 @@
 
 #include "../typedefs.h"
 #include <stdint.h>
-#ifdef __FreeBSD__
 #include <time.h>
-#endif
 
 #ifndef __TIME64_T_TYPE
 #define __TIME64_T_TYPE uint64_t


### PR DESCRIPTION
Fixes build failure with GCC 12:
```
/var/tmp/portage/app-admin/passwordsafe-1.15.0/work/pwsafe-1.15.0/src/os/unix/pws_time.cpp: In function ‘int localtime64_r(const __time64_t*, tm*)’:
/var/tmp/portage/app-admin/passwordsafe-1.15.0/work/pwsafe-1.15.0/src/os/unix/pws_time.cpp:30:10: error: ‘localtime_r’ was not declared in this scope; did you mean ‘localtime64_r’?
   30 |   return localtime_r(tp, result) != nullptr;
      |          ^~~~~~~~~~~
      |          localtime64_r
/var/tmp/portage/app-admin/passwordsafe-1.15.0/work/pwsafe-1.15.0/src/os/unix/pws_time.cpp: In function ‘int pws_os::asctime(TCHAR*, size_t, const tm*)’:
/var/tmp/portage/app-admin/passwordsafe-1.15.0/work/pwsafe-1.15.0/src/os/unix/pws_time.cpp:36:3: error: ‘asctime_r’ was not declared in this scope
   36 |   asctime_r(t, cbuf);
      |   ^~~~~~~~~
```

We had it conditional for FreeBSD but it shouldn't be conditional at all;
it only worked by chance before by way of transitive includes.

Bug: https://bugs.gentoo.org/854144