### PR TITLE
[cli] Add X11 as link library to CMakeLists

### DIFF
--- a/src/ui/cli/CMakeLists.txt
+++ b/src/ui/cli/CMakeLists.txt
@@ -43,7 +43,7 @@ if (XercesC_LIBRARY)
 endif (XercesC_LIBRARY)
 
 if (NOT WIN32)
-	target_link_libraries(pwsafe-cli pthread magic)
+	target_link_libraries(pwsafe-cli pthread magic X11)
 else ()
 	target_link_libraries(pwsafe-cli Rpcrt4)
 	set_target_properties(pwsafe-cli PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CACHEFILE_DIR})


### PR DESCRIPTION
On Debian, linking pwsafe-cli fails with the following error.

```
[ 61%] Linking CXX executable pwsafe-cli
/usr/bin/ld: wxWidgets-3.2.0/wxbuild/lib/libwx_gtk3u_core-3.2.a(utilsx11.cpp.o): undefined reference to symbol 'XGetWindowAttributes'
/usr/bin/ld: /lib/x86_64-linux-gnu/libX11.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

The dependency on wx and thus on X11 surprises me for the comand line version of pwsafe.