### PR TITLE
Allow copy of field content in View Entry by Ctrl-C/Command-C.

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -157,7 +157,7 @@ AddEditPropSheetDlg::AddEditPropSheetDlg(wxWindow *parent, PWScore &core,
   SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY|wxWS_EX_BLOCK_EVENTS);
   wxPropertySheetDialog::Create( parent, id, caption, pos, size, style );
 
-  int flags = (m_Type == SheetType::VIEW) ? (wxCLOSE|wxHELP) : (wxOK|wxCANCEL|wxHELP);
+  int flags = (m_Type == SheetType::VIEW) ? (wxCANCEL|wxHELP) : (wxOK|wxCANCEL|wxHELP); // Use Cancel instead of wxCLOSE on view to allow Command-C as copy operation in macOS, otherwise the Command-C is connected to the Close-Button.
   CreateButtons(flags);
   CreateControls();
   ApplyFontPreferences();


### PR DESCRIPTION
Allow copy of field content in View Entry by Ctrl-C/Command-C.. The Close buttons standard-binding is to this key. So using Abort instead of Close will lead to demanded functionality,