### PR TITLE
Avoid error message "Dots are not allowed in group names" with Read O…

### DIFF
--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -1016,8 +1016,9 @@ void TreeCtrl::OnEndLabelEdit( wxTreeEvent& evt )
 {
   const wxString &label = (evt.IsEditCancelled() ? GetItemText(evt.GetItem()) : evt.GetLabel());
 
-  if (label.empty()) {
-    // empty entry or group names are a non-no...
+  if (label.empty() || IsReadOnly()) { // end editing without message to avoid error "Dots are not allowed in group names" with Read Only data base and a dot in a shown name
+    // 1st empty entry or group names are a non-no...
+    // 2nd In Read-Only data base we do not change anything
     evt.Veto();
     return;
   }


### PR DESCRIPTION
…nly data base. I do not know how, but sometimes I can clock in the list view and this is opening the editing of the entry label. In case this label is including a dot by chance the before given error is shown. To avoid entering the real edit dialog and the error message about a dot I like to include the Read Only condition into the initial condition with veto() without error message.