### PR TITLE
Initialize the newly constructed buffer instead of setting it to null…

### DIFF
--- a/src/ui/Windows/DDStatic.cpp
+++ b/src/ui/Windows/DDStatic.cpp
@@ -466,7 +466,7 @@ BOOL CDDStatic::OnRenderGlobalData(LPFORMATETC lpFormatEtc, HGLOBAL* phGlobal)
     if (ilen == 0) {
       dwBufLen = 1;
       lpszA = new char[dwBufLen];
-      lpszA = '\0';
+      *lpszA = '\0';
     } else {
       lpszW = const_cast<LPWSTR>(cs_dragdata.c_str());
       dwBufLen = WideCharToMultiByte(CP_ACP, 0, lpszW, -1, NULL, 0, NULL, NULL);


### PR DESCRIPTION
Setting a pointer nullptr right after allocating it is almost certainly not the intended behavior.  This PR is the minimal change to avoid this, but one might also ask if the whole buffer should be zeroed and if the allocations should be managed through something like `std::unique_ptr<>`. 