### PR TITLE
Make the XPM arrays "const".

### DIFF
--- a/src/ui/wxWidgets/DragBarCtrl.cpp
+++ b/src/ui/wxWidgets/DragBarCtrl.cpp
@@ -87,10 +87,10 @@ enum
 struct DragbarToolInfo {
   const wxWindowID id;
   const wxString name;
-  const char** bitmap;
-  const char** bitmap_disabled;
-  const char** classic_bitmap;
-  const char** classic_bitmap_disabled;
+  const char* const* const bitmap;
+  const char* const* const bitmap_disabled;
+  const char* const* const classic_bitmap;
+  const char* const* const classic_bitmap_disabled;
   const CItemData::FieldType field_type;
 
   DragbarToolInfo() :
@@ -101,8 +101,8 @@ struct DragbarToolInfo {
 
   DragbarToolInfo(
     wxWindowID id, const wxString &name,
-    const char** bitmap, const char** bitmap_disabled,
-    const char** classic_bitmap, const char** classic_bitmap_disabled,
+    const char* const* bitmap, const char* const* bitmap_disabled,
+    const char* const* classic_bitmap, const char* const* classic_bitmap_disabled,
     CItemData::FieldType field_type
   ) :
     id(id), name(name),

--- a/src/ui/wxWidgets/PWFiltersEditor.cpp
+++ b/src/ui/wxWidgets/PWFiltersEditor.cpp
@@ -164,7 +164,7 @@ void pwFiltersActiveRenderer::CreateControls()
 {
   // As the list is static it has to be build up only at first time
   if(m_initialied == false) {
-    const char **xpmPWFList[] = {
+    static const char* const* const xpmPWFList[] = {
       empty_xpm,              // 0
       checked_xpm,            // 1
       unchecked_xpm,          // 2
@@ -173,7 +173,7 @@ void pwFiltersActiveRenderer::CreateControls()
       unchecked_disabled_xpm, // 5
     };
 #if wxVERSION_NUMBER >= 3103
-    const char **xpmPWFDarkList[] = {
+    static const char* const* const xpmPWFDarkList[] = {
       empty_dark_xpm,              // 0
       checked_dark_xpm,            // 1
       unchecked_dark_xpm,          // 2
@@ -182,8 +182,8 @@ void pwFiltersActiveRenderer::CreateControls()
       unchecked_disabled_dark_xpm, // 5
     };
 #endif
-  
-    const int Nimages = sizeof(xpmPWFList)/sizeof(xpmPWFList[0]);
+
+    constexpr int Nimages = sizeof(xpmPWFList)/sizeof(xpmPWFList[0]);
 #if wxVERSION_NUMBER >= 3103
     const bool bIsDark = wxSystemSettings::GetAppearance().IsUsingDarkBackground();
     wxASSERT(Nimages == (sizeof(xpmPWFDarkList)/sizeof(xpmPWFDarkList[0])));

--- a/src/ui/wxWidgets/PasswordSafeSearch.cpp
+++ b/src/ui/wxWidgets/PasswordSafeSearch.cpp
@@ -76,10 +76,10 @@ enum {
 struct SearchBarToolInfo {
   wxWindowID id;
   const wxString tooltip;
-  const char** bitmap_normal;
-  const char** bitmap_disabled;
-  const char** bitmap_classic;
-  const char** bitmap_classic_disabled;
+  const char* const* const bitmap_normal;
+  const char* const* const bitmap_disabled;
+  const char* const* const bitmap_classic;
+  const char* const* const bitmap_classic_disabled;
   wxItemKind tool_type;
 
   SearchBarToolInfo() :
@@ -90,8 +90,8 @@ struct SearchBarToolInfo {
 
   SearchBarToolInfo(
     wxWindowID id, const wxString &tooltip,
-    const char** bitmap_normal, const char** bitmap_disabled,
-    const char** bitmap_classic, const char** bitmap_classic_disabled,
+    const char* const* const bitmap_normal, const char* const* bitmap_disabled,
+    const char* const* const bitmap_classic, const char* const* bitmap_classic_disabled,
     wxItemKind tool_type
   ) :
     id(id), tooltip(tooltip),

--- a/src/ui/wxWidgets/ToolbarButtons.h
+++ b/src/ui/wxWidgets/ToolbarButtons.h
@@ -180,10 +180,10 @@ struct _PwsToolbarInfo {
   int id;
   const wxString toollabel;
   const wxString tooltip;
-  const char** bitmap_normal;
-  const char** bitmap_disabled;
-  const char** bitmap_classic;
-  const char** bitmap_classic_disabled;
+  const char* const* const bitmap_normal;
+  const char* const* const bitmap_disabled;
+  const char* const* const bitmap_classic;
+  const char* const* const bitmap_classic_disabled;
 
   bool IsSeparator() const
   {
@@ -202,7 +202,7 @@ struct _PwsToolbarInfo {
   wxBitmap GetBitmapForEnabledButton() const
   {
     return UseNewToolbarStyle() ? bitmap_normal : bitmap_classic;
-  };
+  }
 
   /**
    * Provides the bitmap that represents an disabled toolbar item in the new or classic style, depending on user preferences.
@@ -216,8 +216,8 @@ struct _PwsToolbarInfo {
   // Following ctor's required to shut up some compiler warnings
 _PwsToolbarInfo() : id(0), toollabel(wxEmptyString), tooltip(wxEmptyString), bitmap_normal(nullptr), bitmap_disabled(nullptr),
     bitmap_classic(nullptr), bitmap_classic_disabled(nullptr) {}
-_PwsToolbarInfo(int aid, const wxString &atoollabel, const wxString &atooltip, const char** abitmap_normal,
-                const char** abitmap_disabled, const char** abitmap_classic, const char** abitmap_classic_disabled) :
+_PwsToolbarInfo(int aid, const wxString &atoollabel, const wxString &atooltip, const char* const* abitmap_normal,
+                const char* const* abitmap_disabled, const char* const* abitmap_classic, const char* const* abitmap_classic_disabled) :
   id(aid), toollabel(atoollabel), tooltip(atooltip), bitmap_normal(abitmap_normal), bitmap_disabled(abitmap_disabled),
     bitmap_classic(abitmap_classic), bitmap_classic_disabled(abitmap_classic_disabled) {}
 } PwsToolbarButtons[] =

--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -276,7 +276,7 @@ void TreeCtrlBase::CreateControls()
 {
 ////@begin TreeCtrl content construction
 ////@end TreeCtrl content construction
-  const char **xpmList[] = {
+  static const char* const* const xpmList[] = {
     abase_exp_xpm,    // 0
     abase_warn_xpm,   // 1
     abase_xpm,        // 2
@@ -292,7 +292,7 @@ void TreeCtrlBase::CreateControls()
     empty_node_xpm,   // 12
   };
 #if wxVERSION_NUMBER >= 3103
-  const char **xpmDarkList[] = {
+  static const char* const* const xpmDarkList[] = {
     abase_exp_dark_xpm,    // 0
     abase_warn_dark_xpm,   // 1
     abase_dark_xpm,        // 2

--- a/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/backups.xpm
+++ b/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/backups.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * backups_xpm[] = {
+static const char * const backups_xpm[] = {
 "64 64 153 2",
 "  	c None",
 ". 	c #48A0DC",

--- a/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/display.xpm
+++ b/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/display.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * display_xpm[] = {
+static const char * const display_xpm[] = {
 "64 64 92 2",
 "  	c None",
 ". 	c #5A5A5B",

--- a/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/history.xpm
+++ b/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/history.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * history_xpm[] = {
+static const char * const history_xpm[] = {
 "64 64 290 2",
 "  	c None",
 ". 	c #B2BCBB",

--- a/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/miscellaneous.xpm
+++ b/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/miscellaneous.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * miscellaneous_xpm[] = {
+static const char * const miscellaneous_xpm[] = {
 "64 64 64 1",
 " 	c None",
 ".	c #D7DEED",

--- a/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/security.xpm
+++ b/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/security.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * security_xpm[] = {
+static const char * const security_xpm[] = {
 "64 64 138 2",
 "  	c None",
 ". 	c #D7ECFF",

--- a/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/shortcuts.xpm
+++ b/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/shortcuts.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * shortcuts_xpm[] = {
+static const char * const shortcuts_xpm[] = {
 "64 64 260 2",
 "  	c None",
 ". 	c #E4EAF6",

--- a/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/system.xpm
+++ b/src/ui/wxWidgets/graphics/OptionsPropertySheetDlg/system.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * system_xpm[] = {
+static const char * const system_xpm[] = {
 "64 64 211 2",
 "  	c None",
 ". 	c #EFF2FA",

--- a/src/ui/wxWidgets/graphics/Yubikey-button.xpm
+++ b/src/ui/wxWidgets/graphics/Yubikey-button.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * Yubikey_button_xpm[] = {
+static const char * const Yubikey_button_xpm[] = {
 "80 27 36 1",
 " 	c None",
 ".	c #85DA00",

--- a/src/ui/wxWidgets/graphics/abase.xpm
+++ b/src/ui/wxWidgets/graphics/abase.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *abase_xpm[] = {
+static const char * const abase_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 22 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/abase_dark.xpm
+++ b/src/ui/wxWidgets/graphics/abase_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *abase_dark_xpm[] = {
+static const char * const abase_dark_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 22 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/abase_exp.xpm
+++ b/src/ui/wxWidgets/graphics/abase_exp.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *abase_exp_xpm[] = {
+static const char * const abase_exp_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 17 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/abase_exp_dark.xpm
+++ b/src/ui/wxWidgets/graphics/abase_exp_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *abase_exp_dark_xpm[] = {
+static const char * const abase_exp_dark_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 17 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/abase_warn.xpm
+++ b/src/ui/wxWidgets/graphics/abase_warn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *abase_warn_xpm[] = {
+static const char * const abase_warn_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 21 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/abase_warn_dark.xpm
+++ b/src/ui/wxWidgets/graphics/abase_warn_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *abase_warn_dark_xpm[] = {
+static const char * const abase_warn_dark_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 21 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/about.xpm
+++ b/src/ui/wxWidgets/graphics/about.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *about_xpm[] = {
+static const char * const about_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 161 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/alias.xpm
+++ b/src/ui/wxWidgets/graphics/alias.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *alias_xpm[] = {
+static const char * const alias_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 21 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/alias_dark.xpm
+++ b/src/ui/wxWidgets/graphics/alias_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *alias_dark_xpm[] = {
+static const char * const alias_dark_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 21 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/checked.xpm
+++ b/src/ui/wxWidgets/graphics/checked.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *checked_xpm[] = {
+static const char * const checked_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/checked_dark.xpm
+++ b/src/ui/wxWidgets/graphics/checked_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *checked_dark_xpm[] = {
+static const char * const checked_dark_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/checked_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/checked_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *checked_disabled_xpm[] = {
+static const char * const checked_disabled_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/checked_disabled_dark.xpm
+++ b/src/ui/wxWidgets/graphics/checked_disabled_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *checked_disabled_dark_xpm[] = {
+static const char * const checked_disabled_dark_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/cpane.xpm
+++ b/src/ui/wxWidgets/graphics/cpane.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cpane_xpm[] = {
+static const char * const cpane_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "98 98 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/Dnd.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/Dnd.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_Dnd_xpm[] = {
+static const char * const classic_Dnd_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/DndX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/DndX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_DndX_xpm[] = {
+static const char * const classic_DndX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/Group.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/Group.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_Group_xpm[] = {
+static const char * const classic_Group_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/GroupX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/GroupX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_GroupX_xpm[] = {
+static const char * const classic_GroupX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/Notes.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/Notes.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_Notes_xpm[] = {
+static const char * const classic_Notes_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/NotesX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/NotesX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_NotesX_xpm[] = {
+static const char * const classic_NotesX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/Password.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/Password.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_Password_xpm[] = {
+static const char * const classic_Password_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/PasswordX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/PasswordX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_PasswordX_xpm[] = {
+static const char * const classic_PasswordX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/Title.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/Title.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_Title_xpm[] = {
+static const char * const classic_Title_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/TitleX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/TitleX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_TitleX_xpm[] = {
+static const char * const classic_TitleX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/URL.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/URL.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_URL_xpm[] = {
+static const char * const classic_URL_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/URLX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/URLX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_URLX_xpm[] = {
+static const char * const classic_URLX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/User.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/User.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_User_xpm[] = {
+static const char * const classic_User_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/UserX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/UserX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_UserX_xpm[] = {
+static const char * const classic_UserX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/email.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/email.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_Email_xpm[] = {
+static const char * const classic_Email_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/classic/emailx.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/classic/emailx.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_EmailX_xpm[] = {
+static const char * const classic_EmailX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/Dnd.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/Dnd.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Dnd_xpm[] = {
+static const char * const Dnd_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "16 16 96 2 ",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/DndX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/DndX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *DndX_xpm[] = {
+static const char * const DndX_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "16 16 48 2 ",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/Email.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/Email.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Email_xpm[] = {
+static const char * const Email_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 147 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/EmailX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/EmailX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *EmailX_xpm[] = {
+static const char * const EmailX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 92 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/Group.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/Group.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Group_xpm[] = {
+static const char * const Group_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 149 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/GroupX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/GroupX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *GroupX_xpm[] = {
+static const char * const GroupX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 94 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/Notes.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/Notes.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Notes_xpm[] = {
+static const char * const Notes_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 124 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/NotesX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/NotesX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *NotesX_xpm[] = {
+static const char * const NotesX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 76 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/Password.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/Password.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Password_xpm[] = {
+static const char * const Password_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 105 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/PasswordX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/PasswordX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *PasswordX_xpm[] = {
+static const char * const PasswordX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 256 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/Title.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/Title.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *Title_xpm[] = {
+static const char * const Title_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 87 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/TitleX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/TitleX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *TitleX_xpm[] = {
+static const char * const TitleX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 256 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/URL.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/URL.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *URL_xpm[] = {
+static const char * const URL_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 191 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/URLX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/URLX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *URLX_xpm[] = {
+static const char * const URLX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 256 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/User.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/User.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *User_xpm[] = {
+static const char * const User_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 145 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/dragbar/new/UserX.xpm
+++ b/src/ui/wxWidgets/graphics/dragbar/new/UserX.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *UserX_xpm[] = {
+static const char * const UserX_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 256 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/empty.xpm
+++ b/src/ui/wxWidgets/graphics/empty.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *empty_xpm[] = {
+static const char * const empty_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/empty_dark.xpm
+++ b/src/ui/wxWidgets/graphics/empty_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *empty_dark_xpm[] = {
+static const char * const empty_dark_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/empty_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/empty_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *empty_disabled_xpm[] = {
+static const char * const empty_disabled_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/empty_disabled_dark.xpm
+++ b/src/ui/wxWidgets/graphics/empty_disabled_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *empty_disabled_dark_xpm[] = {
+static const char * const empty_disabled_dark_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/empty_node.xpm
+++ b/src/ui/wxWidgets/graphics/empty_node.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *empty_node_xpm[] = {
+static const char * const empty_node_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 16 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/empty_node_dark.xpm
+++ b/src/ui/wxWidgets/graphics/empty_node_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *empty_node_dark_xpm[] = {
+static const char * const empty_node_dark_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 16 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/exit.xpm
+++ b/src/ui/wxWidgets/graphics/exit.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *exit_xpm[] = {
+static const char * const exit_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 180 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/classic/find.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/classic/find.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_find_xpm[] = {
+static const char * const classic_find_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/classic/find_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/classic/find_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_find_disabled_xpm[] = {
+static const char * const classic_find_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 63 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/classic/findadvanced.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/classic/findadvanced.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_findadvanced_xpm[] = {
+static const char * const classic_findadvanced_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/classic/findcase_i.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/classic/findcase_i.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_findcase_i_xpm[] = {
+static const char * const classic_findcase_i_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/classic/findcase_s.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/classic/findcase_s.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_findcase_s_xpm[] = {
+static const char * const classic_findcase_s_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/classic/findclear.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/classic/findclear.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_findclear_xpm[] = {
+static const char * const classic_findclear_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/classic/findclose.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/classic/findclose.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_findclose_xpm[] = {
+static const char * const classic_findclose_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 2 1 ",
 "  c black",

--- a/src/ui/wxWidgets/graphics/findtoolbar/classic/findreport.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/classic/findreport.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_findreport_xpm[] = {
+static const char * const classic_findreport_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/new/find.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/new/find.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *find_xpm[] = {
+static const char * const find_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 101 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/new/find_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/new/find_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *find_disabled_xpm[] = {
+static const char * const find_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 63 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/new/findadvanced.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/new/findadvanced.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *findadvanced_xpm[] = {
+static const char * const findadvanced_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 113 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/new/findcase_i.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/new/findcase_i.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *findcase_i_xpm[] = {
+static const char * const findcase_i_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 23 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/new/findcase_s.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/new/findcase_s.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *findcase_s_xpm[] = {
+static const char * const findcase_s_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 22 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/new/findclear.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/new/findclear.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *findclear_xpm[] = {
+static const char * const findclear_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 104 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/findtoolbar/new/findclose.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/new/findclose.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *findclose_xpm[] = {
+static const char * const findclose_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 256 2 ",
 "   c #C4C6C4",

--- a/src/ui/wxWidgets/graphics/findtoolbar/new/findreport.xpm
+++ b/src/ui/wxWidgets/graphics/findtoolbar/new/findreport.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *findreport_xpm[] = {
+static const char * const findreport_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 140 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/lock.xpm
+++ b/src/ui/wxWidgets/graphics/lock.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *lock_xpm[] = {
+static const char * const lock_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 176 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/locked_tray.xpm
+++ b/src/ui/wxWidgets/graphics/locked_tray.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * locked_tray_xpm[] = {
+static const char * const locked_tray_xpm[] = {
 "32 32 4 1",
 " 	c None",
 ".	c #00FF00",

--- a/src/ui/wxWidgets/graphics/node.xpm
+++ b/src/ui/wxWidgets/graphics/node.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *node_xpm[] = {
+static const char * const node_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 17 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/node_dark.xpm
+++ b/src/ui/wxWidgets/graphics/node_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *node_dark_xpm[] = {
+static const char * const node_dark_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 17 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/normal.xpm
+++ b/src/ui/wxWidgets/graphics/normal.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *normal_xpm[] = {
+static const char * const normal_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 30 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/normal_dark.xpm
+++ b/src/ui/wxWidgets/graphics/normal_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *normal_dark_xpm[] = {
+static const char * const normal_dark_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 30 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/normal_exp.xpm
+++ b/src/ui/wxWidgets/graphics/normal_exp.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *normal_exp_xpm[] = {
+static const char * const normal_exp_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 24 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/normal_exp_dark.xpm
+++ b/src/ui/wxWidgets/graphics/normal_exp_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *normal_exp_dark_xpm[] = {
+static const char * const normal_exp_dark_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 24 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/normal_warn.xpm
+++ b/src/ui/wxWidgets/graphics/normal_warn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *normal_warn_xpm[] = {
+static const char * const normal_warn_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 30 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/normal_warn_dark.xpm
+++ b/src/ui/wxWidgets/graphics/normal_warn_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *normal_warn_dark_xpm[] = {
+static const char * const normal_warn_dark_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 30 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/psafetxt.xpm
+++ b/src/ui/wxWidgets/graphics/psafetxt.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * psafetxt_xpm[] = {
+static const char * const psafetxt_xpm[] = {
 "222 34 466 2",
 "  	c None",
 ". 	c #909090",

--- a/src/ui/wxWidgets/graphics/pwsafe16.xpm
+++ b/src/ui/wxWidgets/graphics/pwsafe16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pwsafe16[] = {
+static const char * const pwsafe16[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 23 1",
 "  c #330000",

--- a/src/ui/wxWidgets/graphics/pwsafe32.xpm
+++ b/src/ui/wxWidgets/graphics/pwsafe32.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pwsafe32[] = {
+static const char * const pwsafe32[] = {
 /* columns rows colors chars-per-pixel */
 "32 32 42 1",
 "  c black",

--- a/src/ui/wxWidgets/graphics/pwsafe48.xpm
+++ b/src/ui/wxWidgets/graphics/pwsafe48.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pwsafe48[] = {
+static const char * const pwsafe48[] = {
 /* columns rows colors chars-per-pixel */
 "48 48 37 1",
 "  c #161616",

--- a/src/ui/wxWidgets/graphics/sbase.xpm
+++ b/src/ui/wxWidgets/graphics/sbase.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sbase_xpm[] = {
+static const char * const sbase_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 22 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/sbase_dark.xpm
+++ b/src/ui/wxWidgets/graphics/sbase_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sbase_dark_xpm[] = {
+static const char * const sbase_dark_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 22 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/sbase_exp.xpm
+++ b/src/ui/wxWidgets/graphics/sbase_exp.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sbase_exp_xpm[] = {
+static const char * const sbase_exp_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 19 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/sbase_exp_dark.xpm
+++ b/src/ui/wxWidgets/graphics/sbase_exp_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sbase_exp_dark_xpm[] = {
+static const char * const sbase_exp_dark_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 19 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/sbase_warn.xpm
+++ b/src/ui/wxWidgets/graphics/sbase_warn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sbase_warn_xpm[] = {
+static const char * const sbase_warn_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 23 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/sbase_warn_dark.xpm
+++ b/src/ui/wxWidgets/graphics/sbase_warn_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sbase_warn_dark_xpm[] = {
+static const char * const sbase_warn_dark_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 23 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/shortcut.xpm
+++ b/src/ui/wxWidgets/graphics/shortcut.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *shortcut_xpm[] = {
+static const char * const shortcut_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 21 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/shortcut_dark.xpm
+++ b/src/ui/wxWidgets/graphics/shortcut_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *shortcut_dark_xpm[] = {
+static const char * const shortcut_dark_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "13 13 21 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/add.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/add.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_add_xpm[] = {
+static const char * const classic_add_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/add_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/add_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_add_disabled_xpm[] = {
+static const char * const classic_add_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/addgroup.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/addgroup.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_addgroup_xpm[] = {
+static const char * const classic_addgroup_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 5 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/addgroup_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/addgroup_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_addgroup_disabled_xpm[] = {
+static const char * const classic_addgroup_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 5 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/applyfilter.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/applyfilter.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_applyfilter_xpm[] = {
+static const char * const classic_applyfilter_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 5 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/applyfilter_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/applyfilter_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_applyfilter_disabled_xpm[] = {
+static const char * const classic_applyfilter_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 5 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/autotype.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/autotype.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_autotype_xpm[] = {
+static const char * const classic_autotype_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/autotype_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/autotype_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_autotype_disabled_xpm[] = {
+static const char * const classic_autotype_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/browseurl.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/browseurl.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_browseurl_xpm[] = {
+static const char * const classic_browseurl_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/browseurl_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/browseurl_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_browseurl_disabled_xpm[] = {
+static const char * const classic_browseurl_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/browseurlplus.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/browseurlplus.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_browseurlplus_xpm[] = {
+static const char * const classic_browseurlplus_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/browseurlplus_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/browseurlplus_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_browseurlplus_disabled_xpm[] = {
+static const char * const classic_browseurlplus_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/clearclipboard.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/clearclipboard.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_clearclipboard_xpm[] = {
+static const char * const classic_clearclipboard_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 6 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/clearclipboard_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/clearclipboard_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_clearclipboard_disabled_xpm[] = {
+static const char * const classic_clearclipboard_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 6 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/close.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/close.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_close_xpm[] = {
+static const char * const classic_close_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/close_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/close_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_close_disabled_xpm[] = {
+static const char * const classic_close_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/collapseall.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/collapseall.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_collapseall_xpm[] = {
+static const char * const classic_collapseall_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/collapseall_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/collapseall_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_collapseall_disabled_xpm[] = {
+static const char * const classic_collapseall_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/compare.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/compare.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_compare_xpm[] = {
+static const char * const classic_compare_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 8 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/compare_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/compare_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_compare_disabled_xpm[] = {
+static const char * const classic_compare_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 7 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/copynotes.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/copynotes.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_copynotes_xpm[] = {
+static const char * const classic_copynotes_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/copynotes_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/copynotes_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_copynotes_disabled_xpm[] = {
+static const char * const classic_copynotes_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/copypassword.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/copypassword.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_copypassword_xpm[] = {
+static const char * const classic_copypassword_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/copypassword_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/copypassword_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_copypassword_disabled_xpm[] = {
+static const char * const classic_copypassword_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/copyuser.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/copyuser.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_copyuser_xpm[] = {
+static const char * const classic_copyuser_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/copyuser_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/copyuser_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_copyuser_disabled_xpm[] = {
+static const char * const classic_copyuser_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/delete.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/delete.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_delete_xpm[] = {
+static const char * const classic_delete_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/delete_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/delete_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_delete_disabled_xpm[] = {
+static const char * const classic_delete_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/duplicategroup.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/duplicategroup.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_duplicategroup_xpm[] = {
+static const char * const classic_duplicategroup_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 5 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/duplicategroup_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/duplicategroup_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_duplicategroup_disabled_xpm[] = {
+static const char * const classic_duplicategroup_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 5 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/expandall.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/expandall.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_expandall_xpm[] = {
+static const char * const classic_expandall_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/expandall_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/expandall_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_expandall_disabled_xpm[] = {
+static const char * const classic_expandall_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/exportXML.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/exportXML.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_exportxml_xpm[] = {
+static const char * const classic_exportxml_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/exportXML_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/exportXML_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_exportXML_disabled_xpm[] = {
+static const char * const classic_exportXML_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/exporttext.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/exporttext.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_exporttext_xpm[] = {
+static const char * const classic_exporttext_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/exporttext_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/exporttext_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_exporttext_disabled_xpm[] = {
+static const char * const classic_exporttext_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/help.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/help.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_help_xpm[] = {
+static const char * const classic_help_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/help_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/help_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_help_disabled_xpm[] = {
+static const char * const classic_help_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/importXML.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/importXML.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_importxml_xpm[] = {
+static const char * const classic_importxml_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/importXML_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/importXML_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_importXML_disabled_xpm[] = {
+static const char * const classic_importXML_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/importtext.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/importtext.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_importtext_xpm[] = {
+static const char * const classic_importtext_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/importtext_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/importtext_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_importtext_disabled_xpm[] = {
+static const char * const classic_importtext_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 2 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/listtree.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/listtree.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_listtree_xpm[] = {
+static const char * const classic_listtree_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/listtree_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/listtree_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_listtree_disabled_xpm[] = {
+static const char * const classic_listtree_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/lock.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/lock.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_lock_xpm[] = {
+static const char * const classic_lock_xpm[] = {
 "16 16 11 1",
 " 	c None",
 ".	c #858585",

--- a/src/ui/wxWidgets/graphics/toolbar/classic/lock_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/lock_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_lock_disabled_xpm[] = {
+static const char * const classic_lock_disabled_xpm[] = {
 "16 16 11 1",
 " 	c None",
 ".	c #858585",

--- a/src/ui/wxWidgets/graphics/toolbar/classic/managefilters.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/managefilters.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_managefilters_xpm[] = {
+static const char * const classic_managefilters_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 6 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/managefilters_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/managefilters_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_managefilters_disabled_xpm[] = {
+static const char * const classic_managefilters_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 6 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/merge.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/merge.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_merge_xpm[] = {
+static const char * const classic_merge_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/merge_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/merge_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_merge_disabled_xpm[] = {
+static const char * const classic_merge_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/new.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/new.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_new_xpm[] = {
+static const char * const classic_new_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/new_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/new_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_new_disabled_xpm[] = {
+static const char * const classic_new_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/open.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/open.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_open_xpm[] = {
+static const char * const classic_open_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 5 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/open_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/open_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_open_disabled_xpm[] = {
+static const char * const classic_open_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 5 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/options.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/options.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_options_xpm[] = {
+static const char * const classic_options_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/options_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/options_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_options_disabled_xpm[] = {
+static const char * const classic_options_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/passwordchars.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/passwordchars.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_passwordchars_xpm[] = {
+static const char * const classic_passwordchars_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/passwordchars_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/passwordchars_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_passwordchars_disabled_xpm[] = {
+static const char * const classic_passwordchars_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/redo.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/redo.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_redo_xpm[] = {
+static const char * const classic_redo_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 15 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/redo_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/redo_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_redo_disabled_xpm[] = {
+static const char * const classic_redo_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 14 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/runcmd.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/runcmd.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_runcmd_xpm[] = {
+static const char * const classic_runcmd_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/runcmd_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/runcmd_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_runcmd_disabled_xpm[] = {
+static const char * const classic_runcmd_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/save.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/save.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_save_xpm[] = {
+static const char * const classic_save_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/save_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/save_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_save_disabled_xpm[] = {
+static const char * const classic_save_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/saveas.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/saveas.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_saveas_xpm[] = {
+static const char * const classic_saveas_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 6 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/saveas_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/saveas_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_saveas_disabled_xpm[] = {
+static const char * const classic_saveas_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 6 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/sendemail.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/sendemail.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_sendemail_xpm[] = {
+static const char * const classic_sendemail_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 5 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/sendemail_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/sendemail_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_sendemail_disabled_xpm[] = {
+static const char * const classic_sendemail_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 5 1",
 "  c None",

--- a/src/ui/wxWidgets/graphics/toolbar/classic/setfilter.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/setfilter.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_setfilter_xpm[] = {
+static const char * const classic_setfilter_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 6 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/setfilter_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/setfilter_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_setfilter_disabled_xpm[] = {
+static const char * const classic_setfilter_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 6 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/synchronize.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/synchronize.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_synchronize_xpm[] = {
+static const char * const classic_synchronize_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 45 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/synchronize_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/synchronize_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_synchronize_disabled_xpm[] = {
+static const char * const classic_synchronize_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 41 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/undo.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/undo.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_undo_xpm[] = {
+static const char * const classic_undo_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 15 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/undo_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/undo_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_undo_disabled_xpm[] = {
+static const char * const classic_undo_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 15 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/viewedit.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/viewedit.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_viewedit_xpm[] = {
+static const char * const classic_viewedit_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/viewedit_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/viewedit_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_viewedit_disabled_xpm[] = {
+static const char * const classic_viewedit_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 4 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/viewreports.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/viewreports.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_viewreports_xpm[] = {
+static const char * const classic_viewreports_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 6 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/classic/viewreports_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/classic/viewreports_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *classic_viewreports_disabled_xpm[] = {
+static const char * const classic_viewreports_disabled_xpm[] = {
 /* width height ncolors chars_per_pixel */
 "16 16 6 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/add.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/add.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *add_xpm[] = {
+static const char * const add_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 174 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/add_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/add_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *add_disabled_xpm[] = {
+static const char * const add_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 99 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/addgroup.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/addgroup.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *addgroup_xpm[] = {
+static const char * const addgroup_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 123 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/addgroup_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/addgroup_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *addgroup_disabled_xpm[] = {
+static const char * const addgroup_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 89 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/applyfilter.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/applyfilter.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *applyfilter_xpm[] = {
+static const char * const applyfilter_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 182 2",
 /* color */

--- a/src/ui/wxWidgets/graphics/toolbar/new/applyfilter_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/applyfilter_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *applyfilter_disabled_xpm[] = {
+static const char * const applyfilter_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 116 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/autotype.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/autotype.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *autotype_xpm[] = {
+static const char * const autotype_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 113 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/autotype_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/autotype_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *autotype_disabled_xpm[] = {
+static const char * const autotype_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 71 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/browseurl.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/browseurl.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *browseurl_xpm[] = {
+static const char * const browseurl_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 190 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/browseurl_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/browseurl_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *browseurl_disabled_xpm[] = {
+static const char * const browseurl_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 98 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/browseurlplus.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/browseurlplus.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *browseurlplus_xpm[] = {
+static const char * const browseurlplus_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 200 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/browseurlplus_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/browseurlplus_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *browseurlplus_disabled_xpm[] = {
+static const char * const browseurlplus_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 104 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/clearclipboard.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/clearclipboard.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *clearclipboard_xpm[] = {
+static const char * const clearclipboard_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 190 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/clearclipboard_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/clearclipboard_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *clearclipboard_disabled_xpm[] = {
+static const char * const clearclipboard_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 118 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/close.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/close.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *close_xpm[] = {
+static const char * const close_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 120 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/close_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/close_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *close_disabled_xpm[] = {
+static const char * const close_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 81 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/collapseall.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/collapseall.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *collapseall_xpm[] = {
+static const char * const collapseall_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 104 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/collapseall_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/collapseall_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *collapseall_disabled_xpm[] = {
+static const char * const collapseall_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 74 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/compare.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/compare.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *compare_xpm[] = {
+static const char * const compare_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 111 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/compare_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/compare_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *compare_disabled_xpm[] = {
+static const char * const compare_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 70 1",
 /* pixels */

--- a/src/ui/wxWidgets/graphics/toolbar/new/copynotes.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/copynotes.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *copynotes_xpm[] = {
+static const char * const copynotes_xpm[] = {
 "16 16 151 2",
 /* colors */
 "  	c None",

--- a/src/ui/wxWidgets/graphics/toolbar/new/copynotes_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/copynotes_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *copynotes_disabled_xpm[] = {
+static const char * const copynotes_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 96 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/copypassword.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/copypassword.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *copypassword_xpm[] = {
+static const char * const copypassword_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 136 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/copypassword_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/copypassword_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *copypassword_disabled_xpm[] = {
+static const char * const copypassword_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 98 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/copyuser.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/copyuser.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *copyuser_xpm[] = {
+static const char * const copyuser_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 157 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/copyuser_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/copyuser_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *copyuser_disabled_xpm[] = {
+static const char * const copyuser_disabled_xpm[] = {
 "16 16 104 2",
 /* colors */
 "  	g None",

--- a/src/ui/wxWidgets/graphics/toolbar/new/delete.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/delete.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *delete_xpm[] = {
+static const char * const delete_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 183 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/delete_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/delete_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *delete_disabled_xpm[] = {
+static const char * const delete_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 91 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/duplicategroup.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/duplicategroup.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *duplicategroup_xpm[] = {
+static const char * const duplicategroup_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 131 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/duplicategroup_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/duplicategroup_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *duplicategroup_disabled_xpm[] = {
+static const char * const duplicategroup_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 88 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/expandall.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/expandall.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *expandall_xpm[] = {
+static const char * const expandall_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 113 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/expandall_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/expandall_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *expandall_disabled_xpm[] = {
+static const char * const expandall_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 80 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/exportXML.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/exportXML.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *exportxml_xpm[] = {
+static const char * const exportxml_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 154 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/exportXML_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/exportXML_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *exportxml_disabled_xpm[] = {
+static const char * const exportxml_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 100 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/exporttext.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/exporttext.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *exporttext_xpm[] = {
+static const char * const exporttext_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 144 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/exporttext_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/exporttext_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *exporttext_disabled_xpm[] = {
+static const char * const exporttext_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 92 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/help.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/help.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *help_xpm[] = {
+static const char * const help_xpm[] = {
 "16 16 162 2",
 /* colors */
 "  	c None",

--- a/src/ui/wxWidgets/graphics/toolbar/new/help_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/help_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *help_disabled_xpm[] = {
+static const char * const help_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 104 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/importXML.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/importXML.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *importxml_xpm[] = {
+static const char * const importxml_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 154 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/importXML_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/importXML_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *importxml_disabled_xpm[] = {
+static const char * const importxml_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 102 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/importtext.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/importtext.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *importtext_xpm[] = {
+static const char * const importtext_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 144 2",
 /* color */

--- a/src/ui/wxWidgets/graphics/toolbar/new/importtext_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/importtext_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *importtext_disabled_xpm[] = {
+static const char * const importtext_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 90 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/listtree.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/listtree.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *listtree_xpm[] = {
+static const char * const listtree_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 76 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/listtree_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/listtree_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *listtree_disabled_xpm[] = {
+static const char * const listtree_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 59 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/lock.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/lock.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *lock_xpm[] = {
+static const char * const lock_xpm[] = {
 "16 16 172 2",
 "  	c None",
 ". 	c #A5A5A5",

--- a/src/ui/wxWidgets/graphics/toolbar/new/lock_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/lock_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *lock_disabled_xpm[] = {
+static const char * const lock_disabled_xpm[] = {
 "16 16 100 2",
 "  	c None",
 ". 	c #A5A5A5",

--- a/src/ui/wxWidgets/graphics/toolbar/new/managefilters.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/managefilters.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *managefilters_xpm[] = {
+static const char * const managefilters_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 179 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/managefilters_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/managefilters_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *managefilters_disabled_xpm[] = {
+static const char * const managefilters_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 110 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/merge.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/merge.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *merge_xpm[] = {
+static const char * const merge_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 101 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/merge_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/merge_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *merge_disabled_xpm[] = {
+static const char * const merge_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 60 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/new.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/new.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *new_xpm[] = {
+static const char * const new_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 130 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/new_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/new_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *new_disabled_xpm[] = {
+static const char * const new_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 77 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/open.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/open.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *open_xpm[] = {
+static const char * const open_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 155 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/open_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/open_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *open_disabled_xpm[] = {
+static const char * const open_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 84 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/options.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/options.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *options_xpm[] = {
+static const char * const options_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 67 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/options_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/options_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *options_disabled_xpm[] = {
+static const char * const options_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 49 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/passwordchars.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/passwordchars.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *passwordchars_xpm[] = {
+static const char * const passwordchars_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 46 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/passwordchars_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/passwordchars_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *passwordchars_disabled_xpm[] = {
+static const char * const passwordchars_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 43 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/redo.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/redo.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *redo_xpm[] = {
+static const char * const redo_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 15 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/redo_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/redo_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *redo_disabled_xpm[] = {
+static const char * const redo_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 15 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/runcmd.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/runcmd.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *runcmd_xpm[] = {
+static const char * const runcmd_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 112 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/runcmd_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/runcmd_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *runcmd_disabled_xpm[] = {
+static const char * const runcmd_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 77 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/save.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/save.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *save_xpm[] = {
+static const char * const save_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 155 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/save_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/save_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *save_disabled_xpm[] = {
+static const char * const save_disabled_xpm[] = {
 "16 16 79 1",
 /* colors */
 " 	g None",

--- a/src/ui/wxWidgets/graphics/toolbar/new/saveas.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/saveas.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *saveas_xpm[] = {
+static const char * const saveas_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 120 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/saveas_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/saveas_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *saveas_disabled_xpm[] = {
+static const char * const saveas_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 76 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/sendemail.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/sendemail.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sendemail_xpm[] = {
+static const char * const sendemail_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 166 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/sendemail_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/sendemail_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sendemail_disabled_xpm[] = {
+static const char * const sendemail_disabled_xpm[] = {
 "16 16 106 2",
 /* colors */
 "  	g None",

--- a/src/ui/wxWidgets/graphics/toolbar/new/setfilter.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/setfilter.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *setfilter_xpm[] = {
+static const char * const setfilter_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 188 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/setfilter_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/setfilter_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *setfilter_disabled_xpm[] = {
+static const char * const setfilter_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 109 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/synchronize.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/synchronize.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *synchronize_xpm[] = {
+static const char * const synchronize_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 45 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/synchronize_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/synchronize_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *synchronize_disabled_xpm[] = {
+static const char * const synchronize_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 41 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/undo.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/undo.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *undo_xpm[] = {
+static const char * const undo_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 15 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/undo_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/undo_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *undo_disabled_xpm[] = {
+static const char * const undo_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 15 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/viewedit.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/viewedit.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *viewedit_xpm[] = {
+static const char * const viewedit_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 63 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/viewedit_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/viewedit_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *viewedit_disabled_xpm[] = {
+static const char * const viewedit_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 48 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/viewreports.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/viewreports.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *viewreports_xpm[] = {
+static const char * const viewreports_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 102 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/toolbar/new/viewreports_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/toolbar/new/viewreports_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *viewreports_disabled_xpm[] = {
+static const char * const viewreports_disabled_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 85 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/tray.xpm
+++ b/src/ui/wxWidgets/graphics/tray.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * tray_xpm[] = {
+static const char * const tray_xpm[] = {
 "32 32 4 1",
 " 	c None",
 ".	c #000000",

--- a/src/ui/wxWidgets/graphics/unchecked.xpm
+++ b/src/ui/wxWidgets/graphics/unchecked.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *unchecked_xpm[] = {
+static const char * const unchecked_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/unchecked_dark.xpm
+++ b/src/ui/wxWidgets/graphics/unchecked_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *unchecked_dark_xpm[] = {
+static const char * const unchecked_dark_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/unchecked_disabled.xpm
+++ b/src/ui/wxWidgets/graphics/unchecked_disabled.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *unchecked_disabled_xpm[] = {
+static const char * const unchecked_disabled_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/unchecked_disabled_dark.xpm
+++ b/src/ui/wxWidgets/graphics/unchecked_disabled_dark.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *unchecked_disabled_dark_xpm[] = {
+static const char * const unchecked_disabled_dark_xpm[] = {
 /* width height num_colors chars_per_pixel */
 "13 13 3 1",
 /* colors */

--- a/src/ui/wxWidgets/graphics/unlock.xpm
+++ b/src/ui/wxWidgets/graphics/unlock.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *unlock_xpm[] = {
+static const char * const unlock_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 157 2",
 /* colors */

--- a/src/ui/wxWidgets/graphics/unlocked_tray.xpm
+++ b/src/ui/wxWidgets/graphics/unlocked_tray.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * unlocked_tray_xpm[] = {
+static const char * const unlocked_tray_xpm[] = {
 "32 32 4 1",
 " 	c None",
 ".	c #FF0000",

--- a/src/ui/wxWidgets/graphics/vkbd.xpm
+++ b/src/ui/wxWidgets/graphics/vkbd.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *vkbd_xpm[] = {
+static const char * const vkbd_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "31 16 4 1",
 /* colors */


### PR DESCRIPTION
This complicates editing XPM files, but moves many things to read-only data segments.  The first commit only changes the code to treat the arrays as `const`, which works even for XPM arrays that are not `const` and is simply good practice.  The second commit is the one that would mean more work when editing XPM files, because the resulting `.xpm` files are no longer canonical XPM files since they would have declarations of the form,
``` cpp
static const char * const <filename>_xpm[] = {
```
instead of,
``` cpp
static const char * <filename>_xpm[] = {
```
This conversion could also be done at build time, at the cost of a little more build complexity.

As to why a three-decade old image standard only added `const` to the individual strings..?  Being able to change individual strings in the XPM image arrays at runtime would be a rather niche requirement.

Note also that unless the linker is set up to merge identical data symbols, some images will be included in the resulting binary multiple times:
```
$ find src -type f -iname "*.cpp" | xargs grep -h "#include" | grep "\.xpm" | sort | uniq -d -c
      4 #include "graphics/cpane.xpm"
      4 #include "graphics/toolbar/new/copypassword.xpm"
      3 #include "graphics/toolbar/new/copypassword_disabled.xpm"
      6 #include "graphics/Yubikey-button.xpm"
```
One might consider handling those four XPMs from a central repository instead of `#include`ing them directly.