### PR TITLE
Remove an x86/x64 include from UnicodeUtils.cpp.

### DIFF
--- a/src/Tools/Windows/I18N/ResText/UnicodeUtils.cpp
+++ b/src/Tools/Windows/I18N/ResText/UnicodeUtils.cpp
@@ -19,7 +19,6 @@
 #include "stdafx.h"
 #include "UnicodeUtils.h"
 #include <memory>
-#include <emmintrin.h>
 
 CUnicodeUtils::CUnicodeUtils(void)
 {


### PR DESCRIPTION
No x86/x64 intrinsics are used and it breaks arm64 builds.