### PR TITLE
EXE/DLL "Details" Copyright Symbol Corruption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,11 +94,11 @@ if (NOT DEFINED pwsafe_VERSION_MINOR)
   message (FATAL_ERROR "VER_MINOR undefined in ${VERSION_FILE} - unable to proceed")
 endif (NOT DEFINED pwsafe_VERSION_MINOR)
 
-if (pwsafe_REVISION)
-   set (pwsafe_VERSION "${pwsafe_VERSION_MAJOR}.${pwsafe_VERSION_MINOR}.${pwsafe_REVISION}")
-else ()
-   set (pwsafe_VERSION "${pwsafe_VERSION_MAJOR}.${pwsafe_VERSION_MINOR}.0")
-endif (pwsafe_REVISION)
+if (NOT pwsafe_REVISION)
+  set (pwsafe_REVISION 0)
+endif ()
+
+set (pwsafe_VERSION "${pwsafe_VERSION_MAJOR}.${pwsafe_VERSION_MINOR}.${pwsafe_REVISION}")
 
 # Configurable options:
 option (NO_YUBI "Set ON to disable YubiKey support" OFF)
@@ -228,15 +228,37 @@ include_directories ("${PROJECT_SOURCE_DIR}/src"
   "${PROJECT_SOURCE_DIR}/src/core"
   "${PROJECT_SOURCE_DIR}/src/ui/wxWidgets")
 
-execute_process(COMMAND "git" "describe" "--all" "--always" "--dirty=+" "--long"
-  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-  RESULT_VARIABLE res
-  OUTPUT_VARIABLE pwsafe_VERSTRING
-  ERROR_QUIET
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-if (res)
+find_package(Git)
+
+if (Git_FOUND)
+  execute_process(COMMAND "${GIT_EXECUTABLE}" describe --all --always --dirty=+ --long
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    RESULT_VARIABLE res
+    OUTPUT_VARIABLE pwsafe_VERSTRING
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if (res)
+    set(pwsafe_VERSTRING "local")
+  endif ()
+
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" show -s --format=%ci HEAD
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    OUTPUT_VARIABLE pwsafe_TIMESTAMP
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+   )
+
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" config --get remote.origin.url
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    OUTPUT_VARIABLE pwsafe_REPO_URL
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+else ()
   set(pwsafe_VERSTRING "local")
-endif()
+endif ()
 
 # Assume that we're either MSVC or a Unix-like
 if (MSVC)
@@ -301,6 +323,34 @@ if (WIN32 AND NOT WX_WINDOWS)
 else (WIN32 AND NOT WX_WINDOWS)
   set(VERSION_IN "${PROJECT_SOURCE_DIR}/src/ui/wxWidgets/version.in")
 endif (WIN32 AND NOT WX_WINDOWS)
+
+set (PWS_VERSION_MAJOR "${pwsafe_VERSION_MAJOR}")
+set (PWS_VERSION_MINOR "${pwsafe_VERSION_MINOR}")
+set (PWS_VERSION_PATCH "${pwsafe_REVISION}")
+
+set (PWS_PRODUCTVER "${pwsafe_VERSION_MAJOR}, ${pwsafe_VERSION_MINOR}, ${pwsafe_REVISION}" )
+set (PWS_PRODUCTVER_STR "${pwsafe_VERSION_MAJOR}.${pwsafe_VERSION_MINOR}.${pwsafe_REVISION}${pwsafe_SPECIALBUILD} ${pwsafe_VERSTRING}")
+
+set (PWS_FILEVER "${PWS_PRODUCTVER}")
+set (PWS_FILEVER_STR "${PWS_PRODUCTVER_STR}")
+
+set (PWS_DESCRIBE_STR "${pwsafe_VERSTRING}")
+
+if (pwsafe_PRIVATEBUILD)
+  set (PWS_PRIVATEBUILD_STR "${pwsafe_PRIVATEBUILD}")
+endif ()
+
+if (pwsafe_SPECIALBUILD)
+  set (PWS_SPECIALBUILD_STR "${pwsafe_SPECIALBUILD}")
+endif ()
+
+if (pwsafe_TIMESTAMP)
+  set (PWS_TIMESTAMP_STR "${pwsafe_TIMESTAMP}")
+endif ()
+
+if (pwsafe_REPO_URL)
+  set (PWS_REPO_URL_STR "${pwsafe_REPO_URL}")
+endif ()
 
 configure_file (
   ${VERSION_IN}

--- a/src/Tools/Windows/I18N/ResPWSL/ResPWSL.rc
+++ b/src/Tools/Windows/I18N/ResPWSL/ResPWSL.rc
@@ -1,5 +1,7 @@
-//Microsoft Developer Studio generated resource script.
+// Microsoft Visual C++ generated resource script.
 //
+#pragma code_page(65001)
+
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
@@ -13,13 +15,10 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// English (U.S.) resources
+// English (United States) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
-#pragma code_page(1252)
-#endif //_WIN32
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -27,18 +26,18 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 // TEXTINCLUDE
 //
 
-1 TEXTINCLUDE DISCARDABLE 
+1 TEXTINCLUDE 
 BEGIN
     "resource.h\0"
 END
 
-2 TEXTINCLUDE DISCARDABLE 
+2 TEXTINCLUDE 
 BEGIN
     "#include ""afxres.h""\r\n"
     "\0"
 END
 
-3 TEXTINCLUDE DISCARDABLE 
+3 TEXTINCLUDE 
 BEGIN
     "\r\n"
     "\0"
@@ -47,7 +46,6 @@ END
 #endif    // APSTUDIO_INVOKED
 
 
-#ifndef _MAC
 /////////////////////////////////////////////////////////////////////////////
 //
 // Version
@@ -73,14 +71,13 @@ BEGIN
             VALUE "Comments", "Utility to create/modify Version String table in Password Safe Language Resource-Only DLLs - using code produced by Denis Zabavchik.  See http://www.codeproject.com/library/VerInfoLib.asp"
             VALUE "CompanyName", "Rony Shapiro"
             VALUE "FileDescription", "Password Safe DLL Creator/Modifier"
-            VALUE "FileVersion", "2, 0, 0, 0\0"
+            VALUE "FileVersion", "2.0.0.0"
             VALUE "InternalName", "ResPWSL"
-            VALUE "LegalCopyright", "Copyright © 2003-2023 Rony Shapiro, Denis Zabavchik 2006"
-            VALUE "LegalTrademarks", "Copyright © 2003-2023 Rony Shapiro, Denis Zabavchik 2006"
+            VALUE "LegalCopyright", "Copyright Â© 2003-2023 Rony Shapiro, Denis Zabavchik 2006"
+            VALUE "LegalTrademarks", "Copyright Â© 2003-2023 Rony Shapiro, Denis Zabavchik 2006"
             VALUE "OriginalFilename", "ResPWSL.exe"
             VALUE "ProductName", "Password Safe DLL Creator/Modifier"
-            VALUE "ProductVersion", "2, 0, 0, 0\0"
-            VALUE "SpecialBuild", "\0"
+            VALUE "ProductVersion", "2.0.0.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -89,9 +86,7 @@ BEGIN
     END
 END
 
-#endif    // !_MAC
-
-#endif    // English (U.S.) resources
+#endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/src/Tools/Windows/I18N/ResText/ResText.rc
+++ b/src/Tools/Windows/I18N/ResText/ResText.rc
@@ -1,5 +1,7 @@
-//Microsoft Developer Studio generated resource script.
+// Microsoft Visual C++ generated resource script.
 //
+#pragma code_page(65001)
+
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
@@ -13,13 +15,10 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// English (U.S.) resources
+// English (United States) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
-#pragma code_page(1252)
-#endif //_WIN32
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -27,18 +26,18 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 // TEXTINCLUDE
 //
 
-1 TEXTINCLUDE DISCARDABLE 
+1 TEXTINCLUDE 
 BEGIN
     "resource.h\0"
 END
 
-2 TEXTINCLUDE DISCARDABLE 
+2 TEXTINCLUDE 
 BEGIN
     "#include ""afxres.h""\r\n"
     "\0"
 END
 
-3 TEXTINCLUDE DISCARDABLE 
+3 TEXTINCLUDE 
 BEGIN
     "\r\n"
     "\0"
@@ -47,7 +46,6 @@ END
 #endif    // APSTUDIO_INVOKED
 
 
-#ifndef _MAC
 /////////////////////////////////////////////////////////////////////////////
 //
 // Version
@@ -73,14 +71,13 @@ BEGIN
             VALUE "Comments", "Slightly modified for PasswordSafe. Original: TortoiseSVN.  See http://tortoisesvn.net/"
             VALUE "CompanyName", "Rony Shapiro"
             VALUE "FileDescription", "PasswordSafe Create/Modify Resource strings"
-            VALUE "FileVersion", "1, 0, 0, 0\0"
+            VALUE "FileVersion", "1.0.0.0"
             VALUE "InternalName", "ResText"
-            VALUE "LegalCopyright", "© 2003-2013 TortoiseSVN, Rony Shapiro"
-            VALUE "LegalTrademarks", "© 2003-2013 TortoiseSVN, Rony Shapiro"
+            VALUE "LegalCopyright", "Â© 2003-2013 TortoiseSVN, Rony Shapiro"
+            VALUE "LegalTrademarks", "Â© 2003-2013 TortoiseSVN, Rony Shapiro"
             VALUE "OriginalFilename", "ResText.exe"
             VALUE "ProductName", "Password Safe Create/Modify Resource strings"
-            VALUE "ProductVersion", "1, 0, 0, 0\0"
-            VALUE "SpecialBuild", "\0"
+            VALUE "ProductVersion", "1.0.0.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -89,9 +86,7 @@ BEGIN
     END
 END
 
-#endif    // !_MAC
-
-#endif    // English (U.S.) resources
+#endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
 
 

--- a/src/os/windows/pws_autotype/pws_at.rc
+++ b/src/os/windows/pws_autotype/pws_at.rc
@@ -1,5 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
+#pragma code_page(65001)
+
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
@@ -13,13 +15,10 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// English (U.S.) resources
+// English (United States) resources
 
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENG)
-#ifdef _WIN32
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
-#pragma code_page(1252)
-#endif //_WIN32
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -48,16 +47,17 @@ BEGIN
     "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)\r\n"
     "#ifdef _WIN32\r\n"
     "LANGUAGE 9, 1\r\n"
-    "#pragma code_page(1252)\r\n"
-    "#include ""pws_at.rc2"  // Version information
+    "#include ""pws_at.rc2""\r\n"
     "#endif\r\n"
     "#endif\r\0"
 END
 
 #endif    // APSTUDIO_INVOKED
 
-#endif    // English (U.S.) resources
+#endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
+
+
 
 #ifndef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -72,8 +72,7 @@ END
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 #ifdef _WIN32
 LANGUAGE 9, 1
-#pragma code_page(1252)
-#include "pws_at.rc2"  // non-MS VC++ edited Version resources
+#include "pws_at.rc2"
 #endif
 #endif
 

--- a/src/os/windows/pws_autotype/pws_at.rc2
+++ b/src/os/windows/pws_autotype/pws_at.rc2
@@ -13,18 +13,27 @@
 //
 
 #include "version.h"
-VS_VERSION_INFO VERSIONINFO
- FILEVERSION FILEVER
- PRODUCTVERSION PRODUCTVER
- FILEFLAGSMASK 0x3fL
-#ifdef _DEBUG
- FILEFLAGS 0x1L
+
+#if defined(SPECIAL_BUILD)
+#define PWS_FLAGS_PRIVATEBUILD (VS_FF_PRIVATEBUILD|VS_FF_PRERELEASE)
 #else
- FILEFLAGS 0x0L
+#define PWS_FLAGS_PRIVATEBUILD 0L
 #endif
- FILEOS 0x4L
- FILETYPE 0x1L
- FILESUBTYPE 0x0L
+
+#ifdef _DEBUG
+#define PWS_FILEFLAGS (VS_FF_DEBUG | VS_FF_PRERELEASE | PWS_FLAGS_PRIVATEBUILD)
+#else
+#define PWS_FILEFLAGS PWS_FLAGS_PRIVATEBUILD
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+    FILEVERSION FILEVER
+    PRODUCTVERSION PRODUCTVER
+    FILEFLAGSMASK 0x3fL
+    FILEFLAGS PWS_FILEFLAGS
+    FILEOS VOS_NT_WINDOWS32
+    FILETYPE VFT_DLL
+    FILESUBTYPE 0x0L
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
@@ -35,11 +44,14 @@ BEGIN
             VALUE "FileDescription", "Password Safe Autotype DLL"
             VALUE "FileVersion", STRATFILEVER
             VALUE "InternalName", "Password Safe"
-            VALUE "LegalCopyright", "Copyright © 2003-2023 Rony Shapiro"
-            VALUE "LegalTrademarks", "Copyright © 1997-8 by Counterpane Systems, 2003-2023 Rony Shapiro"
+            VALUE "LegalCopyright", "Copyright Â© 2003-2023 Rony Shapiro"
+            VALUE "LegalTrademarks", "Copyright Â© 1997-8 by Counterpane Systems, 2003-2023 Rony Shapiro"
             VALUE "OriginalFilename", "pws_at.dll"
             VALUE "ProductName", "Password Safe Autotype DLL"
             VALUE "ProductVersion", STRATPRODUCTVER
+#if defined(SPECIAL_BUILD)
+            VALUE "PrivateBuild", SPECIAL_BUILD
+#endif
         END
     END
     BLOCK "VarFileInfo"

--- a/src/os/windows/pws_osk/pws_osk.rc
+++ b/src/os/windows/pws_osk/pws_osk.rc
@@ -1,5 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
+#pragma code_page(65001)
+
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
@@ -13,13 +15,10 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// English (U.S.) resources
+// English (United States) resources
 
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENG)
-#ifdef _WIN32
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
-#pragma code_page(1252)
-#endif //_WIN32
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -48,16 +47,17 @@ BEGIN
     "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)\r\n"
     "#ifdef _WIN32\r\n"
     "LANGUAGE 9, 1\r\n"
-    "#pragma code_page(1252)\r\n"
-    "#include ""pws_osk.rc2"  // Version information
+    "#include ""pws_osk.rc2""\r\n"
     "#endif\r\n"
     "#endif\r\0"
 END
 
 #endif    // APSTUDIO_INVOKED
 
-#endif    // English (U.S.) resources
+#endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
+
+
 
 #ifndef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -72,8 +72,7 @@ END
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 #ifdef _WIN32
 LANGUAGE 9, 1
-#pragma code_page(1252)
-#include "pws_osk.rc2"  // non-MS VC++ edited Version resources
+#include "pws_osk.rc2"
 #endif
 #endif
 

--- a/src/os/windows/pws_osk/pws_osk.rc2
+++ b/src/os/windows/pws_osk/pws_osk.rc2
@@ -13,18 +13,33 @@
 //
 
 #include "version.h"
-VS_VERSION_INFO VERSIONINFO
- FILEVERSION FILEVER
- PRODUCTVERSION PRODUCTVER
- FILEFLAGSMASK 0x3fL
-#ifdef _DEBUG
- FILEFLAGS 0x1L
+
+#if defined(SPECIAL_BUILD)
+#define PWS_FLAGS_PRIVATEBUILD (VS_FF_PRIVATEBUILD|VS_FF_PRERELEASE)
 #else
- FILEFLAGS 0x0L
+#define PWS_FLAGS_PRIVATEBUILD 0L
 #endif
- FILEOS 0x4L
- FILETYPE 0x1L
- FILESUBTYPE 0x0L
+
+#ifdef _DEBUG
+#define PWS_FILEFLAGS (VS_FF_DEBUG | VS_FF_PRERELEASE | PWS_FLAGS_PRIVATEBUILD)
+#else
+#define PWS_FILEFLAGS PWS_FLAGS_PRIVATEBUILD
+#endif
+
+#if defined(RESOURCE_DLL)
+#define PWS_FILETYPE VFT_DLL
+#else
+#define PWS_FILETYPE VFT_APP
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+    FILEVERSION FILEVER
+    PRODUCTVERSION PRODUCTVER
+    FILEFLAGSMASK 0x3fL
+    FILEFLAGS PWS_FILEFLAGS
+    FILEOS VOS_NT_WINDOWS32
+    FILETYPE VFT_DLL
+    FILESUBTYPE 0x0L
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
@@ -35,11 +50,14 @@ BEGIN
             VALUE "FileDescription", "Password Safe OnScreen Keyboard DLL"
             VALUE "FileVersion", STROSKFILEVER
             VALUE "InternalName", "Password Safe"
-            VALUE "LegalCopyright", "Copyright © 2003-2023 Rony Shapiro"
-            VALUE "LegalTrademarks", "Copyright © 1997-8 by Counterpane Systems, 2003-2023 Rony Shapiro"
+            VALUE "LegalCopyright", "Copyright Â© 2003-2023 Rony Shapiro"
+            VALUE "LegalTrademarks", "Copyright Â© 1997-8 by Counterpane Systems, 2003-2023 Rony Shapiro"
             VALUE "OriginalFilename", "pws_osk.dll"
             VALUE "ProductName", "Password Safe OnScreen Keyboard DLL"
             VALUE "ProductVersion", STROSKPRODUCTVER
+#if defined(SPECIAL_BUILD)
+            VALUE "PrivateBuild", SPECIAL_BUILD
+#endif
         END
     END
     BLOCK "VarFileInfo"

--- a/src/ui/Windows/PWSversion.cpp
+++ b/src/ui/Windows/PWSversion.cpp
@@ -39,46 +39,16 @@ void PWSversion::DeleteInstance()
 }
 
 PWSversion::PWSversion()
-  : m_nMajor(0), m_nMinor(0), m_nBuild(0), m_bModified(false)
+  : m_nMajor(PWS_VERSION_MAJOR), m_nMinor(PWS_VERSION_MINOR), m_nBuild(PWS_VERSION_PATCH), m_bModified(false)
 {
-  CString csFileVersion = WIDEN(STRFILEVER);
-  m_SpecialBuild = SPECIAL_BUILD;
+  CString csFileVersion = WIDEN(PWS_FILEVER_STR);
+#ifdef PWS_SPECIALBUILD_STR
+  m_SpecialBuild = PWS_SPECIALBUILD_STR;
+#endif
 
   m_builtOn = CString(__DATE__) + CString(L" ") + CString(__TIME__);
 
-  CString resToken;
-  int curPos = 0, index = 0;
-  
-  // Tokenize the file version to get the values in order
-  // Revision is either a number or a number with '+',
-  // so we need to get it from the file version string
-  // which is of the form "MM, NN, BB, rev"
-  resToken = csFileVersion.Tokenize(L",", curPos);
-  while (resToken != L"" && curPos != -1) {
-    resToken.Trim();
-    if (resToken.IsEmpty())
-      resToken = L"0";
-    
-    // Note: if token not numeric, returned value of _wtoi is zero
-    switch (index) {
-      case 0:
-        m_nMajor = _wtoi(resToken);
-        break;
-      case 1:
-        m_nMinor = _wtoi(resToken);
-        break;
-      case 2:
-        m_nBuild = _wtoi(resToken);
-        break;
-      case 3:
-        if (resToken.Right(1) == L"+")
-          m_bModified = true;
-        m_Revision = resToken;
-        break;
-      default:
-        ASSERT(0);
-    }
-    index++;
-    resToken = csFileVersion.Tokenize(L",", curPos);
-  };
+  m_Revision = PWS_DESCRIBE_STR;
+  if (m_Revision.Right(1) == L"+")
+    m_bModified = true;
 }

--- a/src/ui/Windows/PasswordSafe.rc
+++ b/src/ui/Windows/PasswordSafe.rc
@@ -1,5 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
+#pragma code_page(65001)
+
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
@@ -8,10 +10,11 @@
 // Generated from the TEXTINCLUDE 2 resource.
 //
 #include "afxres.h"
+#include "verrsrc.h"
 #include "resource2.h"  // Menu, Toolbar & Accelerator resources
 #include "resource3.h"  // STRING resources
-#include "..\..\core\core.h"  // core STRING resources
-#include "VirtualKeyboard\VKresource.h"  // Virtual Keyboard resource
+#include "../../core/core.h"  // core STRING resources
+#include "VirtualKeyboard/VKresource.h"  // Virtual Keyboard resource
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -21,7 +24,84 @@
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
-#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""afxres.h""\r\n"
+    "#include ""verrsrc.h""\r\n"
+    "#include ""resource2.h""  // Menu, Toolbar & Accelerator resources\r\n"
+    "#include ""resource3.h""  // STRING resources\r\n"
+    "#include ""../../core/core.h""  // core STRING resources\r\n"
+    "#include ""VirtualKeyboard/VKresource.h""  // Virtual Keyboard resource\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "#define _AFX_NO_SPLITTER_RESOURCES\r\n"
+    "#define _AFX_NO_OLE_RESOURCES\r\n"
+    "#define _AFX_NO_TRACKER_RESOURCES\r\n"
+    "#define _AFX_NO_PROPERTY_RESOURCES\r\n"
+    "\r\n"
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)\r\n"
+    "#ifdef _WIN32\r\n"
+    "LANGUAGE 9, 1\r\n"
+    "#include ""res/PasswordSafe2.rc2""  // non-MS VC++ edited Version, Menu, Toolbar & Accelerator resources\r\n"
+    "#include ""res/PasswordSafe3.rc2""  // non-MS VC++ edited STRING resources\r\n"
+    "#include ""VirtualKeyboard/res/VKPasswordSafe3.rc2""  // non-MS VC++ edited STRING resources\r\n"
+    "#include ""../../core/core.rc2""  // non-MS VC++ edited STRING resources\r\n"
+    "#include ""afxres.rc""      // Standard components\r\n"
+    "#endif\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""afxres.h""\r\n"
+    "#include ""resource2.h""  // Menu, Toolbar & Accelerator resources\r\n"
+    "#include ""resource3.h""  // STRING resources\r\n"
+    "#include ""../../core/core.h""  // core STRING resources\r\n"
+    "#include ""VirtualKeyboard/VKresource.h""  // Virtual Keyboard resource\r\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "#define _AFX_NO_SPLITTER_RESOURCES\r\n"
+    "#define _AFX_NO_OLE_RESOURCES\r\n"
+    "#define _AFX_NO_TRACKER_RESOURCES\r\n"
+    "#define _AFX_NO_PROPERTY_RESOURCES\r\n"
+    "\r\n"
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)\r\n"
+    "#ifdef _WIN32\r\n"
+    "LANGUAGE 9, 1\r\n"
+    "#include ""res/PasswordSafe2.rc2""  // non-MS VC++ edited Version, Menu, Toolbar & Accelerator resources\r\n"
+    "#include ""res/PasswordSafe3.rc2""  // non-MS VC++ edited STRING resources\r\n"
+    "#include ""VirtualKeyboard/res/VKPasswordSafe3.rc2""  // non-MS VC++ edited STRING resources\r\n"
+    "#include ""../../core/core.rc2""    // non-MS VC++ edited core STRING resources\r\n"
+    "#include ""afxres.rc""         // Standard components\r\n"
+    "#endif\r\n"
+    "#endif\r\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -1986,49 +2066,6 @@ BEGIN
 END
 
 
-#ifdef APSTUDIO_INVOKED
-/////////////////////////////////////////////////////////////////////////////
-//
-// TEXTINCLUDE
-//
-
-1 TEXTINCLUDE 
-BEGIN
-    "resource.h\0"
-END
-
-2 TEXTINCLUDE 
-BEGIN
-    "#include ""afxres.h""\r\n"
-    "#include ""resource2.h""  // Menu, Toolbar & Accelerator resources\r\n"
-    "#include ""resource3.h""  // STRING resources\r\n"
-    "#include ""..\\..\\core\\core.h""  // core STRING resources\r\n"
-    "#include ""VirtualKeyboard\\VKresource.h""  // Virtual Keyboard resource\r\0"
-END
-
-3 TEXTINCLUDE 
-BEGIN
-    "#define _AFX_NO_SPLITTER_RESOURCES\r\n"
-    "#define _AFX_NO_OLE_RESOURCES\r\n"
-    "#define _AFX_NO_TRACKER_RESOURCES\r\n"
-    "#define _AFX_NO_PROPERTY_RESOURCES\r\n"
-    "\r\n"
-    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)\r\n"
-    "#ifdef _WIN32\r\n"
-    "LANGUAGE 9, 1\r\n"
-    "#pragma code_page(1252)\r\n"
-    "#include ""res\\PasswordSafe2.rc2""  // non-MS VC++ edited Version, Menu, Toolbar & Accelerator resources\r\n"
-    "#include ""res\\PasswordSafe3.rc2""  // non-MS VC++ edited STRING resources\r\n"
-    "#include ""VirtualKeyboard\\res\\VKPasswordSafe3.rc2""  // non-MS VC++ edited STRING resources\r\n"
-    "#include ""..\\..\\core\\core.rc2""    // non-MS VC++ edited core STRING resources\r\n"
-    "#include ""afxres.rc""         // Standard components\r\n"
-    "#endif\r\n"
-    "#endif\r\0"
-END
-
-#endif    // APSTUDIO_INVOKED
-
-
 /////////////////////////////////////////////////////////////////////////////
 //
 // Icon
@@ -3269,12 +3306,11 @@ END
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 #ifdef _WIN32
 LANGUAGE 9, 1
-#pragma code_page(1252)
-#include "res\PasswordSafe2.rc2"  // non-MS VC++ edited Version, Menu, Toolbar & Accelerator resources
-#include "res\PasswordSafe3.rc2"  // non-MS VC++ edited STRING resources
-#include "VirtualKeyboard\res\VKPasswordSafe3.rc2"  // non-MS VC++ edited STRING resources
-#include "..\..\core\core.rc2"    // non-MS VC++ edited core STRING resources
-#include "afxres.rc"         // Standard components
+#include "res/PasswordSafe2.rc2"  // non-MS VC++ edited Version, Menu, Toolbar & Accelerator resources
+#include "res/PasswordSafe3.rc2"  // non-MS VC++ edited STRING resources
+#include "VirtualKeyboard/res/VKPasswordSafe3.rc2"  // non-MS VC++ edited STRING resources
+#include "../../core/core.rc2"  // non-MS VC++ edited STRING resources
+#include "afxres.rc"      // Standard components
 #endif
 #endif
 

--- a/src/ui/Windows/res/PasswordSafe2.rc2
+++ b/src/ui/Windows/res/PasswordSafe2.rc2
@@ -7,24 +7,63 @@
     #error this file is not editable by Microsoft Visual C++
 #endif //APSTUDIO_INVOKED
 
+#include "verrsrc.h"
+
 /////////////////////////////////////////////////////////////////////////////
 //
 // Version
 //
 
 #include "version.h"
-VS_VERSION_INFO VERSIONINFO
- FILEVERSION FILEVER
- PRODUCTVERSION PRODUCTVER
- FILEFLAGSMASK 0x3fL
-#ifdef _DEBUG
- FILEFLAGS 0x1L
+
+#if defined(PWS_PRIVATEBUILD_STR)
+#define PWS_FLAGS_PRIVATEBUILD (VS_FF_PRIVATEBUILD | VS_FF_PRERELEASE)
 #else
- FILEFLAGS 0x0L
+#define PWS_FLAGS_PRIVATEBUILD 0L
 #endif
- FILEOS 0x4L
- FILETYPE 0x1L
- FILESUBTYPE 0x0L
+
+#if defined(PWS_SPECIALBUILD_STR)
+#define PWS_FLAGS_SPECIALBUILD (VS_FF_SPECIALBUILD | VS_FF_PRERELEASE)
+#else
+#define PWS_FLAGS_SPECIALEBUILD 0L
+#endif
+
+#ifndef PWS_FILEFLAGS
+#ifdef _DEBUG
+#define PWS_FILEFLAGS (VS_FF_DEBUG | VS_FF_PRERELEASE | PWS_FLAGS_PRIVATEBUILD | PWS_FLAGS_SPECIALBUILD)
+#else
+#define PWS_FILEFLAGS (PWS_FLAGS_PRIVATEBUILD | PWS_FLAGS_SPECIALBUILD)
+#endif
+#endif
+
+#ifndef PWS_FILETYPE
+#if defined(RESOURCE_DLL)
+#define PWS_FILETYPE VFT_DLL
+#else
+#define PWS_FILETYPE VFT_APP
+#endif
+#endif
+
+#ifndef PWS_FILEDESCRIPTION
+#if defined(RESOURCE_DLL)
+#define PWS_FILEDESCRIPTION "Password Safe Language DLL"
+#else
+#ifdef _DEBUG
+#define PWS_FILEDESCRIPTION "Password Safe Application (Debug)"
+#else
+#define PWS_FILEDESCRIPTION "Password Safe Application"
+#endif
+#endif
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+    FILEVERSION PWS_FILEVER
+    PRODUCTVERSION PWS_PRODUCTVER
+    FILEFLAGSMASK 0x3fL
+    FILEFLAGS PWS_FILEFLAGS
+    FILEOS VOS_NT_WINDOWS32
+    FILETYPE PWS_FILETYPE
+    FILESUBTYPE 0x0L
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
@@ -32,12 +71,8 @@ BEGIN
         BEGIN
             VALUE "Comments", "PasswordSafe was originally written by Counterpane Systems, and is now an open source project under https://pwsafe.org"
             VALUE "CompanyName", "Rony Shapiro"
-#if !defined(RESOURCE_DLL)
-            VALUE "FileDescription", "Password Safe Application"
-#else
-            VALUE "FileDescription", "Password Safe Language DLL"
-#endif
-            VALUE "FileVersion", STRFILEVER
+            VALUE "FileDescription", PWS_FILEDESCRIPTION
+            VALUE "FileVersion", PWS_FILEVER_STR
             VALUE "InternalName", "Password Safe"
             VALUE "LegalCopyright", "Copyright © 2003-2023 Rony Shapiro"
             VALUE "LegalTrademarks", "Copyright © 1997-8 by Counterpane Systems, 2003-2023 Rony Shapiro"
@@ -48,7 +83,13 @@ BEGIN
             VALUE "OriginalFilename", "pwsafeLL_CC.dll"
             VALUE "ProductName", "Password Safe Language DLL for <language>"
 #endif
-            VALUE "ProductVersion", STRPRODUCTVER
+            VALUE "ProductVersion", PWS_PRODUCTVER_STR
+#if defined(PWS_PRIVATEBUILD_STR)
+            VALUE "PrivateBuild", PWS_PRIVATEBUILD_STR
+#endif
+#if defined(PWS_SPECIALBUILD_STR)
+            VALUE "SpecialBuild", PWS_SPECIALBUILD_STR
+#endif
         END
     END
     BLOCK "VarFileInfo"

--- a/src/ui/Windows/res/PasswordSafe2.rc2
+++ b/src/ui/Windows/res/PasswordSafe2.rc2
@@ -39,8 +39,8 @@ BEGIN
 #endif
             VALUE "FileVersion", STRFILEVER
             VALUE "InternalName", "Password Safe"
-            VALUE "LegalCopyright", "Copyright � 2003-2023 Rony Shapiro"
-            VALUE "LegalTrademarks", "Copyright � 1997-8 by Counterpane Systems, 2003-2023 Rony Shapiro"
+            VALUE "LegalCopyright", "Copyright © 2003-2023 Rony Shapiro"
+            VALUE "LegalTrademarks", "Copyright © 1997-8 by Counterpane Systems, 2003-2023 Rony Shapiro"
 #if !defined(RESOURCE_DLL)
             VALUE "OriginalFilename", "pwsafe.exe"
             VALUE "ProductName", "Password Safe"

--- a/src/ui/Windows/version.in
+++ b/src/ui/Windows/version.in
@@ -25,11 +25,27 @@
 //   Revision != 0 for all Intermediate versions
 // Full information shown in AboutBox; only Major & Minor are displayed in initial dialog
 
-#define PRODUCTVER     @pwsafe_VERSION_MAJOR@, @pwsafe_VERSION_MINOR@, @pwsafe_REVISION@
-#define STRPRODUCTVER  "@pwsafe_VERSION_MAJOR@, @pwsafe_VERSION_MINOR@, @pwsafe_REVISION@, @pwsafe_VERSTRING@\0"
-#define SPECIAL_BUILD L"@pwsafe_SPECIALBUILD@"
+#define PWS_VERSION_MAJOR    @PWS_VERSION_MAJOR@
+#define PWS_VERSION_MINOR    @PWS_VERSION_MINOR@
+#define PWS_VERSION_PATCH    @PWS_VERSION_PATCH@
 
-#define FILEVER        PRODUCTVER
-#define STRFILEVER     STRPRODUCTVER
+#define PWS_PRODUCTVER      @PWS_PRODUCTVER@
+
+#ifdef _DEBUG
+#define PWS_PRODUCTVER_STR  "@PWS_PRODUCTVER_STR@ (Debug)"
+#else
+#define PWS_PRODUCTVER_STR  "@PWS_PRODUCTVER_STR@"
+#endif
+
+#define PWS_FILEVER         @PWS_FILEVER@
+#define PWS_FILEVER_STR     "@PWS_FILEVER_STR@"
+
+#cmakedefine PWS_PRIVATEBUILD_STR   "@PWS_PRIVATEBUILD_STR@"
+#cmakedefine PWS_SPECIALBUILD_STR   "@PWS_SPECIALBUILD_STR@"
+
+#define PWS_DESCRIBE_STR    "@PWS_DESCRIBE_STR@"
+
+#cmakedefine PWS_TIMESTAMP_STR  "@PWS_TIMESTAMP_STR@"
+#cmakedefine PWS_REPO_URL_STR   "@PWS_REPO_URL_STR@"
 
 #endif // _VERSION_H_


### PR DESCRIPTION
The RC files have `#pragma code_page(1252)` which forces `rc.exe` to interpret the files as Windows-1252 code page when parsing them.  Modern text editors tend to save files in UTF-8, so this makes keeping the version string copyright symbol from degenerating into mojibake difficult.  These commits switch the RC files to declare the UTF-8 code page (65001) and fixes the current copyright symbol corruption.  Round-tripping through VS2022's Resource Editor was done and the code page directive did survive.

Microsoft's Raymond Chen has a blog post about this problem: [_The Resource Compiler defaults to CP_ACP, even in the face of subtle hints that the file is UTF-8_](https://devblogs.microsoft.com/oldnewthing/20190607-00/?p=102569)

Note that the encoding for the strings inside the resulting binaries was already Unicode as can be seen from the "1200" in the "[VarFileInfo](https://learn.microsoft.com/en-us/windows/win32/menurc/varfileinfo-block)":
```
    BLOCK "VarFileInfo"
    BEGIN
        VALUE "Translation", 0x409, 1200
    END
```

This PR is marked "draft" since it is on top of PR #915.