### PR TITLE
Make sure UNICODE is defined.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,13 @@ if (res)
   set(pwsafe_VERSTRING "local")
 endif()
 
+add_compile_definitions(
+  __STDC_WANT_LIB_EXT1__=1
+  UNICODE
+  $<$<CONFIG:DEBUG>:_DEBUG>
+  $<$<NOT:$<CONFIG:DEBUG>>:NDEBUG>
+)
+
 # Assume that we're either MSVC or a Unix-like
 if (MSVC)
 # Debug build looks for dlls with _D postfix, this provides it:


### PR DESCRIPTION
This is to undo damage from [3f79a06e](https://github.com/pwsafe/pwsafe/commit/3f79a06e867a669bd4be91d91c3173050644ed16).  This bit got missed when I extracted the changes from another branch.  The system was still using Unicode, but likely because it is the default.