### PR TITLE
[macOs] Update to wxWidgets 3.2.2.1

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -28,12 +28,12 @@ jobs:
     - name: Set build parameters
       # If you need to rebuild wxWidgets for some reason, say you changed the build params, just increment FORCE_REBUILD_WX
       run: |
-        echo "WX_VERS=3.2.1" >> $GITHUB_ENV
+        echo "WX_VERS=3.2.2.1" >> $GITHUB_ENV
         echo "MACOS_VER_MIN=10.14" >> $GITHUB_ENV
         echo "WX_SRC_DIR=$HOME/wxWidgets" >> $GITHUB_ENV
         echo "WX_BUILD_DIR=$HOME/wxbuild" >> $GITHUB_ENV
         echo "XCODE_VER=14.0.1" >> $GITHUB_ENV
-        echo "FORCE_REBUILD_WX=5" >> $GITHUB_ENV
+        echo "FORCE_REBUILD_WX=6" >> $GITHUB_ENV
 
     - name: Force compatible Xcode version
       run: sudo xcode-select -s /Applications/Xcode_${XCODE_VER}.app/Contents/Developer


### PR DESCRIPTION
I'd like to suggest we update to wxWidgets 3.2.2.1 (the current version).  3.2.1 has a Mac specific bug that does strange things to the font rendering.  For example, in the tree view, as I click around, the list font seems to toggle between normal and a highlight or bold look.  It might depend on font size and whether or not you have a HiDPI monitor (I don't.). I've been using 3.2.2.1 since its release and I haven't noticed any new problems.

This commit only changes the macOS build and sets FORCE_REBUILD_WX=6. 