### PR TITLE
add targets for Windows ARM64

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -71,6 +71,30 @@
           "type": "FILEPATH"
         }
       ]
+    },
+    {
+      "name": "arm64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_arm64_x64" ],
+      "variables": []
+    },
+    {
+      "name": "arm64-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "-DNO_GTEST=TRUE",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_arm64_x64" ],
+      "variables": []
     }
   ]
 }

--- a/src/core/CoreImpExp.cpp
+++ b/src/core/CoreImpExp.cpp
@@ -248,7 +248,7 @@ struct TextRecordWriter {
         m_pcore->UpdateWizard(sx_exported.c_str());
 
         CUTF8Conv conv; // can't make a member, as no copy c'tor!
-        const unsigned char *utf8;
+        const unsigned char *utf8 = nullptr;
         size_t utf8Len;
         if (conv.ToUTF8(line, utf8, utf8Len)) {
           m_ofs.write(reinterpret_cast<const char *>(utf8), utf8Len);

--- a/src/core/PwsPlatform.h
+++ b/src/core/PwsPlatform.h
@@ -84,7 +84,7 @@
 // * Windows 32                                 *
 // **********************************************
 #if defined(_WIN32)
-  #if defined(x86) || defined(_x86) || defined(_X86) || defined(_X86_) || defined(_M_IX86) || defined(_M_X64)
+  #if defined(x86) || defined(_x86) || defined(_X86) || defined(_X86_) || defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM64)
     #define PWS_LITTLE_ENDIAN
   #endif
 // **********************************************


### PR DESCRIPTION
use CMake template msvc_arm64_x64

also "fix" one issue in struct TextRecordWriter, const unsigned char *utf8 was considered uninitialized. Initialize as nullptr.