### PR TITLE
Single-click to activate password entry.

### DIFF
--- a/src/ui/Windows/SystemTray.cpp
+++ b/src/ui/Windows/SystemTray.cpp
@@ -736,7 +736,7 @@ LRESULT CSystemTray::OnTrayNotification(WPARAM wParam, LPARAM lParam)
     }
     m_menulist.clear();
     menu.DestroyMenu();
-  } else if (LOWORD(lParam) == WM_LBUTTONDBLCLK) { // WM_RBUTTONUP
+  } else if (LOWORD(lParam) == WM_LBUTTONUP) { // WM_RBUTTONUP
     ASSERT(m_pTarget != NULL);
     // double click received, the default action is to execute default menu item
     m_pTarget->SetForegroundWindow();  
@@ -756,7 +756,7 @@ LRESULT CSystemTray::OnTrayNotification(WPARAM wParam, LPARAM lParam)
 
     m_pTarget->SendMessage(WM_COMMAND, uItem, 0);
     menu.DestroyMenu();
-  } // WM_LBUTTONDBLCLK
+  } // WM_LBUTTONUP
   return 1L;
 }
 


### PR DESCRIPTION
Observe WM_LBUTTONUP instead of WM_LBUTTONDBLCLK on pwsafe system tray icon to activate pwsafe and trigger login.
https://github.com/pwsafe/pwsafe/issues/959

IMPORTANT: This change will modify the Windows UX from requiring a double-click to only needing a single-click upon the Windows system tray icon in order to activate the pwsafe password entry modal dialog box. All Windows system tray icons/apps observed on a handful of systems use only a single-click to activate app windows, and a single-click is both faster and more ergonomically friendly. If most Windows system tray icons use a single click, this change should also allow pwsafe to align its system tray usage with Windows product testing around system tray icons (i.e., it seems likely there is more user coverage for single-click system tray notification implementations). This change has been tested on the latest Windows 11 and Windows 10.