### PR TITLE
macOS: Check for new version crashes the app

### DIFF
--- a/src/core/CheckVersion.cpp
+++ b/src/core/CheckVersion.cpp
@@ -62,8 +62,8 @@ CheckVersion::CheckLatestVersion(const stringT &xml, stringT &latest) const
 
         const stringT variant(pVariant);
         // Determine which variant is relevant for us
-        if ((SysInfo::IsLinux()  && variant == _T("Linux")) ||
-            (!SysInfo::IsLinux() && variant == _T("PC"))) {
+        if ((SysInfo::IsWXUI()  && variant == _T("Linux")) ||
+            (!SysInfo::IsWXUI() && variant == _T("PC"))) {
             const int xmajor = it->attribute(_T("major")).as_int();
             const int xminor = it->attribute(_T("minor")).as_int();
             const int xbuild = it->attribute(_T("build")).as_int();

--- a/src/core/SysInfo.cpp
+++ b/src/core/SysInfo.cpp
@@ -41,9 +41,10 @@ bool SysInfo::IsUnderPw2go()
   return !pws_os::getenv("PWS2GO", false).empty();
 }
 
-bool SysInfo::IsLinux()
+// The wxWidgets UI is used for Linux and macOS
+bool SysInfo::IsWXUI()
 {
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
   return true;
 #else
   return false;

--- a/src/core/SysInfo.h
+++ b/src/core/SysInfo.h
@@ -28,7 +28,7 @@ public:
   static void DeleteInstance();
 
   static bool IsUnderPw2go();
-  static bool IsLinux();
+  static bool IsWXUI();
 
   void SetEffectiveUser(const stringT &u) {m_euser = u;}
   void SetEffectiveHost(const stringT &h) {m_esysname = h;}

--- a/src/ui/wxWidgets/AboutDlg.cpp
+++ b/src/ui/wxWidgets/AboutDlg.cpp
@@ -417,9 +417,10 @@ bool AboutDlg::CheckDatabaseStatus()
     // Notify PasswordSafeFrame to close database.
     // If there are any unsaved changes PasswordSafeFrame 
     // will prompt the user to save them.
-    pwsafe->CloseDB([](bool closed) {
+    pwsafe->CloseDB([this](bool closed) {
       if (closed) {
-        // database closed, reopen dialog and check
+        // database closed. Close the existing About dialog then reopen and check
+        Close();
         DestroyWrapper<AboutDlg> wrapper(wxGetApp().GetPasswordSafeFrame());
         wrapper.Get()->ShowAndCheckForUpdate();
       }

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -2954,7 +2954,8 @@ void PasswordSafeFrame::CloseAllWindows(TimedTaskChain* taskChain, CloseFlags fl
   bool vetoed = false;
   while (itr != endItr) {
     wxTopLevelWindow* win = *itr;
-    if (win) {
+    // In case we got here via the About Dialog window, don't close it here. It will get special handling later.
+    if (win && (dynamic_cast<AboutDlg *>(win) == nullptr)) {
       if (win->IsShown()) {
         if (win == m_pengingCloseWindow) { // close already sheduled, but still not done
           pws_os::Trace(L"Waiting for window close <%ls> (%ls), flags=%d\n", ToStr(win->GetTitle()), ToStr(win->GetName()), flags);


### PR DESCRIPTION
Clicking the link to check for a newer version from the About dialog causes the app to abort when closing the database.  (See attached screenshot.)
The first commit fixes that problem by delaying closing the About dialog until after the process to close the database.  I don't currently have a Linux environment set-up to test this patch.  For that matter, I'm not really sure if the problem even happens on Linux, there are some differences in that part of wxWidgets.  I hope someone can test the Linux build before merging this PR.  If there is a problem, or some other reason for discomfort, these changes should be easy to ifdef.

Secondary problem:  Once it stopped crashing, I discovered it was checking the PC version number instead of the combined Mac/Linux WX version.  The second commit fixes that.

![evtloop abort 2023-05-25](https://github.com/pwsafe/pwsafe/assets/61946508/bdfbe19b-302a-46c6-b1e4-5beb0da50cd7)
