### PR TITLE
macOS: Let the External Keyboard Button.cpp do something

### DIFF
--- a/src/ui/wxWidgets/ExternalKeyboardButton.cpp
+++ b/src/ui/wxWidgets/ExternalKeyboardButton.cpp
@@ -95,7 +95,7 @@ void ExternalKeyboardButton::HandleCommandEvent(wxCommandEvent& evt)
   wxString command = wxString("open x-apple.systempreferences:com.apple.preference.universalaccess?Keyboard");
 
   if ( wxExecute(command, wxEXEC_ASYNC, nullptr) > 0) {
-    wxMessageBox(_("Please, enable the Accissibility Keyboard in System Settings"), "", wxOK | wxICON_INFORMATION);
+    wxMessageBox(_("Please, enable the Accessibility Keyboard in System Settings; the on-screen keyboard should then appear."), "", wxOK | wxICON_INFORMATION);
   } else {
     wxMessageBox(_("Could not launch the MacOS Settings App"),
                   _("Could not launch external onscreen keyboard"), wxOK | wxICON_ERROR);

--- a/src/ui/wxWidgets/ExternalKeyboardButton.cpp
+++ b/src/ui/wxWidgets/ExternalKeyboardButton.cpp
@@ -90,4 +90,16 @@ void ExternalKeyboardButton::HandleCommandEvent(wxCommandEvent& evt)
   }
 #endif
 
+#ifdef __WXOSX__
+  // If we can't open the virtual keyboard, at least open the settings app so the user can do it for us!
+  wxString command = wxString("open x-apple.systempreferences:com.apple.preference.universalaccess?Keyboard");
+
+  if ( wxExecute(command, wxEXEC_ASYNC, nullptr) > 0) {
+    wxMessageBox(_("Please, enable the Accissibility Keyboard in System Settings"), "", wxOK | wxICON_INFORMATION);
+  } else {
+    wxMessageBox(_("Could not launch the MacOS Settings App"),
+                  _("Could not launch external onscreen keyboard"), wxOK | wxICON_ERROR);
+  }
+#endif
+
 }


### PR DESCRIPTION
On macOS, the external keyboard button on the open dialog doesn't do anything.  I'm not sure this is good but I can't figure out how to open the virtual keyboard, so this patch will open the System Settings app to the right page and prompt the user to enable it.  Any thoughts?