### PR TITLE
Fix clear clipboard on minimize option

### DIFF
--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -2527,12 +2527,12 @@ void PasswordSafeFrame::OnIconize(wxIconizeEvent& evt) {
 #else
       LockDb();
 #endif
-      if (PWSprefs::GetInstance()->GetPref(PWSprefs::ClearClipboardOnMinimize)) {
-        Clipboard::GetInstance()->ClearCBData();
-      }
     }
     else {
       m_guiInfo->Save(this);
+    }
+    if (PWSprefs::GetInstance()->GetPref(PWSprefs::ClearClipboardOnMinimize)) {
+      Clipboard::GetInstance()->ClearCBData();
     }
   }
   else{


### PR DESCRIPTION
The clear clipboard on minimize option does not work unless the lock DB on minimize option is set.  This change will clear  the clipboard in either case.  This would affect both Mac and Linux, but I've only tested on Mac.