### PR TITLE
wx: Prevent core files and debugging in release builds

### DIFF
--- a/src/os/mac/debug.cpp
+++ b/src/os/mac/debug.cpp
@@ -95,11 +95,17 @@ bool pws_os::DisableDumpAttach()
 #else   /* _DEBUG || DEBUG */
 #include <sys/types.h>
 #include <sys/ptrace.h>
+#include <sys/resource.h>
 
 bool pws_os::DisableDumpAttach()
 {
+  int pret, lret;
+  struct rlimit rl = {0, 0};
+
   // prevent ptrace and creation of core dumps
-  return ptrace(PT_DENY_ATTACH, 0, 0, 0) == 0;
+  lret = setrlimit(RLIMIT_CORE, &rl);
+  pret = ptrace(PT_DENY_ATTACH, 0, 0, 0);
+  return (pret == 0 && lret == 0);
 }
 
 void pws_os::Trace(LPCTSTR , ...)

--- a/src/ui/cli/main.cpp
+++ b/src/ui/cli/main.cpp
@@ -387,6 +387,12 @@ int main(int argc, char *argv[])
     return 1;
 #endif // _WIN32
 
+  // prevent ptrace and creation of core dumps in release build
+  if (!pws_os::DisableDumpAttach()) {
+    wcerr << L"Failed to block ptrace and core dumps" << endl;
+    exit(1);
+  }
+
   UserArgs ua;
   if (!parseArgs(argc, argv, ua)) {
     usage(basename(argv[0]));


### PR DESCRIPTION
- Add a call to setrlimit() to prevent core files in a release build (macOS only, already in Unix versions) 
(In normal execution, the soft limit defaults to 0, but I was able to get around it.)
- Add a call to pws_os::DisableDumpAttach() to pwsafe-cli so it too will have core files and debugging restricted. (Potentially affects all builds.)

This was tested on macOS Ventura 13.5 with Xcode 14.3.1 and wxWidgets 3.2.2.1.   pwsafe-cli should be tested on Linux as well.