### PR TITLE
Mac: Unlock with dock icon

### DIFF
--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -672,6 +672,13 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
   return bRes;
 }
 
+#ifdef __WXMAC__
+void PWSafeApp::MacNewFile()
+{
+  GetPasswordSafeFrame()->UnlockSafe(true, false);
+}
+#endif // __WXMAC__
+
 /*!
  * Cleanup for PWSafeApp
  */

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -673,6 +673,8 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
 }
 
 #ifdef __WXMAC__
+// On macOS, this enables file unlock and UI restore upon left-click of the dock icon.
+// Not to be confused with the system tray (menu bar) icon.
 void PWSafeApp::MacNewFile()
 {
   GetPasswordSafeFrame()->UnlockSafe(true, false);

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -64,17 +64,19 @@ public:
   void Init();
 
   /// Initialises the application
-  virtual bool OnInit();
+  virtual bool OnInit() wxOVERRIDE;
 
   /// Handle asserts without showing the assert dialog until locale is initialized.
 #ifdef __WXDEBUG__
-  virtual void OnAssertFailure(const wxChar *file, int line, const wxChar *func, const wxChar *cond, const wxChar *msg);
+  virtual void OnAssertFailure(const wxChar *file, int line, const wxChar *func, const wxChar *cond, const wxChar *msg) wxOVERRIDE;
 #endif
   /// Called on exit
-  virtual int OnExit();
+  virtual int OnExit() wxOVERRIDE;
 
 ////@begin PWSafeApp event handler declarations
-
+#ifdef __WXMAC__
+  virtual void MacNewFile() wxOVERRIDE;
+#endif // __WXMAC__
 ////@end PWSafeApp event handler declarations
 
 ////@begin PWSafeApp member function declarations
@@ -94,7 +96,7 @@ public:
   void RestoreFrameCoords(void);
 
   //virtual override from some ancestor, to handle Help commands from all windows
-  virtual int FilterEvent(wxEvent& evt);
+  virtual int FilterEvent(wxEvent& evt) wxOVERRIDE;
 
   wxIconBundle GetAppIcons() const { return m_appIcons; }
 


### PR DESCRIPTION
  - (Mac only) When the system tray is enabled, a locked window cannot be restored by clicking on the dock icon.  Allowing this makes the behavior more Mac like.
  - Fixed a few override warnings in PWSafeApp.h, since I was there anyway.

This was tested on macOS Ventura 13.5 with Xcode 14.3.1 and wxWidgets 3.2.2.1. 