### PR TITLE
Mac and Linux: Save/Restore tree view on lock/unlock

### DIFF
--- a/src/ui/wxWidgets/GuiInfo.cpp
+++ b/src/ui/wxWidgets/GuiInfo.cpp
@@ -55,6 +55,10 @@ void CollectExpandedNodes(TreeCtrl* tree, wxTreeItemId root, wxArrayString& expa
 
 void GuiInfo::SaveTreeViewInfo(TreeCtrl* tree)
 {
+  //has the tree been cleared?
+  if (tree->HasItems() == 0)
+    return;
+
   //save the first visible item
   wxTreeItemId treeItem = tree->GetFirstVisibleItem();
   if (treeItem.IsOk() && treeItem != tree->GetRootItem()) {

--- a/src/ui/wxWidgets/GuiInfo.cpp
+++ b/src/ui/wxWidgets/GuiInfo.cpp
@@ -53,6 +53,12 @@ void CollectExpandedNodes(TreeCtrl* tree, wxTreeItemId root, wxArrayString& expa
   }
 }
 
+//
+// NOTE: The Save/Restore Tree/Grid view routines are called multiple times for
+// a single lock/restore operation.  When locking, the final call to Save*ViewInfo
+// happens after the info has been cleared.  For now, we test for that condition.
+// In the future, this is an opportunity for improvement.
+//
 void GuiInfo::SaveTreeViewInfo(TreeCtrl* tree)
 {
   //has the tree been cleared?


### PR DESCRIPTION
Ensure the tree view information is preserved on lock so it can be restored when the file is unlocked.
See discussion in #1001 and #954.  The crux of the problem is redundant calls to GuiInfo::SaveTreeViewInfo, the last one happening after the info has been cleared.  I noted that GuiInfo::SaveGridViewInfo already had a check for an empty grid, so I added a similar check to GuiInfo::SaveTreeViewInfo.  Note that there are also redundant calls to restore the grid/tree views. 

This was tested on macOS Ventura 13.5 with Xcode 14.3.1 and wxWidgets 3.2.2.1.   It needs re-testing on Linux.
