### PR TITLE
Keep pwsafe foreground on taskbar activation.

### DIFF
--- a/src/ui/Windows/DboxMain.cpp
+++ b/src/ui/Windows/DboxMain.cpp
@@ -2376,11 +2376,6 @@ bool DboxMain::RestoreWindowsData(bool bUpdateWindows, bool bShow)
     const bool bUseSysTray = PWSprefs::GetInstance()->
                              GetPref(PWSprefs::UseSystemTray);
 
-    // Hide the Window while asking for the passphrase
-    if (IsWindowVisible()) {
-      ShowWindow(SW_HIDE);
-    }
-
     if (m_bOpen) {
       int flags = 0;
       if (m_core.IsReadOnly())


### PR DESCRIPTION
When a locked pwsafe is activated by a user taskbar click, it should not hide its window because doing relinquishes its foreground status, preventing the password input dialog from becomming foreground window. This affects pwsafe when "Put icon in System Tray" is unchecked. https://github.com/pwsafe/pwsafe/issues/1014