### PR TITLE
Make YubiKey polling interval configurable

### DIFF
--- a/src/ui/wxWidgets/DbSelectionPanel.cpp
+++ b/src/ui/wxWidgets/DbSelectionPanel.cpp
@@ -114,8 +114,10 @@ DbSelectionPanel::DbSelectionPanel(wxWindow* parent,
 #ifndef NO_YUBI
   SetupMixin(FindWindow(ID_YUBIBTN), FindWindow(ID_YUBISTATUS));
   Bind(wxEVT_TIMER, &DbSelectionPanel::OnPollingTimer, this);
-  m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
-  m_pollingTimer->Start(YubiMixin::POLLING_INTERVAL);
+  if (YubiMixin::IsPollingEnabled()) {
+    m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
+    m_pollingTimer->Start(YubiMixin::GetPollingInterval());
+  }
 #endif
   
   //The parent window must call our TransferDataToWindow and TransferDataFromWindow
@@ -124,7 +126,10 @@ DbSelectionPanel::DbSelectionPanel(wxWindow* parent,
 
 DbSelectionPanel::~DbSelectionPanel()
 {
-  delete m_pollingTimer;
+  if (m_pollingTimer != nullptr) {
+    delete m_pollingTimer;
+    m_pollingTimer = nullptr;
+  }
 }
 
 void DbSelectionPanel::SelectCombinationText()

--- a/src/ui/wxWidgets/DbSelectionPanel.cpp
+++ b/src/ui/wxWidgets/DbSelectionPanel.cpp
@@ -126,10 +126,7 @@ DbSelectionPanel::DbSelectionPanel(wxWindow* parent,
 
 DbSelectionPanel::~DbSelectionPanel()
 {
-  if (m_pollingTimer != nullptr) {
-    delete m_pollingTimer;
-    m_pollingTimer = nullptr;
-  }
+  delete m_pollingTimer;
 }
 
 void DbSelectionPanel::SelectCombinationText()

--- a/src/ui/wxWidgets/ExportTextWarningDlg.cpp
+++ b/src/ui/wxWidgets/ExportTextWarningDlg.cpp
@@ -158,15 +158,20 @@ ExportTextWarningDlgBase::ExportTextWarningDlgBase(wxWindow *parent) : wxDialog(
   SetSizerAndFit(mainSizer);
 #ifndef NO_YUBI
   SetupMixin(FindWindow(ID_YUBIBTN), FindWindow(ID_YUBISTATUS));
-  m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
-  m_pollingTimer->Start(YubiMixin::POLLING_INTERVAL);
+  if (YubiMixin::IsPollingEnabled()) {
+    m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
+    m_pollingTimer->Start(YubiMixin::GetPollingInterval());
+  }
 #endif
 }
 
 ExportTextWarningDlgBase::~ExportTextWarningDlgBase()
 {
   delete selCriteria;
-  delete m_pollingTimer;
+  if (m_pollingTimer != nullptr) {
+    delete m_pollingTimer;
+    m_pollingTimer = nullptr;
+  }
 }
 
 void ExportTextWarningDlgBase::OnAdvancedSelection( wxCommandEvent& evt )

--- a/src/ui/wxWidgets/ExportTextWarningDlg.cpp
+++ b/src/ui/wxWidgets/ExportTextWarningDlg.cpp
@@ -168,10 +168,7 @@ ExportTextWarningDlgBase::ExportTextWarningDlgBase(wxWindow *parent) : wxDialog(
 ExportTextWarningDlgBase::~ExportTextWarningDlgBase()
 {
   delete selCriteria;
-  if (m_pollingTimer != nullptr) {
-    delete m_pollingTimer;
-    m_pollingTimer = nullptr;
-  }
+  delete m_pollingTimer;
 }
 
 void ExportTextWarningDlgBase::OnAdvancedSelection( wxCommandEvent& evt )

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -59,6 +59,9 @@
 #include "version.h"
 #include "wxMessages.h"
 #include "Clipboard.h"
+#ifndef NO_YUBI
+#include "YubiMixin.h"
+#endif
 
 #include <iostream> // currently for debugging
 #include <clocale>  // to get the locales specified by the environment 
@@ -128,6 +131,11 @@ static const wxCmdLineEntryDesc cmdLineDesc[] = {
   {wxCMD_LINE_OPTION, STR("g"), STR("config_file"),
    STR("use specified configuration file instead of default"),
    wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
+#ifndef NO_YUBI
+  {wxCMD_LINE_OPTION, nullptr, STR("yubi-polling-interval"),
+   STR("use specified polling interval for YubiKey instead of default"),
+   wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL},
+#endif
   {wxCMD_LINE_PARAM, nullptr, nullptr, STR("database"),
    wxCMD_LINE_VAL_STRING,
    (wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE)},
@@ -343,6 +351,10 @@ bool PWSafeApp::OnInit()
   bool cmd_user = cmdParser.Found(wxT("u"), &user);
   bool cmd_host = cmdParser.Found(wxT("h"), &host);
   bool cmd_cfg = cmdParser.Found(wxT("g"), &cfg_file);
+#ifndef NO_YUBI
+  long int yubi_polling_interval;
+  bool cmd_yubi_polling_interval = cmdParser.Found(wxT("y"), &yubi_polling_interval);
+#endif
   bool file_in_cmd = false;
   size_t count = cmdParser.GetParamCount();
   if (count == 1) {
@@ -401,6 +413,11 @@ bool PWSafeApp::OnInit()
   if (cmd_cfg) {
     PWSprefs::SetConfigFile(tostdstring(cfg_file));
   }
+#ifndef NO_YUBI
+  if (cmd_yubi_polling_interval) {
+    YubiMixin::SetPollingInterval(static_cast<int>(yubi_polling_interval));
+  }
+#endif
 
   m_core.SetReadOnly(cmd_ro);
   // OK to load prefs now

--- a/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
@@ -91,8 +91,10 @@ SafeCombinationChangeDlg::SafeCombinationChangeDlg(wxWindow *parent, PWScore &co
   m_yubiMixin1.SetPrompt1(_("Enter old safe combination (if any) and click on top Yubikey button"));
   m_yubiMixin2.SetupMixin(FindWindow(ID_YUBIBTN2), FindWindow(ID_YUBISTATUS));
   m_yubiMixin2.SetPrompt1(_("Enter old safe combination (if any) and click on top Yubikey button"));
-  m_pollingTimer = new wxTimer(this, YubiMixin::POLLING_TIMER_ID);
-  m_pollingTimer->Start(2*YubiMixin::POLLING_INTERVAL); // 2 controls
+  if (YubiMixin::IsPollingEnabled()) {
+    m_pollingTimer = new wxTimer(this, YubiMixin::POLLING_TIMER_ID);
+    m_pollingTimer->Start(2*YubiMixin::GetPollingInterval()); // 2 controls
+  }
 #endif
 }
 
@@ -112,7 +114,10 @@ SafeCombinationChangeDlg::~SafeCombinationChangeDlg()
 ////@begin SafeCombinationChangeDlg destruction
 ////@end SafeCombinationChangeDlg destruction
 #ifndef NO_YUBI
-  delete m_pollingTimer;
+  if (m_pollingTimer != nullptr) {
+    delete m_pollingTimer;
+    m_pollingTimer = nullptr;
+  }
 #endif
 }
 

--- a/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
@@ -114,10 +114,7 @@ SafeCombinationChangeDlg::~SafeCombinationChangeDlg()
 ////@begin SafeCombinationChangeDlg destruction
 ////@end SafeCombinationChangeDlg destruction
 #ifndef NO_YUBI
-  if (m_pollingTimer != nullptr) {
-    delete m_pollingTimer;
-    m_pollingTimer = nullptr;
-  }
+  delete m_pollingTimer;
 #endif
 }
 

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -136,10 +136,7 @@ SafeCombinationEntryDlg::~SafeCombinationEntryDlg()
 ////@begin SafeCombinationEntryDlg destruction
 ////@end SafeCombinationEntryDlg destruction
 #ifndef NO_YUBI
-  if (m_pollingTimer != nullptr) {
-    delete m_pollingTimer;
-    m_pollingTimer = nullptr;
-  }
+  delete m_pollingTimer;
 #endif
 }
 

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -114,8 +114,10 @@ SafeCombinationEntryDlg::SafeCombinationEntryDlg(wxWindow *parent, PWScore &core
 ////@end SafeCombinationEntryDlg creation
 #ifndef NO_YUBI
   SetupMixin(FindWindow(ID_YUBIBTN), FindWindow(ID_YUBISTATUS));
-  m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
-  m_pollingTimer->Start(YubiMixin::POLLING_INTERVAL);
+  if (YubiMixin::IsPollingEnabled()) {
+    m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
+    m_pollingTimer->Start(YubiMixin::GetPollingInterval());
+  }
 #endif
 }
 
@@ -134,7 +136,10 @@ SafeCombinationEntryDlg::~SafeCombinationEntryDlg()
 ////@begin SafeCombinationEntryDlg destruction
 ////@end SafeCombinationEntryDlg destruction
 #ifndef NO_YUBI
-  delete m_pollingTimer;
+  if (m_pollingTimer != nullptr) {
+    delete m_pollingTimer;
+    m_pollingTimer = nullptr;
+  }
 #endif
 }
 

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -120,10 +120,7 @@ SafeCombinationPromptDlg::~SafeCombinationPromptDlg()
 ////@begin SafeCombinationPromptDlg destruction
 ////@end SafeCombinationPromptDlg destruction
 #ifndef NO_YUBI
-  if (m_pollingTimer != nullptr) {
-    delete m_pollingTimer;
-    m_pollingTimer = nullptr;
-  }
+  delete m_pollingTimer;
 #endif
 }
 

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -93,8 +93,10 @@ SafeCombinationPromptDlg::SafeCombinationPromptDlg(wxWindow *parent, PWScore &co
 ////@end SafeCombinationPromptDlg creation
 #ifndef NO_YUBI
   SetupMixin(FindWindow(ID_YUBIBTN), FindWindow(ID_YUBISTATUS));
-  m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
-  m_pollingTimer->Start(YubiMixin::POLLING_INTERVAL);
+  if (YubiMixin::IsPollingEnabled()) {
+    m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
+    m_pollingTimer->Start(YubiMixin::GetPollingInterval());
+  }
 #endif
 }
 
@@ -118,7 +120,10 @@ SafeCombinationPromptDlg::~SafeCombinationPromptDlg()
 ////@begin SafeCombinationPromptDlg destruction
 ////@end SafeCombinationPromptDlg destruction
 #ifndef NO_YUBI
-  delete m_pollingTimer;
+  if (m_pollingTimer != nullptr) {
+    delete m_pollingTimer;
+    m_pollingTimer = nullptr;
+  }
 #endif
 }
 

--- a/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
@@ -104,10 +104,7 @@ SafeCombinationSetupDlg::~SafeCombinationSetupDlg()
 ////@begin SafeCombinationSetupDlg destruction
 ////@end SafeCombinationSetupDlg destruction
 #ifndef NO_YUBI
-  if (m_pollingTimer != nullptr) {
-    delete m_pollingTimer;
-    m_pollingTimer = nullptr;
-  }
+  delete m_pollingTimer;
 #endif
 }
 

--- a/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
@@ -83,8 +83,10 @@ SafeCombinationSetupDlg::SafeCombinationSetupDlg(wxWindow *parent, wxWindowID id
 ////@end SafeCombinationSetupDlg creation
 #ifndef NO_YUBI
   SetupMixin(FindWindow(ID_YUBIBTN), FindWindow(ID_YUBISTATUS));
-  m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
-  m_pollingTimer->Start(YubiMixin::POLLING_INTERVAL);
+  if (YubiMixin::IsPollingEnabled()) {
+    m_pollingTimer = new wxTimer(this, POLLING_TIMER_ID);
+    m_pollingTimer->Start(YubiMixin::GetPollingInterval());
+  }
 #endif
 }
 
@@ -102,7 +104,10 @@ SafeCombinationSetupDlg::~SafeCombinationSetupDlg()
 ////@begin SafeCombinationSetupDlg destruction
 ////@end SafeCombinationSetupDlg destruction
 #ifndef NO_YUBI
-  delete m_pollingTimer;
+  if (m_pollingTimer != nullptr) {
+    delete m_pollingTimer;
+    m_pollingTimer = nullptr;
+  }
 #endif
 }
 

--- a/src/ui/wxWidgets/YubiCfgDlg.cpp
+++ b/src/ui/wxWidgets/YubiCfgDlg.cpp
@@ -198,7 +198,9 @@ void YubiCfgDlg::CreateControls()
   itemTextCtrl5->SetValidator( wxGenericValidator(& m_yksernum) );
   m_SKCtrl->SetValidator( wxGenericValidator(& m_yksk) );
 ////@end YubiCfgDlg content construction
-  m_pollingTimer->Start(YubiMixin::POLLING_INTERVAL);
+  if (YubiMixin::IsPollingEnabled()) {
+    m_pollingTimer->Start(YubiMixin::GetPollingInterval());
+  }
 }
 
 /*!

--- a/src/ui/wxWidgets/YubiMixin.cpp
+++ b/src/ui/wxWidgets/YubiMixin.cpp
@@ -25,6 +25,9 @@
 #include <iomanip>
 #include <sstream>
 
+bool YubiMixin::s_pollingEnabled = true;
+int YubiMixin::s_pollingInterval = YubiMixin::POLLING_INTERVAL_DEFAULT;
+
 void YubiMixin::SetupMixin(wxWindow *btn, wxWindow *status)
 {
   m_prompt1 = _("Click the button labeled 'Yubikey' in green"); // change via SetPrompt1
@@ -78,6 +81,23 @@ void YubiMixin::HandlePollingTimer()
   if (inserted != m_present) {
     m_present = inserted;
     UpdateStatus();
+  }
+}
+
+void YubiMixin::SetPollingInterval(int value) {
+  s_pollingEnabled = true;
+
+  if (value <= 0) {
+    s_pollingEnabled = false;
+  }
+  else if (value < YubiMixin::POLLING_INTERVAL_MIN /* ms */) {
+    s_pollingInterval = YubiMixin::POLLING_INTERVAL_MIN; // limit the polling interval to a minimum
+  }
+  else if (value > YubiMixin::POLLING_INTERVAL_MAX /* ms */) {
+    s_pollingInterval = YubiMixin::POLLING_INTERVAL_MAX; // limit the polling interval to a maximum
+  }
+  else {
+    s_pollingInterval = value;
   }
 }
 

--- a/src/ui/wxWidgets/YubiMixin.h
+++ b/src/ui/wxWidgets/YubiMixin.h
@@ -25,7 +25,7 @@ class wxWindow;
 class YubiMixin
 {
  public:
-  enum {POLLING_INTERVAL = 500}; // mSec
+  enum {POLLING_INTERVAL_MIN = 100, POLLING_INTERVAL_DEFAULT = 500, POLLING_INTERVAL_MAX = 60000}; // mSec
   YubiMixin() : m_present(false), m_btn(nullptr), m_status(nullptr) {}
   ~YubiMixin() {}
 
@@ -53,6 +53,10 @@ class YubiMixin
   // EVT_TIMER(POLLING_TIMER_ID, CFoo::OnPollingTimer)
   void HandlePollingTimer(); // calls UpdateStatus() iff m_present changes
 
+  static void SetPollingInterval(int value);
+  static int GetPollingInterval() { return s_pollingInterval; }
+  static bool IsPollingEnabled() { return s_pollingEnabled; }
+
   enum { POLLING_TIMER_ID = 83 } ; 
   bool m_present; // key present?
 
@@ -61,6 +65,8 @@ class YubiMixin
   wxWindow *m_status;
   wxString m_prompt1;
   wxString m_prompt2;
+  static bool s_pollingEnabled;
+  static int s_pollingInterval;
 };
 
 #endif /* _YUBIMXIN_H_ */


### PR DESCRIPTION
This is an untested attempt to make the Yubi Key polling interval configurable via command line argument "-y".
This PR is related to the suggestion in #882 and has not been tested due to the lack of a Yubi Key.

1. Should the command line argument be "-y, --yubi_polling_interval" or "-p, --polling"?
2. Should an environment variable be used rather than a command line option?