### PR TITLE
Fix minor CStateBitmapManager resource leak.

### DIFF
--- a/src/ui/Windows/StateBitmapManager.cpp
+++ b/src/ui/Windows/StateBitmapManager.cpp
@@ -40,23 +40,13 @@ CStateBitmapManager::CStateBitmapManager(
     int bmHeightDpi = MulDiv(bm.bmHeight, dpi, 96);
 
     UINT bmpIndex = nId - m_idFirst;
-    m_stateBitmaps.push_back(new CBitmap);
+    m_stateBitmaps.push_back(std::make_shared<CBitmap>());
     ASSERT(bmpIndex == m_stateBitmaps.size() - 1);
 
     WinUtil::ResizeBitmap(origBmp, *m_stateBitmaps[bmpIndex], bmWidthDpi, bmHeightDpi);
 
     origBmp.DeleteObject();
   }
-}
-
-CStateBitmapManager::~CStateBitmapManager()
-{
-  std::for_each(
-    m_stateBitmaps.begin(),
-    m_stateBitmaps.end(),
-    [](CBitmap* pbmp) { pbmp->DeleteObject(); }
-  );
-  m_stateBitmaps.clear();
 }
 
 CBitmap& CStateBitmapManager::GetStateBitmap(UINT nIdBitmap)

--- a/src/ui/Windows/StateBitmapManager.h
+++ b/src/ui/Windows/StateBitmapManager.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <vector>
+#include <memory>
 
 class CStateBitmapManager
 {
@@ -21,7 +22,6 @@ public:
     UINT nIdBitmapError,
     UINT rgbTransparentColor = CStateBitmapManager::RGB_COLOR_NOT_TRANSPARENT
   );
-  virtual ~CStateBitmapManager();
   CBitmap& GetStateBitmap(UINT nIdBitmap);
   void GetBitmapInfo(UINT nIdBitmap, BITMAP* pBmpInfo = nullptr, LONG* pBmWidthDpi = nullptr, LONG* pBmHeightDpi = nullptr);
   CBitmap& GetBitmapAndInfo(UINT nIdBitmap, BITMAP* pBmpInfo = nullptr, LONG* pBmWidthDpi = nullptr, LONG* pBmHeightDpi = nullptr);
@@ -33,5 +33,5 @@ private:
   UINT m_idFirst;
   UINT m_idLast;
   UINT m_idError;
-  std::vector<CBitmap*> m_stateBitmaps;
+  std::vector<std::shared_ptr<CBitmap>> m_stateBitmaps;
 };


### PR DESCRIPTION
GDI objects were being deleted, but CBitmap instances remained. Given current usage, leak is minor at ~96 bytes each time a password dialog is dismissed.