### PR TITLE
Fix: password length not updated from the policy in the generator (wx)

### DIFF
--- a/src/ui/wxWidgets/PasswordPolicyDlg.cpp
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.cpp
@@ -789,6 +789,7 @@ void PasswordPolicyDlg::OnPolicynameSelection( wxCommandEvent& WXUNUSED(event) )
   m_pwUseEasyVision     = (policy.flags & PWPolicy::UseEasyVision)     == PWPolicy::UseEasyVision;
   m_pwMakePronounceable = (policy.flags & PWPolicy::MakePronounceable) == PWPolicy::MakePronounceable;
   m_Symbols             = policy.symbols.c_str();
+  m_pwdefaultlength     = policy.length;
 
   TransferDataToWindow();
 }


### PR DESCRIPTION
In the password generator of wx GUI, when a password policy is selected, password length did not get updated, resulting effective settings different from the ones of the selected policy.

Reproduce: 
* Have more than 1 policy configured in the open database
* Manage -> Generate Password
* "Use Database Policy" on
* Change the policy from "Default Policy" to a different one with "Password length" configured to a value different from the one in "Default Policy"

Observed:
* "Password length" does not change
* When a password is generated, it uses the length from the "Default Policy"

Expected:
* "Password length" is update to the value in the selected policy
* Length of generated passwords is as the selected policy says