### PR TITLE
Fix: minimum char class lengths not updated from the policy in the generator (wx)

### DIFF
--- a/src/ui/wxWidgets/PasswordPolicyDlg.cpp
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.cpp
@@ -790,6 +790,10 @@ void PasswordPolicyDlg::OnPolicynameSelection( wxCommandEvent& WXUNUSED(event) )
   m_pwMakePronounceable = (policy.flags & PWPolicy::MakePronounceable) == PWPolicy::MakePronounceable;
   m_Symbols             = policy.symbols.c_str();
   m_pwdefaultlength     = policy.length;
+  m_pwDigitMinLength    = policy.digitminlength;
+  m_pwLowerMinLength    = policy.lowerminlength;
+  m_pwSymbolMinLength   = policy.symbolminlength;
+  m_pwUpperMinLength    = policy.upperminlength;
 
   TransferDataToWindow();
 }


### PR DESCRIPTION
This is a follow-up to #1043, that also relates to minimum numbers of characters requires for different character classes. All descriptions of #1043 are applicable here by extension.