### PR TITLE
Compile error in coretest (needed to include cstdint)

### DIFF
--- a/src/test/TestCommon.h
+++ b/src/test/TestCommon.h
@@ -14,6 +14,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <cstdint>
 #include <vector>
 
 using byte_vector = std::vector<uint8_t>;


### PR DESCRIPTION
Fatal error on Fedora 38:
In file included from /home/pwsafe/pwsafe/src/test/HMAC_SHA1Test.cpp:25: /home/pwsafe/pwsafe/src/test/TestCommon.h:19:33: error: 'uint8_t' was not declared in this scope
   19 | using byte_vector = std::vector<uint8_t>;
      |                                 ^~~~~~~
/home/pwsafe/pwsafe/src/test/TestCommon.h:17:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   16 | #include <cstring>
  +++ |+#include <cstdint>
   17 | #include <vector>