### PR TITLE
MacOS: Compiler warning clean-up

### DIFF
--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		570781742B0C4D330082EB6E /* PWYubi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 570781692B0C4CD30082EB6E /* PWYubi.cpp */; };
 		57BD7D042B19BEC2005C0123 /* helpEN.zip in Resources */ = {isa = PBXBuildFile; fileRef = E690B95612984B1D007EA508 /* helpEN.zip */; };
 		6FF5D4A11DA14EE80032F5B6 /* PasswordSubsetDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF5D49D1DA14AB20032F5B6 /* PasswordSubsetDlg.cpp */; };
-		89A146668BFBBDB52F97EB58 /* TotpCore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8DA345B998C630600DF46F90 /* TotpCore.cpp */; };
+		89A146668BFBBDB52F97EB58 /* TotpCore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8DA345B998C630600DF46F90 /* TotpCore.cpp */; settings = {COMPILER_FLAGS = "-Wno-shorten-64-to-32"; }; };
 		8ED7E1C429D9F24C0012034B /* SetDatabaseIdDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8ED7E1C329D9F24C0012034B /* SetDatabaseIdDlg.cpp */; };
 		A2D181461C8FF86C0018AE03 /* media.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2D181451C8FF86C0018AE03 /* media.cpp */; };
 		A2FE258D1C5ACF7500210C36 /* Item.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25811C5ACF7500210C36 /* Item.cpp */; };
@@ -68,13 +68,13 @@
 		E090D35824D742E90083BA2B /* ViewAttachmentDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E090D35624D742E90083BA2B /* ViewAttachmentDlg.cpp */; };
 		E0A70B9821C8FF8900A2FEA8 /* PolicyManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0A70B9621C8FF8900A2FEA8 /* PolicyManager.cpp */; };
 		E0A70B9B21C905A500A2FEA8 /* libcurl.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E0A70B9A21C905A500A2FEA8 /* libcurl.tbd */; };
-		E0C3C4422379B2C200715124 /* AES.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C42F2379B2C200715124 /* AES.cpp */; };
+		E0C3C4422379B2C200715124 /* AES.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C42F2379B2C200715124 /* AES.cpp */; settings = {COMPILER_FLAGS = "-Wno-shorten-64-to-32"; }; };
 		E0C3C4432379B2C200715124 /* BlowFish.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C4322379B2C200715124 /* BlowFish.cpp */; };
 		E0C3C4442379B2C200715124 /* KeyWrap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C4362379B2C200715124 /* KeyWrap.cpp */; };
 		E0C3C4452379B2C200715124 /* pbkdf2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C4382379B2C200715124 /* pbkdf2.cpp */; };
 		E0C3C4462379B2C200715124 /* sha1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C43A2379B2C200715124 /* sha1.cpp */; };
 		E0C3C4472379B2C200715124 /* sha256.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C43C2379B2C200715124 /* sha256.cpp */; };
-		E0C3C4492379B2C200715124 /* TwoFish.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C43F2379B2C200715124 /* TwoFish.cpp */; };
+		E0C3C4492379B2C200715124 /* TwoFish.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C43F2379B2C200715124 /* TwoFish.cpp */; settings = {COMPILER_FLAGS = "-Wno-shorten-64-to-32"; }; };
 		E0C3C44F2379CD7500715124 /* MenuFileHandlers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C44D2379CA7300715124 /* MenuFileHandlers.cpp */; };
 		E0C3C4502379CD8300715124 /* CryptKeyEntryDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0C3C44A2379CA2A00715124 /* CryptKeyEntryDlg.cpp */; };
 		E60F25D812C4ACEB001E63C4 /* ExternalKeyboardButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E60F25D612C4ACEB001E63C4 /* ExternalKeyboardButton.cpp */; };
@@ -2194,12 +2194,12 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				MACOSX_DEPLOYMENT_TARGET = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = (
+				PRODUCT_NAME = core;
+				USER_HEADER_SEARCH_PATHS = ../src/;
+				WARNING_CFLAGS = (
 					"-Wall",
 					"-Wextra",
 				);
-				PRODUCT_NAME = core;
-				USER_HEADER_SEARCH_PATHS = ../src/;
 			};
 			name = "Debug-no-yubi";
 		};
@@ -2212,12 +2212,12 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				HEADER_SEARCH_PATHS = "/usr/local/include/ykpers-1";
 				MACOSX_DEPLOYMENT_TARGET = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = (
+				PRODUCT_NAME = os;
+				USER_HEADER_SEARCH_PATHS = ../src;
+				WARNING_CFLAGS = (
 					"-Wall",
 					"-Wextra",
 				);
-				PRODUCT_NAME = os;
-				USER_HEADER_SEARCH_PATHS = ../src;
 			};
 			name = "Debug-no-yubi";
 		};
@@ -2263,29 +2263,12 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_ENTITLEMENTS = "pwsafe-cli.entitlements";
 				CODE_SIGN_IDENTITY = "-";
 				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -2305,29 +2288,12 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_ENTITLEMENTS = "pwsafe-cli.entitlements";
 				CODE_SIGN_IDENTITY = "-";
 				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -2347,28 +2313,11 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_ENTITLEMENTS = "pwsafe-cli.entitlements";
 				CODE_SIGN_IDENTITY = "-";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = "compiler-default";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -2518,12 +2467,12 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				MACOSX_DEPLOYMENT_TARGET = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = (
+				PRODUCT_NAME = core;
+				USER_HEADER_SEARCH_PATHS = ../src/;
+				WARNING_CFLAGS = (
 					"-Wall",
 					"-Wextra",
 				);
-				PRODUCT_NAME = core;
-				USER_HEADER_SEARCH_PATHS = ../src/;
 			};
 			name = Debug;
 		};
@@ -2535,12 +2484,12 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				MACOSX_DEPLOYMENT_TARGET = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = (
+				PRODUCT_NAME = core;
+				USER_HEADER_SEARCH_PATHS = ../src/;
+				WARNING_CFLAGS = (
 					"-Wall",
 					"-Wextra",
 				);
-				PRODUCT_NAME = core;
-				USER_HEADER_SEARCH_PATHS = ../src/;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -2554,12 +2503,12 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				HEADER_SEARCH_PATHS = "/usr/local/include/ykpers-1";
 				MACOSX_DEPLOYMENT_TARGET = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = (
+				PRODUCT_NAME = os;
+				USER_HEADER_SEARCH_PATHS = ../src;
+				WARNING_CFLAGS = (
 					"-Wall",
 					"-Wextra",
 				);
-				PRODUCT_NAME = os;
-				USER_HEADER_SEARCH_PATHS = ../src;
 			};
 			name = Debug;
 		};
@@ -2571,12 +2520,12 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				HEADER_SEARCH_PATHS = "/usr/local/include/ykpers-1";
 				MACOSX_DEPLOYMENT_TARGET = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = (
+				PRODUCT_NAME = os;
+				USER_HEADER_SEARCH_PATHS = ../src;
+				WARNING_CFLAGS = (
 					"-Wall",
 					"-Wextra",
 				);
-				PRODUCT_NAME = os;
-				USER_HEADER_SEARCH_PATHS = ../src;
 				ZERO_LINK = NO;
 			};
 			name = Release;

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 		E66FB84B13ACA5C3004DBB97 /* SizeRestrictedPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SizeRestrictedPanel.cpp; sourceTree = "<group>"; };
 		E66FB84C13ACA5C3004DBB97 /* SizeRestrictedPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SizeRestrictedPanel.h; sourceTree = "<group>"; };
 		E683B217150481DF0013D588 /* pugiconfig.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = pugiconfig.hpp; sourceTree = "<group>"; };
-		E683B218150481DF0013D588 /* pugixml.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pugixml.cpp; sourceTree = "<group>"; };
+		E683B218150481DF0013D588 /* pugixml.cpp */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.cpp.cpp; path = pugixml.cpp; sourceTree = "<group>"; tabWidth = 2; usesTabs = 1; };
 		E683B219150481DF0013D588 /* pugixml.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = pugixml.hpp; sourceTree = "<group>"; };
 		E6889E011EE4640F0023E376 /* cleanup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cleanup.cpp; path = unix/cleanup.cpp; sourceTree = "<group>"; };
 		E690B55C12984A1A007EA508 /* pwsafe_filter.xsd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = pwsafe_filter.xsd; path = ../xml/pwsafe_filter.xsd; sourceTree = SOURCE_ROOT; };

--- a/src/core/CoreImpExp.cpp
+++ b/src/core/CoreImpExp.cpp
@@ -2000,7 +2000,6 @@ int PWScore::ImportKeePassV1CSVFile(const StringX &filename,
   cStringXStream iss;
   unsigned char buffer[IMPORT_BUFFER_SIZE + 1];
   bool bError(false);
-  size_t total(0);
   while(!feof(fs)) {
     size_t count = fread(buffer, 1, IMPORT_BUFFER_SIZE, fs);
     if (ferror(fs)) {
@@ -2009,7 +2008,6 @@ int PWScore::ImportKeePassV1CSVFile(const StringX &filename,
     }
     buffer[count] = '\0';
     iss << buffer;
-    total += count;
   }
 
   // Close the file

--- a/src/core/CoreImpExp.cpp
+++ b/src/core/CoreImpExp.cpp
@@ -217,6 +217,7 @@ StringX PWScore::BuildHeader(const CItemData::FieldBits &bsFields, const bool bI
 }
 
 struct TextRecordWriter {
+  TextRecordWriter(const TextRecordWriter&) = default;
   TextRecordWriter(const stringT &subgroup_name,
           const int &subgroup_object, const int &subgroup_function,
           const CItemData::FieldBits &bsFields,
@@ -350,6 +351,7 @@ int PWScore::WritePlaintextFile(const StringX &filename,
 }
 
 struct XMLRecordWriter {
+  XMLRecordWriter(const XMLRecordWriter&) = default;
   XMLRecordWriter(const stringT &subgroup_name,
                   const int subgroup_object, const int subgroup_function,
                   const CItemData::FieldBits &bsFields,

--- a/src/core/PWCharPool.cpp
+++ b/src/core/PWCharPool.cpp
@@ -347,6 +347,7 @@ class FillSC {
   // for "leet" alphabet for pronounceable passwords
   // with usesymbols and/or usedigits specified
 public:
+  FillSC(const FillSC&) = default;
   FillSC(vector<int> &sc, bool digits, bool symbols)
     : m_sc(sc), m_digits(digits), m_symbols(symbols), m_i(0) {}
 

--- a/src/core/PWSFilters.cpp
+++ b/src/core/PWSFilters.cpp
@@ -554,9 +554,9 @@ static string GetFilterXML(const st_filters &filters, bool bWithFormatting)
 }
 
 struct XMLFilterWriterToString {
+  XMLFilterWriterToString(const XMLFilterWriterToString&) = default;
   XMLFilterWriterToString(coStringXStream &os, bool bWithFormatting) :
-  m_os(os), m_bWithFormatting(bWithFormatting)
-  {}
+                          m_os(os), m_bWithFormatting(bWithFormatting) {}
 
   // operator
   void operator()(const pair<const st_Filterkey, st_filters> &p)

--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -588,6 +588,7 @@ void PWScore::NewFile(const StringX &passkey)
 // functor object type for for_each:
 // Writes out all records to a PasswordSafe database of any version
 struct RecordWriter {
+  RecordWriter(const RecordWriter&) = default;
   RecordWriter(PWSfile *pout, PWScore *pcore, PWSfile::VERSION version)
     : m_pout(pout), m_pcore(pcore), m_version(version) {}
 
@@ -1607,6 +1608,7 @@ struct FieldsMatch {
             m_title == item.GetTitle() &&
             m_user  == item.GetUser());
   }
+  FieldsMatch(const FieldsMatch&) = default;
   FieldsMatch(const StringX &a_group, const StringX &a_title,
               const StringX &a_user) :
   m_group(a_group), m_title(a_title), m_user(a_user) {}
@@ -1633,6 +1635,7 @@ struct TitleMatch {
     return (m_title == item.GetTitle());
   }
 
+  TitleMatch(const TitleMatch&) = default;
   TitleMatch(const StringX &a_title) :
     m_title(a_title) {}
 
@@ -1677,6 +1680,7 @@ struct GroupTitle_TitleUserMatch {
             (m_gt == item.GetTitle() && m_tu == item.GetUser()));
   }
 
+  GroupTitle_TitleUserMatch(const GroupTitle_TitleUserMatch&) = default;
   GroupTitle_TitleUserMatch(const StringX &a_grouptitle,
                             const StringX &a_titleuser) :
                             m_gt(a_grouptitle),  m_tu(a_titleuser) {}
@@ -1988,6 +1992,7 @@ void PWScore::MakePolicyUnique(std::map<StringX, StringX> &mapRenamedPolicies,
 // functor object type for for_each:
 // Updates vector with entries using named password policy
 struct AddEntry {
+  AddEntry(const AddEntry&) = default;
   AddEntry(const StringX sxPolicyName, std::vector<st_GroupTitleUser> &ventries)
     : m_sxPolicyName(sxPolicyName), m_pventries(&ventries) {}
 

--- a/src/core/PWSfile.h
+++ b/src/core/PWSfile.h
@@ -162,7 +162,7 @@ protected:
                           size_t length);
   virtual size_t ReadCBC(unsigned char &type, unsigned char* &data,
                          size_t &length);
-  
+
   static void HashRandom256(unsigned char *p256); // when we don't want to expose our RNG
 
   const StringX m_filename;

--- a/src/core/PWSfileV1V2.h
+++ b/src/core/PWSfileV1V2.h
@@ -12,6 +12,11 @@
 #ifndef __PWSFILEV1V2_H
 #define __PWSFILEV1V2_H
 
+#ifndef _MSC_VER
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
+
 #include "PWSfile.h"
 #include "crypto/BlowFish.h"
 
@@ -42,5 +47,9 @@ private:
   int WriteV2Header();
   int ReadV2Header();
 };
+
+#ifndef _MSC_VER
+#pragma GCC diagnostic pop
+#endif
 
 #endif /*  __PWSFILEV1V2_H */

--- a/src/core/PWSfileV4.cpp
+++ b/src/core/PWSfileV4.cpp
@@ -420,6 +420,7 @@ void PWSfileV4::StretchKey(const unsigned char *salt, unsigned long saltLen,
 const short VersionNum = 0x0400;
 
 struct PWSfileV4::CKeyBlocks::KeyBlockFinder {
+  KeyBlockFinder(const KeyBlockFinder&) = default;
   KeyBlockFinder(const StringX &passkey) : passkey(passkey) {}
 
   bool operator()(const KeyBlock &kb) {

--- a/src/core/coredefs.h
+++ b/src/core/coredefs.h
@@ -121,6 +121,7 @@ typedef KBShortcutMap::const_iterator KBShortcutMapConstIter;
 typedef std::pair<int32, pws_os::CUUID> KBShortcutMapPair;
 
 struct PopulatePWPVector {
+  PopulatePWPVector(const PopulatePWPVector&) = default;
   PopulatePWPVector(std::vector<StringX> *pvPWPolicies) :
     m_pvPWPolicies(pvPWPolicies) {}
 

--- a/src/core/pugixml/pugixml.cpp
+++ b/src/core/pugixml/pugixml.cpp
@@ -4524,7 +4524,7 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, float value)
 	{
 		char buf[128];
-		sprintf(buf, "%.9g", value);
+		snprintf(buf, sizeof(buf), "%.9g", value);
 
 		return set_value_ascii(dest, header, header_mask, buf);
 	}
@@ -4533,7 +4533,7 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, double value)
 	{
 		char buf[128];
-		sprintf(buf, "%.17g", value);
+		snprintf(buf, sizeof(buf), "%.17g", value);
 
 		return set_value_ascii(dest, header, header_mask, buf);
 	}

--- a/src/os/mac/file.cpp
+++ b/src/os/mac/file.cpp
@@ -349,6 +349,11 @@ bool pws_os::LockFile(const stringT &filename, stringT &locker, HANDLE &)
 #endif
     return false;
   } else { // valid filehandle, write our info
+
+// Since ASSERT is a no-op in a release build, numWrit
+// becomes an unused variable
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
     ssize_t numWrit;
     const stringT user = pws_os::getusername();
     const stringT host = pws_os::gethostname();
@@ -360,6 +365,8 @@ bool pws_os::LockFile(const stringT &filename, stringT &locker, HANDLE &)
     numWrit += write(fh, _T(":"), sizeof(TCHAR));
     numWrit += write(fh, pid.c_str(), pid.length() * sizeof(TCHAR));
     ASSERT(numWrit > 0);
+#pragma GCC diagnostic pop
+
     close(fh);
 #ifdef UNICODE
     delete[] lfn;

--- a/src/os/unix/PWYubi.cpp
+++ b/src/os/unix/PWYubi.cpp
@@ -126,7 +126,7 @@ bool PWYubi::WriteSK(const unsigned char *yubi_sk_bin, size_t sklen)
     if (ykey == nullptr)
       goto done;
     if (!yk_get_status(ykey, st) ||
-        (ykp_configure_version(cfg, st), !ykp_set_tktflag_CHAL_RESP(cfg,true)) ||
+        (static_cast<void>(ykp_configure_version(cfg, st)), !ykp_set_tktflag_CHAL_RESP(cfg,true)) ||
         !ykp_set_cfgflag_CHAL_HMAC(cfg, true) ||
         !ykp_set_cfgflag_HMAC_LT64(cfg, true) ||
         !ykp_set_cfgflag_CHAL_BTN_TRIG(cfg, true) ||

--- a/src/ui/wxWidgets/ManagePasswordPoliciesDlg.h
+++ b/src/ui/wxWidgets/ManagePasswordPoliciesDlg.h
@@ -119,7 +119,7 @@ protected:
   void OnOkClick( wxCommandEvent& event );
 
   /// wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_CANCEL
-  void OnCancelClick( wxCommandEvent& event );
+  void OnCancelClick( wxCommandEvent& event ) override;
 
   /// wxEVT_COMMAND_BUTTON_CLICKED event handler for wxID_HELP
   void OnHelpClick( wxCommandEvent& event );
@@ -143,8 +143,8 @@ protected:
   static bool ShowToolTips();
 
   // Overridden virtuals
-  virtual bool Show(bool show = true);
-  
+  virtual bool Show(bool show = true) override;
+
   void DoNewClick();
   void DoEditClick();
 

--- a/src/ui/wxWidgets/PWFiltersBoolDlg.h
+++ b/src/ui/wxWidgets/PWFiltersBoolDlg.h
@@ -76,7 +76,7 @@ protected:
   static BoolType ConvertType(FieldType ftype);
 private:
 
-  void InitDialog();
+  void InitDialog() override;
   void SetValidators();
 
   //(*Handlers(pwFiltersBoolDlg)

--- a/src/ui/wxWidgets/PWFiltersDCADlg.h
+++ b/src/ui/wxWidgets/PWFiltersDCADlg.h
@@ -76,7 +76,7 @@ protected:
 
 private:
 
-  void InitDialog();
+  void InitDialog() override;
   void SetValidators();
 
   stringT CurrentDefaultDCAuiString();

--- a/src/ui/wxWidgets/PWFiltersDateDlg.h
+++ b/src/ui/wxWidgets/PWFiltersDateDlg.h
@@ -91,7 +91,7 @@ protected:
 
 private:
 
-  void InitDialog();
+  void InitDialog() override;
   void SetValidators();
 
   //(*Handlers(pwFiltersDateDlg)

--- a/src/ui/wxWidgets/PWFiltersIntegerDlg.h
+++ b/src/ui/wxWidgets/PWFiltersIntegerDlg.h
@@ -85,7 +85,7 @@ protected:
 
 private:
 
-  void InitDialog();
+  void InitDialog() override;
   void SetValidators();
 
   //(*Handlers(pwFiltersIntegerDlg)

--- a/src/ui/wxWidgets/PWFiltersMediaDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersMediaDlg.cpp
@@ -167,10 +167,9 @@ void pwFiltersMediaTypesDlg::InitDialog()
 
   m_MediaTypes->Append(_T("")); // Allow empty selection
   if (m_psMediaTypes != nullptr) {
-    size_t i = 0;
     for (auto iter = m_psMediaTypes->begin();
          iter != m_psMediaTypes->end();
-         i++, iter++) {
+         iter++) {
       wxString value = iter->c_str();
       m_MediaTypes->Append(value);
       // Set column size to fit

--- a/src/ui/wxWidgets/PWFiltersMediaDlg.h
+++ b/src/ui/wxWidgets/PWFiltersMediaDlg.h
@@ -84,7 +84,7 @@ protected:
 
 private:
 
-  void InitDialog();
+  void InitDialog() override;
   void SetValidators();
 
   //(*Handlers(pwFiltersMediaTypesDlg)

--- a/src/ui/wxWidgets/PWFiltersPasswordDlg.h
+++ b/src/ui/wxWidgets/PWFiltersPasswordDlg.h
@@ -85,7 +85,7 @@ protected:
 
 private:
 
-  void InitDialog();
+  void InitDialog() override;
   void SetValidators();
 
   //(*Handlers(pwFiltersPasswordDlg)

--- a/src/ui/wxWidgets/PWFiltersStatusDlg.h
+++ b/src/ui/wxWidgets/PWFiltersStatusDlg.h
@@ -82,7 +82,7 @@ protected:
 
 private:
 
-  void InitDialog();
+  void InitDialog() override;
   void SetValidators();
 
   //(*Handlers(pwFiltersStatusDlg)

--- a/src/ui/wxWidgets/PWFiltersStringDlg.h
+++ b/src/ui/wxWidgets/PWFiltersStringDlg.h
@@ -82,7 +82,7 @@ protected:
 
 private:
 
-  void InitDialog();
+  void InitDialog() override;
   void SetValidators();
 
   //(*Handlers(pwFiltersStringDlg)

--- a/src/ui/wxWidgets/PWFiltersTypeDlg.h
+++ b/src/ui/wxWidgets/PWFiltersTypeDlg.h
@@ -82,7 +82,7 @@ protected:
 
 private:
 
-  void InitDialog();
+  void InitDialog() override;
   void SetValidators();
 
   //(*Handlers(pwFiltersTypeDlg)

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -935,8 +935,6 @@ void PasswordSafeFrame::RefreshToolbarButtons()
  */
 void PasswordSafeFrame::UpdateMainToolbarBitmaps()
 {
-  auto pref = PWSprefs::GetInstance();
-  wxASSERT(pref);
   auto toolbar = GetToolBar();
   wxASSERT(toolbar);
 

--- a/src/ui/wxWidgets/SetDatabaseIdDlg.cpp
+++ b/src/ui/wxWidgets/SetDatabaseIdDlg.cpp
@@ -25,11 +25,11 @@
 #include "graphics/unlocked_tray.xpm"
 
 //(*IdInit(SetDatabaseIdDlg)
-const long SetDatabaseIdDlg::ID_SPINCTRL_DATABASEID = wxNewId();
-const long SetDatabaseIdDlg::ID_COLORPICKERCTRL_LOCKEDTEXTCOLOR = wxNewId();
-const long SetDatabaseIdDlg::ID_STATICBITMAP_LOCKEDICON = wxNewId();
-const long SetDatabaseIdDlg::ID_COLORPICKERCTRL_UNLOCKEDTEXTCOLOR = wxNewId();
-const long SetDatabaseIdDlg::ID_STATICBITMAP_UNLOCKEDICON = wxNewId();
+const wxWindowID SetDatabaseIdDlg::ID_SPINCTRL_DATABASEID = wxNewId();
+const wxWindowID SetDatabaseIdDlg::ID_COLORPICKERCTRL_LOCKEDTEXTCOLOR = wxNewId();
+const wxWindowID SetDatabaseIdDlg::ID_STATICBITMAP_LOCKEDICON = wxNewId();
+const wxWindowID SetDatabaseIdDlg::ID_COLORPICKERCTRL_UNLOCKEDTEXTCOLOR = wxNewId();
+const wxWindowID SetDatabaseIdDlg::ID_STATICBITMAP_UNLOCKEDICON = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(SetDatabaseIdDlg,wxDialog)

--- a/src/ui/wxWidgets/SetDatabaseIdDlg.h
+++ b/src/ui/wxWidgets/SetDatabaseIdDlg.h
@@ -65,11 +65,11 @@ private:
   //*)
 
   //(*Identifiers(SetDatabaseIdDlg)
-  static const long ID_SPINCTRL_DATABASEID;
-  static const long ID_COLORPICKERCTRL_LOCKEDTEXTCOLOR;
-  static const long ID_STATICBITMAP_LOCKEDICON;
-  static const long ID_COLORPICKERCTRL_UNLOCKEDTEXTCOLOR;
-  static const long ID_STATICBITMAP_UNLOCKEDICON;
+  static const wxWindowID ID_SPINCTRL_DATABASEID;
+  static const wxWindowID ID_COLORPICKERCTRL_LOCKEDTEXTCOLOR;
+  static const wxWindowID ID_STATICBITMAP_LOCKEDICON;
+  static const wxWindowID ID_COLORPICKERCTRL_UNLOCKEDTEXTCOLOR;
+  static const wxWindowID ID_STATICBITMAP_UNLOCKEDICON;
   //*)
 
   //(*Declarations(SetDatabaseIdDlg)


### PR DESCRIPTION
After updating the Mac Build to C++17, I decided to make a pass over the 80+ warnings I get from a full build.  Most were simple language related issues.  Many apply to Linux and Windows as well.  With the warning options as set in the project file (-Wall -Wextra on os and core, default elsewhere), it now compiles clean on Xcode 14.2 and 15.1, except for one warning in a WX 3.2.2.1 header. (it's fixed in WX 3.2.4.)

With respect to the "Suppress long to int conversion warnings" commit: Three crypto files generate ~30 warnings, most within macro expansions.  Since I don't have the resources to test all the versions I decided to leave them as-is and just applied "-Wno-shorten-64-to-32" to those three specific files in the Xcode project file.  