### PR TITLE
Retry copying TOTP to clipboard if clipboard busy.

### DIFF
--- a/src/os/debug.h
+++ b/src/os/debug.h
@@ -43,4 +43,18 @@ namespace pws_os {
   bool DisableDumpAttach();
 }
 
+#if defined(_DEBUG) || defined(DEBUG)
+
+#define PWSTRACE(lpszFormat,...) pws_os::Trace(lpszFormat,__VA_ARGS__)
+
+#else
+
+#ifdef _WIN32
+#define PWSTRACE(lpszFormat,...) __noop
+#else
+#define PWSTRACE(lpszFormat,...) do {} while(0)
+#endif
+
+#endif
+
 #endif /* _OSDEBUG_H */

--- a/src/ui/Windows/AddEdit_Basic.cpp
+++ b/src/ui/Windows/AddEdit_Basic.cpp
@@ -1812,11 +1812,11 @@ CSecString CAddEdit_Basic::GetTwoFactorKey()
   return twoFactorKey;
 }
 
-bool CAddEdit_Basic::UpdateAuthCode()
+void CAddEdit_Basic::UpdateAuthCode()
 {
   CItemData* pci_cred = M_pci_credential();
   if (!pci_cred)
-    return false;
+    return;
 
   // During Add/Edit, the UI may have updated 2FA info.
   // Use latest 2FA info to produce the auth code.
@@ -1828,31 +1828,40 @@ bool CAddEdit_Basic::UpdateAuthCode()
   auto r = GetMainDlg()->GetTwoFactoryAuthenticationCode(ciTemp, sxAuthCode, &ratio);
   if (r != PWSTotp::Success) {
     StopAuthenticationCodeUi();
-    return false;
+    return;
   }
-
-  bool bNewCode = false;
-  ClipboardStatus clipboardStatus = ClipboardStatus::Error;
-  if (!m_sxLastAuthCode.empty())
-    clipboardStatus = GetMainDlg()->GetLastSensitiveClipboardItemStatus();
-  if (m_bCopyToClipboard && (m_sxLastAuthCode.empty() || clipboardStatus == ClipboardStatus::SuccessSensitivePresent)) {
-    if (sxAuthCode != m_sxLastAuthCode) {
-      bNewCode = true;
-      m_bCopyToClipboard = GetMainDlg()->SetClipboardData(sxAuthCode);
-      ASSERT(m_bCopyToClipboard);
-      if (m_bCopyToClipboard)
-        GetMainDlg()->UpdateLastClipboardAction(ClipboardDataSource::AuthCode);
-      m_sxLastAuthCode = sxAuthCode;
-    }
-  } else if (m_bCopyToClipboard && clipboardStatus != ClipboardStatus::ClipboardNotAvailable)
-    m_bCopyToClipboard = false;
-
-  if (!m_bCopyToClipboard)
-    m_sxLastAuthCode.clear();
 
   m_btnTwoFactorCode.SetPercent(100.0 * ratio);
 
-  return bNewCode;
+  if (!m_bCopyToClipboard) {
+    m_sxLastAuthCode.clear();
+    return;
+  }
+
+  if (sxAuthCode == m_sxLastAuthCode)
+    return;
+
+  ClipboardStatus clipboardStatus = GetMainDlg()->GetLastSensitiveClipboardItemStatus();
+
+  if (!m_sxLastAuthCode.empty() && clipboardStatus != SuccessSensitivePresent) {
+
+    if (clipboardStatus != ClipboardNotAvailable) {
+      m_bCopyToClipboard = false;
+      m_sxLastAuthCode.clear();
+    }
+
+    return;
+  }
+
+  m_bCopyToClipboard = GetMainDlg()->SetClipboardData(sxAuthCode);
+  ASSERT(m_bCopyToClipboard);
+  if (!m_bCopyToClipboard) {
+    m_sxLastAuthCode.clear();
+    return;
+  }
+
+  GetMainDlg()->UpdateLastClipboardAction(ClipboardDataSource::AuthCode);
+  m_sxLastAuthCode = sxAuthCode;
 }
 
 void CAddEdit_Basic::OnTimer(UINT_PTR nIDEvent)

--- a/src/ui/Windows/AddEdit_Basic.cpp
+++ b/src/ui/Windows/AddEdit_Basic.cpp
@@ -1832,7 +1832,10 @@ bool CAddEdit_Basic::UpdateAuthCode()
   }
 
   bool bNewCode = false;
-  if (m_bCopyToClipboard && (m_sxLastAuthCode.empty() || GetMainDlg()->IsLastSensitiveClipboardItemPresent())) {
+  ClipboardStatus clipboardStatus = ClipboardStatus::Error;
+  if (!m_sxLastAuthCode.empty())
+    clipboardStatus = GetMainDlg()->GetLastSensitiveClipboardItemStatus();
+  if (m_bCopyToClipboard && (m_sxLastAuthCode.empty() || clipboardStatus == ClipboardStatus::SuccessSensitivePresent)) {
     if (sxAuthCode != m_sxLastAuthCode) {
       bNewCode = true;
       m_bCopyToClipboard = GetMainDlg()->SetClipboardData(sxAuthCode);
@@ -1841,7 +1844,7 @@ bool CAddEdit_Basic::UpdateAuthCode()
         GetMainDlg()->UpdateLastClipboardAction(ClipboardDataSource::AuthCode);
       m_sxLastAuthCode = sxAuthCode;
     }
-  } else
+  } else if (m_bCopyToClipboard && clipboardStatus != ClipboardStatus::ClipboardNotAvailable)
     m_bCopyToClipboard = false;
 
   if (!m_bCopyToClipboard)

--- a/src/ui/Windows/AddEdit_Basic.h
+++ b/src/ui/Windows/AddEdit_Basic.h
@@ -146,7 +146,7 @@ private:
   void ShowHideBaseInfo(const CItemData::EntryType &entrytype, CSecString &csBase);
   void SetupAuthenticationCodeUiElements();
   void StopAuthenticationCodeUi();
-  bool UpdateAuthCode();
+  void UpdateAuthCode();
   PWSTotp::TOTP_Result ValidateTotpConfiguration(double *pRatio = nullptr);
 
   CSecString GetTwoFactorKey();

--- a/src/ui/Windows/DboxMain.h
+++ b/src/ui/Windows/DboxMain.h
@@ -315,12 +315,12 @@ public:
   void ResetIdleLockCounter(UINT event = WM_SIZE); // default arg always resets
   bool ClearClipboardData() {
     StopAuthCodeUpdateClipboardTimer();
-    return m_clipboard.ClearCBData();
+    return m_clipboard.ClearCBData() == SuccessSensitivePresent;
   }
   bool SetClipboardData(const StringX &data)
   {return m_clipboard.SetData(data.c_str());}
-  bool IsLastSensitiveClipboardItemPresent()
-  {return m_clipboard.IsLastSensitiveItemPresent();}
+  ClipboardStatus GetLastSensitiveClipboardItemStatus()
+  {return m_clipboard.GetLastSensitiveItemPresent();}
   void AddDDEntries(CDDObList &in_oblist, const StringX &DropGroup,
     const std::vector<StringX> &vsxEmptyGroups);
   PWSTotp::TOTP_Result GetTwoFactoryAuthenticationCode(const CItemData& ci, StringX& sxAuthCode, double* pRatio = nullptr);

--- a/src/ui/Windows/DboxMain.h
+++ b/src/ui/Windows/DboxMain.h
@@ -704,6 +704,7 @@ public:
   void StopAuthCodeUpdateClipboardTimer();
   void OnTwoFactorAuthCodeUpdateClipboardTimer();
   pws_os::CUUID m_uuidEntryTwoFactorAutoCopyToClipboard;
+  StringX m_sxLastAuthCode;
 
   // Generated message map functions
   //{{AFX_MSG(DboxMain)

--- a/src/ui/Windows/DisplayAuthCodeDlg.cpp
+++ b/src/ui/Windows/DisplayAuthCodeDlg.cpp
@@ -344,9 +344,10 @@ void CDisplayAuthCodeDlg::OnTimer(UINT_PTR nIDEvent)
   bool bNewCode = UpdateAuthCode(pciCred);
 
   if (bNewCode && m_bCopyToClipboard) {
-    if (GetMainDlg()->IsLastSensitiveClipboardItemPresent())
+    ClipboardStatus clipboardStatus = GetMainDlg()->GetLastSensitiveClipboardItemStatus();
+    if (clipboardStatus == ClipboardStatus::SuccessSensitivePresent)
       CopyAuthCodeToClipboard();
-    else
+    else if (clipboardStatus != ClipboardStatus::ClipboardNotAvailable)
       m_bCopyToClipboard = false;
   }
 }

--- a/src/ui/Windows/MainEdit.cpp
+++ b/src/ui/Windows/MainEdit.cpp
@@ -2155,7 +2155,8 @@ void DboxMain::OnTwoFactorAuthCodeUpdateClipboardTimer()
     }
   }
 
-  if (!IsLastSensitiveClipboardItemPresent()) {
+  ClipboardStatus clipboardStatus = GetLastSensitiveClipboardItemStatus();
+  if (clipboardStatus != SuccessSensitivePresent && clipboardStatus != ClipboardNotAvailable) {
     StopAuthCodeUpdateClipboardTimer();
     return;
   }

--- a/src/ui/Windows/PWSclipboard.h
+++ b/src/ui/Windows/PWSclipboard.h
@@ -23,6 +23,13 @@
 
 #include "core/StringX.h"
 
+enum ClipboardStatus {
+  Error,
+  ClipboardNotAvailable,
+  SuccessSensitiveNotPresent,
+  SuccessSensitivePresent
+};
+
 class PWSclipboard
 {
 public:
@@ -34,8 +41,8 @@ public:
     bool isSensitive = true,
     CLIPFORMAT cfFormat = CLIPBOARD_TEXT_FORMAT);
   // returns true if succeeded
-  bool ClearCBData(); // return true if cleared or if data wasn't ours
-  bool IsLastSensitiveItemPresent();
+  ClipboardStatus ClearCBData(); // return true if cleared or if data wasn't ours
+  ClipboardStatus GetLastSensitiveItemPresent();
 private:
   bool m_bSensitiveDataOnClipboard;
   unsigned char m_digest[SHA256::HASHLEN];


### PR DESCRIPTION
If a user pastes a TOTP code from the clipboard at the same time as pwsafe attempts to copy a TOTP code to the clipboard, pwsafe may encounter clipboard API errors due to the clipboard being busy. Retry if apparent transient clipboard availability states are detected.