### PR TITLE
wx: Add wxWidgets version number to the About dlg

### DIFF
--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 		575412AB2B14265800507BC5 /* codeql-analysis.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; name = "codeql-analysis.yml"; path = "../.github/workflows/codeql-analysis.yml"; sourceTree = "<group>"; };
 		57C329E72A070EFD00454292 /* ReleaseNotesWX.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = ReleaseNotesWX.md; path = ../docs/ReleaseNotesWX.md; sourceTree = "<group>"; };
 		57C329E82A0715F500454292 /* ReleaseNotes.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = ReleaseNotes.md; path = ../docs/ReleaseNotes.md; sourceTree = "<group>"; };
+		57D3F0072B782AF600E4A662 /* version.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = version.in; path = ../src/ui/wxWidgets/version.in; sourceTree = "<group>"; };
 		5BE1417792CF637AD3D45F4D /* base32.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = base32.cpp; path = crypto/external/Chromium/base32.cpp; sourceTree = "<group>"; };
 		6FF5D49D1DA14AB20032F5B6 /* PasswordSubsetDlg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PasswordSubsetDlg.cpp; sourceTree = "<group>"; };
 		6FF5D49E1DA14AB20032F5B6 /* PasswordSubsetDlg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PasswordSubsetDlg.h; sourceTree = "<group>"; };
@@ -969,6 +970,7 @@
 			isa = PBXGroup;
 			children = (
 				57218E8329C983FA000B1907 /* version.wx */,
+				57D3F0072B782AF600E4A662 /* version.in */,
 				E69541311A01150D00BC85E1 /* pwsafe-debug.xcconfig */,
 				E69541321A01150D00BC85E1 /* pwsafe-release.xcconfig */,
 				574370962A3CE21800B46A7D /* pwsafe-template.plist */,

--- a/src/ui/wxWidgets/AboutDlg.cpp
+++ b/src/ui/wxWidgets/AboutDlg.cpp
@@ -153,7 +153,7 @@ void AboutDlg::CreateControls()
   wxButton* closeButton = new wxButton(aboutDialog, wxID_CLOSE, _("&Close"), wxDefaultPosition, wxDefaultSize, 0);
   rightSizer->Add(closeButton, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5);
 
-  const wxString vstring = pwsafeAppName + L" " + pwsafeVersionString;
+  const wxString vstring = pwsafeAppName + L" (" + wxGetLibraryVersionInfo().GetVersionString() + L") " + pwsafeVersionString;
   versionStaticText->SetLabel(vstring);
   const wxString dstring = _("Build date:") + wxT(" ") + wxT(__DATE__) + wxT(" ") + wxT(__TIME__);
   buildStaticText->SetLabel(dstring);

--- a/src/ui/wxWidgets/AboutDlg.cpp
+++ b/src/ui/wxWidgets/AboutDlg.cpp
@@ -113,6 +113,9 @@ void AboutDlg::CreateControls()
   wxStaticText* versionStaticText = new wxStaticText(aboutDialog, wxID_VERSIONSTR, _("Password Safe")+wxT(" vx.yy (abcd)"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
   rightSizer->Add(versionStaticText, 0, wxALIGN_LEFT|wxALL, 5);
 
+  wxStaticText* wxVersionStaticText = new wxStaticText(aboutDialog, wxID_STATIC, _("Built using: ") + wxGetLibraryVersionInfo().GetVersionString(), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
+  rightSizer->Add(wxVersionStaticText, 0, wxALIGN_LEFT|wxALL, 5);
+
   wxStaticText* buildStaticText = new wxStaticText(aboutDialog, wxID_STATIC, _("Build date:")+wxT(" Mon dd yyyy hh:mm:ss"), wxDefaultPosition, wxDefaultSize, 0);
   rightSizer->Add(buildStaticText, 0, wxALIGN_LEFT|wxALL, 5);
 
@@ -153,7 +156,7 @@ void AboutDlg::CreateControls()
   wxButton* closeButton = new wxButton(aboutDialog, wxID_CLOSE, _("&Close"), wxDefaultPosition, wxDefaultSize, 0);
   rightSizer->Add(closeButton, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5);
 
-  const wxString vstring = pwsafeAppName + L" (" + wxGetLibraryVersionInfo().GetVersionString() + L") " + pwsafeVersionString;
+  const wxString vstring = pwsafeAppName + L" " + pwsafeVersionString;
   versionStaticText->SetLabel(vstring);
   const wxString dstring = _("Build date:") + wxT(" ") + wxT(__DATE__) + wxT(" ") + wxT(__TIME__);
   buildStaticText->SetLabel(dstring);

--- a/src/ui/wxWidgets/version.in
+++ b/src/ui/wxWidgets/version.in
@@ -34,7 +34,7 @@
 #ifdef linux
 #define APPNAME _T("PasswordSafe (linux)")
 #else
-#define APPNAME _T("PasswordSafe (wxWidgets)")
+#define APPNAME _T("PasswordSafe")
 #endif
 
 #define MAJORVERSION @pwsafe_VERSION_MAJOR@


### PR DESCRIPTION
This adds the wxWidgets version number to the About dialog:
![About with version number](https://github.com/pwsafe/pwsafe/assets/61946508/9bad1b04-ab0e-429c-9541-b42dd73ebc03)

One side effect on macOS is the string "(wxWidgets)" is removed from the app name in the main menu (see before and after screenshots) , but I think it looks better this way :-)

![Menu before](https://github.com/pwsafe/pwsafe/assets/61946508/e0871693-4a18-4fa9-9259-4b23452ebc1a)

![Menu after](https://github.com/pwsafe/pwsafe/assets/61946508/a74ed81a-dde1-47d5-9690-ce70df902b68)


The file version.in has a separate "#ifdef linux" branch, but it doesn't seem to be used i.e. this change also works on Linux.  If it's obsolete I can remove it.
