### PR TITLE
Change safe combination to master password in *.cpp files

### DIFF
--- a/src/ui/wxWidgets/DbSelectionPanel.cpp
+++ b/src/ui/wxWidgets/DbSelectionPanel.cpp
@@ -77,7 +77,7 @@ DbSelectionPanel::DbSelectionPanel(wxWindow* parent,
              wxFileDirPickerEventHandler(DbSelectionPanel::OnFilePicked),
              nullptr, this);
 
-  panelSizer->Add(new wxStaticText(this, wxID_ANY, _("Safe Combination:")), borderFlags);
+  panelSizer->Add(new wxStaticText(this, wxID_ANY, _("Master Password:")), borderFlags);
   panelSizer->AddSpacer(RowSeparation);
   
   m_sc = new SafeCombinationCtrl(this);

--- a/src/ui/wxWidgets/ExportTextWarningDlg.cpp
+++ b/src/ui/wxWidgets/ExportTextWarningDlg.cpp
@@ -77,7 +77,7 @@ ExportTextWarningDlgBase::ExportTextWarningDlgBase(wxWindow *parent) : wxDialog(
   auto flexGridSizer = new wxFlexGridSizer(DLGITEM_COLS /*cols*/, 0 /*vgap*/, 0 /*hgap*/);
   flexGridSizer->AddGrowableCol(1);
 
-  auto safeCombinationStaticText = new wxStaticText(this, wxID_ANY, _("Safe Combination:"), wxDefaultPosition, wxDefaultSize, 0);
+  auto safeCombinationStaticText = new wxStaticText(this, wxID_ANY, _("Master Password:"), wxDefaultPosition, wxDefaultSize, 0);
   m_combinationEntry = new SafeCombinationCtrl(this, wxID_ANY, &passKey);
   m_combinationEntry->SetFocus();
   auto showCombinationCheckBox = new wxCheckBox(this, wxID_ANY, _("Show Combination"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -680,7 +680,7 @@ void PasswordSafeFrame::CreateMenubar()
   /////////////////////////////////////////////////////////////////////////////
 
   auto menuManage = new wxMenu;
-  menuManage->Append(ID_CHANGECOMBO, _("&Change Safe Combination..."), wxEmptyString, wxITEM_NORMAL);
+  menuManage->Append(ID_CHANGECOMBO, _("&Change Master Password..."), wxEmptyString, wxITEM_NORMAL);
   menuManage->AppendSeparator();
   menuManage->Append(ID_BACKUP, _("Make &Backup...\tCtrl+B"), wxEmptyString, wxITEM_NORMAL);
   menuManage->Append(ID_RESTORE, _("&Restore from Backup...\tCtrl+R"), wxEmptyString, wxITEM_NORMAL);
@@ -2671,7 +2671,7 @@ void PasswordSafeFrame::OnOpenRecentDB(wxCommandEvent& evt)
 
     case PWScore::USER_CANCEL:
       //In case the file doesn't exist, user will have to cancel
-      //the safe combination entry box.  In that call, fall through
+      //the master password entry box.  In that call, fall through
       //to the default case of removing the file from history
       if (pws_os::FileExists(stringT(dbfile)))
         break;          // An existing file doesn't need to be removed from history

--- a/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
@@ -88,9 +88,9 @@ SafeCombinationChangeDlg::SafeCombinationChangeDlg(wxWindow *parent, PWScore &co
 ////@end SafeCombinationChangeDlg creation
 #ifndef NO_YUBI
   m_yubiMixin1.SetupMixin(this, FindWindow(ID_YUBIBTN), FindWindow(ID_YUBISTATUS), YubiMixin::POLLING_TIMER_ID);
-  m_yubiMixin1.SetPrompt1(_("Enter old safe combination (if any) and click on top Yubikey button"));
+  m_yubiMixin1.SetPrompt1(_("Enter old master password (if any) and click on top Yubikey button"));
   m_yubiMixin2.SetupMixin(this, FindWindow(ID_YUBIBTN2), FindWindow(ID_YUBISTATUS), YubiMixin::POLLING_TIMER2_ID);
-  m_yubiMixin2.SetPrompt1(_("Enter old safe combination (if any) and click on top Yubikey button"));
+  m_yubiMixin2.SetPrompt1(_("Enter old master password (if any) and click on top Yubikey button"));
 #endif
 }
 
@@ -137,7 +137,7 @@ void SafeCombinationChangeDlg::CreateControls()
   itemFlexGridSizer4->AddGrowableCol(1);
   mainSizer->Add(itemFlexGridSizer4, 1, wxALIGN_LEFT|wxALL|wxEXPAND, SideMargin);
 
-  wxStaticText* itemStaticText5 = new wxStaticText( itemDialog1, wxID_STATIC, _("Old safe combination:"), wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT );
+  wxStaticText* itemStaticText5 = new wxStaticText( itemDialog1, wxID_STATIC, _("Old master password:"), wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT );
   itemFlexGridSizer4->Add(itemStaticText5, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
   m_oldPasswdEntry = new SafeCombinationCtrl( itemDialog1, ID_OLDPASSWD, &m_oldpasswd, wxDefaultPosition, wxDefaultSize );
@@ -149,7 +149,7 @@ void SafeCombinationChangeDlg::CreateControls()
   itemFlexGridSizer4->Add(m_YubiBtn, 0, wxALIGN_CENTER|wxLEFT|wxRIGHT|wxSHAPED, 5);
 #endif
 
-  wxStaticText* itemStaticText8 = new wxStaticText( itemDialog1, wxID_STATIC, _("New safe combination:"), wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT );
+  wxStaticText* itemStaticText8 = new wxStaticText( itemDialog1, wxID_STATIC, _("New master password:"), wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT );
   itemFlexGridSizer4->Add(itemStaticText8, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
   m_newPasswdEntry = new SafeCombinationCtrl( itemDialog1, ID_NEWPASSWD, &m_newpasswd, wxDefaultPosition, wxDefaultSize );
@@ -268,15 +268,15 @@ void SafeCombinationChangeDlg::OnOkClick(wxCommandEvent& WXUNUSED(evt))
     const StringX old = m_oldresponse.empty() ? m_oldpasswd : m_oldresponse;
     int rc = m_core.CheckPasskey(m_core.GetCurFile(), old);
     if (rc == PWScore::WRONG_PASSWORD) {
-      wxMessageDialog err(this, _("The old safe combination is not correct"),
+      wxMessageDialog err(this, _("The old master password is not correct"),
                           _("Error"), wxOK | wxICON_EXCLAMATION);
       err.ShowModal();
     } else if (rc == PWScore::CANT_OPEN_FILE) {
-      wxMessageDialog err(this, _("Cannot verify old safe combination - file gone?"),
+      wxMessageDialog err(this, _("Cannot verify old master password - file gone?"),
                           _("Error"), wxOK | wxICON_EXCLAMATION);
       err.ShowModal();
     } else if (m_isPasswordHidden && (m_confirm != m_newpasswd)) {
-      wxMessageDialog err(this, _("New safe combination and confirmation do not match"),
+      wxMessageDialog err(this, _("New master password and confirmation do not match"),
                           _("Error"), wxOK | wxICON_EXCLAMATION);
       err.ShowModal();
     // Vox populi vox dei - folks want the ability to use a weak
@@ -344,9 +344,9 @@ void SafeCombinationChangeDlg::OnYubibtnClick(wxCommandEvent& WXUNUSED(event))
       if (rc == PWScore::WRONG_PASSWORD) {
         m_oldresponse.clear();
         m_yubiStatusCtrl->SetForegroundColour(*wxRED);
-        m_yubiStatusCtrl->SetLabel(_("YubiKey safe combination incorrect"));
+        m_yubiStatusCtrl->SetLabel(_("YubiKey master password incorrect"));
       } else {
-        m_yubiMixin2.SetPrompt1(_("Enter new safe combination (if any) and click on bottom Yubikey button"));
+        m_yubiMixin2.SetPrompt1(_("Enter new master password (if any) and click on bottom Yubikey button"));
         m_yubiMixin2.UpdateStatus();
       }
     }
@@ -378,7 +378,7 @@ void SafeCombinationChangeDlg::OnYubibtn2Click(wxCommandEvent& WXUNUSED(event))
       if (rc == PWScore::WRONG_PASSWORD) {
         m_oldresponse.clear();
         m_yubiStatusCtrl->SetForegroundColour(*wxRED);
-        m_yubiStatusCtrl->SetLabel(_("YubiKey safe combination incorrect"));
+        m_yubiStatusCtrl->SetLabel(_("YubiKey master password incorrect"));
         return;
       }
     } else {
@@ -386,7 +386,7 @@ void SafeCombinationChangeDlg::OnYubibtn2Click(wxCommandEvent& WXUNUSED(event))
       rc = m_core.CheckPasskey(m_core.GetCurFile(), m_oldpasswd);
       if (rc == PWScore::WRONG_PASSWORD) {
         m_yubiStatusCtrl->SetForegroundColour(*wxRED);
-        m_yubiStatusCtrl->SetLabel(_("Current safe combination incorrect"));
+        m_yubiStatusCtrl->SetLabel(_("Current master password incorrect"));
         return;
       }
     }

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -173,7 +173,7 @@ void SafeCombinationEntryDlg::CreateControls()
   wxButton* itemButton11 = new wxButton( itemDialog1, ID_ELLIPSIS, wxT("..."), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT );
   itemBoxSizer9->Add(itemButton11, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  wxStaticText* itemStaticText12 = new wxStaticText( itemDialog1, wxID_STATIC, _("Safe Combination:"), wxDefaultPosition, wxDefaultSize, 0 );
+  wxStaticText* itemStaticText12 = new wxStaticText( itemDialog1, wxID_STATIC, _("Master Password:"), wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer4->Add(itemStaticText12, 0, wxALIGN_LEFT|wxALL, 3);
 
   auto itemBoxSizer10 = new wxBoxSizer(wxHORIZONTAL);

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -138,7 +138,7 @@ void SafeCombinationPromptDlg::CreateControls()
   auto *itemBoxSizer5 = new wxBoxSizer(wxVERTICAL);
   itemBoxSizer3->Add(itemBoxSizer5, 1, wxALL|wxEXPAND, 5);
 
-  wxStaticText* itemStaticText6 = new wxStaticText( itemDialog1, wxID_STATIC, _("Please enter the safe combination for this password database."), wxDefaultPosition, wxDefaultSize, 0 );
+  wxStaticText* itemStaticText6 = new wxStaticText( itemDialog1, wxID_STATIC, _("Please enter the master password for this password database."), wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer5->Add(itemStaticText6, 0, wxALIGN_LEFT|wxALL, 5);
 
   wxStaticText* itemStaticText7 = new wxStaticText( itemDialog1, wxID_STATIC, _("filename"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -150,7 +150,7 @@ void SafeCombinationPromptDlg::CreateControls()
   auto flexGridSizer = new wxFlexGridSizer(2 /*cols*/, 0 /*vgap*/, 0 /*hgap*/);
   flexGridSizer->AddGrowableCol(1);
 
-  wxStaticText* itemStaticText9 = new wxStaticText( itemDialog1, wxID_STATIC, _("Safe combination:"), wxDefaultPosition, wxDefaultSize, 0 );
+  wxStaticText* itemStaticText9 = new wxStaticText( itemDialog1, wxID_STATIC, _("Master password:"), wxDefaultPosition, wxDefaultSize, 0 );
   flexGridSizer->Add(itemStaticText9, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
   m_scctrl = new SafeCombinationCtrl( itemDialog1, ID_PASSWORD, &m_password, wxDefaultPosition, wxDefaultSize );

--- a/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
@@ -113,13 +113,13 @@ void SafeCombinationSetupDlg::CreateControls()
   wxBoxSizer* itemBoxSizer2 = new wxBoxSizer(wxVERTICAL);
   itemDialog1->SetSizer(itemBoxSizer2);
 
-  wxStaticText* itemStaticText3 = new wxStaticText( itemDialog1, wxID_STATIC, _("A new password database will be created.\nThe safe combination will be used to encrypt the password database file.\nYou can use any keyboard character. The combination is case-sensitive."), wxDefaultPosition, wxDefaultSize, 0 );
+  wxStaticText* itemStaticText3 = new wxStaticText( itemDialog1, wxID_STATIC, _("A new password database will be created.\nThe master password will be used to encrypt the password database file.\nYou can use any keyboard character. The combination is case-sensitive."), wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer2->Add(itemStaticText3, 0, wxALIGN_LEFT|wxALL, 15);
 
   wxFlexGridSizer* itemGridSizer4 = new wxFlexGridSizer(2, 0, 10);
   itemBoxSizer2->Add(itemGridSizer4, 0, wxLEFT|wxRIGHT|wxEXPAND, 15);
 
-  wxStaticText* itemStaticText5 = new wxStaticText( itemDialog1, wxID_STATIC, _("Safe Combination:"), wxDefaultPosition, wxDefaultSize, 0 );
+  wxStaticText* itemStaticText5 = new wxStaticText( itemDialog1, wxID_STATIC, _("Master Password:"), wxDefaultPosition, wxDefaultSize, 0 );
   itemGridSizer4->Add(itemStaticText5, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
   wxTextCtrl* itemTextCtrl6 = new wxTextCtrl( itemDialog1, ID_PASSWORD, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PASSWORD );


### PR DESCRIPTION
Unifying the terminology of Password Safe on Windows with Password Safe on non-Windows.
Changing "safe combination" with "master password" in all of *.cpp files.