### PR TITLE
If incorrect master password entered, replace display more friendly message

### DIFF
--- a/src/ui/Windows/res/PasswordSafe3.rc2
+++ b/src/ui/Windows/res/PasswordSafe3.rc2
@@ -237,7 +237,7 @@ BEGIN
   IDS_SYNCHRONIZED        "%d entries synchronized"
   IDS_NOCURRENTSAFE       "[No current database]"
   IDS_CANNOTBEBLANK       "The master password cannot be blank."
-  IDS_INCORRECTKEY        "Most commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or \n - backup database has been opened instead of original, ending with '~' character."
+  IDS_INCORRECTKEY        "Password database can't be opened.\n\nMost commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or \n - backup database has been opened instead of original, ending with '~' character."
   IDS_WEAKPASSPHRASE      "Weak master password:\n\n %s"
   IDS_USEITANYWAY         "\nUse it anyway?"
   IDS_TRYANOTHER          "\nPlease try another"

--- a/src/ui/Windows/res/PasswordSafe3.rc2
+++ b/src/ui/Windows/res/PasswordSafe3.rc2
@@ -237,7 +237,7 @@ BEGIN
   IDS_SYNCHRONIZED        "%d entries synchronized"
   IDS_NOCURRENTSAFE       "[No current database]"
   IDS_CANNOTBEBLANK       "The master password cannot be blank."
-  IDS_INCORRECTKEY        "Password database can't be opened.\n\nMost commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or \n - backup database has been opened instead of original, ending with '~' character."
+  IDS_INCORRECTKEY        "Incorrect master password, not a Password Safe database, or a corrupt database."
   IDS_WEAKPASSPHRASE      "Weak master password:\n\n %s"
   IDS_USEITANYWAY         "\nUse it anyway?"
   IDS_TRYANOTHER          "\nPlease try another"

--- a/src/ui/Windows/res/PasswordSafe3.rc2
+++ b/src/ui/Windows/res/PasswordSafe3.rc2
@@ -237,7 +237,7 @@ BEGIN
   IDS_SYNCHRONIZED        "%d entries synchronized"
   IDS_NOCURRENTSAFE       "[No current database]"
   IDS_CANNOTBEBLANK       "The master password cannot be blank."
-  IDS_INCORRECTKEY        "Incorrect master password, not a PasswordSafe database, or a corrupt database."
+  IDS_INCORRECTKEY        "Most commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or \n - backup database has been opened instead of original, ending with '~' character."
   IDS_WEAKPASSPHRASE      "Weak master password:\n\n %s"
   IDS_USEITANYWAY         "\nUse it anyway?"
   IDS_TRYANOTHER          "\nPlease try another"

--- a/src/ui/wxWidgets/DbSelectionPanel.cpp
+++ b/src/ui/wxWidgets/DbSelectionPanel.cpp
@@ -148,7 +148,7 @@ bool DbSelectionPanel::DoValidation()
     m_combination = m_yubiCombination.empty() ? m_sc->GetCombination() : m_yubiCombination;
     //Does the combination match?
     if (m_core->CheckPasskey(tostringx(wxfn.GetFullPath()), m_combination) != PWScore::SUCCESS) {
-      wxString errmess(_("Incorrect passkey, not a PasswordSafe database, or a corrupt database. (Backup database has same name as original, ending with '~')"));
+      wxString errmess(_("Most commont issues:\n - incorrect Master Password,\n - not a Password Safe database,\n - a corrupt database.\n - backup database has been opened instead of original, ending with '~'"));
       wxMessageBox(errmess, _("Error"), wxOK | wxICON_ERROR, this);
       SelectCombinationText();
       m_combination.clear();

--- a/src/ui/wxWidgets/DbSelectionPanel.cpp
+++ b/src/ui/wxWidgets/DbSelectionPanel.cpp
@@ -148,7 +148,7 @@ bool DbSelectionPanel::DoValidation()
     m_combination = m_yubiCombination.empty() ? m_sc->GetCombination() : m_yubiCombination;
     //Does the combination match?
     if (m_core->CheckPasskey(tostringx(wxfn.GetFullPath()), m_combination) != PWScore::SUCCESS) {
-      wxString errmess(_("Most commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or \n - backup database has been opened instead of original, ending with '~' character."));
+      wxString errmess(_("Password database can't be opened.\n\nMost commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or \n - backup database has been opened instead of original, ending with '~' character."));
       wxMessageBox(errmess, _("Error"), wxOK | wxICON_ERROR, this);
       SelectCombinationText();
       m_combination.clear();

--- a/src/ui/wxWidgets/DbSelectionPanel.cpp
+++ b/src/ui/wxWidgets/DbSelectionPanel.cpp
@@ -148,7 +148,7 @@ bool DbSelectionPanel::DoValidation()
     m_combination = m_yubiCombination.empty() ? m_sc->GetCombination() : m_yubiCombination;
     //Does the combination match?
     if (m_core->CheckPasskey(tostringx(wxfn.GetFullPath()), m_combination) != PWScore::SUCCESS) {
-      wxString errmess(_("Most commont issues:\n - incorrect Master Password,\n - not a Password Safe database,\n - a corrupt database.\n - backup database has been opened instead of original, ending with '~'"));
+      wxString errmess(_("Most commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or \n - backup database has been opened instead of original, ending with '~' character."));
       wxMessageBox(errmess, _("Error"), wxOK | wxICON_ERROR, this);
       SelectCombinationText();
       m_combination.clear();

--- a/src/ui/wxWidgets/DbSelectionPanel.cpp
+++ b/src/ui/wxWidgets/DbSelectionPanel.cpp
@@ -149,7 +149,7 @@ bool DbSelectionPanel::DoValidation()
     //Does the combination match?
     if (m_core->CheckPasskey(tostringx(wxfn.GetFullPath()), m_combination) != PWScore::SUCCESS) {
       wxString errmess(_("Incorrect master password, not a Password Safe database, or a corrupt database."));
-      wxMessageBox(errmess, _("Error"), wxOK | wxICON_ERROR, this);
+      wxMessageBox(errmess, _("Can't open a password database"), wxOK | wxICON_ERROR, this);
       SelectCombinationText();
       m_combination.clear();
       return false;

--- a/src/ui/wxWidgets/DbSelectionPanel.cpp
+++ b/src/ui/wxWidgets/DbSelectionPanel.cpp
@@ -148,7 +148,7 @@ bool DbSelectionPanel::DoValidation()
     m_combination = m_yubiCombination.empty() ? m_sc->GetCombination() : m_yubiCombination;
     //Does the combination match?
     if (m_core->CheckPasskey(tostringx(wxfn.GetFullPath()), m_combination) != PWScore::SUCCESS) {
-      wxString errmess(_("Password database can't be opened.\n\nMost commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or \n - backup database has been opened instead of original, ending with '~' character."));
+      wxString errmess(_("Incorrect master password, not a Password Safe database, or a corrupt database."));
       wxMessageBox(errmess, _("Error"), wxOK | wxICON_ERROR, this);
       SelectCombinationText();
       m_combination.clear();

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -442,7 +442,7 @@ void SafeCombinationEntryDlg::ProcessPhrase()
     if (m_tries++ >= 2) {
       errmess = _("Too many retries - exiting");
     } else {
-      errmess = _("Most commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or \n - backup database has been opened instead of original, ending with '~' character.");
+      errmess = _("Password database can't be opened.\n\nMost commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or \n - backup database has been opened instead of original, ending with '~' character.");
     }
     break;
   } // switch (status)

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -442,7 +442,7 @@ void SafeCombinationEntryDlg::ProcessPhrase()
     if (m_tries++ >= 2) {
       errmess = _("Too many retries - exiting");
     } else {
-      errmess = _("Most commont issues:\n - incorrect Master Password,\n - not a Password Safe database,\n - a corrupt database.\n - backup database has been opened instead of original, ending with '~'");
+      errmess = _("Most commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or \n - backup database has been opened instead of original, ending with '~' character.");
     }
     break;
   } // switch (status)

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -448,7 +448,7 @@ void SafeCombinationEntryDlg::ProcessPhrase()
   } // switch (status)
     // here iff CheckPasskey failed.
   wxMessageDialog err(this, errmess,
-                      _("Error"), wxOK | wxICON_EXCLAMATION);
+                      _("Can't open a password database"), wxOK | wxICON_EXCLAMATION);
   err.ShowModal();
   if (m_tries >= 3) {
     EndModal(wxCANCEL);

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -442,7 +442,7 @@ void SafeCombinationEntryDlg::ProcessPhrase()
     if (m_tries++ >= 2) {
       errmess = _("Too many retries - exiting");
     } else {
-      errmess = _("Incorrect passkey, not a PasswordSafe database, or a corrupt database. (Backup database has same name as original, ending with '~')");
+      errmess = _("Most commont issues:\n - incorrect Master Password,\n - not a Password Safe database,\n - a corrupt database.\n - backup database has been opened instead of original, ending with '~'");
     }
     break;
   } // switch (status)

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -442,7 +442,7 @@ void SafeCombinationEntryDlg::ProcessPhrase()
     if (m_tries++ >= 2) {
       errmess = _("Too many retries - exiting");
     } else {
-      errmess = _("Password database can't be opened.\n\nMost commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or \n - backup database has been opened instead of original, ending with '~' character.");
+      errmess = _("Incorrect master password, not a Password Safe database, or a corrupt database.");
     }
     break;
   } // switch (status)

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -286,7 +286,7 @@ void SafeCombinationPromptDlg::ProcessPhrase()
       errmess = _("Three strikes - yer out!");
     } else {
       m_tries++;
-      errmess = _("Incorrect passkey, not a PasswordSafe database, or a corrupt database. (Backup database has same name as original, ending with '~')");
+      errmess = _("Most commont issues:\n - incorrect Master Password,\n - not a Password Safe database,\n - a corrupt database.\n - backup database has been opened instead of original, ending with '~'");
     }
     wxMessageDialog err(this, errmess,
                         _("Error"), wxOK | wxICON_EXCLAMATION);

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -286,7 +286,7 @@ void SafeCombinationPromptDlg::ProcessPhrase()
       errmess = _("Three strikes - yer out!");
     } else {
       m_tries++;
-      errmess = _("Most commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or\n - backup database has been opened instead of original, ending with '~' character.");
+      errmess = _("Password database can't be opened.\n\nMost commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or\n - backup database has been opened instead of original, ending with '~' character.");
     }
     wxMessageDialog err(this, errmess,
                         _("Error"), wxOK | wxICON_EXCLAMATION);

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -286,7 +286,7 @@ void SafeCombinationPromptDlg::ProcessPhrase()
       errmess = _("Three strikes - yer out!");
     } else {
       m_tries++;
-      errmess = _("Password database can't be opened.\n\nMost commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or\n - backup database has been opened instead of original, ending with '~' character.");
+      errmess = _("Incorrect master password, not a Password Safe database, or a corrupt database.");
     }
     wxMessageDialog err(this, errmess,
                         _("Error"), wxOK | wxICON_EXCLAMATION);

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -289,7 +289,7 @@ void SafeCombinationPromptDlg::ProcessPhrase()
       errmess = _("Incorrect master password, not a Password Safe database, or a corrupt database.");
     }
     wxMessageDialog err(this, errmess,
-                        _("Error"), wxOK | wxICON_EXCLAMATION);
+                        _("Can't open a password database"), wxOK | wxICON_EXCLAMATION);
     err.ShowModal();
     auto *txt = dynamic_cast<wxTextCtrl *>(FindWindow(ID_PASSWORD));
     txt->SetSelection(-1,-1);

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -286,7 +286,7 @@ void SafeCombinationPromptDlg::ProcessPhrase()
       errmess = _("Three strikes - yer out!");
     } else {
       m_tries++;
-      errmess = _("Most commont issues:\n - incorrect Master Password,\n - not a Password Safe database,\n - a corrupt database.\n - backup database has been opened instead of original, ending with '~'");
+      errmess = _("Most commont issues:\n - incorrect master password,\n - not a Password Safe database,\n - a corrupt database, or\n - backup database has been opened instead of original, ending with '~' character.");
     }
     wxMessageDialog err(this, errmess,
                         _("Error"), wxOK | wxICON_EXCLAMATION);


### PR DESCRIPTION
If Master Password is incorrectly typed in, bellow dialog is displayed, which message is little bit confusing, What is "passkey"?, and options are too crowded.
![image](https://github.com/pwsafe/pwsafe/assets/10895030/b7f780fe-2f17-49ee-aca6-44900b96a571)

This pull request changes dialog to:
![image](https://github.com/pwsafe/pwsafe/assets/10895030/dc568080-6621-48a8-869c-abb1d2075427)

