### PR TITLE
Change one word PasswordSafe to two words Password Safe in Manage | Options | System

### DIFF
--- a/src/ui/Windows/PasswordSafe.rc
+++ b/src/ui/Windows/PasswordSafe.rc
@@ -584,7 +584,7 @@ BEGIN
     EDITTEXT        IDC_MAXREITEMS,73,39,17,12,ES_NUMBER
     CONTROL         "",IDC_RESPIN,"msctls_updown32",UDS_SETBUDDYINT | UDS_ARROWKEYS | UDS_HOTTRACK,90,39,10,12
     LTEXT           "used entries in System Tray menu.",IDC_STATIC_MAXREITEMS,103,41,132,15
-    GROUPBOX        "Recent PasswordSafe Databases",IDC_STATIC_GBMRU,6,86,238,64,WS_GROUP
+    GROUPBOX        "Recent Password Safe Databases",IDC_STATIC_GBMRU,6,86,238,64,WS_GROUP
     LTEXT           "(Requires a restart of PasswordSafe to take effect.)",IDC_STATIC_RESTART,14,96,211,18
     RTEXT           "Remember last",IDC_STATIC_REMLAST,13,116,53,8
     EDITTEXT        IDC_MAXMRUITEMS,74,114,17,12,ES_NUMBER
@@ -598,7 +598,7 @@ BEGIN
     CONTROL         "Migrate PasswordSafe configuration to user directory",IDC_MIGRATETOAPPDATA,
                     "Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,10,215,216,15
     PUSHBUTTON      "Apply",IDC_APPLYCONFIGCHANGES,20,237,50,14,WS_DISABLED
-    CONTROL         "Start PasswordSafe at Login",IDC_STARTUP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,71,216,10
+    CONTROL         "Start Password Safe at Login",IDC_STARTUP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,71,216,10
     CONTROL         "Open database read-only by default",IDC_DEFAULTOPENRO,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,9,156,217,10
     CONTROL         "Allow multiple instances (requires all instances to be restarted)",IDC_MULTIPLEINSTANCES,
@@ -1717,7 +1717,7 @@ BEGIN
     EDITTEXT        IDC_MAXREITEMS,69,39,17,12,ES_NUMBER
     CONTROL         "",IDC_RESPIN,"msctls_updown32",UDS_SETBUDDYINT | UDS_ARROWKEYS | UDS_HOTTRACK,86,39,10,12
     LTEXT           "used entries in System Tray menu.",IDC_STATIC_MAXREITEMS,99,41,124,15
-    GROUPBOX        "Recent PasswordSafe Databases",IDC_STATIC_GBMRU,7,86,226,64,WS_GROUP
+    GROUPBOX        "Recent Password Safe Databases",IDC_STATIC_GBMRU,7,86,226,64,WS_GROUP
     LTEXT           "(Requires a restart of PasswordSafe to take effect.)",IDC_STATIC_RESTART,14,96,211,18
     RTEXT           "Remember last",IDC_STATIC_REMLAST,13,116,53,8
     EDITTEXT        IDC_MAXMRUITEMS,69,114,17,12,ES_NUMBER
@@ -1731,7 +1731,7 @@ BEGIN
     CONTROL         "Migrate PasswordSafe configuration to user directory",IDC_MIGRATETOAPPDATA,
                     "Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,246,86,216,15
     PUSHBUTTON      "Apply",IDC_APPLYCONFIGCHANGES,256,108,50,14,WS_DISABLED
-    CONTROL         "Start PasswordSafe at Login",IDC_STARTUP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,71,216,10
+    CONTROL         "Start Password Safe at Login",IDC_STARTUP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,71,216,10
     CONTROL         "Open database read-only by default",IDC_DEFAULTOPENRO,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,245,27,217,10
     CONTROL         "Allow multiple instances (requires all instances to be restarted)",IDC_MULTIPLEINSTANCES,

--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -849,7 +849,7 @@ wxPanel* OptionsPropertySheetDlg::CreateSystemPanel(const wxString& title)
   wxStaticText* itemStaticText111 = new wxStaticText( itemPanel104, ID_STATICTEXT_7, _("used entries in System Tray menu"), wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer108->Add(itemStaticText111, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  wxCheckBox* system_StartupCB = new wxCheckBox( itemPanel104, ID_CHECKBOX31, _("Start PasswordSafe at Login"), wxDefaultPosition, wxDefaultSize, 0 );
+  wxCheckBox* system_StartupCB = new wxCheckBox( itemPanel104, ID_CHECKBOX31, _("Start Password Safe at Login"), wxDefaultPosition, wxDefaultSize, 0 );
   system_StartupCB->SetValue(false);
   itemStaticBoxSizer106->Add(system_StartupCB, 0, wxALIGN_LEFT|wxALL, 5);
 
@@ -858,7 +858,7 @@ wxPanel* OptionsPropertySheetDlg::CreateSystemPanel(const wxString& title)
   m_System_SystemTrayWarningST->SetForegroundColour(*wxRED);
   m_System_SystemTrayWarningST->Hide();
 
-  wxStaticBox* itemStaticBoxSizer113Static = new wxStaticBox(itemPanel104, wxID_ANY, _("Recent PasswordSafe Databases"));
+  wxStaticBox* itemStaticBoxSizer113Static = new wxStaticBox(itemPanel104, wxID_ANY, _("Recent Password Safe Databases"));
   auto *itemStaticBoxSizer113 = new wxStaticBoxSizer(itemStaticBoxSizer113Static, wxVERTICAL);
   itemBoxSizer105->Add(itemStaticBoxSizer113, 0, wxEXPAND|wxALL, 5);
   auto *itemBoxSizer114 = new wxBoxSizer(wxHORIZONTAL);

--- a/src/ui/wxWidgets/pwsafe.pjd
+++ b/src/ui/wxWidgets/pwsafe.pjd
@@ -23108,7 +23108,7 @@ Action:"</string>
                   <long name="proxy-Id value">10184</long>
                   <string name="proxy-Implementation filename">""</string>
                   <bool name="proxy-Initial value">0</bool>
-                  <string name="proxy-Label">"Start PasswordSafe at Login"</string>
+                  <string name="proxy-Label">"Start Password Safe at Login"</string>
                   <string name="proxy-Member variable name">""</string>
                   <string name="proxy-Name">""</string>
                   <string name="proxy-Platform">"&lt;Any platform&gt;"</string>
@@ -23154,7 +23154,7 @@ Action:"</string>
                 <bool name="proxy-Hidden">0</bool>
                 <string name="proxy-Id name">"wxID_ANY"</string>
                 <long name="proxy-Id value">-1</long>
-                <string name="proxy-Label">"Recent PasswordSafe Databases"</string>
+                <string name="proxy-Label">"Recent Password Safe Databases"</string>
                 <string name="proxy-Member variable name">""</string>
                 <string name="proxy-Orientation">"Vertical"</string>
                 <string name="proxy-Parenting">"Use wxWidgets version"</string>


### PR DESCRIPTION
In menu Manage | Options | System change one word "PassworSafe" to two words "Password Safe".
This is just simple fix, to make product branding more recognizable.