### PR TITLE
Rename Yes_No buttons to Delete_Cancel in Delete Group and Delete Entry on non-Windows

### DIFF
--- a/src/ui/wxWidgets/DeleteConfirmationDlg.cpp
+++ b/src/ui/wxWidgets/DeleteConfirmationDlg.cpp
@@ -104,10 +104,10 @@ void DeleteConfirmationDlg::CreateControls()
   wxStdDialogButtonSizer* itemStdDialogButtonSizer5 = new wxStdDialogButtonSizer;
 
   itemBoxSizer2->Add(itemStdDialogButtonSizer5, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5);
-  wxButton* itemButton6 = new wxButton( itemDialog1, wxID_YES, _("&Yes"), wxDefaultPosition, wxDefaultSize, 0 );
+  wxButton* itemButton6 = new wxButton( itemDialog1, wxID_YES, _("&Delete"), wxDefaultPosition, wxDefaultSize, 0 );
   itemStdDialogButtonSizer5->AddButton(itemButton6);
 
-  wxButton* itemButton7 = new wxButton( itemDialog1, wxID_NO, _("&No"), wxDefaultPosition, wxDefaultSize, 0 );
+  wxButton* itemButton7 = new wxButton( itemDialog1, wxID_NO, _("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
   itemButton7->SetDefault();
   itemStdDialogButtonSizer5->AddButton(itemButton7);
 


### PR DESCRIPTION
Attempt to fix [issue 1020](https://github.com/pwsafe/pwsafe/issues/1020)

---
1. **DONE:** This commit is for non-Windows only.
![image](https://github.com/pwsafe/pwsafe/assets/10895030/e941d1a2-d6cf-4a30-81ec-8ca67dbc1136)
---
2. **TODO:** Now searching for Windows strings and I get:
> src/ui/Windows/res/PasswordSafe3.rc2:  IDS_DELGRP              "Are you sure you want to delete the selected group?"
> src/ui/Windows/res/PasswordSafe3.rc2:  IDS_DELENT              "Are you sure you want to delete the selected entry?"

@ronys, can you confirm I should change following two strings in the code? I don't have Windows to build Password Safe Windows build.
![image](https://github.com/pwsafe/pwsafe/assets/10895030/ca9dc637-ee87-461f-9744-7bb75e7094a4)

---
3. **TODO:** @rony, it would be nice this questions have a "exclamation point" icon on the left side. Any tip how to add it?
![image](https://github.com/pwsafe/pwsafe/assets/10895030/5d109853-ae36-4c24-9b98-1b589febbfcb)
