### PR TITLE
Dialog with wrong master password. Remove dialog icon and make dialog less wide

### DIFF
--- a/src/ui/Windows/res/PasswordSafe3.rc2
+++ b/src/ui/Windows/res/PasswordSafe3.rc2
@@ -237,7 +237,7 @@ BEGIN
   IDS_SYNCHRONIZED        "%d entries synchronized"
   IDS_NOCURRENTSAFE       "[No current database]"
   IDS_CANNOTBEBLANK       "The master password cannot be blank."
-  IDS_INCORRECTKEY        "Incorrect master password, not a Password Safe database, or a corrupt database."
+  IDS_INCORRECTKEY        "Incorrect master password, not a Password Safe database,\nor a corrupt database."
   IDS_WEAKPASSPHRASE      "Weak master password:\n\n %s"
   IDS_USEITANYWAY         "\nUse it anyway?"
   IDS_TRYANOTHER          "\nPlease try another"

--- a/src/ui/wxWidgets/DbSelectionPanel.cpp
+++ b/src/ui/wxWidgets/DbSelectionPanel.cpp
@@ -148,8 +148,8 @@ bool DbSelectionPanel::DoValidation()
     m_combination = m_yubiCombination.empty() ? m_sc->GetCombination() : m_yubiCombination;
     //Does the combination match?
     if (m_core->CheckPasskey(tostringx(wxfn.GetFullPath()), m_combination) != PWScore::SUCCESS) {
-      wxString errmess(_("Incorrect master password, not a Password Safe database, or a corrupt database."));
-      wxMessageBox(errmess, _("Can't open a password database"), wxOK | wxICON_ERROR, this);
+      wxString errmess(_("Incorrect master password, not a Password Safe database,\nor a corrupt database."));
+      wxMessageBox(errmess, _("Can't open a password database"), wxOK | wxICON_NONE, this);
       SelectCombinationText();
       m_combination.clear();
       return false;

--- a/src/ui/wxWidgets/DbSelectionPanel.cpp
+++ b/src/ui/wxWidgets/DbSelectionPanel.cpp
@@ -149,7 +149,7 @@ bool DbSelectionPanel::DoValidation()
     //Does the combination match?
     if (m_core->CheckPasskey(tostringx(wxfn.GetFullPath()), m_combination) != PWScore::SUCCESS) {
       wxString errmess(_("Incorrect master password, not a Password Safe database,\nor a corrupt database."));
-      wxMessageBox(errmess, _("Can't open a password database"), wxOK | wxICON_NONE, this);
+      wxMessageBox(errmess, _("Can't open a password database"), wxOK | wxICON_ERROR, this);
       SelectCombinationText();
       m_combination.clear();
       return false;

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -442,13 +442,13 @@ void SafeCombinationEntryDlg::ProcessPhrase()
     if (m_tries++ >= 2) {
       errmess = _("Too many retries - exiting");
     } else {
-      errmess = _("Incorrect master password, not a Password Safe database, or a corrupt database.");
+      errmess = _("Incorrect master password, not a Password Safe database,\nor a corrupt database.");
     }
     break;
   } // switch (status)
     // here iff CheckPasskey failed.
   wxMessageDialog err(this, errmess,
-                      _("Can't open a password database"), wxOK | wxICON_EXCLAMATION);
+                      _("Can't open a password database"), wxOK | wxICON_NONE);
   err.ShowModal();
   if (m_tries >= 3) {
     EndModal(wxCANCEL);

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -448,7 +448,7 @@ void SafeCombinationEntryDlg::ProcessPhrase()
   } // switch (status)
     // here iff CheckPasskey failed.
   wxMessageDialog err(this, errmess,
-                      _("Can't open a password database"), wxOK | wxICON_NONE);
+                      _("Can't open a password database"), wxOK | wxICON_EXCLAMATION);
   err.ShowModal();
   if (m_tries >= 3) {
     EndModal(wxCANCEL);

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -286,10 +286,10 @@ void SafeCombinationPromptDlg::ProcessPhrase()
       errmess = _("Three strikes - yer out!");
     } else {
       m_tries++;
-      errmess = _("Incorrect master password, not a Password Safe database, or a corrupt database.");
+      errmess = _("Incorrect master password, not a Password Safe database,\nor a corrupt database.");
     }
     wxMessageDialog err(this, errmess,
-                        _("Can't open a password database"), wxOK | wxICON_EXCLAMATION);
+                        _("Can't open a password database"), wxOK | wxICON_NONE);
     err.ShowModal();
     auto *txt = dynamic_cast<wxTextCtrl *>(FindWindow(ID_PASSWORD));
     txt->SetSelection(-1,-1);

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -289,7 +289,7 @@ void SafeCombinationPromptDlg::ProcessPhrase()
       errmess = _("Incorrect master password, not a Password Safe database,\nor a corrupt database.");
     }
     wxMessageDialog err(this, errmess,
-                        _("Can't open a password database"), wxOK | wxICON_NONE);
+                        _("Can't open a password database"), wxOK | wxICON_EXCLAMATION);
     err.ShowModal();
     auto *txt = dynamic_cast<wxTextCtrl *>(FindWindow(ID_PASSWORD));
     txt->SetSelection(-1,-1);


### PR DESCRIPTION
I made some additional improvements to "incorrect master password" dialog on top of [PR 1114](https://github.com/pwsafe/pwsafe/pull/1114) that was already merged into master.

Now I see that design changes in PR 1114 was not the best choice, after using program in day-to-day activity. Now I see how distracting "explanation mark" icon is and how wide is actually dialog and so trying for eyes to move so long from end of first line to second line.

- Text is the same.
- Removed icon
- Added line brake to make dialog shorter

Comparisons:

![image](https://github.com/pwsafe/pwsafe/assets/10895030/67479dd8-0a50-4cf7-85a2-5c0361537ea2)
