### PR TITLE
Make Weak master password dialog more pretty.

### DIFF
--- a/src/core/core.rc2
+++ b/src/core/core.rc2
@@ -17,7 +17,7 @@
 
 STRINGTABLE
 BEGIN
-  IDSC_PASSWORDTOOSHORT   "Password is too short"
+  IDSC_PASSWORDTOOSHORT   "Password is too short."
   IDSC_PASSWORDPOOR       "Password should be mixed case, with at least one digit or punctuation character"
 END
 

--- a/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
@@ -286,14 +286,13 @@ void SafeCombinationChangeDlg::OnOkClick(wxCommandEvent& WXUNUSED(evt))
     // PWS_FORCE_STRONG_PASSPHRASE in the build properties/Makefile
     // (also used in CPasskeySetup)
     } else if (!CPasswordCharPool::CheckMasterPassword(m_newpasswd, errmess)) {
-      wxString msg = _("Weak passphrase:");
-      msg += wxT("\n\n");
-      msg += errmess.c_str();
+      wxString msg = errmess.c_str();
 #ifndef PWS_FORCE_STRONG_PASSPHRASE
       msg += wxT("\n");
       msg += _("Use it anyway?");
       wxMessageDialog err(this, msg,
-                          _("Error"), wxYES_NO | wxICON_HAND);
+                          _("Weak Master Password"), wxYES_NO | wxNO_DEFAULT | wxICON_EXCLAMATION);
+      err.SetYesNoLabels(_("Use anyway"), _("Cancel"));
       int rc1 = err.ShowModal();
       if (rc1 == wxID_YES)
         EndModal(wxID_OK);

--- a/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
@@ -231,14 +231,13 @@ void SafeCombinationSetupDlg::OnOkClick(wxCommandEvent& WXUNUSED(evt))
     StringX errmess;
     if (!CPasswordCharPool::CheckMasterPassword(tostringx(m_password), errmess)) {
       wxString cs_msg;
-      cs_msg = _("Weak passphrase:");
-      cs_msg += wxT("\n\n");
-      cs_msg += errmess.c_str();
+      cs_msg = errmess.c_str();
 #ifndef PWS_FORCE_STRONG_PASSPHRASE
       cs_msg += wxT("\n");
       cs_msg += _("Use it anyway?");
-      wxMessageDialog mb(this, cs_msg, _("Warning"),
-                      wxYES_NO | wxNO_DEFAULT | wxICON_HAND);
+      wxMessageDialog mb(this, cs_msg, _("Weak Master Password"),
+                      wxYES_NO | wxNO_DEFAULT | wxICON_EXCLAMATION);
+      mb.SetYesNoLabels(_("Use anyway"), _("Cancel"));
       int rc = mb.ShowModal();
     if (rc == wxID_NO)
       return;


### PR DESCRIPTION
Attempt to fix issue https://github.com/pwsafe/pwsafe/issues/1120

Fixes for two dialogs (that have exactly the same appearing):
- "weak password" dialog if at "change master password" dialog weak password is typed in
- "weak password" dialog if at "create new database" dialog weak password is typed in

Fixes:
1. Exact problem in title instead of old "Error".
2. Replace fatal error icon with explanation point (because fatal icon should be when something is over, can't be continued). By the way on picture bellow on left site is flatpak version that does not uses icons.
3. Nitpick: add full stop and the end of error message.
4. Changed button labels from Yes_No to "action" and Cancel.
5. Set Cancel button as default button (this way already done at new database dialog, but was missing at change master password). If no default is set then default is "Yes", which is what we want to tell user that this is not the best option.

Before and current PR changes:

![image](https://github.com/pwsafe/pwsafe/assets/10895030/1bf39879-5699-47d9-832c-ed86f00919a4)
