### PR TITLE
Unsaved database close down or new database opened

### DIFF
--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -88,9 +88,11 @@ int PasswordSafeFrame::New()
   int rc, rc2;
 
   if (!m_core.IsReadOnly() && m_core.HasDBChanged()) {
-    wxString msg(_("Do you want to save changes to the password database: "));
+    wxString msg(_("Do you want to save changes to the password database:"));
+    msg += wxT("\n");
     msg += m_core.GetCurFile().c_str();
-    wxMessageDialog mbox(this, msg, GetTitle(), wxCANCEL | wxYES_NO | wxICON_QUESTION);
+    wxMessageDialog mbox(this, msg, "Save changes?", wxCANCEL | wxYES_NO | wxICON_QUESTION);
+    mbox.SetYesNoLabels(_("Save"), _("Discard"));
     rc = mbox.ShowModal();
     switch (rc) {
     case wxID_CANCEL:
@@ -563,15 +565,14 @@ int PasswordSafeFrame::SaveIfChanged()
   // Otherwise it won't be saved unless something else has changed
   if ((m_bTSUpdated || m_core.HasDBChanged()) &&
       m_core.GetNumEntries() > 0) {
-    wxString prompt(_("Do you want to save changes to the password database"));
+    wxString prompt(_("Do you want to save changes to the password database:"));
     if (m_core.IsDbOpen()) {
-      prompt += wxT(": ");
+      prompt += wxT("\n");
       prompt += m_core.GetCurFile().c_str();
     }
-    prompt += wxT("?");
-    wxMessageDialog dlg(this, prompt, GetTitle(),
-                        (wxICON_QUESTION | wxCANCEL |
-                         wxYES_NO | wxYES_DEFAULT));
+    wxMessageDialog dlg(this, prompt, "Save changes?",
+                        (wxICON_QUESTION | wxCANCEL | wxYES_NO));
+    dlg.SetYesNoLabels(_("Save"), _("Discard"));
     int rc = dlg.ShowModal();
     switch (rc) {
       case wxID_CANCEL:


### PR DESCRIPTION
Attempt to fix https://github.com/pwsafe/pwsafe/issues/1122

How to test:
1. Open password database and make sure Manage | Options | Backup tab | "Save database immediately after any change" is unchecked.
2. Delete some entry or group and confirm delete action. So change is made that is currently not saved.
3. Click on "New" or "Close" button from toolbar and dialog appears that we have unsaved changes (this PR).

![image](https://github.com/pwsafe/pwsafe/assets/10895030/739e1ae1-9872-452c-9f59-0108182c8f1d)

Above image:
- top and bottom left Password Save 1.18.2 flatpak version
- top and bottom right changes from this PR

- first row what happen if in step 3: New button is clicked
- second row what happens if in step 3: Close button is clicked