### PR TITLE
Display the correct "Are you sure" message when deleting an empty group

### DIFF
--- a/src/ui/wxWidgets/DeleteConfirmationDlg.cpp
+++ b/src/ui/wxWidgets/DeleteConfirmationDlg.cpp
@@ -55,8 +55,8 @@ END_EVENT_TABLE()
  * DeleteConfirmationDlg constructors
  */
 
-DeleteConfirmationDlg::DeleteConfirmationDlg(wxWindow *parent, int num_children, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
-  : m_numchildren(num_children)
+DeleteConfirmationDlg::DeleteConfirmationDlg(wxWindow *parent, bool isGroup, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
+  : m_isGroup(isGroup)
 {
   wxASSERT(!parent || parent->IsTopLevel());
 ////@begin DeleteConfirmationDlg creation
@@ -72,9 +72,9 @@ DeleteConfirmationDlg::DeleteConfirmationDlg(wxWindow *parent, int num_children,
 ////@end DeleteConfirmationDlg creation
 }
 
-DeleteConfirmationDlg* DeleteConfirmationDlg::Create(wxWindow *parent, int num_children, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
+DeleteConfirmationDlg* DeleteConfirmationDlg::Create(wxWindow *parent, bool isGroup, wxWindowID id, const wxString& caption, const wxPoint& pos, const wxSize& size, long style )
 {
-  return new DeleteConfirmationDlg(parent, num_children, id, caption, pos, size, style);
+  return new DeleteConfirmationDlg(parent, isGroup, id, caption, pos, size, style);
 }
 
 /*!
@@ -89,9 +89,9 @@ void DeleteConfirmationDlg::CreateControls()
   itemDialog1->SetSizer(itemBoxSizer2);
 
   m_areyousure = new wxStaticText( itemDialog1, wxID_STATIC,
-                                   m_numchildren == 0 ?
-                                   _("Are you sure you want to delete the selected entry?") :
-                                   _("Are you sure you want to delete the selected group?"),
+                                  m_isGroup ?
+                                   _("Are you sure you want to delete the selected group?") :
+                                   _("Are you sure you want to delete the selected entry?"),
                                    wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer2->Add(m_areyousure, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5);
 
@@ -99,8 +99,8 @@ void DeleteConfirmationDlg::CreateControls()
   itemCheckBox4->SetValue(false);
 
   itemBoxSizer2->Add(itemCheckBox4, 0, wxALIGN_LEFT|wxALL, 5);
-  itemCheckBox4->Show(m_numchildren == 0); // can't shut this up for group deletes
-  
+  itemCheckBox4->Show(!m_isGroup); // Don't show the "Don't ask" checkbox for group deletes
+
   wxStdDialogButtonSizer* itemStdDialogButtonSizer5 = new wxStdDialogButtonSizer;
 
   itemBoxSizer2->Add(itemStdDialogButtonSizer5, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5);

--- a/src/ui/wxWidgets/DeleteConfirmationDlg.h
+++ b/src/ui/wxWidgets/DeleteConfirmationDlg.h
@@ -57,7 +57,7 @@ class DeleteConfirmationDlg : public wxDialog
 
 public:
   /// Creation
-  static DeleteConfirmationDlg* Create(wxWindow *parent, int num_children, wxWindowID id = SYMBOL_DELETECONFIRMATIONDLG_IDNAME, const wxString& caption = SYMBOL_DELETECONFIRMATIONDLG_TITLE, const wxPoint& pos = SYMBOL_DELETECONFIRMATIONDLG_POSITION, const wxSize& size = SYMBOL_DELETECONFIRMATIONDLG_SIZE, long style = SYMBOL_DELETECONFIRMATIONDLG_STYLE );
+  static DeleteConfirmationDlg* Create(wxWindow *parent, bool isGroup, wxWindowID id = SYMBOL_DELETECONFIRMATIONDLG_IDNAME, const wxString& caption = SYMBOL_DELETECONFIRMATIONDLG_TITLE, const wxPoint& pos = SYMBOL_DELETECONFIRMATIONDLG_POSITION, const wxSize& size = SYMBOL_DELETECONFIRMATIONDLG_SIZE, long style = SYMBOL_DELETECONFIRMATIONDLG_STYLE );
 
   /// Destructor
   ~DeleteConfirmationDlg() = default;
@@ -66,7 +66,7 @@ public:
   void SetConfirmdelete(bool value) { m_confirmdelete = value ; }
 protected:
   /// Constructors
-  DeleteConfirmationDlg(wxWindow *parent, int num_children, wxWindowID id = SYMBOL_DELETECONFIRMATIONDLG_IDNAME, const wxString& caption = SYMBOL_DELETECONFIRMATIONDLG_TITLE, const wxPoint& pos = SYMBOL_DELETECONFIRMATIONDLG_POSITION, const wxSize& size = SYMBOL_DELETECONFIRMATIONDLG_SIZE, long style = SYMBOL_DELETECONFIRMATIONDLG_STYLE );
+  DeleteConfirmationDlg(wxWindow *parent, bool isGroup, wxWindowID id = SYMBOL_DELETECONFIRMATIONDLG_IDNAME, const wxString& caption = SYMBOL_DELETECONFIRMATIONDLG_TITLE, const wxPoint& pos = SYMBOL_DELETECONFIRMATIONDLG_POSITION, const wxSize& size = SYMBOL_DELETECONFIRMATIONDLG_SIZE, long style = SYMBOL_DELETECONFIRMATIONDLG_STYLE );
 
   /// Creates the controls and sizers
   void CreateControls();
@@ -96,9 +96,9 @@ protected:
 ////@begin DeleteConfirmationDlg member variables
   wxStaticText* m_areyousure = nullptr;
 private:
+  bool m_isGroup;
   bool m_confirmdelete;
 ////@end DeleteConfirmationDlg member variables
-  int m_numchildren;
 };
 
 #endif // _DELETECONFIRMATIONDLG_H_

--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -135,28 +135,23 @@ void PasswordSafeFrame::OnDeleteClick(wxCommandEvent& WXUNUSED(evt))
   bool dontaskquestion = PWSprefs::GetInstance()->
     GetPref(PWSprefs::DeleteQuestion);
 
-  int num_children = 0;
+  bool isGroup = false;
   // If tree view, check if group selected
   if (m_tree->IsShown()) {
     wxTreeItemId sel = m_tree->GetSelection();
-    if(m_tree->ItemIsGroup(sel)) {
-      num_children = static_cast<int>(m_tree->GetChildrenCount(sel));
-    }
-    else {
-      num_children = 0;
-    }
-    if (num_children > 0) // ALWAYS confirm group delete
+    isGroup = m_tree->ItemIsGroup(sel);
+    if (isGroup) // ALWAYS confirm group delete
       dontaskquestion = false;
   }
-  CallAfter(&PasswordSafeFrame::DoDeleteItems, !dontaskquestion, num_children);
+  CallAfter(&PasswordSafeFrame::DoDeleteItems, !dontaskquestion, isGroup);
 }
 
-void PasswordSafeFrame::DoDeleteItems(bool askConfirmation, int num_children)
-{  
+void PasswordSafeFrame::DoDeleteItems(bool askConfirmation, bool isGroup)
+{
   bool dodelete = true;
   //Confirm whether to delete the item
   if (askConfirmation) {
-    DestroyWrapper<DeleteConfirmationDlg> deleteDlgWrapper(this, num_children);
+    DestroyWrapper<DeleteConfirmationDlg> deleteDlgWrapper(this, isGroup);
     DeleteConfirmationDlg* deleteDlg = deleteDlgWrapper.Get();
     deleteDlg->SetConfirmdelete(PWSprefs::GetInstance()->GetPref(PWSprefs::DeleteQuestion));
     int rc = deleteDlg->ShowModal();

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -735,8 +735,8 @@ private:
   void SaveLayoutPreferences();
   bool LoadLayoutPreferences();
 
-    void DoCreateShortcut(CItemData* item);
-  void DoDeleteItems(bool askConfirmation, int num_children);
+  void DoCreateShortcut(CItemData* item);
+  void DoDeleteItems(bool askConfirmation, bool isGroup);
   void DoImportXML(wxString filename);
   void DoImportText(wxString filename);
   void DoImportKeePass(wxString filename);


### PR DESCRIPTION
This is for issue #1128 .  It converts the unused num_chidren into an isGroup bool.