### PR TITLE
Simplify code at Help About

### DIFF
--- a/src/ui/wxWidgets/AboutDlg.cpp
+++ b/src/ui/wxWidgets/AboutDlg.cpp
@@ -122,11 +122,8 @@ void AboutDlg::CreateControls()
   wxBoxSizer* verCheckSizer = new wxBoxSizer(wxHORIZONTAL);
   rightSizer->Add(verCheckSizer, 0, wxALIGN_LEFT|wxALL, 0);
 
-  wxStaticText* latestStaticTextBegin = new wxStaticText(aboutDialog, wxID_STATIC, _(""), wxDefaultPosition, wxDefaultSize, 0 );
-  verCheckSizer->Add(latestStaticTextBegin, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxLEFT, 5);
-
   wxGenericHyperlinkCtrl* latestCheckButton = new wxGenericHyperlinkCtrl(aboutDialog, ID_CHECKNEW, _("Check"), wxEmptyString, wxDefaultPosition, wxDefaultSize, wxHL_DEFAULT_STYLE);
-  verCheckSizer->Add(latestCheckButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM, 5);
+  verCheckSizer->Add(latestCheckButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxLEFT, 5);
 
   wxStaticText* latestStaticTextEnd = new wxStaticText(aboutDialog, wxID_STATIC, _(" for the latest version."), wxDefaultPosition, wxDefaultSize, 0);
   verCheckSizer->Add(latestStaticTextEnd, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxRIGHT, 5);


### PR DESCRIPTION
In yesterday PR https://github.com/pwsafe/pwsafe/pull/1150 that was already merged master, now I see I have temporally empty the variable, so the only text in it was "" and then forgot to delete and simplify the code.

In this PR it is just a little cleanup of code.

From end-user point of view the Help About dialog looks the same before and after this PR.