### PR TITLE
Title bar PasswordSafe to Password Safe

### DIFF
--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1156,7 +1156,7 @@ wxIcon PasswordSafeFrame::GetIconResource( const wxString& name )
 
 void PasswordSafeFrame::SetTitle(const wxString& title)
 {
-  wxString newtitle = _T("PasswordSafe");
+  wxString newtitle = _T("Password Safe");
   if (!title.empty()) {
     newtitle += _T(" - ");
     StringX fname = tostringx(title);


### PR DESCRIPTION
In program's title bar adds space. Current "PasswordSafe". This PR "Password Safe"
![image](https://github.com/pwsafe/pwsafe/assets/10895030/7bc86757-78c3-4b16-9521-770723a1561f)
