### PR TITLE
Remove word Please from closed database and reopened dialog

### DIFF
--- a/src/ui/Windows/PasswordSafe.rc
+++ b/src/ui/Windows/PasswordSafe.rc
@@ -207,7 +207,7 @@ BEGIN
     PUSHBUTTON      "Cancel",IDCANCEL,128,113,50,14
     PUSHBUTTON      "&Help",ID_HELP,194,113,50,14
     CONTROL         IDB_CLOGO_SMALL,IDC_STATIC_LOGO,"Static",SS_BITMAP,7,35,32,30
-    LTEXT           "Enter the Master Password to unlock password database:",IDC_STATIC,48,10,225,8
+    LTEXT           "Enter the Master Password to unlock the password database:",IDC_STATIC,48,10,225,8
     LTEXT           "Name. Name. Name.",IDC_SELECTED_DATABASE,48,20,229,8,SS_NOPREFIX | SS_PATHELLIPSIS
     RTEXT           "Master Password:",IDC_STATIC,48,34,63,18,SS_CENTERIMAGE
     CONTROL         "",IDC_YUBI_PROGRESS,"msctls_progress32",PBS_SMOOTH | WS_BORDER,115,97,152,14
@@ -232,7 +232,7 @@ BEGIN
     PUSHBUTTON      "Exit",IDC_EXIT,161,116,50,14
     PUSHBUTTON      "&Help",ID_HELP,227,116,50,14
     CONTROL         IDB_CLOGO_SMALL,IDC_STATIC_LOGO,"Static",SS_BITMAP,7,35,32,30
-    LTEXT           "Enter the Master Password to unlock password database:",IDC_STATIC,48,10,229,8
+    LTEXT           "Enter the Master Password to unlock the password database:",IDC_STATIC,48,10,229,8
     LTEXT           "Name. Name. Name.",IDC_SELECTED_DATABASE,48,20,229,8,SS_NOPREFIX | SS_PATHELLIPSIS
     RTEXT           "Master Password:",IDC_STATIC,48,34,63,18,SS_CENTERIMAGE
     CONTROL         "",IDC_YUBI_PROGRESS,"msctls_progress32",PBS_SMOOTH | WS_BORDER,115,96,152,14

--- a/src/ui/Windows/PasswordSafe.rc
+++ b/src/ui/Windows/PasswordSafe.rc
@@ -207,7 +207,7 @@ BEGIN
     PUSHBUTTON      "Cancel",IDCANCEL,128,113,50,14
     PUSHBUTTON      "&Help",ID_HELP,194,113,50,14
     CONTROL         IDB_CLOGO_SMALL,IDC_STATIC_LOGO,"Static",SS_BITMAP,7,35,32,30
-    LTEXT           "Please enter the Master Password for this password database.",IDC_STATIC,48,10,225,8
+    LTEXT           "Enter the Master Password to unlock password database:",IDC_STATIC,48,10,225,8
     LTEXT           "Name. Name. Name.",IDC_SELECTED_DATABASE,48,20,229,8,SS_NOPREFIX | SS_PATHELLIPSIS
     RTEXT           "Master Password:",IDC_STATIC,48,34,63,18,SS_CENTERIMAGE
     CONTROL         "",IDC_YUBI_PROGRESS,"msctls_progress32",PBS_SMOOTH | WS_BORDER,115,97,152,14
@@ -232,7 +232,7 @@ BEGIN
     PUSHBUTTON      "Exit",IDC_EXIT,161,116,50,14
     PUSHBUTTON      "&Help",ID_HELP,227,116,50,14
     CONTROL         IDB_CLOGO_SMALL,IDC_STATIC_LOGO,"Static",SS_BITMAP,7,35,32,30
-    LTEXT           "Please enter the Master Password for this password database.",IDC_STATIC,48,10,229,8
+    LTEXT           "Enter the Master Password to unlock password database:",IDC_STATIC,48,10,229,8
     LTEXT           "Name. Name. Name.",IDC_SELECTED_DATABASE,48,20,229,8,SS_NOPREFIX | SS_PATHELLIPSIS
     RTEXT           "Master Password:",IDC_STATIC,48,34,63,18,SS_CENTERIMAGE
     CONTROL         "",IDC_YUBI_PROGRESS,"msctls_progress32",PBS_SMOOTH | WS_BORDER,115,96,152,14

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -138,7 +138,7 @@ void SafeCombinationPromptDlg::CreateControls()
   auto *itemBoxSizer5 = new wxBoxSizer(wxVERTICAL);
   itemBoxSizer3->Add(itemBoxSizer5, 1, wxALL|wxEXPAND, 5);
 
-  wxStaticText* itemStaticText6 = new wxStaticText( itemDialog1, wxID_STATIC, _("Enter the master password to unlock password database:"), wxDefaultPosition, wxDefaultSize, 0 );
+  wxStaticText* itemStaticText6 = new wxStaticText( itemDialog1, wxID_STATIC, _("Enter the Master Password to unlock the password database:"), wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer5->Add(itemStaticText6, 0, wxALIGN_LEFT|wxALL, 5);
 
   wxStaticText* itemStaticText7 = new wxStaticText( itemDialog1, wxID_STATIC, _("filename"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -138,7 +138,7 @@ void SafeCombinationPromptDlg::CreateControls()
   auto *itemBoxSizer5 = new wxBoxSizer(wxVERTICAL);
   itemBoxSizer3->Add(itemBoxSizer5, 1, wxALL|wxEXPAND, 5);
 
-  wxStaticText* itemStaticText6 = new wxStaticText( itemDialog1, wxID_STATIC, _("Please enter the master password for this password database."), wxDefaultPosition, wxDefaultSize, 0 );
+  wxStaticText* itemStaticText6 = new wxStaticText( itemDialog1, wxID_STATIC, _("Enter the master password to unlock password database:"), wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer5->Add(itemStaticText6, 0, wxALIGN_LEFT|wxALL, 5);
 
   wxStaticText* itemStaticText7 = new wxStaticText( itemDialog1, wxID_STATIC, _("filename"), wxDefaultPosition, wxDefaultSize, 0 );


### PR DESCRIPTION
Unify wording between dialogs:
- remove "Please" word
- explicitly tell user the action that will follow e.g. unlock database

![image](https://github.com/pwsafe/pwsafe/assets/10895030/b349bfd9-5152-4cb0-b6c1-f2b9e67ba624)
