### PR TITLE
Set default focus to the Title box

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -173,6 +173,9 @@ AddEditPropSheetDlg::AddEditPropSheetDlg(wxWindow *parent, PWScore &core,
   if (m_Core.GetReadFileVersion() == PWSfile::V40) {
     InitAttachmentTab();
   }
+
+  // Set the initial focus to the Title control (Otherwise it defaults to the Group control)
+  m_BasicTitleTextCtrl->SetFocus();
 }
 
 AddEditPropSheetDlg* AddEditPropSheetDlg::Create(wxWindow *parent, PWScore &core,


### PR DESCRIPTION
This is for Issue #1158.  That always kind of bugged me too.  

Note that this simple change will *always* default to the Title field.  I can imagine some scenarios where that might not be preferred, so I'm open to discussion and suggestions.

When creating the AddEditPropSheetDlg dialog, the default keyboard focus goes to the Group field.  This patch changes the default to the Title field.