### PR TITLE
Rename Safe List to Password Database in File | Clear Recent Safe List

### DIFF
--- a/src/ui/Windows/res/PasswordSafe2.rc2
+++ b/src/ui/Windows/res/PasswordSafe2.rc2
@@ -114,7 +114,7 @@ BEGIN
         MENUITEM "&Close",                  ID_MENUITEM_CLOSE, MFT_STRING
         MENUITEM "&Lock",                   ID_MENUITEM_LOCK, MFT_STRING
         MENUITEM "", 0, MFT_SEPARATOR
-        MENUITEM "&Clear Recent Safe List", ID_MENUITEM_CLEAR_MRU, MFT_STRING
+        MENUITEM "&Clear Recent Password Databse List", ID_MENUITEM_CLEAR_MRU, MFT_STRING
         MENUITEM "", 0, MFT_SEPARATOR
         MENUITEM "&Save",                   ID_MENUITEM_SAVE, MFT_STRING, MFS_GRAYED
         MENUITEM "Save &As...",             ID_MENUITEM_SAVEAS, MFT_STRING

--- a/src/ui/Windows/res/PasswordSafe2.rc2
+++ b/src/ui/Windows/res/PasswordSafe2.rc2
@@ -114,7 +114,7 @@ BEGIN
         MENUITEM "&Close",                  ID_MENUITEM_CLOSE, MFT_STRING
         MENUITEM "&Lock",                   ID_MENUITEM_LOCK, MFT_STRING
         MENUITEM "", 0, MFT_SEPARATOR
-        MENUITEM "&Clear Recent Password Databse List", ID_MENUITEM_CLEAR_MRU, MFT_STRING
+        MENUITEM "&Clear Recently Opened List", ID_MENUITEM_CLEAR_MRU, MFT_STRING
         MENUITEM "", 0, MFT_SEPARATOR
         MENUITEM "&Save",                   ID_MENUITEM_SAVE, MFT_STRING, MFS_GRAYED
         MENUITEM "Save &As...",             ID_MENUITEM_SAVEAS, MFT_STRING

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -545,7 +545,7 @@ void PasswordSafeFrame::CreateMenubar()
     menuFile->AppendSeparator();
   }
 
-  menuFile->Append(ID_MENU_CLEAR_MRU, _("Clear Recent Opened List"), wxEmptyString, wxITEM_NORMAL);
+  menuFile->Append(ID_MENU_CLEAR_MRU, _("Clear Recently Opened List"), wxEmptyString, wxITEM_NORMAL);
   menuFile->AppendSeparator();
   menuFile->Append(wxID_SAVE, _("&Save..."), wxEmptyString, wxITEM_NORMAL);
   menuFile->Append(wxID_SAVEAS, _("Save &As..."), wxEmptyString, wxITEM_NORMAL);

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -545,7 +545,7 @@ void PasswordSafeFrame::CreateMenubar()
     menuFile->AppendSeparator();
   }
 
-  menuFile->Append(ID_MENU_CLEAR_MRU, _("Clear Recent Password Database List"), wxEmptyString, wxITEM_NORMAL);
+  menuFile->Append(ID_MENU_CLEAR_MRU, _("Clear Recent Opened List"), wxEmptyString, wxITEM_NORMAL);
   menuFile->AppendSeparator();
   menuFile->Append(wxID_SAVE, _("&Save..."), wxEmptyString, wxITEM_NORMAL);
   menuFile->Append(wxID_SAVEAS, _("Save &As..."), wxEmptyString, wxITEM_NORMAL);

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -545,7 +545,7 @@ void PasswordSafeFrame::CreateMenubar()
     menuFile->AppendSeparator();
   }
 
-  menuFile->Append(ID_MENU_CLEAR_MRU, _("Clear Recent Safe List"), wxEmptyString, wxITEM_NORMAL);
+  menuFile->Append(ID_MENU_CLEAR_MRU, _("Clear Recent Password Database List"), wxEmptyString, wxITEM_NORMAL);
   menuFile->AppendSeparator();
   menuFile->Append(wxID_SAVE, _("&Save..."), wxEmptyString, wxITEM_NORMAL);
   menuFile->Append(wxID_SAVEAS, _("Save &As..."), wxEmptyString, wxITEM_NORMAL);


### PR DESCRIPTION
Word "Safe" is confusing and we are replacing it to "Password Database".
- Current: File | Clear Recent **Safe** List
- This PR: File | Clear Recent **Password Database** List

![image](https://github.com/pwsafe/pwsafe/assets/10895030/9172479a-7fef-4d18-9472-3c650b2d8899)
