### PR TITLE
Simplify title of Open dialog

### DIFF
--- a/src/ui/Windows/res/PasswordSafe3.rc2
+++ b/src/ui/Windows/res/PasswordSafe3.rc2
@@ -301,7 +301,7 @@ BEGIN
   IDS_FILECORRUPT         "%s\n\nFile corrupt or truncated!\nData may have been lost or modified.\nContinue anyway?"
   IDS_FILEREADERROR       "File Read Error"
   IDS_SAVEDATABASE        "Do you want to save changes to the password database: %s?"
-  IDS_CHOOSEDATABASE      "Please Choose a Database to Open:"
+  IDS_CHOOSEDATABASE      "Open Password Database"
   IDS_CHOOSEDATABASEV     "Please Choose a Database to Validate:"
   IDS_ALREADYOPEN         "That file is already open."
   IDS_OPENDATABASE        "Open database"

--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -239,7 +239,7 @@ int PasswordSafeFrame::NewFile(StringX &fname)
 
 void PasswordSafeFrame::OnOpenClick(wxCommandEvent& WXUNUSED(evt))
 {
-  int rc = DoOpen(_("Please Choose a Database to Open:"));
+  int rc = DoOpen(_("Open Password Database"));
 
   if (rc == PWScore::SUCCESS) {
     m_core.ResumeOnDBNotification();

--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -479,7 +479,7 @@ void SafeCombinationEntryDlg::OnCancel( wxCommandEvent& event )
 
 void SafeCombinationEntryDlg::OnEllipsisClick(wxCommandEvent& WXUNUSED(evt))
 {
-  wxFileDialog fd(this, _("Please Choose a Database to Open:"),
+  wxFileDialog fd(this, _("Open Password Database"),
                   PWSdirs::GetSafeDir().c_str(), wxEmptyString,
                   _("Password Safe Databases (*.psafe4; *.psafe3; *.dat)|*.psafe4;*.psafe3;*.dat| All files (*.*; *)|*.*;*"),
                   (wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_CHANGE_DIR));


### PR DESCRIPTION
Compare dialog title in Text Editor vs Password Safe.

![image](https://github.com/pwsafe/pwsafe/assets/10895030/b8930ebf-aa68-4192-802e-628c783c5f24)

Simplify wording from:
- current: Please Choose a Database to Open
- this PR: Open Password Database