### PR TITLE
Button name is Confirm Password

### DIFF
--- a/src/ui/Windows/res/PasswordSafe3.rc2
+++ b/src/ui/Windows/res/PasswordSafe3.rc2
@@ -95,7 +95,7 @@ BEGIN
   IDS_EXCLUDE_FROM_SCR_CAP_HELP "Hide Password Safe from screen capture and related apps."
   IDS_DBLOCK             "Locking clears the memory but excludes undo and redo information that can still be used on unlocking of the database."
   IDS_SMARTLABELHELP     "You can click on a field's name to copy its value to the clipboard."
-  IDS_PASSWORDHELP       "A hidden password needs to be entered in the Confirm Password field too. If it's not hidden, Confirm Password shows numbers that may be used to help count the password's characters."
+  IDS_PASSWORDHELP       "A hidden password needs to be entered in the Confirm Password field too. If it's not hidden, the Confirm field shows numbers that may be used to help count the password's characters."
   IDS_PASSWORDHELP2      "Changing the password of an alias will break the link to its base entry."
   IDS_NOTESHELP          "Right-click on the Notes field to access additional functionality."
   IDS_AUTOTYPEHELP       "Click here for help on AutoType."

--- a/src/ui/Windows/res/PasswordSafe3.rc2
+++ b/src/ui/Windows/res/PasswordSafe3.rc2
@@ -95,7 +95,7 @@ BEGIN
   IDS_EXCLUDE_FROM_SCR_CAP_HELP "Hide Password Safe from screen capture and related apps."
   IDS_DBLOCK             "Locking clears the memory but excludes undo and redo information that can still be used on unlocking of the database."
   IDS_SMARTLABELHELP     "You can click on a field's name to copy its value to the clipboard."
-  IDS_PASSWORDHELP       "A hidden password needs to be entered in the Confirm Password field too. If it's not hidden, Confirm shows numbers that may be used to help count the password's characters."
+  IDS_PASSWORDHELP       "A hidden password needs to be entered in the Confirm Password field too. If it's not hidden, Confirm Password shows numbers that may be used to help count the password's characters."
   IDS_PASSWORDHELP2      "Changing the password of an alias will break the link to its base entry."
   IDS_NOTESHELP          "Right-click on the Notes field to access additional functionality."
   IDS_AUTOTYPEHELP       "Click here for help on AutoType."


### PR DESCRIPTION
On Windows only Add Entry dialog and move mouse to the "i" icon. In second case the only "Confirm" is used instead of full name "Confirm Password".