### PR TITLE
Remove Please word from Create Shortcut dialog

### DIFF
--- a/src/ui/wxWidgets/CreateShortcutDlg.cpp
+++ b/src/ui/wxWidgets/CreateShortcutDlg.cpp
@@ -173,7 +173,7 @@ void CreateShortcutDlg::CreateControls()
 {
   //(*Initialize(ShortcutsDialogDial
   auto BoxSizer1 = new wxBoxSizer(wxVERTICAL);
-  auto StaticText1 = new wxStaticText(this, wxID_ANY, _("Please enter the shortcut properties to the selected base entry."), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+  auto StaticText1 = new wxStaticText(this, wxID_ANY, _("Enter the shortcut properties to the selected base entry."), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
   BoxSizer1->Add(StaticText1, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 10);
 
   auto StaticBoxSizer1 = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Shortcut"));


### PR DESCRIPTION
Right mouse click on entry and from menu Edit | Create Shortcut.
Remove "Please" word to simplify.

![image](https://github.com/pwsafe/pwsafe/assets/10895030/a1f22dbe-7cb3-4f38-8278-5dc0203b1714)
