### PR TITLE
Change OK button to Close in File Properties

### DIFF
--- a/src/ui/wxWidgets/PropertiesDlg.cpp
+++ b/src/ui/wxWidgets/PropertiesDlg.cpp
@@ -353,7 +353,7 @@ void PropertiesDlg::CreateControls()
   auto buttonsSizer = new wxStdDialogButtonSizer;
 
   mainSizer->Add(buttonsSizer, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5);
-  auto okButton = new wxButton( this, wxID_OK, _("&OK"), wxDefaultPosition, wxDefaultSize, 0 );
+  auto okButton = new wxButton( this, wxID_OK, _("&Close"), wxDefaultPosition, wxDefaultSize, 0 );
   okButton->SetDefault();
   buttonsSizer->AddButton(okButton);
   buttonsSizer->Realize();


### PR DESCRIPTION
Attempt to fix [1173](https://github.com/pwsafe/pwsafe/issues/1173).

![image](https://github.com/pwsafe/pwsafe/assets/10895030/19bdfe7e-a5c0-48db-b7a1-9ac967649c1b)

By the way, this is fix for Linux build. I have no idea how to fix this on Windows. Any hint? @ronys or can you change it please?