### PR TITLE
Change title bar of Restore Database dialog

### DIFF
--- a/src/ui/wxWidgets/MenuManageHandlers.cpp
+++ b/src/ui/wxWidgets/MenuManageHandlers.cpp
@@ -204,7 +204,7 @@ void PasswordSafeFrame::DoRestoreSafe()
   }
 
   //returns empty string if user cancels
-  wxString wxbf = wxFileSelector(_("Please Choose a Backup to Restore:"),
+  wxString wxbf = wxFileSelector(_("Backup File"),
                                  dir,
                                  currbackup.GetFullName(),
                                  wxT("bak"),


### PR DESCRIPTION
Manage | Restore from Backup. Simplify title bar.

![image](https://github.com/pwsafe/pwsafe/assets/10895030/45e0eb21-a2b6-495f-88a3-4f7c5a59f85e)
