### PR TITLE
[wx] Merge 'AddEditPropSheetDlg::UpdatePasswordTextCtrl' with 'ShowHideText' from wxUtilities to prevent redundant code

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -1612,13 +1612,13 @@ void AddEditPropSheetDlg::OnShowHideClick(wxCommandEvent& WXUNUSED(evt))
       ASSERT(pbci);
       if (pbci) {
         m_IsPasswordHidden = false;
-        UpdatePasswordTextCtrl(m_BasicPasswordConfirmationTextCtrl, pbci->GetPassword().c_str(), m_BasicPasswordTextCtrl, ID_TEXTCTRL_PASSWORD2, wxTE_READONLY);
+        UpdatePasswordTextCtrl(m_BasicSizer, m_BasicPasswordConfirmationTextCtrl, pbci->GetPassword().c_str(), m_BasicPasswordTextCtrl, wxTE_READONLY);
         m_BasicPasswordConfirmationTextCtrl->Enable(true);
       }
     }
     else {
       m_IsPasswordHidden = true;
-      UpdatePasswordTextCtrl(m_BasicPasswordConfirmationTextCtrl, wxEmptyString, m_BasicPasswordTextCtrl, ID_TEXTCTRL_PASSWORD2, wxTE_READONLY);
+      UpdatePasswordTextCtrl(m_BasicSizer, m_BasicPasswordConfirmationTextCtrl, wxEmptyString, m_BasicPasswordTextCtrl, wxTE_READONLY);
       m_BasicPasswordConfirmationTextCtrl->Enable(false);
     }
   }
@@ -1702,38 +1702,10 @@ void AddEditPropSheetDlg::DoAliasButtonClick()
   }
 }
 
-void AddEditPropSheetDlg::UpdatePasswordTextCtrl(wxTextCtrl* &textCtrl, const wxString value, wxTextCtrl* before, const int id, const int style)
-{
-  ASSERT(textCtrl);
-#if defined(__WXGTK__)
-  // Since this function is called with only a single style flag such as "0", "wxTE_PASSWORD" or "wxTE_READONLY",
-  // we do not care about flags already set for the control and therefore do not preserve them.
-  textCtrl->SetWindowStyle(style);
-  textCtrl->ChangeValue(value);
-#else
-  // Per Dave Silvia's suggestion:
-  // Following kludge since wxTE_PASSWORD style is immutable
-  wxTextCtrl *tmp = textCtrl;
-  textCtrl = new wxTextCtrl(m_BasicPanel, id,
-                            value,
-                            wxDefaultPosition, wxDefaultSize,
-                            style);
-  if (!value.IsEmpty()) {
-    textCtrl->ChangeValue(value);
-    textCtrl->SetModified(true);
-  }
-  ApplyFontPreference(textCtrl, PWSprefs::StringPrefs::PasswordFont);
-  textCtrl->MoveAfterInTabOrder(before);
-  m_BasicSizer->Replace(tmp, textCtrl);
-  tmp->Destroy();
-  m_BasicSizer->Layout();
-#endif
-}
-
 void AddEditPropSheetDlg::ShowPassword()
 {
   m_IsPasswordHidden = false;
-  UpdatePasswordTextCtrl(m_BasicPasswordTextCtrl, m_Password.c_str(), m_BasicUsernameTextCtrl, ID_TEXTCTRL_PASSWORD, 0);
+  UpdatePasswordTextCtrl(m_BasicSizer, m_BasicPasswordTextCtrl, m_Password.c_str(), m_BasicUsernameTextCtrl, 0);
   // Disable confirmation Ctrl, as the user can see the password entered
   ApplyFontPreference(m_BasicPasswordConfirmationTextCtrl, PWSprefs::StringPrefs::PasswordFont);
   m_BasicPasswordConfirmationTextCtrl->Clear();
@@ -1744,7 +1716,7 @@ void AddEditPropSheetDlg::HidePassword()
 {
   m_IsPasswordHidden = true;
   const wxString pwd = m_Password.c_str();
-  UpdatePasswordTextCtrl(m_BasicPasswordTextCtrl, pwd, m_BasicUsernameTextCtrl, ID_TEXTCTRL_PASSWORD, wxTE_PASSWORD);
+  UpdatePasswordTextCtrl(m_BasicSizer, m_BasicPasswordTextCtrl, pwd, m_BasicUsernameTextCtrl, wxTE_PASSWORD);
   ApplyFontPreference(m_BasicPasswordConfirmationTextCtrl, PWSprefs::StringPrefs::PasswordFont);
   m_BasicPasswordConfirmationTextCtrl->ChangeValue(pwd);
   m_BasicPasswordConfirmationTextCtrl->Enable(true);
@@ -1763,20 +1735,20 @@ void AddEditPropSheetDlg::ShowAlias()
                 pbci->GetUser()  + L"]";
   }
   m_BasicPasswordTextLabel->SetLabel(_("Alias:"));
-  UpdatePasswordTextCtrl(m_BasicPasswordTextCtrl, m_Password.c_str(), m_BasicUsernameTextCtrl, ID_TEXTCTRL_PASSWORD, wxTE_READONLY);
+  UpdatePasswordTextCtrl(m_BasicSizer, m_BasicPasswordTextCtrl, m_Password.c_str(), m_BasicUsernameTextCtrl, wxTE_READONLY);
   
   m_BasicPasswordConfirmationTextLabel->SetLabel(_("Password:"));
   if (pbci && PWSprefs::GetInstance()->GetPref(PWSprefs::ShowPWDefault)) {
     m_IsPasswordHidden = false;
     const wxString pwd = pbci->GetPassword().c_str();
-    UpdatePasswordTextCtrl(m_BasicPasswordConfirmationTextCtrl, pwd, m_BasicPasswordTextCtrl, ID_TEXTCTRL_PASSWORD2, wxTE_READONLY);
+    UpdatePasswordTextCtrl(m_BasicSizer, m_BasicPasswordConfirmationTextCtrl, pwd, m_BasicPasswordTextCtrl, wxTE_READONLY);
     ApplyFontPreference(m_BasicPasswordConfirmationTextCtrl, PWSprefs::StringPrefs::PasswordFont);
     m_BasicPasswordConfirmationTextCtrl->ChangeValue(pwd);
     m_BasicPasswordConfirmationTextCtrl->Enable(true);
   }
   else {
     m_IsPasswordHidden = true;
-    UpdatePasswordTextCtrl(m_BasicPasswordConfirmationTextCtrl, wxEmptyString, m_BasicPasswordTextCtrl, ID_TEXTCTRL_PASSWORD2, wxTE_READONLY);
+    UpdatePasswordTextCtrl(m_BasicSizer, m_BasicPasswordConfirmationTextCtrl, wxEmptyString, m_BasicPasswordTextCtrl, wxTE_READONLY);
     ApplyFontPreference(m_BasicPasswordConfirmationTextCtrl, PWSprefs::StringPrefs::PasswordFont);
     m_BasicPasswordConfirmationTextCtrl->Clear();
     m_BasicPasswordConfirmationTextCtrl->Enable(false);
@@ -1797,15 +1769,15 @@ void AddEditPropSheetDlg::RemoveAlias()
   
   if (PWSprefs::GetInstance()->GetPref(PWSprefs::ShowPWDefault)) {
     m_IsPasswordHidden = false;
-    UpdatePasswordTextCtrl(m_BasicPasswordTextCtrl, pwd, m_BasicUsernameTextCtrl, ID_TEXTCTRL_PASSWORD, 0);
-    UpdatePasswordTextCtrl(m_BasicPasswordConfirmationTextCtrl, pwd, m_BasicPasswordTextCtrl, ID_TEXTCTRL_PASSWORD2, wxTE_PASSWORD);
+    UpdatePasswordTextCtrl(m_BasicSizer, m_BasicPasswordTextCtrl, pwd, m_BasicUsernameTextCtrl, 0);
+    UpdatePasswordTextCtrl(m_BasicSizer, m_BasicPasswordConfirmationTextCtrl, pwd, m_BasicPasswordTextCtrl, wxTE_PASSWORD);
     m_BasicPasswordConfirmationTextCtrl->Clear();
     m_BasicPasswordConfirmationTextCtrl->Enable(false);
   }
   else {
     m_IsPasswordHidden = true;
-    UpdatePasswordTextCtrl(m_BasicPasswordTextCtrl, pwd, m_BasicUsernameTextCtrl, ID_TEXTCTRL_PASSWORD, wxTE_PASSWORD);
-    UpdatePasswordTextCtrl(m_BasicPasswordConfirmationTextCtrl, pwd, m_BasicPasswordTextCtrl, ID_TEXTCTRL_PASSWORD2, wxTE_PASSWORD);
+    UpdatePasswordTextCtrl(m_BasicSizer, m_BasicPasswordTextCtrl, pwd, m_BasicUsernameTextCtrl, wxTE_PASSWORD);
+    UpdatePasswordTextCtrl(m_BasicSizer, m_BasicPasswordConfirmationTextCtrl, pwd, m_BasicPasswordTextCtrl, wxTE_PASSWORD);
     m_BasicPasswordConfirmationTextCtrl->ChangeValue(pwd);
     m_BasicPasswordConfirmationTextCtrl->Enable(true);
   }

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.h
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.h
@@ -297,7 +297,6 @@ private:
   bool CheckPWPolicyFromUI();
   void ShowPWPSpinners(bool show);
   void EnableNonHexCBs(bool enable);
-  void UpdatePasswordTextCtrl(wxTextCtrl* &textCtrl, const wxString value, wxTextCtrl* before, const int id = ID_TEXTCTRL_PASSWORD, const int style = 0);
   void ShowPassword();
   void HidePassword();
   void ShowAlias();

--- a/src/ui/wxWidgets/YubiCfgDlg.cpp
+++ b/src/ui/wxWidgets/YubiCfgDlg.cpp
@@ -311,7 +311,7 @@ void YubiCfgDlg::ShowSK()
   if (Validate() && TransferDataFromWindow()) {
     m_isSKHidden = false;
     FindWindow(ID_YK_HIDESHOW)->SetLabel(_("Hide"));
-    ShowHideText(m_SKCtrl, m_yksk, m_SKSizer, true);
+    UpdatePasswordTextCtrl(m_SKSizer, m_SKCtrl, m_yksk, nullptr, 0);
   }
 }
 
@@ -320,7 +320,7 @@ void YubiCfgDlg::HideSK()
   if (Validate() && TransferDataFromWindow()) {
     m_isSKHidden = true;
     FindWindow(ID_YK_HIDESHOW)->SetLabel(_("Show"));
-    ShowHideText(m_SKCtrl, m_yksk, m_SKSizer, false);
+    UpdatePasswordTextCtrl(m_SKSizer, m_SKCtrl, m_yksk, nullptr, wxTE_PASSWORD);
   }
 }
 

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -144,23 +144,6 @@ bool MultiCheckboxValidator::Validate(wxWindow* parent)
   }
 }
 
-/**
- * @brief The purpose of this function is to update or remove the style flags "wxTE_PASSWORD" or "wxTE_READONLY" of a wxTextCtrl.
- *
- * According to the documentation of wxTextCtrl the style flags "wxTE_PASSWORD" and "wxTE_READONLY" can be changed during
- * runtime under wxGTK but not wxMSW. This circumstance is taken into account by this function.
- *
- * In the current version, under wxGTK the style flag is applied dynamically to the text control and on other platforms
- * the text control is replaced by a newly created one with the desired style flag.
- *
- * @param sizer the sizer to which the text control belongs
- * @param textCtrl the control whose style are to be changed
- * @param text the text to update the text control with
- * @param before the control element in the layout before "textCtrl" to respect the TAB order
- * @param style the new style flag for "textCtrl" (previous flags will not be preserved)
- *
- * @see https://docs.wxwidgets.org/stable/classwx_text_ctrl.html
- */
 void UpdatePasswordTextCtrl(wxSizer *sizer, wxTextCtrl* &textCtrl, const wxString text, wxTextCtrl* before, const int style)
 {
   ASSERT(textCtrl);

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -176,9 +176,24 @@ inline const wxChar* ToStr(bool b) {
   return b? wxT("True"): wxT("False");
 }
 
-// Workaround for wxTE_PASSWORD being immutable:
-void ShowHideText(wxTextCtrl *&txtCtrl, const wxString &text,
-                  wxSizer *sizer, bool show);
+/**
+ * @brief The purpose of this function is to update or remove the style flags "wxTE_PASSWORD" or "wxTE_READONLY" of a wxTextCtrl.
+ *
+ * According to the documentation of wxTextCtrl the style flags "wxTE_PASSWORD" and "wxTE_READONLY" can be changed during
+ * runtime under wxGTK but not wxMSW. This circumstance is taken into account by this function.
+ *
+ * In the current version, under wxGTK the style flag is applied dynamically to the text control and on other platforms
+ * the text control is replaced by a newly created one with the desired style flag.
+ *
+ * @param sizer the sizer to which the text control belongs
+ * @param textCtrl the control whose style are to be changed
+ * @param text the text to update the text control with
+ * @param before the control element in the layout before "textCtrl" to respect the TAB order
+ * @param style the new style flag for "textCtrl" (previous flags will not be preserved)
+ *
+ * @see https://docs.wxwidgets.org/stable/classwx_text_ctrl.html
+ */
+void UpdatePasswordTextCtrl(wxSizer *sizer, wxTextCtrl* &textCtrl, const wxString text, wxTextCtrl* before, const int style);
 
 //ensures at least one of the checkboxes are selected
 class MultiCheckboxValidator: public wxValidator

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -177,7 +177,7 @@ inline const wxChar* ToStr(bool b) {
 }
 
 /**
- * @brief The purpose of this function is to update or remove the style flags "wxTE_PASSWORD" or "wxTE_READONLY" of a wxTextCtrl.
+ * The purpose of this function is to add/remove the style flags "wxTE_PASSWORD" or "wxTE_READONLY" to/from a wxTextCtrl.
  *
  * According to the documentation of wxTextCtrl the style flags "wxTE_PASSWORD" and "wxTE_READONLY" can be changed during
  * runtime under wxGTK but not wxMSW. This circumstance is taken into account by this function.
@@ -191,7 +191,8 @@ inline const wxChar* ToStr(bool b) {
  * @param before the control element in the layout before "textCtrl" to respect the TAB order
  * @param style the new style flag for "textCtrl" (previous flags will not be preserved)
  *
- * @see https://docs.wxwidgets.org/stable/classwx_text_ctrl.html
+ * @note See <a href="https://docs.wxwidgets.org/stable/classwx_text_ctrl.html">Styles</a> section of wxTextCtrl
+ *       documentation about restrictions.
  */
 void UpdatePasswordTextCtrl(wxSizer *sizer, wxTextCtrl* &textCtrl, const wxString text, wxTextCtrl* before, const int style);
 


### PR DESCRIPTION
- Directly/Dynamically changing the style flags of a password text control also improves the layout behavior of YubiCfgDlg.
- The ShowHideText code in wxUtilities was pretty much identical to that of AddEditPropSheetDlg::UpdatePasswordTextCtrl.