### PR TITLE
[wx] Fix re-editing issue of group name in tree view

### DIFF
--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -971,7 +971,7 @@ void TreeCtrl::PreferencesChanged()
   ;
 }
 
-void EditTreeLabel(wxTreeCtrl* tree, const wxTreeItemId& id)
+void TreeCtrl::EditTreeLabel(wxTreeCtrl* tree, const wxTreeItemId& id)
 {
   if (!id) return;
   wxTextCtrl* edit = tree->EditLabel(id);
@@ -1052,7 +1052,14 @@ void TreeCtrl::OnEndLabelEdit( wxTreeEvent& evt )
             if ((itemText == label.c_str()) && (ti != item)) {
               evt.Veto();
               wxMessageBox(_("Group names on the same level must be unique."), _("Duplicate group name"), wxOK|wxICON_ERROR);
-              EditTreeLabel(this, item);
+              /*
+                Wrapped in a 'CallAfter' so the veto and current event can be finalized.
+                A call to 'EditTreeLabel' will trigger a new event for editing the label
+                and will open a new text entry field, whereas the previously open seems
+                still to exists. Hence, without a delay the new event seems to be in
+                conflict with the current one.
+              */
+              CallAfter(&TreeCtrl::EditTreeLabel, this, item);
               return;
             }
             ti = GetNextSibling(ti);

--- a/src/ui/wxWidgets/TreeCtrl.h
+++ b/src/ui/wxWidgets/TreeCtrl.h
@@ -297,6 +297,8 @@ private:
   bool ProcessDnDData(StringX &sxDropPath, wxMemoryBuffer *inDDmem);
   void AddDnDEntries(MultiCommands *pmCmd, DnDObList &dnd_oblist, StringX &sxDropPath);
 
+  void EditTreeLabel(wxTreeCtrl* tree, const wxTreeItemId& id);
+
 ////@begin TreeCtrl member variables
   wxTreeItemId m_drag_item;
   wxColour m_drag_text_colour;


### PR DESCRIPTION
- Resolves #1145 
- Also seems to fix a crash when ESC cancels editing of a group name.
- Would be great if someone could also check the behavior on a Mac.