### PR TITLE
Use specific commits from the Yubico repos

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -57,11 +57,14 @@ jobs:
 
     - name: Install tools for Yubikey build
       run: brew install autoconf automake libtool
-      
+
+    # The Yubico repos don't maintain tags, so checkout specific commits for the sake of safety and repeatability
+    # These are the master HEAD commits as of 2024-02-08
     - name: Build libyubikey from upstream
       run: |
-        git clone https://github.com/Yubico/yubico-c.git
+        git clone --no-checkout https://github.com/Yubico/yubico-c.git
         cd yubico-c
+        git checkout e4334554857b0367085cbf845bf87dd92433e020
         autoreconf --install
         ./configure --disable-shared --disable-documentation CFLAGS="-O2 -arch arm64 -arch x86_64 -mmacosx-version-min=$MACOS_VER_MIN"
         make -j $HOST_CPU check
@@ -69,8 +72,9 @@ jobs:
 
     - name: Build ykpers from upstream
       run: |
-        git clone https://github.com/Yubico/yubikey-personalization.git
+        git clone --no-checkout https://github.com/Yubico/yubikey-personalization.git
         cd yubikey-personalization
+        git checkout db0c0d641d47ee52e43af94dcee603d76186b6d3
         autoreconf --install
         ./configure --disable-shared --disable-documentation CFLAGS="-O2 -arch arm64 -arch x86_64 -mmacosx-version-min=$MACOS_VER_MIN"
         make -j $HOST_CPU check


### PR DESCRIPTION
Build the Yubico libraries from specific commits, since they don't use tags.  These commits are the current master/HEAD, so they correspond the build that is already in use, and they are the same as proposed for the flathub build.