### PR TITLE
Update macos-latest.yml to use wx 3.2.4

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -35,7 +35,7 @@ jobs:
       # "XCODE_CONFIG=Debug"
       # "XCODE_CONFIG=Debug-no-yubi"
       run: |
-        echo "WX_VERS=3.2.2.1" >> $GITHUB_ENV
+        echo "WX_VERS=3.2.4" >> $GITHUB_ENV
         echo "WX_SRC_DIR=$HOME/wxWidgets" >> $GITHUB_ENV
         echo "WX_BUILD_DIR=$HOME/wxbuild" >> $GITHUB_ENV
         echo "WX_ARCH=arm64,x86_64" >> $GITHUB_ENV


### PR DESCRIPTION
I've been using this version for local builds since its release.  It's also the version used for the flathub build.