### PR TITLE
wx: Compare dialog tables are hard to read in dark mode

### DIFF
--- a/src/ui/wxWidgets/CompareDlg.cpp
+++ b/src/ui/wxWidgets/CompareDlg.cpp
@@ -277,12 +277,12 @@ wxCollapsiblePane* CompareDlg::CreateDataPanel(wxSizer* dlgSizer, const wxString
   //create a way to get to the ComparisonData object from the grid, which is the only thing we have in events
   wxASSERT_MSG(cd->grid->GetClientData() == nullptr, wxT("wxGrid::ClientData is not nullptr on creation.  Need to use that for our purposes"));
   cd->grid->SetClientData(cd);
-#ifndef __WXMSW__
+#if defined(__WXMSW__) || defined(__WXOSX__)
+  cd->grid->SetDefaultCellFont(wxSystemSettings::GetFont(wxSYS_OEM_FIXED_FONT));
+#else
   wxFont monospacedFont(10, wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
   if (monospacedFont.IsFixedWidth())
     cd->grid->SetDefaultCellFont(monospacedFont);
-#else
-  cd->grid->SetDefaultCellFont(wxSystemSettings::GetFont(wxSYS_OEM_FIXED_FONT));
 #endif
   cd->grid->SetColLabelAlignment(wxALIGN_LEFT, wxALIGN_BOTTOM);
   auto *gridSizer = new wxBoxSizer(wxVERTICAL);

--- a/src/ui/wxWidgets/ComparisonGridTable.h
+++ b/src/ui/wxWidgets/ComparisonGridTable.h
@@ -20,11 +20,12 @@
 
 // #define CurrentBackgroundColor    *wxWHITE
 #if wxVERSION_NUMBER >= 3103
-#define CurrentBackgroundColor    (wxSystemSettings::GetAppearance().IsUsingDarkBackground() ? wxColor(29, 30, 32) : *wxWHITE)
+#define CurrentBackgroundColor    (wxSystemSettings::GetAppearance().IsUsingDarkBackground() ? wxTheColourDatabase->Find("DARK GREY") : wxTheColourDatabase->Find("WHITE"))
+#define ComparisonBackgroundColor (wxSystemSettings::GetAppearance().IsUsingDarkBackground() ? wxTheColourDatabase->Find("DIM GREY")  : wxTheColourDatabase->Find("LIGHT GREY"))
 #else
 #define CurrentBackgroundColor    (*wxWHITE)
+#define ComparisonBackgroundColor (*wxWHITE)
 #endif
-#define ComparisonBackgroundColor *wxWHITE
 
 struct SelectionCriteria;
 class PWScore;


### PR DESCRIPTION
On Linux and Mac, the Compare dialog tables are hard to read when the system is using a dark theme.  The screenshots were taken on a Mac, but my Fedora system was similar.  Also, changed the fixed font used on Mac to wxSYS_OEM_FIXED_FONT because it's easier to read than the one that was being selected. (The Linux font is good as is.)
Test systems:
macOS 14.4.1 M1Max, wx 3.2.4, Xcode 15.3
Fedora 39 ARM VM, wx 3.2.4, xfce desktop

Before - Dark mode - note the white text on white background
![before dark](https://github.com/pwsafe/pwsafe/assets/61946508/43022daa-a301-4818-87ab-b4d04ab7bed8)

After - Dark mode
![After dark](https://github.com/pwsafe/pwsafe/assets/61946508/fae949ce-eab5-4de1-a824-db24f86668e0)

After - Light mode
![after light](https://github.com/pwsafe/pwsafe/assets/61946508/03ec82f9-07e8-4b28-9ff6-fa3df5996f55)
