### PR TITLE
Change dialog title from Error to actual problem

### DIFF
--- a/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
@@ -211,7 +211,7 @@ void SafeCombinationSetupDlg::OnOkClick(wxCommandEvent& WXUNUSED(evt))
   if (Validate() && TransferDataFromWindow()) {
     if (m_password != m_verify) {
       wxMessageDialog err(this, _("The two entries do not match."),
-                          _("Mismatch Master Password"), wxOK | wxICON_EXCLAMATION);
+                          _("Mismatching Master Password"), wxOK | wxICON_EXCLAMATION);
       err.ShowModal();
       return;
     }
@@ -283,7 +283,7 @@ void SafeCombinationSetupDlg::OnYubibtnClick(wxCommandEvent& WXUNUSED(event))
   if (Validate() && TransferDataFromWindow()) {
     if (m_password != m_verify) {
       wxMessageDialog err(this, _("The two entries do not match."),
-                          _("Mismatch entries"), wxOK | wxICON_EXCLAMATION);
+                          _("Mismatching entries"), wxOK | wxICON_EXCLAMATION);
       err.ShowModal();
       return;
     }

--- a/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationSetupDlg.cpp
@@ -211,13 +211,13 @@ void SafeCombinationSetupDlg::OnOkClick(wxCommandEvent& WXUNUSED(evt))
   if (Validate() && TransferDataFromWindow()) {
     if (m_password != m_verify) {
       wxMessageDialog err(this, _("The two entries do not match."),
-                          _("Error"), wxOK | wxICON_EXCLAMATION);
+                          _("Mismatch Master Password"), wxOK | wxICON_EXCLAMATION);
       err.ShowModal();
       return;
     }
     if (m_password.empty()) {
       wxMessageDialog err(this, _("Enter the key and verify it."),
-                          _("Error"), wxOK | wxICON_EXCLAMATION);
+                          _("Empty Master Password"), wxOK | wxICON_EXCLAMATION);
       err.ShowModal();
       return;
     }
@@ -283,7 +283,7 @@ void SafeCombinationSetupDlg::OnYubibtnClick(wxCommandEvent& WXUNUSED(event))
   if (Validate() && TransferDataFromWindow()) {
     if (m_password != m_verify) {
       wxMessageDialog err(this, _("The two entries do not match."),
-                          _("Error"), wxOK | wxICON_EXCLAMATION);
+                          _("Mismatch entries"), wxOK | wxICON_EXCLAMATION);
       err.ShowModal();
       return;
     }


### PR DESCRIPTION
Attempt to fix: https://github.com/pwsafe/pwsafe/issues/1208

When new database is created change title of "Error" to actual problem.

Idea is to replace "Error" in title bar with actual problem. We have already fixed "Error" with "Weak Master Password" title when database is created with weak master password.

Few more:
1. When empty password: Empty Master Password.
2. When master password and confirmation do not match: Mismatch Master Password.

Similar issue that I have fixed in the same file:
3. Yubikey entries do not math: Mismatch entries.
