### PR TITLE
Change title of dialog from Error to real action name Duplicate entry

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -1870,7 +1870,7 @@ bool AddEditPropSheetDlg::IsGroupUsernameTitleCombinationUnique()
       wxMessageDialog msg(
         this,
         _("An entry or shortcut with the same Group, Title and Username already exists."),
-        _("Error"),
+        _("Duplicate entry"),
         wxOK|wxICON_ERROR
       );
       msg.ShowModal();


### PR DESCRIPTION
Password Safe v1.19.2-prerelease on Ubuntu 23.10.

1. New Entry and add new entry.
2. Duplicate entry from step 1.
3. Edit Entry and name the entry with the same name as in step 1 and error appears with dialog title "Error". This PR changes "Error" title bar with real problem name "Duplicate entry".