### PR TITLE
Change dialog title, remove word Sorry and unify the same error with the same message

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -3031,7 +3031,7 @@ void AddEditPropSheetDlg::OnEasyReadCBClick(wxCommandEvent& evt)
     // Check if pronounceable is also set - forbid both
     if (m_PasswordPolicyUsePronounceableCtrl->GetValue()) {
       m_PasswordPolicyUseEasyCtrl->SetValue(false);
-      wxMessageBox(_("\"Easy-to-read\" and \"Pronounceable\" cannot be both selected."),
+      wxMessageBox(_("\"Easy-to-read\" and \"pronounceable\" cannot be both selected."),
                    _("Unsupported selection"), wxOK|wxICON_ERROR, this);
       return;
     }

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -3031,7 +3031,7 @@ void AddEditPropSheetDlg::OnEasyReadCBClick(wxCommandEvent& evt)
     // Check if pronounceable is also set - forbid both
     if (m_PasswordPolicyUsePronounceableCtrl->GetValue()) {
       m_PasswordPolicyUseEasyCtrl->SetValue(false);
-      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected"),
+      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected."),
                    _("Duplicate selection"), wxOK|wxICON_ERROR, this);
       return;
     }
@@ -3058,7 +3058,7 @@ void AddEditPropSheetDlg::OnPronouceableCBClick( wxCommandEvent& evt)
     // Check if ezread is also set - forbid both
     if (m_PasswordPolicyUseEasyCtrl->GetValue()) {
       m_PasswordPolicyUsePronounceableCtrl->SetValue(false);
-      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected"),
+      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected."),
                    _("Duplicate selection"), wxOK|wxICON_ERROR, this);
       return;
     }

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -3031,7 +3031,7 @@ void AddEditPropSheetDlg::OnEasyReadCBClick(wxCommandEvent& evt)
     // Check if pronounceable is also set - forbid both
     if (m_PasswordPolicyUsePronounceableCtrl->GetValue()) {
       m_PasswordPolicyUseEasyCtrl->SetValue(false);
-      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected."),
+      wxMessageBox(_("\"Easy-to read\" and \"Pronounceable\" cannot be both selected."),
                    _("Duplicate selection"), wxOK|wxICON_ERROR, this);
       return;
     }

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -3032,7 +3032,7 @@ void AddEditPropSheetDlg::OnEasyReadCBClick(wxCommandEvent& evt)
     if (m_PasswordPolicyUsePronounceableCtrl->GetValue()) {
       m_PasswordPolicyUseEasyCtrl->SetValue(false);
       wxMessageBox(_("\"Easy-to read\" and \"Pronounceable\" cannot be both selected."),
-                   _("Duplicate selection"), wxOK|wxICON_ERROR, this);
+                   _("Unsupported selection"), wxOK|wxICON_ERROR, this);
       return;
     }
 
@@ -3059,7 +3059,7 @@ void AddEditPropSheetDlg::OnPronouceableCBClick( wxCommandEvent& evt)
     if (m_PasswordPolicyUseEasyCtrl->GetValue()) {
       m_PasswordPolicyUsePronounceableCtrl->SetValue(false);
       wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected."),
-                   _("Duplicate selection"), wxOK|wxICON_ERROR, this);
+                   _("Unsupported selection"), wxOK|wxICON_ERROR, this);
       return;
     }
     st_symbols = CPasswordCharPool::GetPronounceableSymbols();

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -3031,8 +3031,8 @@ void AddEditPropSheetDlg::OnEasyReadCBClick(wxCommandEvent& evt)
     // Check if pronounceable is also set - forbid both
     if (m_PasswordPolicyUsePronounceableCtrl->GetValue()) {
       m_PasswordPolicyUseEasyCtrl->SetValue(false);
-      wxMessageBox(_("Sorry, \"easy-to-read\" and \"pronounceable\" cannot be both selected"),
-                   _("Error"), wxOK|wxICON_ERROR, this);
+      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected"),
+                   _("Duplicate selection"), wxOK|wxICON_ERROR, this);
       return;
     }
 
@@ -3058,8 +3058,8 @@ void AddEditPropSheetDlg::OnPronouceableCBClick( wxCommandEvent& evt)
     // Check if ezread is also set - forbid both
     if (m_PasswordPolicyUseEasyCtrl->GetValue()) {
       m_PasswordPolicyUsePronounceableCtrl->SetValue(false);
-      wxMessageBox(_("Sorry, \"pronounceable\" and \"easy-to-read\" cannot be both selected"),
-                   _("Error"), wxOK|wxICON_ERROR, this);
+      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected"),
+                   _("Duplicate selection"), wxOK|wxICON_ERROR, this);
       return;
     }
     st_symbols = CPasswordCharPool::GetPronounceableSymbols();

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -3031,7 +3031,7 @@ void AddEditPropSheetDlg::OnEasyReadCBClick(wxCommandEvent& evt)
     // Check if pronounceable is also set - forbid both
     if (m_PasswordPolicyUsePronounceableCtrl->GetValue()) {
       m_PasswordPolicyUseEasyCtrl->SetValue(false);
-      wxMessageBox(_("\"Easy-to read\" and \"Pronounceable\" cannot be both selected."),
+      wxMessageBox(_("\"Easy-to-read\" and \"Pronounceable\" cannot be both selected."),
                    _("Unsupported selection"), wxOK|wxICON_ERROR, this);
       return;
     }

--- a/src/ui/wxWidgets/PasswordPolicyDlg.cpp
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.cpp
@@ -679,7 +679,7 @@ void PasswordPolicyDlg::OnPronouceableCBClick( wxCommandEvent& event )
     // Check if ezread is also set - forbid both
     if (m_pwpEasyCtrl->GetValue()) {
       m_pwpPronounceCtrl->SetValue(false);
-      wxMessageBox(_("\"Pronounceable\" and "\"easy-to-read\" cannot be both selected."),
+      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected."),
                    _("Unsupported selection"), wxOK|wxICON_ERROR, this);
       return;
     }
@@ -698,7 +698,7 @@ void PasswordPolicyDlg::OnEZreadCBClick( wxCommandEvent& event )
     // Check if pronounceable is also set - forbid both
     if (m_pwpPronounceCtrl->GetValue()) {
       m_pwpEasyCtrl->SetValue(false);
-      wxMessageBox(_("\"Easy-to-read\" and "\"pronounceable\" cannot be both selected."),
+      wxMessageBox(_("\"Easy-to-read\" and \"pronounceable\" cannot be both selected."),
                    _("Unsupported selection"), wxOK|wxICON_ERROR, this);
       return;
     }

--- a/src/ui/wxWidgets/PasswordPolicyDlg.cpp
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.cpp
@@ -679,7 +679,7 @@ void PasswordPolicyDlg::OnPronouceableCBClick( wxCommandEvent& event )
     // Check if ezread is also set - forbid both
     if (m_pwpEasyCtrl->GetValue()) {
       m_pwpPronounceCtrl->SetValue(false);
-      wxMessageBox(_("\"Easy to-read\" and \"Pronounceable\" cannot be both selected."),
+      wxMessageBox(_("\"Pronounceable\" and "\"easy-to-read\" cannot be both selected."),
                    _("Unsupported selection"), wxOK|wxICON_ERROR, this);
       return;
     }
@@ -698,7 +698,7 @@ void PasswordPolicyDlg::OnEZreadCBClick( wxCommandEvent& event )
     // Check if pronounceable is also set - forbid both
     if (m_pwpPronounceCtrl->GetValue()) {
       m_pwpEasyCtrl->SetValue(false);
-      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected."),
+      wxMessageBox(_("\"Easy-to-read\" and "\"pronounceable\" cannot be both selected."),
                    _("Unsupported selection"), wxOK|wxICON_ERROR, this);
       return;
     }

--- a/src/ui/wxWidgets/PasswordPolicyDlg.cpp
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.cpp
@@ -679,8 +679,8 @@ void PasswordPolicyDlg::OnPronouceableCBClick( wxCommandEvent& event )
     // Check if ezread is also set - forbid both
     if (m_pwpEasyCtrl->GetValue()) {
       m_pwpPronounceCtrl->SetValue(false);
-      wxMessageBox(_("Sorry, \"pronounceable\" and \"easy-to-read\" cannot be both selected"),
-                   _("Error"), wxOK|wxICON_ERROR, this);
+      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected"),
+                   _("Duplicate selection"), wxOK|wxICON_ERROR, this);
       return;
     }
   }
@@ -698,8 +698,8 @@ void PasswordPolicyDlg::OnEZreadCBClick( wxCommandEvent& event )
     // Check if pronounceable is also set - forbid both
     if (m_pwpPronounceCtrl->GetValue()) {
       m_pwpEasyCtrl->SetValue(false);
-      wxMessageBox(_("Sorry, \"easy-to-read\" and \"pronounceable\" cannot be both selected"),
-                   _("Error"), wxOK|wxICON_ERROR, this);
+      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected"),
+                   _("Duplicate selection"), wxOK|wxICON_ERROR, this);
       return;
     }
   }

--- a/src/ui/wxWidgets/PasswordPolicyDlg.cpp
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.cpp
@@ -679,7 +679,7 @@ void PasswordPolicyDlg::OnPronouceableCBClick( wxCommandEvent& event )
     // Check if ezread is also set - forbid both
     if (m_pwpEasyCtrl->GetValue()) {
       m_pwpPronounceCtrl->SetValue(false);
-      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected"),
+      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected."),
                    _("Duplicate selection"), wxOK|wxICON_ERROR, this);
       return;
     }
@@ -698,7 +698,7 @@ void PasswordPolicyDlg::OnEZreadCBClick( wxCommandEvent& event )
     // Check if pronounceable is also set - forbid both
     if (m_pwpPronounceCtrl->GetValue()) {
       m_pwpEasyCtrl->SetValue(false);
-      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected"),
+      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected."),
                    _("Duplicate selection"), wxOK|wxICON_ERROR, this);
       return;
     }

--- a/src/ui/wxWidgets/PasswordPolicyDlg.cpp
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.cpp
@@ -679,7 +679,7 @@ void PasswordPolicyDlg::OnPronouceableCBClick( wxCommandEvent& event )
     // Check if ezread is also set - forbid both
     if (m_pwpEasyCtrl->GetValue()) {
       m_pwpPronounceCtrl->SetValue(false);
-      wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected."),
+      wxMessageBox(_("\"Easy to-read\" and \"Pronounceable\" cannot be both selected."),
                    _("Duplicate selection"), wxOK|wxICON_ERROR, this);
       return;
     }

--- a/src/ui/wxWidgets/PasswordPolicyDlg.cpp
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.cpp
@@ -680,7 +680,7 @@ void PasswordPolicyDlg::OnPronouceableCBClick( wxCommandEvent& event )
     if (m_pwpEasyCtrl->GetValue()) {
       m_pwpPronounceCtrl->SetValue(false);
       wxMessageBox(_("\"Easy to-read\" and \"Pronounceable\" cannot be both selected."),
-                   _("Duplicate selection"), wxOK|wxICON_ERROR, this);
+                   _("Unsupported selection"), wxOK|wxICON_ERROR, this);
       return;
     }
   }
@@ -699,7 +699,7 @@ void PasswordPolicyDlg::OnEZreadCBClick( wxCommandEvent& event )
     if (m_pwpPronounceCtrl->GetValue()) {
       m_pwpEasyCtrl->SetValue(false);
       wxMessageBox(_("\"Pronounceable\" and \"easy-to-read\" cannot be both selected."),
-                   _("Duplicate selection"), wxOK|wxICON_ERROR, this);
+                   _("Unsupported selection"), wxOK|wxICON_ERROR, this);
       return;
     }
   }


### PR DESCRIPTION
1. Change Error title to real problem "Duplicate selection".
2. Remove word "Sorry", because it is unusual wording and redundant - simplification.
3. Two pairs of the same problem but order of selections are reversed. Unify the error message.