### PR TITLE
Change title bar from Error to Mismatching passwords

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -1824,8 +1824,8 @@ bool AddEditPropSheetDlg::ValidateBasicData()
     if (password != secondPassword) {
       wxMessageDialog msg(
         this,
-        _("Passwords do not match"),
-        _("Error"),
+        _("Passwords do not match."),
+        _("Mismatching passwords"),
         wxOK|wxICON_ERROR
       );
       msg.ShowModal();


### PR DESCRIPTION
Password Safe v1.19.2-pre on Ubuntu 23.10.
1. Edit Entry.
2. Make sure Password and Confirm are different. Error is returned. This PR changes dialog title from "Error" to "Mismatching passwords" and adds full stop at the end of sentence.