### PR TITLE
[wx] Fix layout issue when showing Yubi controls dynamically

### DIFF
--- a/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
@@ -55,7 +55,6 @@ BEGIN_EVENT_TABLE( SafeCombinationChangeDlg, wxDialog )
   EVT_BUTTON( ID_YUBIBTN,                   SafeCombinationChangeDlg::OnYubibtnClick  )
   EVT_BUTTON( ID_YUBIBTN2,                  SafeCombinationChangeDlg::OnYubibtn2Click )
   EVT_TIMER(  YubiMixin::POLLING_TIMER_ID,  SafeCombinationChangeDlg::OnPollingTimer  )
-  EVT_TIMER(  YubiMixin::POLLING_TIMER2_ID, SafeCombinationChangeDlg::OnPollingTimer  )
 #endif
   EVT_BUTTON( wxID_OK,                      SafeCombinationChangeDlg::OnOkClick       )
   EVT_BUTTON( wxID_CANCEL,                  SafeCombinationChangeDlg::OnCancelClick   )
@@ -88,7 +87,7 @@ SafeCombinationChangeDlg::SafeCombinationChangeDlg(wxWindow *parent, PWScore &co
 #ifndef NO_YUBI
   m_yubiMixin1.SetupMixin(this, FindWindow(ID_YUBIBTN), FindWindow(ID_YUBISTATUS), YubiMixin::POLLING_TIMER_ID);
   m_yubiMixin1.SetPrompt1(_("Enter old master password (if any) and click on top Yubikey button"));
-  m_yubiMixin2.SetupMixin(this, FindWindow(ID_YUBIBTN2), FindWindow(ID_YUBISTATUS), YubiMixin::POLLING_TIMER2_ID);
+  m_yubiMixin2.SetupMixin(this, FindWindow(ID_YUBIBTN2), FindWindow(ID_YUBISTATUS), YubiMixin::POLLING_TIMER_NONE);
   m_yubiMixin2.SetPrompt1(_("Enter old master password (if any) and click on top Yubikey button"));
 #endif
 }
@@ -402,8 +401,6 @@ void SafeCombinationChangeDlg::OnPollingTimer(wxTimerEvent &evt)
 {
   if (evt.GetId() == YubiMixin::POLLING_TIMER_ID) {
     m_yubiMixin1.HandlePollingTimer();
-  }
-  else if (evt.GetId() == YubiMixin::POLLING_TIMER2_ID) {
     m_yubiMixin2.HandlePollingTimer();
   }
 }

--- a/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
@@ -54,7 +54,8 @@ BEGIN_EVENT_TABLE( SafeCombinationChangeDlg, wxDialog )
 #ifndef NO_YUBI
   EVT_BUTTON( ID_YUBIBTN,                   SafeCombinationChangeDlg::OnYubibtnClick  )
   EVT_BUTTON( ID_YUBIBTN2,                  SafeCombinationChangeDlg::OnYubibtn2Click )
-  EVT_TIMER(  YubiMixin::POLLING_TIMER_ID, SafeCombinationChangeDlg::OnPollingTimer  )
+  EVT_TIMER(  YubiMixin::POLLING_TIMER_ID,  SafeCombinationChangeDlg::OnPollingTimer  )
+  EVT_TIMER(  YubiMixin::POLLING_TIMER2_ID, SafeCombinationChangeDlg::OnPollingTimer  )
 #endif
   EVT_BUTTON( wxID_OK,                      SafeCombinationChangeDlg::OnOkClick       )
   EVT_BUTTON( wxID_CANCEL,                  SafeCombinationChangeDlg::OnCancelClick   )
@@ -82,8 +83,6 @@ SafeCombinationChangeDlg::SafeCombinationChangeDlg(wxWindow *parent, PWScore &co
   {
     GetSizer()->SetSizeHints(this);
   }
-  // Allow to resize the dialog in width, only.
-  SetMaxSize(wxSize(wxDefaultCoord, GetMinSize().y));
   Centre();
 ////@end SafeCombinationChangeDlg creation
 #ifndef NO_YUBI

--- a/src/ui/wxWidgets/YubiMixin.cpp
+++ b/src/ui/wxWidgets/YubiMixin.cpp
@@ -73,7 +73,7 @@ bool YubiMixin::IsYubiInserted() const
 void YubiMixin::HandlePollingTimer()
 {
   // Show Yubi controls when inserted first time:
-  if (yubiExists() && !m_btn->IsShown() && !m_status->IsShown()) {
+  if (yubiExists() && (!m_btn->IsShown() || !m_status->IsShown())) {
     m_btn->Show(true);
     m_status->Show(true);
 

--- a/src/ui/wxWidgets/YubiMixin.cpp
+++ b/src/ui/wxWidgets/YubiMixin.cpp
@@ -34,12 +34,14 @@ void YubiMixin::SetupMixin(wxEvtHandler *eventHandler, wxWindow *btn, wxWindow *
   m_btn = btn;
   m_status = status;
   m_present = !IsYubiInserted(); // lie to trigger correct actions in timer even
-  // Hide Yubi controls if user doesn't have one:
-  if (m_btn != nullptr) m_btn->Show(yubiExists());
-  if (m_status != nullptr) m_status->Show(yubiExists());
-  if (IsPollingEnabled()) {
-    m_pollingTimer = new wxTimer(eventHandler, timerId);
-    m_pollingTimer->Start(GetPollingInterval());
+  if ((m_btn != nullptr) && (m_status != nullptr)) {
+    // Hide Yubi controls if user doesn't have one:
+    m_btn->Show(yubiExists());
+    m_status->Show(yubiExists());
+    if (IsPollingEnabled()) {
+      m_pollingTimer = new wxTimer(eventHandler, timerId);
+      m_pollingTimer->Start(GetPollingInterval());
+    }
   }
 }
 
@@ -71,11 +73,11 @@ bool YubiMixin::IsYubiInserted() const
 void YubiMixin::HandlePollingTimer()
 {
   // Show Yubi controls when inserted first time:
-  if (yubiExists()) {
+  if (yubiExists() && !m_btn->IsShown() && !m_status->IsShown()) {
     wxWindow *parent = nullptr; // assume both have same parent
-    if (m_btn != nullptr) {m_btn->Show(true); parent = m_btn->GetParent();}
-    if (m_status != nullptr) {m_status->Show(true); parent = m_btn->GetParent();}
-    if (parent != nullptr) parent->Layout();
+    m_btn->Show(true); parent = m_btn->GetParent();
+    m_status->Show(true); parent = m_btn->GetParent();
+    if (parent != nullptr) parent->GetSizer()->SetSizeHints(parent);
   }
 
   // Currently hmac check is blocking (ugh), so no need to check here

--- a/src/ui/wxWidgets/YubiMixin.cpp
+++ b/src/ui/wxWidgets/YubiMixin.cpp
@@ -74,10 +74,15 @@ void YubiMixin::HandlePollingTimer()
 {
   // Show Yubi controls when inserted first time:
   if (yubiExists() && !m_btn->IsShown() && !m_status->IsShown()) {
-    wxWindow *parent = nullptr; // assume both have same parent
-    m_btn->Show(true); parent = m_btn->GetParent();
-    m_status->Show(true); parent = m_btn->GetParent();
-    if (parent != nullptr) parent->GetSizer()->SetSizeHints(parent);
+    m_btn->Show(true);
+    m_status->Show(true);
+
+    // Update the dialog's size hints to honor the required minimum
+    // control sizes as additional controls have appeared.
+    auto *parent = m_btn->GetParent();
+    if (parent != nullptr) {
+      parent->GetSizer()->SetSizeHints(parent);
+    }
   }
 
   // Currently hmac check is blocking (ugh), so no need to check here

--- a/src/ui/wxWidgets/YubiMixin.cpp
+++ b/src/ui/wxWidgets/YubiMixin.cpp
@@ -38,7 +38,7 @@ void YubiMixin::SetupMixin(wxEvtHandler *eventHandler, wxWindow *btn, wxWindow *
     // Hide Yubi controls if user doesn't have one:
     m_btn->Show(yubiExists());
     m_status->Show(yubiExists());
-    if (IsPollingEnabled()) {
+    if (IsPollingEnabled() && (timerId != YubiMixin::POLLING_TIMER_NONE)) {
       m_pollingTimer = new wxTimer(eventHandler, timerId);
       m_pollingTimer->Start(GetPollingInterval());
     }

--- a/src/ui/wxWidgets/YubiMixin.h
+++ b/src/ui/wxWidgets/YubiMixin.h
@@ -57,7 +57,7 @@ class YubiMixin
   static int GetPollingInterval() { return s_pollingInterval; }
   static bool IsPollingEnabled() { return s_pollingInterval > YubiMixin::POLLING_INTERVAL_OFF; }
 
-  enum { POLLING_TIMER_ID = 83, POLLING_TIMER2_ID = 84 };  
+  enum { POLLING_TIMER_NONE = -1, POLLING_TIMER_ID = 83 };
 
  private:
   bool m_present; // key present?


### PR DESCRIPTION
This PR refers to https://github.com/pwsafe/pwsafe/pull/1215#issuecomment-2059550069 and was fixed by updating the dialog's sizer hints so that the dialog is resized to the new required size.

By manually changing the dialog size, the bottom buttons can no longer be reduced below their required minimum size and thus retain their full size.

Another change is that the layout will only be updated once when the Yubi controls are displayed and no longer periodically with the poll rate (0.5 seconds), in the hope that it has a positive effect on performance.

It would be great if a YubiKey owner could test these changes.