### PR TITLE
Because we now support flatpak, pwsafe is not supported only on popul…

### DIFF
--- a/install/description.txt
+++ b/install/description.txt
@@ -2,4 +2,4 @@ Password Safe is a password manager.
 It stores your passwords in an encrypted file, allowing you to remember only one password (the "master password"), instead of all the username/password combinations that you use.
 For extra security, you can use a Yubikey device to provide two-factor authentication.
 
-Password Safe runs on Windows, popular Linux distributions, macOS and FreeBSD.
+Password Safe runs on Windows, Linux, macOS and FreeBSD.

--- a/install/metainfo/org.pwsafe.pwsafe.metainfo.xml
+++ b/install/metainfo/org.pwsafe.pwsafe.metainfo.xml
@@ -16,7 +16,7 @@
       Password Safe is a password manager. It stores your passwords in an encrypted file, allowing you to remember only one password (the &quot;master password&quot;), instead of all the username/password combinations that you use. For extra security, you can use a Yubikey device to provide two-factor authentication.
     </p>
     <p>
-      Password Safe runs on Windows, popular Linux distributions, macOS and FreeBSD.
+      Password Safe runs on Windows, Linux, macOS and FreeBSD.
     </p>
   </description>
   


### PR DESCRIPTION
…ar Linux distributions, but on 38 distributions flatpak supports so removing text "popular Linux distributions" to "Linux".