### PR TITLE
Add Fedora Asahi Remix to Linux prereqs script

### DIFF
--- a/Misc/setup-linux-dev-env.sh
+++ b/Misc/setup-linux-dev-env.sh
@@ -92,7 +92,7 @@ case "$DISTRO" in
         # dpkg-sig is nice-to-have, not available on debian testing?
         apt-get install -qy dpkg-sig || (echo "dpkg-sig isn't mandatory"; true)
     ;;
-    fedora)
+    fedora|fedora-asahi-remix)
         if test "$RELEASE" -lt 39 ; then
             LIBWXBASE="wxBase3-devel"
             LIBWXGTK="wxGTK3-devel"


### PR DESCRIPTION
The prerequisites are the same for both regular Fedora Linux and Fedora Asahi Remix.

Tested on Fedora Asahi Remix 40. Builds without errors, automated tests pass, and works correctly when run manually.