### PR TITLE
[wx] Remove misplaced Yubi status text control

### DIFF
--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -197,11 +197,6 @@ void SafeCombinationEntryDlg::CreateControls()
   auto* horizontalBoxSizer4 = new wxBoxSizer(wxHORIZONTAL);
   verticalBoxSizer1->Add(horizontalBoxSizer4, 0, wxEXPAND|wxALL, 0);
 
-#ifndef NO_YUBI
-  m_yubiStatusCtrl = new wxStaticText( this, ID_YUBISTATUS, _("Insert YubiKey"), wxDefaultPosition, wxDefaultSize, 0 );
-  horizontalBoxSizer4->Add(m_yubiStatusCtrl, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
-#endif
-
   auto* helpButton = new wxButton(this, wxID_HELP, _("&Help"), wxDefaultPosition, wxDefaultSize, 0);
   horizontalBoxSizer4->Add(
     helpButton,


### PR DESCRIPTION
While testing the last merges I noticed that the Yubi status text appears to the left of the help button on the entry dialog. This is probably code that was forgotten to be removed or result of the merges?!

![PwsafeEntryDlg](https://github.com/pwsafe/pwsafe/assets/4042917/e2c99de5-29d9-46f4-9e36-fa72f8e54fba)
