### PR TITLE
Fix GetDataHere logic to avoid copying the null terminator

### DIFF
--- a/src/ui/wxWidgets/Clipboard.cpp
+++ b/src/ui/wxWidgets/Clipboard.cpp
@@ -56,7 +56,7 @@ public:
 
   virtual bool GetDataHere(void *buf) const wxOVERRIDE
   {
-    strcpy((char *)buf, KDEClipboardSecretMarkerValue);
+    memcpy(buf, KDEClipboardSecretMarkerValue, this->GetDataSize());
     return true;
   }
 


### PR DESCRIPTION
Related PR: #1287 

After checking wxWidgets and KDE source code, it looks like the data is not a null terminated string... Changing to `memcpy` to avoid copying the null terminator, which may not fit in the buffer. 

I have tested this again on Kubuntu 24.04, copy and clear clipboard are working as expected. 

@ronys Sorry that I missed this in my other PR. Please take a look at this change. 
