### PR TITLE
Fix backslash handling for autotype

### DIFF
--- a/src/core/PWSAuxParse.cpp
+++ b/src/core/PWSAuxParse.cpp
@@ -452,13 +452,13 @@ StringX PWSAuxParse::GetAutoTypeString(const StringX &sx_in_autotype,
           sxtmp += TCHAR('\v');
           break;
         case TCHAR('g'):
-          sxtmp += sx_group;
+          sxtmp += duplicateCharInString(sx_group, L'\\');
           break;
         case TCHAR('i'):
-          sxtmp += sx_title;
+          sxtmp += duplicateCharInString(sx_title, L'\\');
           break;
         case TCHAR('u'):
-          sxtmp += sx_user;
+          sxtmp += duplicateCharInString(sx_user, L'\\');
           break;
         case TCHAR('p'):
           sxtmp += duplicateCharInString(sx_pwd, L'\\');
@@ -467,10 +467,10 @@ StringX PWSAuxParse::GetAutoTypeString(const StringX &sx_in_autotype,
           sxtmp += duplicateCharInString(sx_lastpwd, L'\\');
           break;
         case TCHAR('l'):
-          sxtmp += sx_url;
+          sxtmp += duplicateCharInString(sx_url, L'\\');
           break;
         case TCHAR('m'):
-          sxtmp += sx_email;
+          sxtmp += duplicateCharInString(sx_email, L'\\');
           break;
 
         case TCHAR('o'):

--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -877,7 +877,6 @@ void PasswordSafeFrame::DoAutotype(const StringX& sx_autotype,
           }
           break;
         default:
-          sxtmp += L'\\';
           sxtmp += curChar;
           break;
       }


### PR DESCRIPTION
Relates to #1105 and https://github.com/pwsafe/pwsafe/commit/f690c01c8d698052c6f28c4d23680ac1f7a4ef13, and possibly related to #1282 . 

Currently, backslash isn't typed for username (and group, title, url, email) on Windows, and is typed twice for password (and previous password) on Linux. 

Changes: 

1. Add backslash escape to group, title, username, url, and email. 
2. Update `MenuEditHandlers.cpp > PasswordSafeFrame::DoAutotype` (which is used by Linux) to better match `PWSAuxParse.cpp > PWSAuxParse::SendAutoTypeString` (which is used by Windows). 

Linux (Kubuntu 24.04): 
![image](https://github.com/pwsafe/pwsafe/assets/86326640/16537058-af6a-4919-99df-dba7df9cc317)

Windows 10 (VM): 
![image](https://github.com/pwsafe/pwsafe/assets/86326640/a74fe947-9e04-4c16-89fd-fe8b81cf9606)
