### PR TITLE
gettext is already installed

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -53,7 +53,8 @@ jobs:
       run: xcode-select -p
       
     - name: Install dependencies for creating dmg
-      run: brew install gettext create-dmg
+      # gettext is already installed in the runner image
+      run: brew install create-dmg
 
     - name: Install tools for Yubikey build
       run: brew install autoconf automake libtool


### PR DESCRIPTION
The current GitHub macOS image has gettext pre-installed, so this is to eliminate a needless brew error message.