### PR TITLE
Fix logic issues in the Change Master Password dialog

### DIFF
--- a/docs/ReleaseNotesWX.md
+++ b/docs/ReleaseNotesWX.md
@@ -7,6 +7,20 @@ https://pwsafe.org/. Details about changes to older releases may be found in the
 
 In the following, SFxxxx refers to Bug Reports, Feature Requests and Service Requests in PasswordSafe SourceForge Project tickets, and GHxxxx refers to issues in the PasswordSafe GitHub project.
 
+PasswordSafe 1.20 Release ??? 2024
+=====================================
+
+Bugs fixed in 1.20
+------------------
+* [GH1230](https://github.com/pwsafe/pwsafe/issues/1230) The Change Master Password dialog now accepts a blank old password with a Yubikey
+
+New features in 1.20
+--------------------
+
+Changes to existing features in 1.20
+------------------------------------
+
+
 PasswordSafe 1.19 Release 8 June 2024
 =====================================
 

--- a/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
@@ -383,6 +383,14 @@ void SafeCombinationChangeDlg::OnYubibtn2Click(wxCommandEvent& WXUNUSED(event))
         return;
       }
     }
+
+    if (m_confirm != m_newpasswd) {
+      wxMessageDialog err(this, _("New master password and confirmation do not match"),
+                          _("Error"), wxOK | wxICON_EXCLAMATION);
+      err.ShowModal();
+      return;
+    }
+
     StringX response;
     bool oldYubiChallenge = ::wxGetKeyState(WXK_SHIFT); // for pre-0.94 databases
     if (m_yubiMixin2.PerformChallengeResponse(this, m_newpasswd, response, oldYubiChallenge)) {

--- a/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
@@ -298,6 +298,11 @@ void SafeCombinationChangeDlg::OnOkClick(wxCommandEvent& WXUNUSED(evt))
     } else { // password checks out OK.
       EndModal(wxID_OK);
     }
+    // If we got here, there was an error in a PW entry.  A case exists where switching from a
+    // (Yubikey without a PW), to (PW only), we may need to allow the old PW to be
+    // blank again for the next retry.
+    if (!m_oldresponse.empty() && m_oldpasswd.empty())
+      m_oldPasswdEntry->AllowEmptyCombinationOnce();
   }
 }
 
@@ -339,6 +344,11 @@ void SafeCombinationChangeDlg::OnYubibtnClick(wxCommandEvent& WXUNUSED(event))
         m_yubiStatusCtrl->SetForegroundColour(*wxRED);
         m_yubiStatusCtrl->SetLabel(_("YubiKey master password incorrect"));
       } else {
+        // The old password has been validated.  If it was blank, allow it to be blank on the next check.
+        // e.g. changing from (Yubikey w/blank PW) to (PW only).
+        if (m_oldpasswd.empty()) {
+          m_oldPasswdEntry->AllowEmptyCombinationOnce();
+        }
         m_yubiMixin2.SetPrompt1(_("Enter new master password and click on bottom Yubikey button"));
         m_yubiMixin2.UpdateStatus();
       }

--- a/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
@@ -351,6 +351,7 @@ void SafeCombinationChangeDlg::OnYubibtnClick(wxCommandEvent& WXUNUSED(event))
         }
         m_yubiMixin2.SetPrompt1(_("Enter new master password and click on bottom Yubikey button"));
         m_yubiMixin2.UpdateStatus();
+        m_newPasswdEntry->SetFocus();
       }
     }
   }


### PR DESCRIPTION
Resolves #1230

Corrects some behavior when using a Yubikey:
- Allows the old password to be blank
- Requires that the new and confirmation fields match
- After validating the old password/Yubikey combo, advance the focus to the New PW field

Tested on:
macOS M1Max Sonoma 14.5, Xcode 15.4, wx 3.2.4 (local debug build)
Fedora 40 ARM64, Xfce/X11, gcc 14.1.1, wx 3.2.4, GTK 3.24.42
