### PR TITLE
[wx] Use the password strength check with a Yubikey

### DIFF
--- a/docs/ReleaseNotesWX.md
+++ b/docs/ReleaseNotesWX.md
@@ -19,6 +19,7 @@ New features in 1.20
 
 Changes to existing features in 1.20
 ------------------------------------
+* [GH1300](https://github.com/pwsafe/pwsafe/issues/1300) Add the password strength check with a Yubikey
 
 
 PasswordSafe 1.19 Release 8 June 2024

--- a/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp
@@ -23,8 +23,6 @@
 #include <wx/msw/msvcrt.h>
 #endif
 
-#include "core/PWCharPool.h" // for CheckMasterPassword()
-
 ////@begin includes
 #include "ExternalKeyboardButton.h"
 #include "SafeCombinationCtrl.h"
@@ -272,30 +270,8 @@ void SafeCombinationChangeDlg::OnOkClick(wxCommandEvent& WXUNUSED(evt))
       wxMessageDialog err(this, _("New master password and confirmation do not match"),
                           _("Error"), wxOK | wxICON_EXCLAMATION);
       err.ShowModal();
-    // Vox populi vox dei - folks want the ability to use a weak
-    // passphrase, best we can do is warn them...
-    // If someone want to build a version that insists on proper
-    // passphrases, then just define the preprocessor macro
-    // PWS_FORCE_STRONG_PASSPHRASE in the build properties/Makefile
-    // (also used in CPasskeySetup)
-    } else if (!CPasswordCharPool::CheckMasterPassword(m_newpasswd, errmess)) {
-      wxString msg = errmess.c_str();
-#ifndef PWS_FORCE_STRONG_PASSPHRASE
-      msg += wxT("\n");
-      msg += _("Use it anyway?");
-      wxMessageDialog err(this, msg,
-                          _("Weak Master Password"), wxYES_NO | wxNO_DEFAULT | wxICON_EXCLAMATION);
-      err.SetYesNoLabels(_("Use anyway"), _("Cancel"));
-      int rc1 = err.ShowModal();
-      if (rc1 == wxID_YES)
-        EndModal(wxID_OK);
-#else
-      wxMessageDialog err(this, msg,
-                          _("Error"), wxOK | wxICON_HAND);
-      err.ShowModal();
-#endif // PWS_FORCE_STRONG_PASSPHRASE
-    } else { // password checks out OK.
-      EndModal(wxID_OK);
+    } else if (CheckPasswordStrengthAndWarn(this, m_newpasswd)) {
+      EndModal(wxID_OK); // password checks out OK.
     }
     // If we got here, there was an error in a PW entry.  A case exists where switching from a
     // (Yubikey without a PW), to (PW only), we may need to allow the old PW to be
@@ -398,6 +374,10 @@ void SafeCombinationChangeDlg::OnYubibtn2Click(wxCommandEvent& WXUNUSED(event))
       wxMessageDialog err(this, _("New master password and confirmation do not match"),
                           _("Error"), wxOK | wxICON_EXCLAMATION);
       err.ShowModal();
+      return;
+    }
+    // A blank password with a Yubikey is a common use case
+    if (!m_newpasswd.empty() && !CheckPasswordStrengthAndWarn(this, m_newpasswd)) {
       return;
     }
 

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -194,7 +194,6 @@ bool CheckPasswordStrengthAndWarn(wxWindow *win, StringX &password)
   // If someone want to build a version that insists on proper
   // passphrases, then just define the preprocessor macro
   // PWS_FORCE_STRONG_PASSPHRASE in the build properties/Makefile
-  // (also used in CPasskeyChangeDlg)
   StringX errmess;
   if (!CPasswordCharPool::CheckMasterPassword(password, errmess)) {
     wxString cs_msg;

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -196,8 +196,7 @@ bool CheckPasswordStrengthAndWarn(wxWindow *win, StringX &password)
   // PWS_FORCE_STRONG_PASSPHRASE in the build properties/Makefile
   StringX errmess;
   if (!CPasswordCharPool::CheckMasterPassword(password, errmess)) {
-    wxString cs_msg;
-    cs_msg = errmess.c_str();
+    wxString cs_msg = errmess.c_str();
 #ifndef PWS_FORCE_STRONG_PASSPHRASE
     cs_msg += wxT("\n");
     cs_msg += _("Use it anyway?");

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -201,6 +201,15 @@ inline const wxChar* ToStr(bool b) {
  */
 void UpdatePasswordTextCtrl(wxSizer *sizer, wxTextCtrl* &textCtrl, const wxString text, wxTextCtrl* before, const int style);
 
+/**
+ * Checi if the password passes the strength rules, prompt the user if it does not.
+ *
+ * @param win Parent window for the prompt dialog
+ * @param password the proposed password
+ * @returns true if okay to use password, false if not
+ */
+bool CheckPasswordStrengthAndWarn(wxWindow *win, StringX &password);
+
 namespace wxUtilities
 {
   /**

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -202,7 +202,7 @@ inline const wxChar* ToStr(bool b) {
 void UpdatePasswordTextCtrl(wxSizer *sizer, wxTextCtrl* &textCtrl, const wxString text, wxTextCtrl* before, const int style);
 
 /**
- * Checi if the password passes the strength rules, prompt the user if it does not.
+ * Check whether the password passes the strength rules, prompt the user if it does not.
  *
  * @param win Parent window for the prompt dialog
  * @param password the proposed password


### PR DESCRIPTION
Resolves #1300 for Mac and Linux.  Similar changes are still needed for Windows.

- Move some duplicated code to a new function: CheckPasswordStrengthAndWarn() in wxUtilities.cpp
- Add calls to the "Set Master Password" and the "Change Master Password" dialogs; with and without a Yubikey
