### PR TITLE
fix: check for display manager before adding password manager hint

### DIFF
--- a/src/ui/wxWidgets/Clipboard.cpp
+++ b/src/ui/wxWidgets/Clipboard.cpp
@@ -107,6 +107,7 @@ bool Clipboard::SetData(const StringX &data)
   bool res = false;
   if (wxTheClipboard->Open()) {
 #if defined(__UNIX__) && !defined(__WXOSX__)
+    // Copying composite object is currently not working as expected on Wayland
     if (wxUtilities::IsDisplayManagerX11()) {
       wxDataObjectComposite *dataObjectComposite = new wxDataObjectComposite();
       dataObjectComposite->Add(new wxTextDataObjectEx(data.c_str()), true);

--- a/src/ui/wxWidgets/Clipboard.cpp
+++ b/src/ui/wxWidgets/Clipboard.cpp
@@ -107,10 +107,14 @@ bool Clipboard::SetData(const StringX &data)
   bool res = false;
   if (wxTheClipboard->Open()) {
 #if defined(__UNIX__) && !defined(__WXOSX__)
-    wxDataObjectComposite *dataObjectComposite = new wxDataObjectComposite();
-    dataObjectComposite->Add(new wxTextDataObjectEx(data.c_str()), true);
-    dataObjectComposite->Add(new KDEClipboardSecretMarkerObject(), false);
-    res = wxTheClipboard->SetData(dataObjectComposite);
+    if (wxUtilities::IsDisplayManagerX11()) {
+      wxDataObjectComposite *dataObjectComposite = new wxDataObjectComposite();
+      dataObjectComposite->Add(new wxTextDataObjectEx(data.c_str()), true);
+      dataObjectComposite->Add(new KDEClipboardSecretMarkerObject(), false);
+      res = wxTheClipboard->SetData(dataObjectComposite);
+    } else {
+      res = wxTheClipboard->SetData(new wxTextDataObjectEx(data.c_str()));
+    }
 #else
     res = wxTheClipboard->SetData(new wxTextDataObjectEx(data.c_str()));
 #endif

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -263,13 +263,8 @@ bool IsCurrentDesktopKde()
 #endif
 }
 
-bool wxUtilities::IsVirtualKeyboardSupported()
+bool wxUtilities::IsDisplayManagerX11()
 {
-#ifdef __WINDOWS__
-  return false;
-#elif defined __WXOSX__
-  return true;
-#else
   static int isDisplayManagerX11 = 0;
 
   // Get the env. variable only once
@@ -287,6 +282,16 @@ bool wxUtilities::IsVirtualKeyboardSupported()
     }
   }
   return (isDisplayManagerX11 == 1);
+}
+
+bool wxUtilities::IsVirtualKeyboardSupported()
+{
+#ifdef __WINDOWS__
+  return false;
+#elif defined __WXOSX__
+  return true;
+#else
+  return wxUtilities::IsDisplayManagerX11();
 #endif
 }
 

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -427,8 +427,14 @@ namespace wxUtilities
 {
   /**
    * @brief Checks environment variable 'XDG_SESSION_TYPE' for display manager 'x11'.
+   *
+   * @return whether if environment variable is set to 'x11'.
+   */
+  bool IsDisplayManagerX11();
+  /**
+   * @brief Checks if virtual keyboard is supported.
    * 
-   * @return true if environment variable is set to 'x11' on Linux,
+   * @return true if IsDisplayManagerX11() returns true on Linux,
    *         always true on Mac and false on Windows.
    */
   bool IsVirtualKeyboardSupported();

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -428,7 +428,7 @@ namespace wxUtilities
   /**
    * @brief Checks environment variable 'XDG_SESSION_TYPE' for display manager 'x11'.
    *
-   * @return whether if environment variable is set to 'x11'.
+   * @return whether the environment variable is set to 'x11'.
    */
   bool IsDisplayManagerX11();
   /**

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -443,8 +443,7 @@ namespace wxUtilities
   /**
    * @brief Checks if virtual keyboard is supported.
    * 
-   * @return true if IsDisplayManagerX11() returns true on Linux,
-   *         always true on Mac and false on Windows.
+   * @return IsDisplayManagerX11() on Linux, true on Mac, and false on Windows.
    */
   bool IsVirtualKeyboardSupported();
 }


### PR DESCRIPTION
As per #1308 and #1307, copying composite objects are not working as expected on Wayland. 

I checked around the Internet, and it looks like some other projects are also having difficulties with composite objects and Wayland (example: https://github.com/flameshot-org/flameshot/issues/2848)

Adding a check for the display manager and only add the password manager hint when the display manager is X11. 