### PR TITLE
[wx] Clear old lock on open

### DIFF
--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -3357,8 +3357,12 @@ void PWScore::UnlockFile(const stringT &filename)
 
 void PWScore::SafeUnlockCurFile()
 {
-  const std::wstring filename(GetCurFile().c_str());
+  const stringT filename(GetCurFile().c_str());
+  SafeUnlockFile(filename);
+}
 
+void PWScore::SafeUnlockFile(const stringT &filename)
+{
   // The only way we're the locker is if it's locked & we're !readonly
   if (!filename.empty() && !IsReadOnly() && IsLockedFile(filename))
     UnlockFile(filename);

--- a/src/core/PWScore.h
+++ b/src/core/PWScore.h
@@ -249,6 +249,7 @@ public:
   void UnlockFile(const stringT &filename);
 
   void SafeUnlockCurFile(); // unlocks current file iff we locked it.
+  void SafeUnlockFile(const stringT &filename);
 
   // Following 3 routines only for SaveAs to use a temporary lock handle
   // LockFile2, UnLockFile2 & MoveLock

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1389,10 +1389,8 @@ int PasswordSafeFrame::Open(const wxString &fname)
   if (rc != PWScore::SUCCESS)
     return rc;
 
-  // Clear the lock on the old file, if any.
-  // This has to be done after the old file is saved (see SaveIfChanged() above)
-  // and before a call to SetCurFile() (see below)
-  m_core.SafeUnlockCurFile();
+  // Save the current file name so we can unlock it later.
+  stringT oldfn = GetCurrentFile().c_str();
 
   // prompt for password, try to Load.
   DestroyWrapper<SafeCombinationPromptDlg> pwdpromptWrapper(this, m_core, fname);
@@ -1406,6 +1404,9 @@ int PasswordSafeFrame::Open(const wxString &fname)
       m_InitialTreeDisplayStatusAtOpen = true;
       Show();
       wxGetApp().recentDatabases().AddFileToHistory(fname);
+
+      // The new file is open.  Clear the lock on the old file, if any.
+      m_core.SafeUnlockFile(oldfn);
     }
     return retval;
   } else

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1389,6 +1389,9 @@ int PasswordSafeFrame::Open(const wxString &fname)
   if (rc != PWScore::SUCCESS)
     return rc;
 
+  // Clear the lock on the old file, if any.
+  m_core.SafeUnlockCurFile();
+
   // prompt for password, try to Load.
   DestroyWrapper<SafeCombinationPromptDlg> pwdpromptWrapper(this, m_core, fname);
   SafeCombinationPromptDlg* pwdprompt = pwdpromptWrapper.Get();

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1390,6 +1390,8 @@ int PasswordSafeFrame::Open(const wxString &fname)
     return rc;
 
   // Clear the lock on the old file, if any.
+  // This has to be done after the old file is saved (see SaveIfChanged() above)
+  // and before a call to SetCurFile() (see below)
   m_core.SafeUnlockCurFile();
 
   // prompt for password, try to Load.


### PR DESCRIPTION
When a file is already open, and the user tries to open a different file via "File->Open..." or the Open button, the already open file is saved and closed, but its lock file is not removed.