### PR TITLE
Add a FLATPAK define symbol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ include(create-harden-interface)
 
 
 # Configurable options:
+option (FLATPAK "Set ON to build for Flatpak" OFF)
 option (NO_YUBI "Set ON to disable YubiKey support" OFF)
 option (NO_GTEST "Set ON to disable gtest unit testing" OFF)
 option (GTEST_BUILD "Set OFF to disable gtest download and build on-fly" ON)
@@ -134,6 +135,11 @@ if (NOT WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_YUBI")
     message(STATUS "Yubikey support disabled")
   endif(NOT HAVE_YKPERS_H)
+
+  if(FLATPAK)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFLATPAK")
+    message(STATUS "Building for Flatpak")
+  endif(FLATPAK)
 endif (NOT WIN32)
 
 if (XML_XERCESC)

--- a/src/ui/wxWidgets/AboutDlg.cpp
+++ b/src/ui/wxWidgets/AboutDlg.cpp
@@ -119,6 +119,7 @@ void AboutDlg::CreateControls()
   wxStaticText* buildStaticText = new wxStaticText(aboutDialog, wxID_STATIC, _("Build date:")+wxT(" Mon dd yyyy hh:mm:ss"), wxDefaultPosition, wxDefaultSize, 0);
   rightSizer->Add(buildStaticText, 0, wxALIGN_LEFT|wxALL, 5);
 
+#ifndef FLATPAK
   wxBoxSizer* verCheckSizer = new wxBoxSizer(wxHORIZONTAL);
   rightSizer->Add(verCheckSizer, 0, wxALIGN_LEFT|wxALL, 0);
 
@@ -127,6 +128,7 @@ void AboutDlg::CreateControls()
 
   wxStaticText* latestStaticTextEnd = new wxStaticText(aboutDialog, wxID_STATIC, _(" for the latest version."), wxDefaultPosition, wxDefaultSize, 0);
   verCheckSizer->Add(latestStaticTextEnd, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxRIGHT, 5);
+#endif //FLATPAK
 
   wxBoxSizer* visitSiteSizer = new wxBoxSizer(wxHORIZONTAL);
   rightSizer->Add(visitSiteSizer, 0, wxALIGN_LEFT|wxALL, 0);


### PR DESCRIPTION
Partial fix for #1343.  This will not take effect until -DFLATPAK is added to the Flatpak manifest file.
- Adds Cmake logic to append -DFLATPAK to the compiler flags
- Adds #ifndef to remove the version check link if FLATPAK is defined
