### PR TITLE
[wx] Yubikey error messages not displayed

### DIFF
--- a/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp
@@ -594,10 +594,10 @@ void SafeCombinationEntryDlg::OnYubibtnClick(wxCommandEvent& WXUNUSED(event))
         if (ProcessPhrase()) {
           EndModal(wxID_OK);
         }
+        UpdateStatus();
       }
     }
   }
-  UpdateStatus();
 }
 
 void SafeCombinationEntryDlg::OnPollingTimer(wxTimerEvent &evt)

--- a/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
+++ b/src/ui/wxWidgets/SafeCombinationPromptDlg.cpp
@@ -317,10 +317,10 @@ void SafeCombinationPromptDlg::OnYubibtnClick(wxCommandEvent& WXUNUSED(event))
         if (ProcessPhrase()) {
           EndModal(wxID_OK);
         }
+        UpdateStatus();
       }
     }
   }
-  UpdateStatus();
 }
 
 void SafeCombinationPromptDlg::OnPollingTimer(wxTimerEvent &evt)


### PR DESCRIPTION
A minor regression in PR #1335 prevents Yubikey related error messages (e.g. Timeout) from being displayed in the status field.