### PR TITLE
Replaced Carbon include with CoreFoundation for iOS compatibility

### DIFF
--- a/src/os/mac/dir.cpp
+++ b/src/os/mac/dir.cpp
@@ -17,7 +17,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <sys/stat.h>
-#include <Carbon/Carbon.h>
+#include <CoreFoundation/CoreFoundation.h>
 
 /*
  * GetStringTFromURLRef


### PR DESCRIPTION
Carbon is macOS only, both support CoreFoundation.