### PR TITLE
Use CoreServices for determining mime type

### DIFF
--- a/src/os/mac/media.cpp
+++ b/src/os/mac/media.cpp
@@ -2,35 +2,46 @@
 * \file Mac-specific implementation of media.h
 */
 
-#include <wx/filename.h>
-#include <wx/mimetype.h>
+#include <CoreServices/CoreServices.h>
+#include <CoreFoundation/CoreFoundation.h>
 
 #include "../media.h"
-#include "../file.h"
 #include "../utf8conv.h"
-
-#include <cstdlib>
-#include <cstdio>
-
-#include "wxUtilities.h"
 
 using namespace std;
 
-static const char *unknown_type = "unknown";
+static const stringT unknown_type = L"unknown";
 
 stringT pws_os::GetMediaType(const stringT & sfilename)
 {
-  wxString result(unknown_type);
-  wxFileName wxfn(sfilename.c_str());
-  
-  if (wxfn.GetExt().empty())
-    return tostdstring(unknown_type);
-  
-  wxMimeTypesManager mimeTypesManager;
-  wxFileType* wxft = mimeTypesManager.GetFileTypeFromExtension(wxfn.GetExt());
-  
-  if(! wxft || ! wxft->GetMimeType(&result) ) {
-      return tostdstring(unknown_type);
-  }
-  return tostdstring(_(result));
+    // Convert stringT to CFStringRef
+    CFStringRef filename = CFStringCreateWithCString(kCFAllocatorDefault, pws_os::tomb(sfilename).c_str(), kCFStringEncodingUTF8);
+    if (filename == NULL)
+        return unknown_type;
+
+    // Extract the file extension
+    CFRange range = CFStringFind(filename, CFSTR("."), kCFCompareBackwards);
+    if (range.location == kCFNotFound)
+        return unknown_type;
+    CFStringRef fileExtension = CFStringCreateWithSubstring(kCFAllocatorDefault, filename, CFRangeMake(range.location + 1, CFStringGetLength(filename) - range.location - 1));
+    CFRelease(filename);
+    if (fileExtension == NULL)
+        return unknown_type;
+
+    // Determine uniform type identifier
+    CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, fileExtension, NULL);
+    CFRelease(fileExtension);
+    if (uti == NULL)
+        return unknown_type;
+
+    // Get mime type from UTI
+    CFStringRef mime_type = UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType);
+    CFRelease(uti);
+    if (mime_type == NULL)
+        return unknown_type;
+
+    // Convert mime_type to stringT
+    stringT retval = pws_os::towc(CFStringGetCStringPtr(mime_type, kCFStringEncodingUTF8));
+    CFRelease(mime_type);
+    return retval;
 }


### PR DESCRIPTION
This removes the dependency of mac/media.cpp on the wx framework. On iOS the wx framework is not available.

To determine a file's mimetype, the CoreServices framework is used, which is available on both macOS and iOS by default.
This uses the native mimetype database from macOS/iOS, as used by all programs and the OS itself.