### PR TITLE
[WX] Converting co-ordinates to width and height needs a +1

### DIFF
--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -796,7 +796,8 @@ void PWSafeApp::RestoreFrameCoords(void)
   long top, bottom, left, right;
   PWSprefs::GetInstance()->GetPrefRect(top, bottom, left, right);
   if (!(left == -1 && top == -1 && right == -1 && bottom == -1)) {
-    wxRect rcApp(static_cast<int>(left), static_cast<int>(top), static_cast<int>(right - left), static_cast<int>(bottom - top));
+    wxRect rcApp(static_cast<int>(left), static_cast<int>(top), 
+                 static_cast<int>(right - left + 1), static_cast<int>(bottom - top + 1));
 
     int displayWidth, displayHeight;
     ::wxDisplaySize(&displayWidth, &displayHeight);


### PR DESCRIPTION
Each time the app is started and exited, the window size, as saved in the config file, shrinks by one pixel.  When subtracting co-ordinates  (e.g. bottom-top) we need to add one to get the number of pixels, inclusive.