### PR TITLE
Added SetTotpStartTime(time_t t) similar to other time_t fields

### DIFF
--- a/src/core/ItemData.h
+++ b/src/core/ItemData.h
@@ -210,6 +210,7 @@ public:
   void UpdatePassword(const StringX &password); // use when password changed!
   void SetTwoFactorKey(const StringX& value) { CItem::SetField(TWOFACTORKEY, value); }
   bool SetTotpConfig(const StringX& value) { return SetFieldAsByte(TOTPCONFIG, value.c_str()); }
+  void SetTotpStartTime(time_t t) { CItem::SetTime(TOTPSTARTTIME, t); }
   bool SetTotpStartTime(const StringX& value) { return SetTime(TOTPSTARTTIME, value.c_str(), true); }
   bool SetTotpTimeStep(const StringX& value) { return SetFieldAsByte(TOTPTIMESTEP, value.c_str()); }
   bool SetTotpLength(const StringX& value) { return SetFieldAsByte(TOTPLENGTH, value.c_str()); }


### PR DESCRIPTION
This avoids an unnecessary time_t -> StringX -> time_t conversion roundtrip in the iOS app, I think useful to other platforms too