### PR TITLE
[br1372][linux] Regression: man page now installs in correct location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,7 +345,7 @@ if (NOT WIN32)
                      COMMAND ${GZIP} ARGS -9 -n -c ${PROJECT_SOURCE_DIR}/docs/pwsafe.1 > pwsafe.1.gz
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   ADD_CUSTOM_TARGET(manpage ALL DEPENDS ${CMAKE_BINARY_DIR}/pwsafe.1.gz)
-  install (FILES ${CMAKE_BINARY_DIR}/pwsafe.1.gz TYPE MAN)
+  install (FILES ${CMAKE_BINARY_DIR}/pwsafe.1.gz DESTINATION "share/man/man1")
   install (FILES "install/desktop/pwsafe.desktop" DESTINATION "share/applications")
   install (FILES "install/metainfo/org.pwsafe.pwsafe.metainfo.xml" DESTINATION "share/metainfo")
   install (FILES "install/graphics/48x48/pwsafe.png" DESTINATION "share/icons/hicolor/48x48/apps/")

--- a/docs/ReleaseNotesWX.md
+++ b/docs/ReleaseNotesWX.md
@@ -14,6 +14,7 @@ Bugs fixed in 1.20.0
 --------------------
 * [1331](https://github.com/pwsafe/pwsafe/issues/1331) Correctly display long paths with ellipsis (...) in Master Password Entry window
 * [1332](https://github.com/pwsafe/pwsafe/issues/1332) Correctly display long paths with ellipsis (...) in Unlock Password Database window
+* [1372](https://github.com/pwsafe/pwsafe/issues/1372) Man page is now installed in the correct location (regression).
 
 
 New features in 1.20.0


### PR DESCRIPTION
Fixes #1372 , per Balazs's suggestion.