### PR TITLE
[macOS] Use the drop down month date picker on macOS, if supported

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -461,7 +461,12 @@ wxPanel* AddEditPropSheetDlg::CreateDatesTimesPanel()
   m_DatesTimesExpireOnCtrl = new wxRadioButton(panel, ID_RADIOBUTTON_ON, _("On"), wxDefaultPosition, wxDefaultSize, 0);
   itemFlexGridSizer63->Add(m_DatesTimesExpireOnCtrl, 0, wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-  m_DatesTimesExpiryDateCtrl = new wxDatePickerCtrl(panel, ID_DATECTRL_EXP_DATE, wxDateTime(), wxDefaultPosition, wxDefaultSize, wxDP_DEFAULT);
+  auto DatePickerType = wxDP_DEFAULT;
+#if wxCHECK_VERSION(3, 1, 0)
+  if ((wxGetOsVersion() & wxOS_MAC) && wxCheckOsVersion(10, 15, 4))
+    DatePickerType = wxDP_DROPDOWN;
+#endif
+  m_DatesTimesExpiryDateCtrl = new wxDatePickerCtrl(panel, ID_DATECTRL_EXP_DATE, wxDateTime(), wxDefaultPosition, wxDefaultSize, DatePickerType);
   itemFlexGridSizer63->Add(m_DatesTimesExpiryDateCtrl, 0, wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
   itemFlexGridSizer63->AddStretchSpacer();


### PR DESCRIPTION
Mac only follow-on to PR #1353 

Other platforms have a drop down calendar feature on their date picker control.  wxWidgets does not use that by default on macOS, apparently because it was not available prior to macOS 10.15.4.

This PR enables the wxDP_DROPDOWN option on macOS 10.15.4 and above, otherwise we continue to use the current value (wxDP_DEFAULT) because the documentation is somewhat vague as to the behavior in other cases.  This was tested on:
macOS M1Max Sonoma 14.6.1, Xcode 15.4, wx 3.2.4 and 3.2.5
Fedora 40 ARM64 VMware,    KDE/Wayland,   gcc 14.1.1, wx 3.2.4, GTK 3.24.43
Ubuntu 24.04 ARM64 VMware, Gnome/Wayland, gcc 13.2.0, wx 3.2.4, GTK 3.24.41

wxCHECK_VERSION was added to allow it to compile with wx3.0.5, but that build was not tested.