### PR TITLE
If caller requests UTF8 encoding then use UTF8 encoding

### DIFF
--- a/src/core/UTF8Conv.cpp
+++ b/src/core/UTF8Conv.cpp
@@ -91,7 +91,7 @@ bool CUTF8Conv::FromUTF8(const unsigned char *utf8, size_t utf8Len,
   // first get needed wide char buffer size
   size_t wcLen = pws_os::mbstowcs(nullptr, 0,
                                   reinterpret_cast<const char *>(utf8),
-                                  size_t(-1), !m_cp_acp);
+                                  utf8Len, !m_cp_acp);
   if (wcLen == 0) { // uh-oh
     // it seems that this always returns non-zero, even if encoding
     // broken. Therefore, we'll give a conservative value here,
@@ -110,7 +110,7 @@ bool CUTF8Conv::FromUTF8(const unsigned char *utf8, size_t utf8Len,
   // next translate to buffer
   wcLen = pws_os::mbstowcs(m_wc, wcLen,
                            reinterpret_cast<const char *>(utf8),
-                           size_t(-1), !m_cp_acp);
+                           utf8Len, !m_cp_acp);
 #ifdef _WIN32
   if (wcLen == 0) {
     DWORD errCode = GetLastError();

--- a/src/core/UTF8Conv.cpp
+++ b/src/core/UTF8Conv.cpp
@@ -91,7 +91,7 @@ bool CUTF8Conv::FromUTF8(const unsigned char *utf8, size_t utf8Len,
   // first get needed wide char buffer size
   size_t wcLen = pws_os::mbstowcs(nullptr, 0,
                                   reinterpret_cast<const char *>(utf8),
-                                  utf8Len, !m_cp_acp);
+                                  size_t(-1), !m_cp_acp);
   if (wcLen == 0) { // uh-oh
     // it seems that this always returns non-zero, even if encoding
     // broken. Therefore, we'll give a conservative value here,
@@ -110,7 +110,7 @@ bool CUTF8Conv::FromUTF8(const unsigned char *utf8, size_t utf8Len,
   // next translate to buffer
   wcLen = pws_os::mbstowcs(m_wc, wcLen,
                            reinterpret_cast<const char *>(utf8),
-                           utf8Len, !m_cp_acp);
+                           size_t(-1), !m_cp_acp);
 #ifdef _WIN32
   if (wcLen == 0) {
     DWORD errCode = GetLastError();

--- a/src/os/mac/utf8conv.cpp
+++ b/src/os/mac/utf8conv.cpp
@@ -45,6 +45,9 @@ size_t pws_os::wcstombs(char *dst, size_t maxdstlen,
   if (!isUTF8)
     return ::wcstombs(dst, src, maxdstlen) + 1;
 
+  if (srclen == size_t(-1))
+    srclen = wcslen(src);
+
   // Convert to UTF-16
   CFStringRef str = CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const unsigned char *>(src), srclen*sizeof(wchar_t), wcharEncoding, false);
   if (str == NULL)
@@ -71,6 +74,9 @@ size_t pws_os::mbstowcs(wchar_t *dst, size_t maxdstlen,
 {
   if (!isUTF8)
     return ::mbstowcs(dst, src, maxdstlen) + 1;
+
+  if (srclen == size_t(-1))
+    srclen = strlen(src);
 
   // Convert to UTF-16
   CFStringRef str = CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const unsigned char *>(src), srclen, kCFStringEncodingUTF8, false);

--- a/src/os/mac/utf8conv.cpp
+++ b/src/os/mac/utf8conv.cpp
@@ -21,9 +21,9 @@
 #include <CoreFoundation/CoreFoundation.h>
 
 #if defined(PWS_LITTLE_ENDIAN)
-static const CFStringEncoding wcharEncoding = kCFStringEncodingUTF32LE;
+#define wcharEncoding kCFStringEncodingUTF32LE
 #else
-static const CFStringEncoding wcharEncoding = kCFStringEncodingUTF32BE;
+#define wcharEncoding kCFStringEncodingUTF32BE
 #endif
 
 using namespace std;

--- a/src/os/mac/utf8conv.cpp
+++ b/src/os/mac/utf8conv.cpp
@@ -18,6 +18,14 @@
 #include <cstring>
 #include <string>
 
+#include <CoreFoundation/CoreFoundation.h>
+
+#if defined(PWS_LITTLE_ENDIAN)
+static const CFStringEncoding wcharEncoding = kCFStringEncodingUTF32LE;
+#else
+static const CFStringEncoding wcharEncoding = kCFStringEncodingUTF32BE;
+#endif
+
 using namespace std;
 
 class Startup {
@@ -32,9 +40,30 @@ public:
 static Startup startup;
 
 size_t pws_os::wcstombs(char *dst, size_t maxdstlen,
-                        const wchar_t *src, size_t , bool )
+                        const wchar_t *src, size_t srclen, bool isUTF8)
 {
-  return ::wcstombs(dst, src, maxdstlen) + 1;
+  if (!isUTF8)
+    return ::wcstombs(dst, src, maxdstlen) + 1;
+
+  // Convert to UTF-16
+  CFStringRef str = CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const unsigned char *>(src), srclen*sizeof(wchar_t), wcharEncoding, false);
+  if (str == NULL)
+    return 0;  // return wcstombs + 1, so 0 to signal error
+
+  CFRange range = CFRangeMake(0, CFStringGetLength(str));
+  CFIndex usedBufLen;
+
+  // Convert to UTF-8
+  // Note: in case dst == NULL this only calculates usedBufLen
+  CFIndex idx = CFStringGetBytes(str, range, kCFStringEncodingUTF8, 0, false, reinterpret_cast<unsigned char *>(dst), maxdstlen, &usedBufLen);
+  CFRelease(str);
+  if (idx != range.length)
+    return 0;  // return wcstombs + 1, so 0 to signal error
+
+  if (dst != NULL && usedBufLen < maxdstlen)
+    dst[usedBufLen] = 0;
+
+  return usedBufLen + 1;
 }
 
 size_t pws_os::mbstowcs(wchar_t *dst, size_t maxdstlen,


### PR DESCRIPTION
On macOS, pws_os::wcstombs ignored the isUTF8 argument. By calling std::wcstombs the user-preferred encoding is used (as instructed by Startup). This causes e.g. incorrect calculations of stretched keys if a non-UTF8 locale is used. This PR fixes that.

Below is a simple code snippet that demonstrates the issue on macOS (unit-tests do not run on macOS, so that is why I include it here for reference). After applying this PR the test works ok.

- PWScore::CheckPasskey will try both true and false for isUTF8 (using PWS_PK_CP_ACP). This allows unlocking safes that were saved with incorrect stretched keys as pws_os::wcstombs will fallback to the old (erroneous) behavior.
- pws_os::mbstowcs needs similar fix, seems to have less impact, will add that to this PR.
- there might be compatibility issues reading other parts of the safe (not yet encountered though), is a mechanism needed similar to PWS_PK_CP_ACP to revert to the old behavior during reading a safe?

Thoughts?

```
    chdir(NSTemporaryDirectory().fileSystemRepresentation);
    StringX passphrase(_T("é"));
    StringX fname(_T("test.psafe"));
    
    const char* loc = std::setlocale(LC_ALL, "en_US.UTF-8");
    NSAssert(loc != NULL, @"Failed to set locale to en_US.UTF-8");

    // Create empty safe with non-ascii passkey
    PWSfileV4 fw(fname, PWSfile::Write, PWSfile::V40);
    NSAssert(fw.Open(passphrase) == PWSfile::SUCCESS, @"write open error");
    NSAssert(fw.Close() == PWSfile::SUCCESS, @"write close error");
    
    // Reread with en_US.UTF-8 locale
    PWSfileV4 fr(fname, PWSfile::Read, PWSfile::V40);
    NSAssert(fr.Open(passphrase) == PWSfile::SUCCESS, @"read 1 open error");
    NSAssert(fr.Close() == PWSfile::SUCCESS, @"read 1 close error");

    // Now change the locale, should have no impact in theory
    loc = std::setlocale(LC_ALL, "de_DE.ISO8859-15");
    NSAssert(loc != NULL, @"Failed to set locale to de_DE.ISO8859-15. To list the available locales: locale -a");

    // Reread with de_DE.ISO8859-15 locale
    PWSfileV4 fr2(fname, PWSfile::Read, PWSfile::V40);
    NSAssert(fr2.Open(passphrase) == PWSfile::SUCCESS, @"read 2 open error");  //  <-- crashes here
    NSAssert(fr2.Close() == PWSfile::SUCCESS, @"read 2 close error");
```
