### PR TITLE
Make writing safe optional on changing passkey

### DIFF
--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -1593,11 +1593,12 @@ bool PWScore::BackupCurFile(unsigned int maxNumIncBackups, int backupSuffix,
   return pws_os::RenameFile(m_currfile.c_str(), bu_fname);
 }
 
-void PWScore::ChangePasskey(const StringX &newPasskey)
+void PWScore::ChangePasskey(const StringX &newPasskey, bool bWriteFile)
 {
   SetPassKey(newPasskey);
   time(&m_hdr.m_whenpwdlastchanged); // update master password changed timestamp
-  WriteCurFile(); // Save immediately!
+  if (bWriteFile)
+    WriteCurFile(); // Save immediately!
 }
 
 // functor object type for find_if:

--- a/src/core/PWScore.h
+++ b/src/core/PWScore.h
@@ -161,7 +161,7 @@ public:
 
   // Check/Change master passphrase
   int CheckPasskey(const StringX &filename, const StringX &passkey);
-  void ChangePasskey(const StringX &newPasskey);
+  void ChangePasskey(const StringX &newPasskey, bool bWriteFile = true);
   void SetPassKey(const StringX &new_passkey);
 
   // Database functions


### PR DESCRIPTION
This allows for custom save strategies like backup file etc.
Also, on Mac filesystem operations must be wrapped inside a file coordinator.