### PR TITLE
[SF921] Ctrl-Backspace clears password fields (CSecEditExtn controls)

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,6 +11,7 @@ New features in 3.67.0
 ----------------------
 
 * [GH1301](https://github.com/pwsafe/pwsafe/issues/1301), [SF918](https://sourceforge.net/p/passwordsafe/feature-requests/918/) TOTP authorization code can be used in autotype via '\2'
+* [SF921](https://sourceforge.net/p/passwordsafe/feature-requests/921/) Ctrl-Backspace now clears password fields, both for entries and master passwords.
 
 PasswordSafe 3.66.1 Release Jun 4 2024
 ======================================

--- a/src/ui/Windows/ControlExtns.cpp
+++ b/src/ui/Windows/ControlExtns.cpp
@@ -990,6 +990,17 @@ CSecEditExtn::~CSecEditExtn()
   delete m_pImpl;
 }
 
+BOOL CSecEditExtn::PreTranslateMessage(MSG* pMsg)
+{
+  // Clear the text when Ctrl + Backspace is pressed
+  if (pMsg->message == WM_KEYDOWN && (GetKeyState(VK_CONTROL) & 0x8000) && pMsg->wParam == VK_BACK)
+    {
+      SetWindowText(_T(""));
+      return TRUE;
+    }
+  return CEdit::PreTranslateMessage(pMsg);
+}
+
 void CSecEditExtn::SetSecure(bool on_off)
 {
   m_secure = on_off;

--- a/src/ui/Windows/ControlExtns.h
+++ b/src/ui/Windows/ControlExtns.h
@@ -210,6 +210,9 @@ public:
   CSecEditExtn(std::vector<st_context_menu> vmenu_items);
   virtual ~CSecEditExtn();
 
+  virtual BOOL PreTranslateMessage(MSG* pMsg) override;
+
+
   // Overriding virtuals doesn't work, due to defective
   // implementation of DDX_Text. Grr.
   void DoDDX(CDataExchange *pDX, CSecString &str);


### PR DESCRIPTION
Per feature request in https://sourceforge.net/p/passwordsafe/feature-requests/921/, this PR allows Ctrl+Backspace to clear the text of any CSecEditExtn control, that is, all controls where password and master passwords are entered/displayed.

The original FR requests this for password database fields, but I don't think this is worth the effort, since the data there can be discovered easily in other places.