### PR TITLE
CoreFoundation encodes NUL characters (no special treatment)

### DIFF
--- a/src/os/mac/utf8conv.cpp
+++ b/src/os/mac/utf8conv.cpp
@@ -47,6 +47,8 @@ size_t pws_os::wcstombs(char *dst, size_t maxdstlen,
 
   if (srclen == size_t(-1))
     srclen = wcslen(src);
+  else
+    srclen = wcsnlen(src, srclen);  // CoreFoundation encodes NUL characters (no special treatment), make sure the input does not contain any NUL characters
 
   // Convert to UTF-16
   CFStringRef str = CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const unsigned char *>(src), srclen*sizeof(wchar_t), wcharEncoding, false);
@@ -77,6 +79,8 @@ size_t pws_os::mbstowcs(wchar_t *dst, size_t maxdstlen,
 
   if (srclen == size_t(-1))
     srclen = strlen(src);
+  else
+    srclen = strnlen(src, srclen);  // CoreFoundation encodes NUL characters (no special treatment), make sure the input does not contain any NUL characters
 
   // Convert to UTF-16
   CFStringRef str = CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const unsigned char *>(src), srclen, kCFStringEncodingUTF8, false);


### PR DESCRIPTION
Make sure the input does not contain any NUL characters

Fixes #1387 