### PR TITLE
Fixed regression, an entry's password history list responds to clicks again

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,13 +7,17 @@ In the following, SFxxxx refers to Bug Reports, Feature Requests and Service Req
 PasswordSafe 3.67.0 Release ??? ?? 2024
 =======================================
 
-New features in 3.67.0
+Bugs Fixed in 3.67.0
 ----------------------
-
+* [GH1390](https://github.com/pwsafe/pwsafe/issues/1390) Fixed regression, an entry's password history list now responds to mouse clicks.
 * [GH1371](https://github.com/pwsafe/pwsafe/issues/1371) Fixed regresssion, recently used files are now remembered correctly.
 * [GH1351](https://github.com/pwsafe/pwsafe/issues/1351) Fixed crash in pwsafe-cli when exporting database with named policy to XML.
+
+New features in 3.67.0
+----------------------
 * [GH1301](https://github.com/pwsafe/pwsafe/issues/1301), [SF918](https://sourceforge.net/p/passwordsafe/feature-requests/918/) TOTP authorization code can be used in autotype via '\2'
 * [SF921](https://sourceforge.net/p/passwordsafe/feature-requests/921/) Ctrl-Backspace now clears password fields, both for entries and master passwords.
+
 
 PasswordSafe 3.66.1 Release Jun 4 2024
 ======================================

--- a/src/ui/Windows/AddEdit_PropertyPage.cpp
+++ b/src/ui/Windows/AddEdit_PropertyPage.cpp
@@ -58,9 +58,6 @@ BOOL CAddEdit_PropertyPage::OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pRes
   ASSERT(pResult != NULL);
   NMHDR* pNMHDR = (NMHDR*)lParam;
 
-  if (pNMHDR->hwndFrom != m_hWnd && pNMHDR->hwndFrom != ::GetParent(m_hWnd))
-    return FALSE;
-
   if (pNMHDR->code == PSN_QUERYINITIALFOCUS) {
     CWnd* pCtl = GetDlgItem(IDC_TITLE);
     if (pCtl) {


### PR DESCRIPTION
Fixes #1390 