### PR TITLE
Persistent active filter via pref

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,7 +4,7 @@ https://pwsafe.org/. Details about changes to older releases may be found in the
 
 In the following, SFxxxx refers to Bug Reports, Feature Requests and Service Requests in PasswordSafe SourceForge Project tickets, and GHxxxx refers to issues in the PasswordSafe GitHub project.
 
-PasswordSafe 3.67.0 Release ??? ?? 2024
+PasswordSafe 3.67.0 Release Oct ?? 2024
 =======================================
 
 Bugs Fixed in 3.67.0
@@ -17,6 +17,7 @@ New features in 3.67.0
 ----------------------
 * [GH1301](https://github.com/pwsafe/pwsafe/issues/1301), [SF918](https://sourceforge.net/p/passwordsafe/feature-requests/918/) TOTP authorization code can be used in autotype via '\2'
 * [SF921](https://sourceforge.net/p/passwordsafe/feature-requests/921/) Ctrl-Backspace now clears password fields, both for entries and master passwords.
+* [SF912](https://sourceforge.net/p/passwordsafe/feature-requests/912/) If a view filter is active when a database is closed, it will be activated the next time the database is opened.
 
 
 PasswordSafe 3.66.1 Release Jun 4 2024

--- a/src/core/PWSprefs.cpp
+++ b/src/core/PWSprefs.cpp
@@ -222,7 +222,7 @@ const PWSprefs::stringPref PWSprefs::m_string_prefs[NumStringPrefs] = {
   {_T("AddEditSampleText"), _T("AaBbYyZz 0O1IlL"), ptApplication},  // application
   {_T("AltNotesEditorCmdLineParms"), _T(""), ptApplication},        // application
   {_T("TreeSort"), _T("group"), ptApplication},                     // application
-
+  {_T("ActiveFilterName"), _T(""), ptDatabase},                     // database
 };
 
 PWSprefs *PWSprefs::GetInstance()

--- a/src/core/PWSprefs.h
+++ b/src/core/PWSprefs.h
@@ -158,6 +158,7 @@ public:
     LastUsedKeyboard, VKeyboardFontName, VKSampleText, AltNotesEditor,
     LanguageFile, DefaultSymbols, NotesFont, NotesSampleText, AutotypeTaskDelays,
     AddEditFont, AddEditSampleText, AltNotesEditorCmdLineParms, TreeSort,
+    ActiveFilterName,
     NumStringPrefs};
 
   // for DoubleClickAction and ShiftDoubleClickAction

--- a/src/ui/Windows/MainFilters.cpp
+++ b/src/ui/Windows/MainFilters.cpp
@@ -102,6 +102,9 @@ bool DboxMain::ApplyFilter(bool bJustDoIt)
   else
     m_bFilterActive = !m_bFilterActive;
 
+  // Set/Clear ActiveFilterName DB preference
+  PWSprefs::GetInstance()->SetPref(PWSprefs::ActiveFilterName, m_bFilterActive ? CurrentFilter().fname.c_str() : L"");
+
   ApplyFilters();
   return true;
 }


### PR DESCRIPTION
As discussed in https://sourceforge.net/p/passwordsafe/feature-requests/912/ 
This allows a user to specify a filter that will be automatically applied when a database is open.