### PR TITLE
Fix relative include paths

### DIFF
--- a/src/core/CheckVersion.h
+++ b/src/core/CheckVersion.h
@@ -18,7 +18,7 @@
  */
 //-----------------------------------------------------------------------------
 
-#include "os/typedefs.h" // for stringT
+#include "../os/typedefs.h" // for stringT
 
 class CheckVersion {
  public:

--- a/src/core/Command.h
+++ b/src/core/Command.h
@@ -17,7 +17,7 @@ class CommandInterface;
 #include "ItemData.h"
 #include "PWSfile.h"
 #include "StringX.h"
-#include "os/UUID.h"
+#include "../os/UUID.h"
 
 #include "coredefs.h"
 

--- a/src/core/DBCompareData.h
+++ b/src/core/DBCompareData.h
@@ -11,9 +11,9 @@
 /// DBCompareData.h
 //-----------------------------------------------------------------------------
 
-#include "core/ItemData.h"
-#include "core/StringX.h"
-#include "os/UUID.h"
+#include "ItemData.h"
+#include "StringX.h"
+#include "../os/UUID.h"
 
 enum {BOTH = -1 , CURRENT = 0, COMPARE = 1};
 

--- a/src/core/ExpiredList.h
+++ b/src/core/ExpiredList.h
@@ -12,7 +12,7 @@
 #define __EXPIREDLIST_H
 
 #include "StringX.h"
-#include "os/UUID.h"
+#include "../os/UUID.h"
 #include "ItemData.h"
 
 #include <vector>

--- a/src/core/ItemAtt.h
+++ b/src/core/ItemAtt.h
@@ -14,7 +14,7 @@
 #include "Util.h"
 #include "Match.h"
 #include "Item.h"
-#include "os/UUID.h"
+#include "../os/UUID.h"
 #include "StringX.h"
 
 #include <time.h> // for time_t

--- a/src/core/ItemData.h
+++ b/src/core/ItemData.h
@@ -16,7 +16,7 @@
 #include "Item.h"
 #include "PWSprefs.h"
 #include "PWPolicy.h"
-#include "os/UUID.h"
+#include "../os/UUID.h"
 #include "StringX.h"
 #include "TotpCore.h"
 

--- a/src/core/PWCharPool.h
+++ b/src/core/PWCharPool.h
@@ -11,7 +11,7 @@
 #ifndef __PWCHARPOOL_H
 #define __PWCHARPOOL_H
 
-#include "os/typedefs.h"
+#include "../os/typedefs.h"
 #include "StringX.h"
 #include "PWPolicy.h"
 

--- a/src/core/PWSLog.h
+++ b/src/core/PWSLog.h
@@ -9,8 +9,8 @@
 #ifndef _PWSLOG_H
 #define _PWSLOG_H
 
-#include "os/typedefs.h"
-#include "os/logit.h"
+#include "../os/typedefs.h"
+#include "../os/logit.h"
 
 #include <deque>
 

--- a/src/core/PWScore.h
+++ b/src/core/PWScore.h
@@ -11,7 +11,7 @@
 // PWScore.h
 //-----------------------------------------------------------------------------
 
-#include "os/pws_tchar.h"
+#include "../os/pws_tchar.h"
 #include "StringX.h"
 #include "PWSfile.h"
 #include "PWSFilters.h"

--- a/src/core/PWSdirs.h
+++ b/src/core/PWSdirs.h
@@ -15,7 +15,7 @@
 // PWS_PREFSDIR if defined.
 //
 //-----------------------------------------------------------------------------
-#include "os/typedefs.h"
+#include "../os/typedefs.h"
 #include <stack>
 
 class PWSdirs

--- a/src/core/PWSfileHeader.h
+++ b/src/core/PWSfileHeader.h
@@ -15,7 +15,7 @@
 //-----------------------------------------------------------------------------
 
 #include <vector>
-#include "os/UUID.h"
+#include "../os/UUID.h"
 #include "StringX.h"
 #include "coredefs.h"
 

--- a/src/core/PWSprefs.h
+++ b/src/core/PWSprefs.h
@@ -31,7 +31,7 @@
 
 #include "StringX.h"
 #include "Proxy.h"
-#include "os/typedefs.h"
+#include "../os/typedefs.h"
 
 #include <vector>
 

--- a/src/core/PolicyManager.h
+++ b/src/core/PolicyManager.h
@@ -1,8 +1,8 @@
 #ifndef _POLICYMANAGER_H_
 #define _POLICYMANAGER_H_
 
-#include "core/Command.h"
-#include "core/CommandInterface.h"
+#include "Command.h"
+#include "CommandInterface.h"
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // The Policy Manager

--- a/src/core/RUEList.h
+++ b/src/core/RUEList.h
@@ -17,7 +17,7 @@
 #include <vector>
 #include "ItemData.h"
 #include "StringX.h"
-#include "os/UUID.h"
+#include "../os/UUID.h"
 #include "coredefs.h"
 //-----------------------------------------------------------------------------
 class PWScore;

--- a/src/core/Report.h
+++ b/src/core/Report.h
@@ -11,7 +11,7 @@
 
 // Create an action report file
 
-#include "os/typedefs.h"
+#include "../os/typedefs.h"
 #include "StringXStream.h"
 #include <map>
 

--- a/src/core/StringX.h
+++ b/src/core/StringX.h
@@ -25,7 +25,7 @@
 #include <cstdlib> // for malloc
 #include <cstring> // for memset
 
-#include "os/typedefs.h"
+#include "../os/typedefs.h"
 #include "PwsPlatform.h"
 
 // Using extern definition here instead of including "Util.h" because Util.h

--- a/src/core/SysInfo.h
+++ b/src/core/SysInfo.h
@@ -19,7 +19,7 @@
 // The "effective" is initially set to be == the real value, but
 // may be overridden by the relevant SetEffective*() member function.
 //-----------------------------------------------------------------
-#include "os/typedefs.h"
+#include "../os/typedefs.h"
 
 class SysInfo
 {

--- a/src/core/Util.h
+++ b/src/core/Util.h
@@ -17,9 +17,9 @@
 #include "crypto/Fish.h"
 #include "PwsPlatform.h"
 
-#include "os/debug.h"
-#include "os/typedefs.h"
-#include "os/mem.h"
+#include "../os/debug.h"
+#include "../os/typedefs.h"
+#include "../os/mem.h"
 
 #include <sstream>
 #include <stdarg.h>

--- a/src/core/VerifyFormat.h
+++ b/src/core/VerifyFormat.h
@@ -14,7 +14,7 @@
 
 #include "StringX.h"
 #include "PwsPlatform.h"
-#include "os/typedefs.h"
+#include "../os/typedefs.h"
 
 // Verify PWHistory String return codes
 enum {PWH_OK = 0, PWH_IGNORE, PWH_INVALID_HDR, PWH_INVALID_STATUS,

--- a/src/core/XMLprefs.h
+++ b/src/core/XMLprefs.h
@@ -8,7 +8,7 @@
 #ifndef __XMLPREFS_H
 #define __XMLPREFS_H
 
-#include "os/typedefs.h"
+#include "../os/typedefs.h"
 #include "PWSprefs.h"
 
 #include "pugixml/pugixml.hpp"

--- a/src/core/coredefs.h
+++ b/src/core/coredefs.h
@@ -13,7 +13,7 @@
 #include <set>
 #include <list>
 
-#include "os/UUID.h"
+#include "../os/UUID.h"
 #include "ItemData.h"
 #include "ItemAtt.h"
 

--- a/src/core/crypto/AES.h
+++ b/src/core/crypto/AES.h
@@ -13,7 +13,7 @@
 #define __AES_H
 
 #include "Fish.h"
-#include "os/typedefs.h"
+#include "../../os/typedefs.h"
 
 struct rijndael_key {
    ulong32 eK[60], dK[60];

--- a/src/core/crypto/BlowFish.h
+++ b/src/core/crypto/BlowFish.h
@@ -11,7 +11,7 @@
 #define __BLOWFISH_H
 
 #include "Fish.h"
-#include "os/typedefs.h"
+#include "../../os/typedefs.h"
 
 class BlowFish : public Fish
 {

--- a/src/core/crypto/TwoFish.h
+++ b/src/core/crypto/TwoFish.h
@@ -13,7 +13,7 @@
 #define __TWOFISH_H
 
 #include "Fish.h"
-#include "os/typedefs.h"
+#include "../../os/typedefs.h"
 
 #ifndef TWOFISH_SMALL
 struct twofish_key {

--- a/src/core/crypto/sha1.h
+++ b/src/core/crypto/sha1.h
@@ -7,7 +7,7 @@
 */
 #ifndef __SHA1_H
 #define __SHA1_H
-#include "os/typedefs.h"
+#include "../../os/typedefs.h"
 
 class SHA1
 {

--- a/src/core/crypto/sha256.h
+++ b/src/core/crypto/sha256.h
@@ -12,7 +12,7 @@
 #ifndef __SHA256_H
 #define __SHA256_H
 
-#include "os/typedefs.h"
+#include "../../os/typedefs.h"
 #include "../PwsPlatform.h"
 
 class SHA256


### PR DESCRIPTION
This PR fixes the relative paths in the include statements in the header files in core and crypto.

The changes were made easily with these commands (on Mac, sed has slightly different arguments as on Linux):
```
cd core
sed -E -i "" -e 's/include +"os\//include "..\/os\//g' *.h
sed -E -i "" -e 's/include +"core\//include "/g' *.h
cd crypto
sed -E -i "" -e 's/include +"os\//include "..\/..\/os\//g' *.h
```

I understand why the includes worked with the incorrect paths (-I. -I.. -I../..) but that trick does not work for my attempt to package this in a SPM package, which does not offer tricks like this.
And I think it is cleaner to use the correct paths anyway.

This also makes the includes more consistent as e.g. crypto/Fish.h already used
```
#include "../../os/mem.h"
```