### PR TITLE
[GH1408] Update time fields correctly in sync operations

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,6 +4,13 @@ https://pwsafe.org/. Details about changes to older releases may be found in the
 
 In the following, SFxxxx refers to Bug Reports, Feature Requests and Service Requests in PasswordSafe SourceForge Project tickets, and GHxxxx refers to issues in the PasswordSafe GitHub project.
 
+PasswordSafe 3.67.1pre Release ???
+==================================
+
+Bugs Fixed in 3.67.1pre
+-----------------------
+* [GH1408](https://github.com/pwsafe/pwsafe/issues/1408) Time fields (such as password modification time) are now copied over correctly in sync operations between databases.
+
 PasswordSafe 3.67.0 Release Oct 20 2024
 =======================================
 

--- a/src/core/Item.cpp
+++ b/src/core/Item.cpp
@@ -227,6 +227,7 @@ bool CItem::SetTextField(int ft, const unsigned char *value,
 
 void CItem::SetTime(const int whichtime, time_t t)
 {
+  ASSERT(IsTimeField(whichtime));
   unsigned char buf[sizeof(time_t)];
   putInt(buf, t);
   SetField(whichtime, buf, sizeof(time_t));
@@ -300,6 +301,7 @@ StringX CItem::GetField(const CItemField &field) const
 
 void CItem::GetTime(int whichtime, time_t &t) const
 {
+  ASSERT(IsTimeField(whichtime));
   auto fiter = m_fields.find(whichtime);
   if (fiter != m_fields.end()) {
     unsigned char in[TwoFish::BLOCKSIZE] = {0}; // required by GetField

--- a/src/core/Item.h
+++ b/src/core/Item.h
@@ -124,6 +124,13 @@ public:
     LAST_FIELD
   };
 
+  static bool IsTimeField(int ft)
+  {
+    return ft == CTIME || ft == PMTIME || ft == ATIME || ft == XTIME || ft == RMTIME ||
+      ft == TOTPSTARTTIME ||
+      ft == ATTCTIME || ft == FILECTIME || ft == FILEMTIME || ft == FILEATIME;
+  }
+
   // Status returns from "ProcessInputRecordField"
   enum {SUCCESS = 0, FAILURE, END_OF_FILE = 8};
 
@@ -151,6 +158,14 @@ public:
   virtual void Clear();
   void ClearField(int ft) {m_fields.erase(ft);}
 
+  void CopyTime(int ft, const CItem & src)
+  {
+    ASSERT(IsTimeField(ft));
+    time_t t;
+    src.GetTime(ft, t);
+    SetTime(ft, t);
+  }
+
   bool operator==(const CItem &that) const;
 
   size_t GetSize() const;
@@ -166,7 +181,7 @@ public:
     }
   }
   void push(std::vector<char> &v, char type, const StringX &str) const;
-    
+
 protected:
   typedef std::map<int, CItemField> FieldMap;
   typedef FieldMap::const_iterator FieldConstIter;

--- a/src/core/PWScore.h
+++ b/src/core/PWScore.h
@@ -191,6 +191,11 @@ public:
                    const int &subgroup_object, const int &subgroup_function,
                    int &numUpdated, CReport *pRpt, bool *pbCancel = nullptr);
 
+  // helper function to Sync a single item, returns true if dstItem was updated.
+  // Adds ProcessPolicyName command to multiCommand if a password policy was updated.
+  bool SyncItem(const CItemData& srcItem, CItemData& dstItem,
+                const CItemData::FieldBits& bsFields, MultiCommands &mcmd, PWScore *potherCore);
+
   // Used for Empty Groups during Merge
   bool MatchGroupName(const StringX &stValue, const StringX &subgroup_name,
                       const int &iFunction) const;

--- a/src/ui/Windows/MainFile.cpp
+++ b/src/ui/Windows/MainFile.cpp
@@ -3778,10 +3778,16 @@ LRESULT DboxMain::SynchCompareResult(PWScore *pfromcore, PWScore *ptocore,
              sxSync_DateTime, IDSC_SYNCPOLICY);
         if (pPolicyCmd != NULL)
           pmulticmds->Add(pPolicyCmd);
+      } else if (i == 8) { // XXX hack test theory
+        time_t t;
+        updtEntry.SetPMTime(pfromEntry->GetPMTime(t));
       } else {
         if (sxValue != updtEntry.GetFieldValue((CItemData::FieldType)i)) {
           bUpdated = true;
-          updtEntry.SetFieldValue((CItemData::FieldType)i, sxValue);
+          if (!CItem::IsTimeField(i))
+            updtEntry.SetFieldValue((CItemData::FieldType)i, sxValue);
+          else
+            updtEntry.CopyTime(i, *pfromEntry); // avoid hassle of parsing locale-time representations
         }
       }
     }

--- a/src/ui/Windows/MainFile.cpp
+++ b/src/ui/Windows/MainFile.cpp
@@ -3761,11 +3761,13 @@ LRESULT DboxMain::SynchCompareResult(PWScore *pfromcore, PWScore *ptocore,
 
   bool bUpdated(false);
   for (size_t i = 0; i < m_SaveAdvValues[CAdvancedDlg::COMPARESYNCH].bsFields.size(); i++) {
+    const CItem::FieldType ft = static_cast<CItem::FieldType>(i);
+
     if (m_SaveAdvValues[CAdvancedDlg::COMPARESYNCH].bsFields.test(i)) {
-      const StringX sxValue = pfromEntry->GetFieldValue((CItemData::FieldType)i);
+      const StringX sxValue = pfromEntry->GetFieldValue(ft);
 
       // Special processing for password policies (default & named)
-      if ((CItemData::FieldType)i == CItemData::POLICYNAME) {
+      if (ft == CItemData::POLICYNAME) {
         // Don't really need the map and vector as only sync'ing 1 entry
         std::map<StringX, StringX> mapRenamedPolicies;
         std::vector<StringX> vs_PoliciesAdded;
@@ -3778,16 +3780,13 @@ LRESULT DboxMain::SynchCompareResult(PWScore *pfromcore, PWScore *ptocore,
              sxSync_DateTime, IDSC_SYNCPOLICY);
         if (pPolicyCmd != NULL)
           pmulticmds->Add(pPolicyCmd);
-      } else if (i == 8) { // XXX hack test theory
-        time_t t;
-        updtEntry.SetPMTime(pfromEntry->GetPMTime(t));
       } else {
-        if (sxValue != updtEntry.GetFieldValue((CItemData::FieldType)i)) {
+        if (sxValue != updtEntry.GetFieldValue(ft)) {
           bUpdated = true;
-          if (!CItem::IsTimeField(i))
-            updtEntry.SetFieldValue((CItemData::FieldType)i, sxValue);
+          if (!CItem::IsTimeField(ft))
+            updtEntry.SetFieldValue(ft, sxValue);
           else
-            updtEntry.CopyTime(i, *pfromEntry); // avoid hassle of parsing locale-time representations
+            updtEntry.CopyTime(ft, *pfromEntry); // avoid hassle of parsing locale-time representations
         }
       }
     }

--- a/src/ui/Windows/MainFile.cpp
+++ b/src/ui/Windows/MainFile.cpp
@@ -3759,38 +3759,9 @@ LRESULT DboxMain::SynchCompareResult(PWScore *pfromcore, PWScore *ptocore,
 
   MultiCommands *pmulticmds = MultiCommands::Create(ptocore);
 
-  bool bUpdated(false);
-  for (size_t i = 0; i < m_SaveAdvValues[CAdvancedDlg::COMPARESYNCH].bsFields.size(); i++) {
-    const CItem::FieldType ft = static_cast<CItem::FieldType>(i);
-
-    if (m_SaveAdvValues[CAdvancedDlg::COMPARESYNCH].bsFields.test(i)) {
-      const StringX sxValue = pfromEntry->GetFieldValue(ft);
-
-      // Special processing for password policies (default & named)
-      if (ft == CItemData::POLICYNAME) {
-        // Don't really need the map and vector as only sync'ing 1 entry
-        std::map<StringX, StringX> mapRenamedPolicies;
-        std::vector<StringX> vs_PoliciesAdded;
-
-        const StringX sxSync_DateTime = PWSUtil::GetTimeStamp(true).c_str();
-        StringX sxPolicyName = pfromEntry->GetPolicyName();
-
-        Command *pPolicyCmd = ptocore->ProcessPolicyName(pfromcore, updtEntry,
-             mapRenamedPolicies, vs_PoliciesAdded, sxPolicyName, bUpdated,
-             sxSync_DateTime, IDSC_SYNCPOLICY);
-        if (pPolicyCmd != NULL)
-          pmulticmds->Add(pPolicyCmd);
-      } else {
-        if (sxValue != updtEntry.GetFieldValue(ft)) {
-          bUpdated = true;
-          if (!CItem::IsTimeField(ft))
-            updtEntry.SetFieldValue(ft, sxValue);
-          else
-            updtEntry.CopyTime(ft, *pfromEntry); // avoid hassle of parsing locale-time representations
-        }
-      }
-    }
-  }
+   bool bUpdated = ptocore->SyncItem(*pfromEntry, updtEntry,
+                                     m_SaveAdvValues[CAdvancedDlg::COMPARESYNCH].bsFields,
+                                     *pmulticmds, pfromcore);
 
   if (bUpdated) {
     updtEntry.SetStatus(CItemData::ES_MODIFIED);

--- a/version.mfc
+++ b/version.mfc
@@ -5,8 +5,8 @@
 
 VER_MAJOR = 3
 VER_MINOR = 67
-VER_REV = 0
-#VER_SPECIAL = pre
+VER_REV = 1
+VER_SPECIAL = pre
 
 # Following values for "helper" dlls used by MFC build:
 # 'AT' for pws_at.dll (AutoType helper), 'OSK' for pws_osk.dll (Virtual Keyboard data)


### PR DESCRIPTION
Fix for #1408 is currently Windows-only. Needs to be applied to wx as well.