### PR TITLE
Attachment support in V3

### DIFF
--- a/docs/formatV3.txt
+++ b/docs/formatV3.txt
@@ -204,6 +204,7 @@ PasswordSafe V3.29 introduced Format 0x030B
 PasswordSafe V3.29Y introduced Format 0x030C
 PasswordSafe V3.30 introduced Format 0x030D
 PasswordSafe V3.47 introduced Format 0x030E
+PasswordSafe V3.68 introduced Format 0x030F
 
 [2] A universally unique identifier is needed in order to synchronize
 databases across different machine. Representation is described in
@@ -543,6 +544,7 @@ Note: A 'base' entry can not have both aliases and shortcuts.
 
 [22] The UUID of an attachment record associated with an entry.
 Different entries can refer to the same attachment uuid.
+This was introduced in version 0x030F (PasswordSafe V3.68).
 
 [23] This is the shared secret for sites using Time-Based One-Time
 Password Algorithm (per RFC6238) such as Google Authenticator. At

--- a/docs/formatV3.txt
+++ b/docs/formatV3.txt
@@ -362,7 +362,7 @@ Own symbols for password    0x16        Text          Y              [18]
 Shift Double-Click Action   0x17        2 bytes       Y              [15]
 Password Policy Name        0x18        Text          Y              [19]
 Entry keyboard shortcut     0x19        4 bytes       Y              [20]
-*RESERVED*                  0x1a        UUID          -              [22]
+AttRef                      0x1a        UUID          Y              [22]
 Two-Factor Key              0x1b        Binary        N              [23]
 Credit Card Number          0x1c        Text          N              [24]
 Credit Card Expiration      0x1d        Text          N              [24]
@@ -541,8 +541,8 @@ This was introduced in version 0x030D (PasswordSafe V3.30).
   e. Shortcut entry (as described in note [4])
 Note: A 'base' entry can not have both aliases and shortcuts.
 
-[22] This value is used in V4 of the PasswordSafe format. Reserving it here to
-maintain consistency with values that follow.
+[22] The UUID of an attachment record associated with an entry.
+Different entries can refer to the same attachment uuid.
 
 [23] This is the shared secret for sites using Time-Based One-Time
 Password Algorithm (per RFC6238) such as Google Authenticator. At
@@ -590,6 +590,88 @@ These TOTP parameters fields have the following format:
                       start counting time steps. If not specified, the
                       default is 0. The format is that of a 40 bit (5 byte)
                       Password Safe time_t value as specified in Section 3.1.3.
+
+3.4 Attachments
+
+3.4.1 Attachment record fields
+
+An Attachment record has the following fields:
+
+Name                        Value        Type     Mandatory       Comments
+--------------------------------------------------------------------------
+AttUUID                     0x60        UUID          Y              [1]
+Title                       0x61        Text          N              [2]
+Creation Time               0x62        time_t        Y              [3]
+MediaType                   0x63        Text          Y              [4]
+FileName                    0x64        Text          N              [5]
+FilePath                    0x65        Text          N              [6]
+FileCreationTime            0x66        time_t        N              [7]
+FileModificationTime        0x67        time_t        N              [7]
+FileAccessTime              0x68        time_t        N              [7]
+AttEK                       0x70        32 bytes      Y              [8]
+AttAK                       0x71        32 bytes      Y              [9]
+ATTIV                       0x71        binary        Y              [10]
+Content                     0x73        4 byte+binary Y              [11]
+ContentHMAC                 0x74        32 bytes      Y              [12]
+End of Entry                0xff        [empty]       Y              
+
+[1] This is the UUID of the attachment record, which is referred to by
+password entries' AttRef field. Representation is described in Section
+3.1.1. This is the first field in the record, and identifies it as an
+attachment record.
+[2] The title is a user-friendly name for the attachment.
+[3] The time when the attachment was added. Representation is as
+described in Section 3.1.3.
+[4] MIME type - text string describing Media Type, per
+http://www.iana.org/assignments/media-types
+[5] Original file name - kept mainly for the extension, to support
+applications that require this for proper viewing.
+[6] Path component of file. May be relative or absolute (or absent).
+[7] Times associated with the attachment file at the time of attachment.
+Application may try to restore these when exporting the attachment.
+Representation is as described in Section 3.1.3.
+[8] Attachment encryption key: This is a 256 bit random key encrypting the
+content.
+[9] Attachment authentication key: This is a 256 bit random key used to
+verify the integrity of the content.
+[10] The initialization vector (IV) used in the CBC encryption of the
+attachment. Size is the blocksize of the underlying block cipher.
+[11] The binary representation of the attachment. Note that this is limited
+to 4GB (2^32 bytes), which should suffice.
+The first block of this field is encrypted under the database's
+encryption key. This is so the field's type and length can be determined
+without relying on the implicit order of the fields. The length of
+this field is 4, and its contents is 4 byte little-endian value of the
+length of the actual content, padded as usual with random data. The
+actual content is in the following blocks, that are encrypted under
+the AttEK in CBC mode with the value of ATTIV as the IV, using the
+same algorithm as the rest of the database. Padding of content is done
+with random data, as needed.
+[12] The content HMAC is calculated over the same plaintext data that
+is protected using the AttEK, including padding. HMAC calculation uses
+AttAK and SHA256.
+This field is encrypted with K (see 2.2.5). The first block of the
+Content field is used as the IV, so as to continue the database CBC
+stream. This field must immediately follow the Content field.
+
+3.4.2 Changes to database HMAC calculation
+
+3.4.2.1 The HMAC of the database file will not be calculated over the data
+that is covered by content field HMAC. This enables saving databases
+without the need to recalculate the HMAC of contents.
+
+3.4.2.2 The database HMAC will cover the attachment records' other fields,
+specifically the content HMAC key and the HMAC calculated under that key.
+The database HMAC will also cover the first block of the attachment content
+fields, as these are not covered by content HMAC.
+
+3.4.3 Implementation note
+
+When reading the database, it is assumed that the offsets of the attachment
+records will be noted for rapid access to the attachments when
+required. Care must be taken to ensure that the database was not modified
+between when the offsets were recorded and when they are actually
+required.
 
 4. Extensibility
 

--- a/docs/formatV3.txt
+++ b/docs/formatV3.txt
@@ -542,8 +542,10 @@ This was introduced in version 0x030D (PasswordSafe V3.30).
   e. Shortcut entry (as described in note [4])
 Note: A 'base' entry can not have both aliases and shortcuts.
 
-[22] The UUID of an attachment record associated with an entry.
-Different entries can refer to the same attachment uuid.
+[22] The UUID of an attachment record associated with an entry.  An
+entry record can have zero or more such fields. Each attachment field
+in a given password entry record must have a different value, but
+different entries can refer to the same attachment uuid.
 This was introduced in version 0x030F (PasswordSafe V3.68).
 
 [23] This is the shared secret for sites using Time-Based One-Time

--- a/src/core/ItemAtt.cpp
+++ b/src/core/ItemAtt.cpp
@@ -383,9 +383,7 @@ int CItemAtt::Read(PWSfile *in)
         trashMemory(EK, sizeof(EK));
         const unsigned int BS = fish.GetBlockSize();
 
-        auto *in4 = dynamic_cast<PWSfileV4 *>(in);
-        ASSERT(in4 != nullptr);
-        size_t nread = in4->ReadContent(&fish, IV, content, content_len);
+        size_t nread = in->ReadContent(&fish, IV, content, content_len);
         // nread should be content_len rounded up to nearest BS:
         ASSERT(nread == (content_len/BS + 1)*BS);
         if (nread != (content_len/BS + 1)*BS) {
@@ -516,13 +514,10 @@ int CItemAtt::Write(PWSfile *out) const
   auto fiter = m_fields.find(CONTENT);
   // XXX TBD - fail if no content, as this is a mandatory field
   if (fiter != m_fields.end()) {
-    auto *out4 = dynamic_cast<PWSfileV4 *>(out);
-    ASSERT(out4 != nullptr);
-
     size_t clength = fiter->second.GetLength() + BlowFish::BLOCKSIZE;
     auto *content = new unsigned char[clength];
     CItem::GetField(fiter->second, content, clength);
-    out4->WriteContentFields(content, clength);
+    out->WriteContentFields(content, clength);
     trashMemory(content, clength);
     delete[] content;
   }

--- a/src/core/ItemData.cpp
+++ b/src/core/ItemData.cpp
@@ -374,6 +374,12 @@ int CItemData::Write(PWSfile *out) const
   const StringX saved_password = GetPassword();
   self->SetSpecialPasswords(); // encode baseuuid in password if IsDependent
 
+  if (IsFieldSet(ATTREF)) {
+    uuid_array_t ref_uuid;
+    GetUUID(ref_uuid, ATTREF);
+    out->WriteField(ATTREF, ref_uuid, sizeof(uuid_array_t));
+  }
+
   int status = WriteCommon(out);
 
   self->SetPassword(saved_password);

--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -669,8 +669,8 @@ int PWScore::WriteFile(const StringX &filename, PWSfile::VERSION version,
     RecordWriter write_record(out, this, version);
     for_each(m_pwlist.begin(), m_pwlist.end(), write_record);
 
-    // Write attachments (only from V4)
-    if (version >= PWSfile::V40)
+    // Write attachments (only from V3)
+    if (version >= PWSfile::V30)
       for_each(m_attlist.begin(), m_attlist.end(),
                [&](std::pair<CUUID const, CItemAtt> &p)
                {

--- a/src/core/PWSfile.h
+++ b/src/core/PWSfile.h
@@ -117,6 +117,17 @@ public:
   virtual int WriteRecord(const CItemData &item) = 0;
   virtual int ReadRecord(CItemData &item) = 0;
 
+  virtual int WriteRecord(const CItemAtt &att) = 0;
+  virtual int ReadRecord(CItemAtt &att) = 0;
+
+  // Following writes AttIV, AttEK, AttAK, AttContent
+  // and AttContentHMAC per format spec.
+  // All except the content are generated internally.
+  virtual size_t WriteContentFields(unsigned char *content, size_t len) = 0;
+  // Following allocates content, caller responsible for deallocating
+  virtual size_t ReadContent(Fish *fish, unsigned char *cbcbuffer,
+                       unsigned char *&content, size_t clen) = 0;
+
   const PWSfileHeader &GetHeader() const {return m_hdr;}
   void SetHeader(const PWSfileHeader &h) {m_hdr = h;}
 

--- a/src/core/PWSfileV1V2.cpp
+++ b/src/core/PWSfileV1V2.cpp
@@ -331,6 +331,25 @@ int PWSfileV1V2::WriteRecord(const CItemData &item)
   return status;
 }
 
+int PWSfileV1V2::WriteRecord(const CItemAtt &att)
+{
+  ASSERT(0);
+  return UNSUPPORTED_VERSION;
+}
+
+size_t PWSfileV1V2::WriteContentFields(unsigned char *content, size_t len)
+{
+  ASSERT(0);
+  return 0;
+}
+
+size_t PWSfileV1V2::ReadContent(Fish *fish,  unsigned char *cbcbuffer,
+                              unsigned char *&content, size_t clen)
+{
+  ASSERT(0);
+  return 0;
+}
+
 static void ExtractAutoTypeCmd(StringX &notesStr, StringX &autotypeStr)
 {
   StringX instr(notesStr);
@@ -502,4 +521,10 @@ int PWSfileV1V2::ReadRecord(CItemData &item)
       ASSERT(0);
       return UNSUPPORTED_VERSION;
   }
+}
+
+int PWSfileV1V2::ReadRecord(CItemAtt &att)
+{
+  ASSERT(0);
+  return UNSUPPORTED_VERSION;
 }

--- a/src/core/PWSfileV1V2.h
+++ b/src/core/PWSfileV1V2.h
@@ -35,6 +35,13 @@ public:
   virtual int WriteRecord(const CItemData &item);
   virtual int ReadRecord(CItemData &item);
 
+  virtual int WriteRecord(const CItemAtt &att);
+  virtual int ReadRecord(CItemAtt &att);
+
+  virtual size_t WriteContentFields(unsigned char *content, size_t len);
+  virtual size_t ReadContent(Fish *fish, unsigned char *cbcbuffer,
+                       unsigned char *&content, size_t clen);
+
 protected:
   virtual size_t WriteCBC(unsigned char type, const StringX &data);
 

--- a/src/core/PWSfileV3.cpp
+++ b/src/core/PWSfileV3.cpp
@@ -54,9 +54,10 @@ using pws_os::CUUID;
  *         V3.29Y          0x030C
  *         V3.30           0x030D
  *         V3.47           0x030E
+ *         V3.68           0x030F
 */
 
-const short VersionNum = 0x030E;
+const short VersionNum = 0x030F;
 
 static unsigned char TERMINAL_BLOCK[TwoFish::BLOCKSIZE] = {
   'P', 'W', 'S', '3', '-', 'E', 'O', 'F',

--- a/src/core/PWSfileV3.h
+++ b/src/core/PWSfileV3.h
@@ -64,6 +64,15 @@ public:
   int WriteHeader();
   int ReadHeader();
 
+  // Following to allow rollback when reverting an ItemAtt read
+  // as an ItemData
+  long m_savepos;
+  unsigned char m_saveIV[TwoFish::BLOCKSIZE];
+  HMAC<SHA256, SHA256::HASHLEN, SHA256::BLOCKSIZE> m_savehmac;
+
+  void SaveState();
+  void RestoreState();
+
   static int SanityCheck(FILE *stream); // Check for TAG and EOF marker
   static void StretchKey(const unsigned char *salt, unsigned long saltLen,
                          const StringX &passkey,

--- a/src/core/PWSfileV3.h
+++ b/src/core/PWSfileV3.h
@@ -21,6 +21,7 @@
 class PWSfileV3 : public PWSfile
 {
 public:
+  enum {KLEN = 32};
 
   static int CheckPasskey(const StringX &filename,
                           const StringX &passkey,
@@ -36,6 +37,13 @@ public:
 
   virtual int WriteRecord(const CItemData &item);
   virtual int ReadRecord(CItemData &item);
+
+  virtual int WriteRecord(const CItemAtt &att);
+  virtual int ReadRecord(CItemAtt &att);
+
+  virtual size_t WriteContentFields(unsigned char *content, size_t len);
+  virtual size_t ReadContent(Fish *fish, unsigned char *cbcbuffer,
+                       unsigned char *&content, size_t clen);
 
   virtual uint32 GetNHashIters() const {return m_nHashIters;}
   virtual void SetNHashIters(uint32 N) {m_nHashIters = N;}

--- a/src/core/PWSfileV4.h
+++ b/src/core/PWSfileV4.h
@@ -41,15 +41,11 @@ public:
   virtual int WriteRecord(const CItemData &item);
   virtual int ReadRecord(CItemData &item);
 
-  int WriteRecord(const CItemAtt &att);
-  int ReadRecord(CItemAtt &att);
+  virtual int WriteRecord(const CItemAtt &att);
+  virtual int ReadRecord(CItemAtt &att);
 
-  // Following writes AttIV, AttEK, AttAK, AttContent
-  // and AttContentHMAC per format spec.
-  // All except the content are generated internally.
-  size_t WriteContentFields(unsigned char *content, size_t len);
-  // Following allocates content, caller responsible for deallocating
-  size_t ReadContent(Fish *fish, unsigned char *cbcbuffer,
+  virtual size_t WriteContentFields(unsigned char *content, size_t len);
+  virtual size_t ReadContent(Fish *fish, unsigned char *cbcbuffer,
                      unsigned char *&content, size_t clen);
 
   uint32 GetNHashIters() const {return m_nHashIters;}


### PR DESCRIPTION
Here is a draft PR to accommodate attachments in V3.

- Unit tests copied from V4 to V3 (with minimal changes applied)

- I've moved some of the V4 method prototypes (related to attachments) up from PWSfileV4.h to PWSfile.h to make them available to V3 (and future versions). I kept the implementation where it was (forking V4 to V3) to allow version specific changes in the future. This also allowed cleaning up some of the V4 specific hacks that were present in CItemData. In V1V2 I've added minimal code to always fail as this does not apply there. An alternative would be to introduce another PWSfileWithAttachment layer and move V3 and V4 there, but that introduces more complexity than it's worth.

- There is some SaveState() / RestoreState() wizard stuff in V4 ReadRecord. I've copied that to V3, though it might be better to move that to PWScore. That is, leaving the save/restore code in the file code, but moving the logic when to call it to PWScore::ReadFile. What do you think?

- Documentation updated (mostly copied from V4).

    For the AttRef field there are two representations, the on-disk on (which can differ per database version) and the in-memory one (stored in CItem::m_fields, which must be database version independent, and needs special attention when storing multi-valued fields).

    So we can just mimic the V4 behavior and store multiple AttRef fields per entry. The core lib just needs to be extended to store/retrieve these correctly in one m_fields element to support more than 1 attachment per entry. Which is best done in a separate PR as that will also improve V4.