### PR TITLE
Added setters for CItemAtt filename/filepath/mediatype

### DIFF
--- a/src/core/ItemAtt.cpp
+++ b/src/core/ItemAtt.cpp
@@ -71,6 +71,21 @@ void CItemAtt::SetTitle(const StringX &title)
   CItem::SetField(ATTTITLE, title);
 }
 
+void CItemAtt::SetFileName(const StringX &fileName)
+{
+  CItem::SetField(FILENAME, fileName);
+}
+
+void CItemAtt::SetFilePath(const StringX &filePath)
+{
+  CItem::SetField(FILEPATH, filePath);
+}
+
+void CItemAtt::SetMediaType(const StringX &mediaType)
+{
+  CItem::SetField(MEDIATYPE, mediaType);
+}
+
 void CItemAtt::CreateUUID()
 {
   CUUID uuid;

--- a/src/core/ItemAtt.h
+++ b/src/core/ItemAtt.h
@@ -70,6 +70,9 @@ public:
   void SetTitle(const StringX &title);
   void SetCTime(time_t t);
   void SetContent(const unsigned char *content, size_t clen);
+  void SetFileName(const StringX &fileName);
+  void SetFilePath(const StringX &filePath);
+  void SetMediaType(const StringX &mediaType);
 
   StringX GetTitle() const {return GetField(ATTTITLE);}
   void GetUUID(uuid_array_t &) const;


### PR DESCRIPTION
This allows setting the properties when the attachment is not imported. The filepath is probably less relevant in this context, just added for completeness sake.