### PR TITLE
V4 rounding issue for files with size multiple of 16 bytes

### DIFF
--- a/src/core/ItemAtt.cpp
+++ b/src/core/ItemAtt.cpp
@@ -402,8 +402,8 @@ int CItemAtt::Read(PWSfile *in)
         ASSERT(in4 != nullptr);
         size_t nread = in4->ReadContent(&fish, IV, content, content_len);
         // nread should be content_len rounded up to nearest BS:
-        ASSERT(nread == (content_len/BS + 1)*BS);
-        if (nread != (content_len/BS + 1)*BS) {
+        ASSERT(nread == roundUp(content_len, BS));
+        if (nread != roundUp(content_len, BS)) {
           status = PWSfile::READ_FAIL;
           goto exit;
         }

--- a/src/core/PWSfileV4.cpp
+++ b/src/core/PWSfileV4.cpp
@@ -324,7 +324,7 @@ size_t PWSfileV4::ReadContent(Fish *fish,  unsigned char *cbcbuffer,
   ASSERT(clen > 0 && fish != nullptr && cbcbuffer != nullptr);
   // round up clen to nearest BS:
   const unsigned int BS = fish->GetBlockSize();
-  size_t blen = (clen/BS + 1)*BS;
+  size_t blen = roundUp(clen, BS);
 
   content = new unsigned char[blen]; // caller's responsible for delete[]
   return _readcbc(m_fd, content, blen, fish, cbcbuffer);

--- a/src/core/Util.h
+++ b/src/core/Util.h
@@ -265,6 +265,10 @@ inline void byteswap(T& v) {
   byteswap(a, a + sizeof(v) - 1);
 }
 
+inline size_t roundUp(size_t x, const size_t m) {
+    return ((x + m - 1) / m) * m;
+}
+
 namespace PWSUtil {
 
   // namespace of common utility functions


### PR DESCRIPTION
![test](https://github.com/user-attachments/assets/8dd4ab72-1b50-47ac-bf2d-b2a17fc423d1)

To reproduce, simply add the above file as attachment to a V4 database, close the database and notice that you cannot open it anymore.

This PR fixes the issue by:

- adding another unit test to check this specific case
- adding new inline roundUp inline function to Util.h. Nothing spectacular, but apparently complicated enough to mixup.
    Could be deployed in a few other places too (PWScore.cpp and Util.cpp), not done in this PR to keep focus.
- using this function to fix the calculations in src/core/ItemAtt.cpp and src/core/PWSfileV4.cpp

Without this PR, there is a 1:16 chance of not being able to reopen a database after adding an attachment. The database is written correctly, so no risk of a corrupted database, but still not openable without this PR applied.