### PR TITLE
Improve naming of IsDbOpen

### DIFF
--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -174,7 +174,6 @@ PWScore::PWScore() :
                      m_ReadFileVersion(PWSfile::UNKNOWN_VERSION),
                      m_bIsReadOnly(false),
                      m_bNotifyDB(false),
-                     m_bIsOpen(false),
                      m_nRecordsWithUnknownFields(0),
                      m_DBCurrentState(CLEAN),
                      m_pFileSig(nullptr),
@@ -555,9 +554,6 @@ void PWScore::ClearDBData()
 
   // Clear any unknown preferences from previous databases
   PWSprefs::GetInstance()->ClearUnknownPrefs();
-
-  // OK now closed
-  m_bIsOpen = false;
 }
 
 void PWScore::ReInit(bool bNewFile)
@@ -1428,9 +1424,6 @@ int PWScore::ReadFile(const StringX &a_filename, const StringX &a_passkey,
   // Make return code negative if validation errors
   if (closeStatus == SUCCESS && bValidateRC)
     closeStatus = OK_WITH_VALIDATION_ERRORS;
-
-  // OK DB open
-  m_bIsOpen = true;
 
   return closeStatus;
 }

--- a/src/core/PWScore.h
+++ b/src/core/PWScore.h
@@ -127,7 +127,7 @@ public:
   void ReInit(bool bNewfile = false);
 
   // Following used to read/write databases and Get/Set file name
-  bool IsDbOpen() const { return !m_currfile.empty(); }
+  bool IsDbFileSet() const { return !m_currfile.empty(); }
   StringX GetCurFile() const {return m_currfile;}
   void SetCurFile(const StringX &file) {m_currfile = file;}
 
@@ -580,7 +580,6 @@ private:
   bool m_bIsReadOnly;
   bool m_bUniqueGTUValidated;
   bool m_bNotifyDB;
-  bool m_bIsOpen;
 
     PWSfileHeader m_hdr;
   StringX m_InitialDBName, m_InitialDBDesc;

--- a/src/ui/Windows/DboxMain.cpp
+++ b/src/ui/Windows/DboxMain.cpp
@@ -1160,7 +1160,7 @@ BOOL DboxMain::OnInitDialog()
   m_UnLockedIcon = app.LoadIcon(IDI_UNLOCKEDICON);
 
   m_ClosedIcon = app.LoadIcon(IDI_CORNERICON);
-  auto initialIcon = m_core.IsDbOpen() ? m_LockedIcon : m_ClosedIcon;
+  auto initialIcon = m_core.IsDbFileSet() ? m_LockedIcon : m_ClosedIcon;
   m_pTrayIcon = new CSystemTray(this, PWS_MSG_ICON_NOTIFY, L"PasswordSafe",
                                 initialIcon, m_RUEList,
                                 PWS_MSG_ICON_NOTIFY, IDR_POPTRAY);

--- a/src/ui/Windows/MainFile.cpp
+++ b/src/ui/Windows/MainFile.cpp
@@ -153,7 +153,7 @@ BOOL DboxMain::OpenOnInit()
       UpdateSystemTray(UNLOCKED);
       break;
     case PWScore::CANT_OPEN_FILE:
-      if (!m_core.IsDbOpen()) {
+      if (!m_core.IsDbFileSet()) {
         // Empty filename. Assume they are starting Password Safe
         // for the first time and don't confuse them.
         // fall through to New()
@@ -395,7 +395,7 @@ int DboxMain::NewFile(StringX &newfilename)
   CString cf(MAKEINTRESOURCE(IDS_DEFDBNAME)); // reasonable default for first time user
   std::wstring newFileName = PWSUtil::GetNewFileName(LPCWSTR(cf), DEFAULT_SUFFIX);
   std::wstring dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = PWSdirs::GetSafeDir();
   else {
     std::wstring cdrive, cdir, dontCare;
@@ -642,7 +642,7 @@ int DboxMain::Open(const UINT uiTitle)
   StringX sx_Filename;
   CString cs_text(MAKEINTRESOURCE(uiTitle));
   std::wstring DBpath, cdrive, cdir, dontCare;
-  if (!m_core.IsDbOpen()) {
+  if (!m_core.IsDbFileSet()) {
     // Can't use same directory as currently open DB as there isn't one.
     // Attempt to get path from last opened database from MRU
     // If valid and accessible, use it, if not valid or not accessible use
@@ -1442,7 +1442,7 @@ int DboxMain::SaveAs()
                 current_version == PWSfile::V40 ? V4_SUFFIX : V3_SUFFIX);
 
   std::wstring dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = PWSdirs::GetSafeDir();
   else {
     std::wstring cdrive, cdir, dontCare;
@@ -1458,7 +1458,7 @@ int DboxMain::SaveAs()
                         OFN_LONGNAMES | OFN_OVERWRITEPROMPT,
                         CString(MAKEINTRESOURCE(current_version == PWSfile::V40 ? IDS_FDF_V4_ALL : IDS_FDF_V3_ALL)),
                      this);
-    if (!m_core.IsDbOpen())
+    if (!m_core.IsDbFileSet())
       cs_text.LoadString(IDS_NEWNAME1);
     else
       cs_text.LoadString(IDS_NEWNAME2);
@@ -1627,7 +1627,7 @@ void DboxMain::OnExportVx(UINT nID)
   cs_text.LoadString(IDS_NAMEEXPORTFILE);
 
   std::wstring dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = PWSdirs::GetSafeDir();
   else {
     std::wstring cdrive, cdir, dontCare;
@@ -2330,7 +2330,7 @@ void DboxMain::OnImportText()
   CString cs_text;
 
   std::wstring dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = PWSdirs::GetSafeDir();
   else {
     std::wstring cdrive, cdir, dontCare;
@@ -2484,7 +2484,7 @@ void DboxMain::OnImportKeePassV1CSV()
   CString cs_title, cs_msg;
   cs_title.LoadString(IDS_PICKKEEPASSFILE);
   std::wstring dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = PWSdirs::GetSafeDir();
   else {
     std::wstring cdrive, cdir, dontCare;
@@ -2591,7 +2591,7 @@ void DboxMain::OnImportKeePassV1TXT()
   CString cs_title, cs_msg;
   cs_title.LoadString(IDS_PICKKEEPASSFILE);
   std::wstring dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = PWSdirs::GetSafeDir();
   else {
     std::wstring cdrive, cdir, dontCare;
@@ -2727,7 +2727,7 @@ void DboxMain::OnImportXML()
 
   std::wstring ImportedPrefix(dlg.m_groupName);
   std::wstring dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = PWSdirs::GetSafeDir();
   else {
     std::wstring cdrive, cdir, dontCare;
@@ -3094,7 +3094,7 @@ void DboxMain::OnChangeMode()
 
 void DboxMain::OnCompare()
 {
-  if (!m_core.IsDbOpen() || m_core.GetNumEntries() == 0) {
+  if (!m_core.IsDbFileSet() || m_core.GetNumEntries() == 0) {
     CGeneralMsgBox gmb;
     gmb.AfxMessageBox(IDS_NOCOMPAREFILE, MB_OK | MB_ICONWARNING);
     return;
@@ -3142,7 +3142,7 @@ void DboxMain::OnMerge()
 void DboxMain::OnSynchronize()
 {
   // disable in read-only mode or empty
-  if (m_core.IsReadOnly() || !m_core.IsDbOpen() || m_core.GetNumEntries() == 0)
+  if (m_core.IsReadOnly() || !m_core.IsDbFileSet() || m_core.GetNumEntries() == 0)
     return;
 
   CWZPropertySheet wizard(ID_MENUITEM_SYNCHRONIZE,
@@ -4037,7 +4037,7 @@ void DboxMain::SavePreferencesOnExit()
     // Naughty Windows saves information in the registry for every Open and Save!
     RegistryAnonymity();
   } else
-    if (m_core.IsDbOpen()) {
+    if (m_core.IsDbFileSet()) {
       std::wstring curFile = m_core.GetCurFile().c_str();
       WinUtil::RelativizePath(curFile);
       prefs->SetPref(PWSprefs::CurrentFile, curFile.c_str());

--- a/src/ui/Windows/MainFilters.cpp
+++ b/src/ui/Windows/MainFilters.cpp
@@ -335,7 +335,7 @@ void DboxMain::ExportFilters(PWSFilters &Filters)
                                                   L"filters.xml");
   cs_text.LoadString(IDS_NAMEXMLFILE);
   std::wstring dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = PWSdirs::GetSafeDir();
   else {
     std::wstring cdrive, cdir, dontCare;
@@ -396,7 +396,7 @@ void DboxMain::ImportFilters()
   }
 
   std::wstring dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = PWSdirs::GetSafeDir();
   else {
     std::wstring cdrive, cdir, dontCare;

--- a/src/ui/Windows/MainManage.cpp
+++ b/src/ui/Windows/MainManage.cpp
@@ -75,7 +75,7 @@ int DboxMain::BackupSafe()
   CString cs_temp, cs_title;
 
   std::wstring dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = PWSdirs::GetSafeDir();
   else {
     std::wstring cdrive, cdir, dontCare;
@@ -147,7 +147,7 @@ int DboxMain::RestoreSafe()
   cs_text.LoadString(IDS_PICKRESTORE);
 
   std::wstring dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = PWSdirs::GetSafeDir();
   else {
     std::wstring cdrive, cdir, dontCare;

--- a/src/ui/Windows/MainView.cpp
+++ b/src/ui/Windows/MainView.cpp
@@ -2702,7 +2702,7 @@ bool DboxMain::LockDataBase()
   PWS_LOGIT;
 
   // Bug 1149: Check DB open before doing anything
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     return true;
 
   /*
@@ -3056,7 +3056,7 @@ void DboxMain::ChangeFont(const CFontsDialog::FontType iType)
 void DboxMain::UpdateSystemTray(const DBSTATE s)
 {
   CString csTooltip(L"");
-  if (m_core.IsDbOpen()) {
+  if (m_core.IsDbFileSet()) {
     std::wstring cdrive, cdir, cFilename, cExtn;
     pws_os::splitpath(m_core.GetCurFile().c_str(), cdrive, cdir, cFilename, cExtn);
 

--- a/src/ui/Windows/ThisMfcApp.cpp
+++ b/src/ui/Windows/ThisMfcApp.cpp
@@ -1201,7 +1201,7 @@ BOOL ThisMfcApp::InitInstance()
   // PWScore needs it to get into database header if/when saved
   m_core.SetApplicationNameAndVersion(AfxGetAppName(), m_dwMajorMinor, m_dwBuildRevision);
 
-  if (!m_core.IsDbOpen()) {
+  if (!m_core.IsDbFileSet()) {
     std::wstring path = prefs->GetPref(PWSprefs::CurrentFile).c_str();
     pws_os::AddDrive(path);
     m_core.SetCurFile(path.c_str());

--- a/src/ui/wxWidgets/DnDFile.cpp
+++ b/src/ui/wxWidgets/DnDFile.cpp
@@ -45,7 +45,7 @@ bool DnDFile::OnDropFiles(wxCoord x, wxCoord y, const wxArrayString& filenames)
   
   if (m_pOwner != NULL)
   {
-    if(! m_pOwner->m_core.IsDbOpen()) {
+    if(! m_pOwner->m_core.IsDbFileSet()) {
       if(m_pOwner->Open(filenames[0]) != PWScore::SUCCESS)
         return false;
     }

--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -318,7 +318,7 @@ int PasswordSafeFrame::Save(SaveType savetype /* = SaveType::INVALID*/)
     m_tree->SaveGroupDisplayState();
   }
 
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     return SaveAs();
 
   switch (m_core.GetReadFileVersion()) {
@@ -396,7 +396,7 @@ int PasswordSafeFrame::Save(SaveType savetype /* = SaveType::INVALID*/)
 
   if (rc != PWScore::SUCCESS) { // Save failed!
     // Restore backup, if we have one
-    if (!bu_fname.empty() && m_core.IsDbOpen())
+    if (!bu_fname.empty() && m_core.IsDbFileSet())
       pws_os::RenameFile(bu_fname, m_core.GetCurFile().c_str());
     // Show user that we have a problem
     DisplayFileWriteError(rc, m_core.GetCurFile());
@@ -441,7 +441,7 @@ int PasswordSafeFrame::SaveAs()
   }
   wxString v3FileName = towxstring(PWSUtil::GetNewFileName(cf.c_str(), DEFAULT_SUFFIX));
 
-  wxString title = (!m_core.IsDbOpen()? _("Choose a name for the current (Untitled) database:") :
+  wxString title = (!m_core.IsDbFileSet()? _("Choose a name for the current (Untitled) database:") :
                                     _("Choose a new name for the current database:"));
   wxFileName filename(v3FileName);
   wxString dir = filename.GetPath();
@@ -566,7 +566,7 @@ int PasswordSafeFrame::SaveIfChanged()
   if ((m_bTSUpdated || m_core.HasDBChanged()) &&
       m_core.GetNumEntries() > 0) {
     wxString prompt(_("Do you want to save changes to the password database:"));
-    if (m_core.IsDbOpen()) {
+    if (m_core.IsDbFileSet()) {
       prompt += wxT("\n");
       prompt += m_core.GetCurFile().c_str();
     }
@@ -1312,7 +1312,7 @@ void PasswordSafeFrame::OnSynchronize(wxCommandEvent& evt)
 void PasswordSafeFrame::DoSynchronize(wxString filename)
 {
   // disable in read-only mode or empty
-  wxCHECK_RET(!m_core.IsReadOnly() && m_core.IsDbOpen() && m_core.GetNumEntries() != 0,
+  wxCHECK_RET(!m_core.IsReadOnly() && m_core.IsDbFileSet() && m_core.GetNumEntries() != 0,
                 wxT("Synchronize menu enabled for empty or read-only database!"));
 
   SyncWizard wiz(this, &m_core, filename);

--- a/src/ui/wxWidgets/MenuManageHandlers.cpp
+++ b/src/ui/wxWidgets/MenuManageHandlers.cpp
@@ -114,7 +114,7 @@ void PasswordSafeFrame::DoPreferencesClick()
     if (m_sysTray && prefs->GetPref(PWSprefs::UseSystemTray))
         m_sysTray->ShowIcon();
 
-    if (m_core.IsDbOpen() && !m_core.IsReadOnly() &&
+    if (m_core.IsDbFileSet() && !m_core.IsReadOnly() &&
         m_core.GetReadFileVersion() >= PWSfile::V30) { // older versions don't have prefs
       if (sxOldDBPrefsString != sxNewDBPrefsString ||
           m_core.GetHashIters() != window->GetHashItersValue()) {
@@ -147,7 +147,7 @@ void PasswordSafeFrame::OnBackupSafe(wxCommandEvent& WXUNUSED(evt))
   const wxString title(_("Choose a Name for this Backup:"));
 
   wxString dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = towxstring(PWSdirs::GetSafeDir());
   else {
     wxFileName::SplitPath(towxstring(m_core.GetCurFile()), &dir, nullptr, nullptr);
@@ -196,7 +196,7 @@ void PasswordSafeFrame::DoRestoreSafe()
   const wxFileName currbackup(towxstring(PWSprefs::GetInstance()->GetPref(PWSprefs::CurrentBackup)));
 
   wxString dir;
-  if (!m_core.IsDbOpen())
+  if (!m_core.IsDbFileSet())
     dir = towxstring(PWSdirs::GetSafeDir());
   else {
     wxFileName::SplitPath(towxstring(m_core.GetCurFile()), &dir, nullptr, nullptr);

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -735,7 +735,7 @@ int PWSafeApp::OnExit()
   m_idleTimer->Stop();
   recentDatabases().Save();
   PWSprefs *prefs = PWSprefs::GetInstance();
-  if (m_core.IsDbOpen()) {
+  if (m_core.IsDbFileSet()) {
     prefs->SetPref(PWSprefs::CurrentFile, m_core.GetCurFile());
     // Don't leave dangling locks!
     m_core.SafeUnlockCurFile();

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -404,7 +404,7 @@ PasswordSafeFrame::~PasswordSafeFrame()
 {
 ////@begin PasswordSafeFrame destruction
 ////@end PasswordSafeFrame destruction
-  if (m_core.IsDbOpen())
+  if (m_core.IsDbFileSet())
     SaveIfChanged(); // moved here from PWSafeApp::OnExit(), where it's called too late.
 
   m_AuiManager.UnInit();
@@ -1935,7 +1935,7 @@ CItemData* PasswordSafeFrame::GetBaseEntry(const CItemData *item) const
 
 bool PasswordSafeFrame::CheckReportPresent(int iAction)
 {
-  if(m_core.IsDbOpen()) {
+  if(m_core.IsDbFileSet()) {
     CReport rpt;
     rpt.StartReport(iAction, m_core.GetCurFile().c_str(), false);
     return rpt.ReportExistsOnDisk();
@@ -1971,7 +1971,7 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
 
   switch (evt.GetId()) {
     case wxID_SAVE:
-      evt.Enable(m_core.IsDbOpen() && !isFileReadOnly && (m_core.HasDBChanged() || m_core.HaveDBPrefsChanged()));
+      evt.Enable(m_core.IsDbFileSet() && !isFileReadOnly && (m_core.HasDBChanged() || m_core.HaveDBPrefsChanged()));
       break;
 
     case wxID_SAVEAS:
@@ -1985,7 +1985,7 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
 #ifndef NO_YUBI
     case ID_YUBIKEY_MNG:
 #endif
-      evt.Enable(m_core.IsDbOpen());
+      evt.Enable(m_core.IsDbFileSet());
       break;
       
     case ID_REPORT_SYNCHRONIZE:
@@ -2040,21 +2040,21 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
     case ID_SORT_TREE_BY_GROUP:
     case ID_SORT_TREE_BY_NAME:
     case ID_SORT_TREE_BY_DATE:
-      evt.Enable(m_core.IsDbOpen() && isTreeView);
+      evt.Enable(m_core.IsDbFileSet() && isTreeView);
       break;
       
     case ID_EXPORTMENU:
     case ID_COMPARE:
-      evt.Enable(m_core.IsDbOpen() && m_core.GetNumEntries() != 0);
+      evt.Enable(m_core.IsDbFileSet() && m_core.GetNumEntries() != 0);
       break;
 
     case ID_ADDGROUP:
-      evt.Enable((isTreeViewGroupSelected || isTreeViewEmpty || !isTreeViewItemSelected) && !isFileReadOnly && IsTreeSortGroup() && m_core.IsDbOpen());
+      evt.Enable((isTreeViewGroupSelected || isTreeViewEmpty || !isTreeViewItemSelected) && !isFileReadOnly && IsTreeSortGroup() && m_core.IsDbFileSet());
       break;
 
     case ID_EXPANDALL:
     case ID_COLLAPSEALL:
-      evt.Enable(!isTreeViewEmpty && m_core.IsDbOpen());
+      evt.Enable(!isTreeViewEmpty && m_core.IsDbFileSet());
       break;
 
     case ID_RENAME:
@@ -2122,19 +2122,19 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
       break;
 
     case ID_SYNCHRONIZE:
-      evt.Enable(!isFileReadOnly && m_core.IsDbOpen() && m_core.GetNumEntries() != 0);
+      evt.Enable(!isFileReadOnly && m_core.IsDbFileSet() && m_core.GetNumEntries() != 0);
       break;
 
     case ID_CHANGECOMBO:
-      evt.Enable(!isFileReadOnly && m_core.IsDbOpen());
+      evt.Enable(!isFileReadOnly && m_core.IsDbFileSet());
       break;
 
     case wxID_FIND:
-      evt.Enable(m_core.IsDbOpen() && m_core.GetNumEntries() != 0);
+      evt.Enable(m_core.IsDbFileSet() && m_core.GetNumEntries() != 0);
       break;
 
     case wxID_ADD:
-      evt.Enable(!isFileReadOnly && m_core.IsDbOpen());
+      evt.Enable(!isFileReadOnly && m_core.IsDbFileSet());
       break;
 
     case wxID_DELETE:
@@ -2146,34 +2146,34 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
       break;
 
     case ID_SHOWHIDE_UNSAVED:
-      evt.Enable((m_CurrentPredefinedFilter == UNSAVED) || ((m_CurrentPredefinedFilter == NONE) && m_core.IsDbOpen() && !isFileReadOnly && m_core.HasDBChanged()));
+      evt.Enable((m_CurrentPredefinedFilter == UNSAVED) || ((m_CurrentPredefinedFilter == NONE) && m_core.IsDbFileSet() && !isFileReadOnly && m_core.HasDBChanged()));
       evt.Check(m_CurrentPredefinedFilter == UNSAVED);
       break;
 
     case ID_SHOW_ALL_EXPIRY:
       evt.Enable((m_CurrentPredefinedFilter == EXPIRY) || ((m_CurrentPredefinedFilter == NONE) &&
-       m_core.IsDbOpen() &&
+       m_core.IsDbFileSet() &&
        m_core.GetExpirySize() != 0));
       evt.Check(m_CurrentPredefinedFilter == EXPIRY);
       break;
 
     case ID_SHOW_LAST_FIND_RESULTS:
       evt.Enable((m_CurrentPredefinedFilter == LASTFIND) || ((m_CurrentPredefinedFilter == NONE) &&
-                  m_core.IsDbOpen() &&
+                  m_core.IsDbFileSet() &&
                   m_FilterManager.GetFindFilterSize() != 0));
       evt.Check(m_CurrentPredefinedFilter == LASTFIND);
       break;
 
     case ID_MERGE:
     case ID_IMPORTMENU:
-      evt.Enable(!isFileReadOnly && m_core.IsDbOpen());
+      evt.Enable(!isFileReadOnly && m_core.IsDbFileSet());
       break;
       
     case ID_IMPORT_XML:
 #if (!defined(_WIN32) && USE_XML_LIBRARY == MSXML)
       evt.Enable(false);
 #else
-      evt.Enable(!isFileReadOnly && m_core.IsDbOpen());
+      evt.Enable(!isFileReadOnly && m_core.IsDbFileSet());
 #endif
       break;
 
@@ -2189,23 +2189,23 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
     case ID_PWDPOLSM:
     case ID_LOCK_SAFE:
     case ID_SETDATABASEID:
-      evt.Enable(m_core.IsDbOpen() && !m_sysTray->IsLocked());
+      evt.Enable(m_core.IsDbFileSet() && !m_sysTray->IsLocked());
       break;
 
     case ID_UNLOCK_SAFE:
-      evt.Enable(m_core.IsDbOpen() && m_sysTray->IsLocked());
+      evt.Enable(m_core.IsDbFileSet() && m_sysTray->IsLocked());
       break;
 
     case ID_FILTERMENU:
-      evt.Enable(m_core.IsDbOpen());
+      evt.Enable(m_core.IsDbFileSet());
       break;
       
     case ID_EDITFILTER:
-      evt.Enable(m_core.IsDbOpen() && m_CurrentPredefinedFilter == NONE); // Mark unimplemented
+      evt.Enable(m_core.IsDbFileSet() && m_CurrentPredefinedFilter == NONE); // Mark unimplemented
       break;
       
     case ID_APPLYFILTER:
-      evt.Enable(m_core.IsDbOpen() && (m_bFilterActive || CurrentFilter().IsActive()));
+      evt.Enable(m_core.IsDbFileSet() && (m_bFilterActive || CurrentFilter().IsActive()));
       if(m_bFilterActive) {
         m_ApplyClearFilter->SetItemLabel(_("&Clear current"));
       }
@@ -2215,15 +2215,15 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
       break;
       
     case ID_MANAGEFILTERS:
-      evt.Enable(m_core.IsDbOpen() && m_CurrentPredefinedFilter == NONE); // Mark unimplemented
+      evt.Enable(m_core.IsDbFileSet() && m_CurrentPredefinedFilter == NONE); // Mark unimplemented
       break;
       
     case ID_SHOW_EMPTY_GROUP_IN_FILTER:
-      evt.Enable(m_core.IsDbOpen() && isTreeView && m_bFilterActive);
+      evt.Enable(m_core.IsDbFileSet() && isTreeView && m_bFilterActive);
       break;
 
     case ID_SUBVIEWSMENU:
-      evt.Enable(m_core.IsDbOpen());
+      evt.Enable(m_core.IsDbFileSet());
       break;
 
     case ID_CUSTOMIZETOOLBAR:
@@ -2241,10 +2241,10 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
     case ID_CHANGEMODE:
     {
       bool bFileIsReadOnly = true;
-      if(m_core.IsDbOpen()) {
+      if(m_core.IsDbFileSet()) {
         pws_os::FileExists(m_core.GetCurFile().c_str(), bFileIsReadOnly);
       }
-      evt.Enable(m_core.IsDbOpen() && !bFileIsReadOnly);
+      evt.Enable(m_core.IsDbFileSet() && !bFileIsReadOnly);
       break;
     }
     default:
@@ -2254,7 +2254,7 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
 
 bool PasswordSafeFrame::IsClosed() const
 {
-  return (!m_core.IsDbOpen() && m_core.GetNumEntries() == 0 &&
+  return (!m_core.IsDbFileSet() && m_core.GetNumEntries() == 0 &&
           !m_core.HasDBChanged() && !m_core.AnyToUndo() && !m_core.AnyToRedo());
 }
 
@@ -2516,7 +2516,7 @@ void PasswordSafeFrame::SetFocus()
 void PasswordSafeFrame::OnIconize(wxIconizeEvent& evt) {
 
   // If database was closed than there is nothing to do
-  if (!m_core.IsDbOpen()) {
+  if (!m_core.IsDbFileSet()) {
     return;
   }
 
@@ -2707,7 +2707,7 @@ void PasswordSafeFrame::UpdateStatusBar()
   if(menuBar != nullptr) {
     menu = menuBar->FindItem(ID_CHANGEMODE);
   }
-  if (m_core.IsDbOpen()) {
+  if (m_core.IsDbFileSet()) {
     wxString text;
     // SB_DBLCLICK pane is set per selected entry, not here
 
@@ -3034,7 +3034,7 @@ void PasswordSafeFrame::CloseDB(std::function<void(bool)> callback)
 
   // Save Application related preferences
   prefs->SaveApplicationPreferences();
-  if( m_core.IsDbOpen() ) {
+  if( m_core.IsDbFileSet() ) {
     int rc = SaveIfChanged();
     if (rc != PWScore::SUCCESS) {
       if (callback != nullptr)


### PR DESCRIPTION
The m_bIsOpen ivar is updated internally but currently never used.

From a naming perspective this PR is almost obviously correct, though some code may depend on the old behavior.

Current invocations can be replaced with !GetCurFile().empty() which will make sure everything stays unchanged, but most likely the invokers will want the correct logic.