### PR TITLE
Getfield fix

### DIFF
--- a/src/core/Item.cpp
+++ b/src/core/Item.cpp
@@ -252,11 +252,8 @@ void CItem::GetField(const CItemField &field,
 
 void CItem::GetField(const CItemField &field, std::vector<unsigned char> &v) const
 {
-  size_t length = field.GetLength();
-  if (length < TwoFish::BLOCKSIZE)
-    length = TwoFish::BLOCKSIZE;
+  size_t length = roundUp(field.GetLength(), BlowFish::BLOCKSIZE);
   v.resize(length);
-  length = v.size();
   field.Get(& v[0], length, MakeBlowFish());
   v.resize(length);
 }


### PR DESCRIPTION
This PR adds just one fix (commit 382eeb112875b9f0facf73686ad620031abc8c43) to #1420 

As that PR has not been committed yet, it is included here as it references the new roundUp function. I can rebase this PR after #1420 is applied, leaving just the one commit.

An issue in CItem::GetField(const CItemField &field, std::vector<unsigned char> &v) is fixed:

v is correctly resized before decryption, this was only done for small (< BS) lengths, but not for bigger ones.