### PR TITLE
Added sha256 mac using commoncrypto (improved performance)

### DIFF
--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -10,6 +10,47 @@
 // Tom St Denis, tomstdenis@iahu.ca, http://libtomcrypt.org
 //-----------------------------------------------------------------------------
 #include "sha256.h"
+
+#ifdef __APPLE__
+/*
+  Initialize the hash state
+*/
+SHA256::SHA256()
+{
+  CC_SHA256_Init(&ctx);
+}
+
+SHA256::~SHA256()
+{
+  // CC_SHA256_Final has erased ctx
+}
+
+/*
+  Process a block of memory though the hash
+  @param in     The data to hash
+  @param inlen  The length of the data (octets)
+*/
+void SHA256::Update(const unsigned char *in, size_t inlen)
+{
+  while (inlen) {
+    unsigned int len = inlen > UINT32_MAX ? UINT32_MAX : (unsigned int) inlen;
+    CC_SHA256_Update(&ctx, in, len);
+    in += len;
+    inlen -= len;
+  }
+}
+
+/*
+  Terminate the hash to get the digest
+  @param digest The destination of the hash (32 bytes)
+*/
+void SHA256::Final(unsigned char digest[HASHLEN])
+{
+  CC_SHA256_Final(digest, &ctx);
+}
+#else
+// not __APPLE__
+
 #include "bitops.h"
 #include "../Util.h"
 
@@ -281,3 +322,4 @@ void SHA256::Final(unsigned char digest[HASHLEN])
   trashMemory(buf, sizeof(buf));
 #endif
 }
+#endif

--- a/src/core/crypto/sha256.h
+++ b/src/core/crypto/sha256.h
@@ -14,6 +14,9 @@
 
 #include "../../os/typedefs.h"
 #include "../PwsPlatform.h"
+#ifdef __APPLE__
+#include <CommonCrypto/CommonDigest.h>
+#endif
 
 class SHA256
 {
@@ -26,10 +29,14 @@ public:
   void Final(unsigned char digest[HASHLEN]);
 
 private:
+#ifdef __APPLE__
+  CC_SHA256_CTX ctx;
+#else
   ulong64 length;
   size_t curlen;
   ulong32 state[8];
   unsigned char buf[BLOCKSIZE];
+#endif
 };
 
 #endif /* __SHA256_H */


### PR DESCRIPTION
This adds a separate implementation for Mac, almost trivial wrapper around CommonCrypto.

Measurements indicate that this provides 8 to 10 times better performance, allowing the user to select higher Unlock Difficulty, as the unlock speed is almost completely determined by sha256 performance.