### PR TITLE
Update MIN_HASH_ITERATIONS to 16,384

### DIFF
--- a/docs/formatV3.txt
+++ b/docs/formatV3.txt
@@ -51,7 +51,7 @@ version 3 file. This tag has no cryptographic value.
 2.3 P' is the "stretched key" generated from the user's passphrase and
 the SALT, as defined by the hash-function-based key stretching
 algorithm in [KEYSTRETCH] (Section 4.1), with SHA-256 [SHA256] as the
-hash function, and ITER iterations (at least 2048, i.e., t = 11).
+hash function, and ITER iterations (at least 16,348).
 
 2.4 ITER is the number of iterations on the hash function to calculate P',
 stored as a 32 bit little-endian value. This value is stored here in order

--- a/docs/formatV4.txt
+++ b/docs/formatV4.txt
@@ -93,7 +93,7 @@ in processing power.
 user's passphrase (UTF-8 encoded) and the SALT, as defined by the
 hash-function-based key stretching algorithm in [PBKDF2], with SHA-256
 [SHA256] as the hash function, and ITER iterations (at least
-2048). The intention is that Key Block i will be generated with user
+16,348). The intention is that Key Block i will be generated with user
 i's passphrase. All keyblocks protect the same K and L values (see
 below).
 

--- a/src/core/PWSfile.h
+++ b/src/core/PWSfile.h
@@ -29,7 +29,7 @@
 // HASH_ITERATIONS is used by the key stretching algorithm.
 // MIN_HASH_ITERATIONS is a lower limit - anything lower than this
 // is considered inherently insecure.
-#define MIN_HASH_ITERATIONS 2048
+#define MIN_HASH_ITERATIONS 16384
 // MAX_USABLE_HASH_ITERS is a guesstimate on what's acceptable to a user
 // with a reasonably powerful CPU. Real limit's 2^32-1.
 #define MAX_USABLE_HASH_ITERS (1 << 22)

--- a/src/core/PWSfileV3.cpp
+++ b/src/core/PWSfileV3.cpp
@@ -234,10 +234,8 @@ int PWSfileV3::CheckPasskey(const StringX &filename,
   { // block to shut up compiler warning w.r.t. goto
     const uint32 N = getInt32(Nb);
 
-    ASSERT(N >= MIN_HASH_ITERATIONS);
     if (N < MIN_HASH_ITERATIONS) {
-      retval = FAILURE;
-      goto err;
+      PWSTRACE(L"File's ITER value %d is below current minimum %d. It will be updated when file is saved", N, MIN_HASH_ITERATIONS);
     }
 
     if (nITER != nullptr)
@@ -330,7 +328,6 @@ void PWSfileV3::StretchKey(const unsigned char *salt, unsigned long saltLen,
   trashMemory(pstr, passLen);
   delete[] pstr;
 
-  ASSERT(N >= MIN_HASH_ITERATIONS); // minimal value we're willing to use
   for (unsigned int i = 0; i < N; i++) {
     SHA256 H;
     // The 2nd param in next line was sizeof(X) in Beta-1

--- a/src/core/PWSfileV4.cpp
+++ b/src/core/PWSfileV4.cpp
@@ -121,6 +121,8 @@ int PWSfileV4::Open(const StringX &passkey)
     // Nonce is used to detect end of keyblocks
     static_assert(int(NONCELEN) == int(SHA256::HASHLEN), "can't call HashRandom256");
     HashRandom256(m_nonce); // Generate nonce
+    if (m_nHashIters < MIN_HASH_ITERATIONS) // here we silently upgrade files to the new MIN_HASH_ITERATIONS value
+      m_nHashIters = MIN_HASH_ITERATIONS;
     if (!m_keyblocks.GetKeys(passkey, m_nHashIters, m_key, m_ell)) {
       PWSfile::Close();
       return WRONG_PASSWORD;
@@ -403,7 +405,9 @@ void PWSfileV4::StretchKey(const unsigned char *salt, unsigned long saltLen,
   * by the hash-function-based key stretching algorithm PBKDF2, with SHA-256
   * as the hash function, and N iterations.
   */
-  ASSERT(N >= MIN_HASH_ITERATIONS); // minimal value we're willing to use
+  if (N < MIN_HASH_ITERATIONS) {
+    PWSTRACE(L"File's ITER value %d is below current minimum %d. It will be updated when file is saved", N, MIN_HASH_ITERATIONS);
+  }
   size_t passLen = 0;
   unsigned char *pstr = nullptr;
 


### PR DESCRIPTION
Also, allow files to be silently upgraded to this new value upon save.

This is a fully backwards comaptible change, although users may notice the slower open and save times.