### PR TITLE
Use filename extension to detect V4 database

### DIFF
--- a/src/core/PWSfileV4.cpp
+++ b/src/core/PWSfileV4.cpp
@@ -1281,7 +1281,8 @@ int PWSfileV4::ReadHeader()
 
 bool PWSfileV4::IsV4x(const StringX &filename, const StringX &passkey, VERSION &v)
 {
-  if (CheckPasskey(filename, passkey) == SUCCESS) {
+  if (filename.rfind(_T(".") V4_SUFFIX) == filename.size() - wcslen(V4_SUFFIX) - 1
+      || CheckPasskey(filename, passkey) == SUCCESS) {
     v = V40;
     return true;
   } else

--- a/src/test/FileV3Test.cpp
+++ b/src/test/FileV3Test.cpp
@@ -13,6 +13,8 @@
 
 #include "core/PWSfileV3.h"
 #include "os/file.h"
+#include "core/PWScore.h"
+#include <cstdio>
 
 #include "gtest/gtest.h"
 
@@ -176,4 +178,23 @@ TEST_F(FileV3Test, UnknownPersistencyTest)
   EXPECT_EQ(d1, item);
   EXPECT_EQ(PWSfile::END_OF_FILE, fr.ReadRecord(item));
   EXPECT_EQ(PWSfile::SUCCESS, fr.Close());
+}
+
+TEST_F(FileV3Test, V4Extension)
+{
+  PWScore core;
+  stringT fname4(_T("V3test.psafe4"));
+
+  PWSfileV3 fw(fname.c_str(), PWSfile::Write, PWSfile::V30);
+  ASSERT_EQ(PWSfile::SUCCESS, fw.Open(passphrase));
+  ASSERT_EQ(PWSfile::SUCCESS, fw.Close());
+  ASSERT_TRUE(pws_os::FileExists(fname));
+
+  // Change extension to psafe4
+  ASSERT_EQ(0, std::rename("V3test.psafe3", "V3test.psafe4"));
+
+  EXPECT_EQ(PWSfile::WRONG_PASSWORD, core.ReadFile(fname4.c_str(), L"WrongPassword", true));
+  EXPECT_EQ(PWSfile::SUCCESS, core.ReadFile(fname4.c_str(), passphrase, true));
+
+  ASSERT_EQ(0, std::rename("V3test.psafe4", "V3test.psafe3"));
 }

--- a/src/test/FileV4Test.cpp
+++ b/src/test/FileV4Test.cpp
@@ -293,7 +293,7 @@ TEST_F(FileV4Test, CoreRWTest)
   EXPECT_EQ(PWSfile::SUCCESS, core.WriteFile(fname.c_str(), PWSfile::V40));
 
   core.ClearDBData();
-  EXPECT_EQ(PWSfile::FAILURE, core.ReadFile(fname.c_str(), L"WrongPassword", true));
+  EXPECT_EQ(PWSfile::WRONG_PASSWORD, core.ReadFile(fname.c_str(), L"WrongPassword", true));
   EXPECT_EQ(PWSfile::SUCCESS, core.ReadFile(fname.c_str(), passkey, true));
   ASSERT_EQ(1U, core.GetNumEntries());
   ASSERT_EQ(1U, core.GetNumAtts());


### PR DESCRIPTION
This prevents executing the key stretching twice (one on version detection, one to read the file). It also allows returning wrong_password instead of failure for incorrect passwords.