### PR TITLE
Fixes for FreeBSD

### DIFF
--- a/Makefile.freebsd
+++ b/Makefile.freebsd
@@ -34,8 +34,6 @@ GIT := git
 GZIP := gzip
 ECHO := /bin/echo
 
-export NO_YUBI := yes
-
 GPG := /usr/local/bin/gpg
 GPG_SIGN := $(GPG) --detach-sign --default-key $(GPG_KEY)
 SIGN_CMD := $(foreach file, $(wildcard $(RELEASEDIR)/*$(RELEASENAME)*), $(GPG_SIGN) $(file); )

--- a/Makefile.freebsd
+++ b/Makefile.freebsd
@@ -45,12 +45,9 @@ SF_UPLOAD_CMD := /usr/local/bin/rsync -avP -e ssh
 SF_UPLOAD_DST := $(SF_UPLOAD_ROOT)/Linux-BETA/$(RELEASENUM)
 RELTAG = wx$(subst .,_,$(RELEASENAME))
 
-export CPPFLAGS += -std=c++11
-export CXXFLAGS += --stdlib=libc++ -I/usr/local/include
+export CPPFLAGS += -std=c++14
+export CXXFLAGS += -I/usr/local/include
 export CFLAGS += -I/usr/local/include
-export CC = clang
-export CXX = clang++
-export CPP = clang++
 export PLATFORM = FreeBSD
 
 all: I18N unicodedebug unicoderelease

--- a/src/core/Makefile
+++ b/src/core/Makefile
@@ -27,7 +27,7 @@ WX_CONFIG?=$(shell if [ -e $(WX3) ]; then echo $(WX3); else echo $(WX2); fi)
 NOTSRC          = PWSclipboard.cpp
 
 LIBSRC          = CheckVersion.cpp \
-                  Item.cpp ItemData.cpp ItemAtt.cpp ItemField.cpp  \
+                  Item.cpp ItemData.cpp ItemAtt.cpp ItemField.cpp \
                   Match.cpp PolicyManager.cpp PWCharPool.cpp CoreImpExp.cpp \
                   PWPolicy.cpp PWHistory.cpp PWSAuxParse.cpp \
                   PWScore.cpp PWSdirs.cpp PWSfile.cpp PWSfileHeader.cpp \
@@ -36,20 +36,22 @@ LIBSRC          = CheckVersion.cpp \
                   Command.cpp PWSrand.cpp Report.cpp \
                   core_st.cpp RUEList.cpp \
                   StringX.cpp SysInfo.cpp \
+                  TotpCore.cpp \
                   UnknownField.cpp  \
                   UTF8Conv.cpp Util.cpp CoreOtherDB.cpp \
                   VerifyFormat.cpp XMLprefs.cpp \
-                  ExpiredList.cpp PWStime.cpp\
+                  ExpiredList.cpp PWStime.cpp \
                   pugixml/pugixml.cpp \
                   XML/Pugi/PFileXMLProcessor.cpp XML/Pugi/PFilterXMLProcessor.cpp \
                   XML/XMLFileHandlers.cpp XML/XMLFileValidation.cpp \
                   XML/Xerces/XFileSAX2Handlers.cpp XML/Xerces/XFileValidator.cpp \
                   XML/Xerces/XFileXMLProcessor.cpp XML/Xerces/XFilterSAX2Handlers.cpp \
                   XML/Xerces/XFilterXMLProcessor.cpp XML/Xerces/XSecMemMgr.cpp PWSLog.cpp \
-				  RUEList.cpp \
-				  crypto/AES.cpp crypto/BlowFish.cpp crypto/pbkdf2.cpp \
-				  crypto/KeyWrap.cpp crypto/sha1.cpp crypto/sha256.cpp \
-				  crypto/TwoFish.cpp
+                  RUEList.cpp \
+                  crypto/AES.cpp crypto/BlowFish.cpp crypto/pbkdf2.cpp \
+                  crypto/KeyWrap.cpp crypto/sha1.cpp crypto/sha256.cpp \
+                  crypto/TwoFish.cpp \
+                  crypto/external/Chromium/base32.cpp
 
 SRC             = $(LIBSRC)
 
@@ -110,10 +112,10 @@ clean:
 	@rm core_st.cpp core_st.h
 
 setup:
-	@mkdir -p $(OBJPATH) $(OBJPATH)/pugixml $(OBJPATH)/crypto $(OBJPATH)/XML/Xerces $(OBJPATH)/XML/Pugi $(LIBPATH) $(DEPDIR)
+	@mkdir -p $(OBJPATH) $(OBJPATH)/pugixml $(OBJPATH)/crypto/external/Chromium $(OBJPATH)/XML/Xerces $(OBJPATH)/XML/Pugi $(LIBPATH) $(DEPDIR)
 
 $(DEPDIR)/%.d: %.cpp
-	@set -e; mkdir -p $(DEPDIR) $(DEPDIR)/pugixml $(DEPDIR)/crypto; \
+	@set -e; mkdir -p $(DEPDIR) $(DEPDIR)/pugixml $(DEPDIR)/crypto/external/Chromium; \
 	mkdir -p $(DEPDIR)/XML/Xerces $(DEPDIR)/XML/Pugi; \
 	$(RM) $@; \
 	$(CXX) -MM $(CPPFLAGS) $< > $@.$$$$; \

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -365,7 +365,7 @@ void wxUtilities::DisableIfUnsupported(enum Feature feature, wxWindow* window)
 // on Fedora or Ubuntu
 bool IsTaskBarIconAvailable()
 {
-#if defined(__WXGTK__) && !defined(__OpenBSD__)
+#if defined(__WXGTK__) && !defined(__OpenBSD__) && !defined(__FreeBSD__)
   const wxVersionInfo verInfo = wxGetLibraryVersionInfo();
   int major = verInfo.GetMajor();
   int minor = verInfo.GetMinor();


### PR DESCRIPTION
Port was overdue an update (from 1.12.0 to 1.20.0).

1. `src/core/Makefile` is broken for all builds that use gmake.
2. Yubikey works fine on FreeBSD
3. there's no need to use clang38, not available in FreeBSD ports and builds fine with clang 18.1.6 in base OS.