### PR TITLE
Properly handle nullptr in release code

### DIFF
--- a/src/core/PWSfileV3.cpp
+++ b/src/core/PWSfileV3.cpp
@@ -1001,6 +1001,8 @@ int PWSfileV3::ReadHeader()
     FILE *fd = pws_os::FOpen(filename.c_str(), _T("rb"));
 
     ASSERT(fd != nullptr);
+    if (fd == nullptr)
+      return false;
     char tag[sizeof(V3TAG)];
     auto nread = fread(tag, 1, sizeof(tag), fd);
     fclose(fd);


### PR DESCRIPTION
There are many reasons the FOpen can fail in production scenarios (files being moved, permissions, etc.).

This check makes sure that a proper response is returned instead of continuing (resulting is segmentation fault).