### PR TITLE
The absence of X11 != Wayland (i.e. macOS)

### DIFF
--- a/src/ui/wxWidgets/Clipboard.cpp
+++ b/src/ui/wxWidgets/Clipboard.cpp
@@ -108,7 +108,7 @@ bool Clipboard::SetData(const StringX &data)
   if (wxTheClipboard->Open()) {
 #if defined(__UNIX__) && !defined(__WXOSX__)
     // Copying composite object is currently not working as expected on Wayland
-    if (wxUtilities::IsDisplayManagerX11()) {
+    if (wxUtilities::WhatWindowSystem() == wxUtilities::X11) {
       wxDataObjectComposite *dataObjectComposite = new wxDataObjectComposite();
       dataObjectComposite->Add(new wxTextDataObjectEx(data.c_str()), true);
       dataObjectComposite->Add(new KDEClipboardSecretMarkerObject(), false);

--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -1406,7 +1406,7 @@ void OptionsPropertySheetDlg::OnPWHistApply(wxCommandEvent& WXUNUSED(evt))
 void OptionsPropertySheetDlg::OnUpdateUI(wxUpdateUIEvent& evt)
 {
   bool dbIsReadOnly = m_core.IsReadOnly();
-  const bool isX11  = wxUtilities::IsDisplayManagerX11();
+  const bool isWayland = wxUtilities::IsDisplayManagerWayland();
 
   switch (evt.GetId()) {
   /////////////////////////////////////////////////////////////////////////////
@@ -1444,7 +1444,7 @@ void OptionsPropertySheetDlg::OnUpdateUI(wxUpdateUIEvent& evt)
       evt.Enable(!dbIsReadOnly);
       break;
     case ID_TEXTCTRL11:
-      evt.Enable(isX11 && !dbIsReadOnly);
+      evt.Enable(!dbIsReadOnly && !isWayland);
       break;
     case ID_CHECKBOX24:
       evt.Enable(!dbIsReadOnly);

--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -1406,7 +1406,7 @@ void OptionsPropertySheetDlg::OnPWHistApply(wxCommandEvent& WXUNUSED(evt))
 void OptionsPropertySheetDlg::OnUpdateUI(wxUpdateUIEvent& evt)
 {
   bool dbIsReadOnly = m_core.IsReadOnly();
-  const bool isWayland = wxUtilities::IsDisplayManagerWayland();
+  const bool isWayland = (wxUtilities::WhatWindowSystem() == wxUtilities::Wayland);
 
   switch (evt.GetId()) {
   /////////////////////////////////////////////////////////////////////////////

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1959,7 +1959,7 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
   const bool isTreeViewGroupSelected = isTreeView && m_tree->IsGroupSelected();
   const bool isTreeViewEmpty         = isTreeView && !m_tree->HasItems(); // excludes the invisible root item
   const bool isTreeViewItemSelected  = isTreeView && m_tree->HasSelection();
-  const bool isWayland               = wxUtilities::IsDisplayManagerWayland();
+  const bool isWayland               = (wxUtilities::WhatWindowSystem() == wxUtilities::Wayland);
 
   pci = GetSelectedEntry();
 

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1959,7 +1959,7 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
   const bool isTreeViewGroupSelected = isTreeView && m_tree->IsGroupSelected();
   const bool isTreeViewEmpty         = isTreeView && !m_tree->HasItems(); // excludes the invisible root item
   const bool isTreeViewItemSelected  = isTreeView && m_tree->HasSelection();
-  const bool isX11                   = wxUtilities::IsDisplayManagerX11();
+  const bool isWayland               = wxUtilities::IsDisplayManagerWayland();
 
   pci = GetSelectedEntry();
 
@@ -2094,7 +2094,7 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
       break;
 
     case ID_AUTOTYPE:
-      evt.Enable(isX11 && !isTreeViewGroupSelected && pci);
+      evt.Enable(!isWayland && !isTreeViewGroupSelected && pci);
       break;
 
     case ID_EDIT:

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -311,34 +311,25 @@ enum wxUtilities::WindowSystem wxUtilities::WhatWindowSystem()
 
   // Get the env. variable and OS version only once
   if (wsType == Undefined) {
+    wsType = Unknown;
     osid = wxGetOsVersion();
-    switch (osid) {
-    case wxOS_MAC:
+    
+    if (osid & wxOS_MAC) {
       wsType = macOS;
-      break;
-    case wxOS_WINDOWS:
+    } else if (osid & wxOS_WINDOWS) {
       wsType = Windows;
-      break;
-    case wxOS_UNIX:
-      {
-        wsType = Unknown;
-        wxString XDG_SESSION_TYPE = wxEmptyString;
+    } else if (osid & wxOS_UNIX) {
+      wxString XDG_SESSION_TYPE = wxEmptyString;
 
-        if (wxGetEnv(wxT("XDG_SESSION_TYPE"), &XDG_SESSION_TYPE)) { // provides 'x11' or 'wayland'
-          if (!XDG_SESSION_TYPE.IsEmpty()) {
-            if (XDG_SESSION_TYPE == wxT("x11")) {
-              wsType = X11;
-            } else if (XDG_SESSION_TYPE == wxT("Wayland")) {
-              wsType = Wayland;
-            }
+      if (wxGetEnv(wxT("XDG_SESSION_TYPE"), &XDG_SESSION_TYPE)) { // provides 'x11' or 'wayland'
+        if (!XDG_SESSION_TYPE.IsEmpty()) {
+          if (XDG_SESSION_TYPE == wxT("x11")) {
+            wsType = X11;
+          } else if (XDG_SESSION_TYPE == wxT("wayland")) {
+            wsType = Wayland;
           }
         }
-        break;
       }
-
-    default:
-      wsType = Unknown;
-      break;
     }
   }
   return wsType;
@@ -351,7 +342,7 @@ bool wxUtilities::IsVirtualKeyboardSupported()
 #elif defined __WXOSX__
   return true;
 #else
-  return wxUtilities::IsDisplayManagerX11();
+  return (wxUtilities::WhatWindowSystem() == wxUtilities::X11);
 #endif
 }
 

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -340,6 +340,11 @@ bool wxUtilities::IsDisplayManagerX11()
   return (isDisplayManagerX11 == 1);
 }
 
+bool wxUtilities::IsDisplayManagerWayland()
+{
+  return (wxGetOsVersion() == wxOS_UNIX_LINUX) && !wxUtilities::IsDisplayManagerX11();
+}
+
 bool wxUtilities::IsVirtualKeyboardSupported()
 {
 #ifdef __WINDOWS__
@@ -353,9 +358,7 @@ bool wxUtilities::IsVirtualKeyboardSupported()
 
 void wxUtilities::DisableIfUnsupported(enum Feature feature, wxWindow* window)
 {
-  const bool isWayland = !wxUtilities::IsDisplayManagerX11();
-
-  if (feature == Autotype && isWayland) {
+  if (feature == Autotype && IsDisplayManagerWayland()) {
     window->Disable();
     window->SetToolTip(_("Not supported by Wayland"));
   }

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -304,45 +304,44 @@ wxBitmap wxUtilities::GetBitmapResource( const wxString& name )
 
 int pless(int* first, int* second) { return *first - *second; }
 
-bool IsCurrentDesktopKde()
+enum wxUtilities::WindowSystem wxUtilities::WhatWindowSystem()
 {
-#ifdef __WINDOWS__
-  return false;
-#else
-  wxString currentDesktop = wxEmptyString;
+  static enum wxUtilities::WindowSystem wsType = Undefined;
+  wxOperatingSystemId osid;
 
-  if (!wxGetEnv(wxT("XDG_CURRENT_DESKTOP"), &currentDesktop)) {
-    return false; // Environment variable does not exist
-  }
+  // Get the env. variable and OS version only once
+  if (wsType == Undefined) {
+    osid = wxGetOsVersion();
+    switch (osid) {
+    case wxOS_MAC:
+      wsType = macOS;
+      break;
+    case wxOS_WINDOWS:
+      wsType = Windows;
+      break;
+    case wxOS_UNIX:
+      {
+        wsType = Unknown;
+        wxString XDG_SESSION_TYPE = wxEmptyString;
 
-  return (!currentDesktop.IsEmpty() && (currentDesktop.MakeLower().Trim() == wxT("kde")));
-#endif
-}
-
-bool wxUtilities::IsDisplayManagerX11()
-{
-  static int isDisplayManagerX11 = 0;
-
-  // Get the env. variable only once
-  if (isDisplayManagerX11 == 0) {
-    wxString XDG_SESSION_TYPE = wxEmptyString;
-    if (wxGetEnv(wxT("XDG_SESSION_TYPE"), &XDG_SESSION_TYPE)) { // provides 'x11' or 'wayland'
-
-      if (!XDG_SESSION_TYPE.IsEmpty() && XDG_SESSION_TYPE == wxT("x11")) {
-        isDisplayManagerX11 = 1;
-      } else {
-        isDisplayManagerX11 = 2; // Don't call wxGetEnv() more than once per process if value is bad
+        if (wxGetEnv(wxT("XDG_SESSION_TYPE"), &XDG_SESSION_TYPE)) { // provides 'x11' or 'wayland'
+          if (!XDG_SESSION_TYPE.IsEmpty()) {
+            if (XDG_SESSION_TYPE == wxT("x11")) {
+              wsType = X11;
+            } else if (XDG_SESSION_TYPE == wxT("Wayland")) {
+              wsType = Wayland;
+            }
+          }
+        }
+        break;
       }
-    } else {
-      isDisplayManagerX11 = 3; // Don't call wxGetEnv() more than once per process if value is not set/available
+
+    default:
+      wsType = Unknown;
+      break;
     }
   }
-  return (isDisplayManagerX11 == 1);
-}
-
-bool wxUtilities::IsDisplayManagerWayland()
-{
-  return (wxGetOsVersion() == wxOS_UNIX_LINUX) && !wxUtilities::IsDisplayManagerX11();
+  return wsType;
 }
 
 bool wxUtilities::IsVirtualKeyboardSupported()
@@ -358,7 +357,7 @@ bool wxUtilities::IsVirtualKeyboardSupported()
 
 void wxUtilities::DisableIfUnsupported(enum Feature feature, wxWindow* window)
 {
-  if (feature == Autotype && IsDisplayManagerWayland()) {
+  if (feature == Autotype && WhatWindowSystem() == Wayland) {
     window->Disable();
     window->SetToolTip(_("Not supported by Wayland"));
   }

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -312,13 +312,13 @@ enum wxUtilities::WindowSystem wxUtilities::WhatWindowSystem()
   // Get the env. variable and OS version only once
   if (wsType == Undefined) {
     wsType = Unknown;
-    osid = wxGetOsVersion();
-    
+    osid = wxGetOsVersion();    // Returns a bit flag.  The wxOS_* symbols used below are groups.
+
     if (osid & wxOS_MAC) {
       wsType = macOS;
     } else if (osid & wxOS_WINDOWS) {
       wsType = Windows;
-    } else if (osid & wxOS_UNIX) {
+    } else if (osid & wxOS_UNIX) {    // Includes Linux
       wxString XDG_SESSION_TYPE = wxEmptyString;
 
       if (wxGetEnv(wxT("XDG_SESSION_TYPE"), &XDG_SESSION_TYPE)) { // provides 'x11' or 'wayland'

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -430,25 +430,25 @@ public:
 typedef wxTextDataObject wxTextDataObjectEx;
 #endif // __WXGTK20__
 
-bool IsCurrentDesktopKde();
 
 namespace wxUtilities
 {
   enum Feature { Autotype };
+  enum WindowSystem {
+    Undefined,
+    Unknown,
+    X11,
+    Wayland,
+    macOS,
+    Windows
+  };
 
   /**
-   * @brief Checks environment variable 'XDG_SESSION_TYPE' for display manager 'x11'.
+   * @brief Identifies the type of window manager (X11, Wayland, etc.).
    *
-   * @return whether the environment variable is set to 'x11'.
+   * @return Window system type or Unknown
    */
-  bool IsDisplayManagerX11();
-
-  /**
-   * @brief True if the Linux system is using Wayland
-   *
-   * @return true if OS is Linux and IsDisplayManagerX11 == false.
-   */
-  bool IsDisplayManagerWayland();
+  enum WindowSystem WhatWindowSystem();
 
   /**
    * @brief Checks if virtual keyboard is supported.

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -453,7 +453,7 @@ namespace wxUtilities
   /**
    * @brief Checks if virtual keyboard is supported.
    * 
-   * @return IsDisplayManagerX11() on Linux, true on Mac, and false on Windows.
+   * @return True on X11, true on Mac, and false on Windows.
    */
   bool IsVirtualKeyboardSupported();
 

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -435,7 +435,7 @@ namespace wxUtilities
 {
   enum Feature { Autotype };
   enum WindowSystem {
-    Undefined,
+    Undefined,    // Only used to identify the first pass through WhatWindowSystem()
     Unknown,
     X11,
     Wayland,

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -444,6 +444,13 @@ namespace wxUtilities
   bool IsDisplayManagerX11();
 
   /**
+   * @brief True if the Linux system is using Wayland
+   *
+   * @return true if OS is Linux and IsDisplayManagerX11 == false.
+   */
+  bool IsDisplayManagerWayland();
+
+  /**
    * @brief Checks if virtual keyboard is supported.
    * 
    * @return IsDisplayManagerX11() on Linux, true on Mac, and false on Windows.


### PR DESCRIPTION
This is a regression from 1.20
PR [#1415](https://github.com/pwsafe/pwsafe/pull/1415) tries to disable all autotype controls when running on a system using Wayland. However, the logic only tests for the absence of X11, so autotype is also disabled on macOS. ~~This PR adds a wxUtilities::IsDisplayManagerWayland() function which is: OS == Linux and not X11.~~. This PR adds a WhatWindowSystem() function to return the type of environment.  The recognized types are: X11, Wayland, macOS, Windows, and Unknown.  The design easily allows other types to be added if and when needed.  Currently, the only use case is to determine when running on a Wayland based system.