### PR TITLE
[wx] TOTP - Proposal to fix error message when copying auth code from an unsaved entry

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -1856,9 +1856,7 @@ void AddEditPropSheetDlg::OnShowHideTotpClick(wxCommandEvent& WXUNUSED(evt))
 
 void AddEditPropSheetDlg::OnCopyAuthCodeClick(wxCommandEvent &event)
 {
-  CItemData temp(m_Item);
-  ApplyTwoFactorKey(temp);
-  const_cast<PasswordSafeFrame*>(GetPwSafe())->CopyAuthCodeToClipboard(&temp);
+  const_cast<PasswordSafeFrame*>(GetPwSafe())->CopyAuthCodeToClipboard(&m_ItemTotp);
 }
 
 /*!

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.h
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.h
@@ -432,6 +432,7 @@ private:
   StringX m_Password;
   bool m_IsPasswordHidden = true;
   bool m_IsTotpHidden = true;
+  bool m_UpdateTotpInClipboard = false;
 
   AliasChanges m_AliasChange = AliasChanges::NoChange;
 


### PR DESCRIPTION
Proposed change to db85aa9, because 'm_ItemTotp' already contains the two-factor key the user entered at the Additional tab.
