### PR TITLE
[FR1439] Windows: Use system default text and background colors

### DIFF
--- a/src/ui/Windows/ControlExtns.cpp
+++ b/src/ui/Windows/ControlExtns.cpp
@@ -32,9 +32,8 @@ static char THIS_FILE[] = __FILE__;
 
 #define EDIT_CLIPBOARD_TEXT_FORMAT  CF_UNICODETEXT
 
-const COLORREF crefInFocus = (RGB(222, 255, 222));  // Light green
-const COLORREF crefNoFocus = (RGB(255, 255, 255));  // White
-const COLORREF crefBlack   = (RGB(  0,   0,   0));  // Black
+const COLORREF crefInFocus = RGB(222, 255, 222);  // Light green
+const COLORREF crefNoFocus = ::GetSysColor(COLOR_WINDOW);
 
 // timer event numbers used to by ControlExtns for ListBox tooltips. See DboxMain.h
 #define TIMER_LB_HOVER     0x0A
@@ -286,7 +285,7 @@ HBRUSH CEditExtnX::CtlColor(CDC* pDC, UINT /*nCtlColor*/)
   if (!this->IsWindowEnabled())
     return NULL;
 
-  pDC->SetTextColor(crefBlack);
+  pDC->SetTextColor(::GetSysColor(COLOR_WINDOWTEXT));
   if (m_bIsFocused == TRUE) {
     pDC->SetBkColor(m_crefInFocus);
     return m_brInFocus;

--- a/src/ui/Windows/PWListCtrl.cpp
+++ b/src/ui/Windows/PWListCtrl.cpp
@@ -285,8 +285,8 @@ void CPWListCtrlX::SetFilterState(bool bState)
 {
   m_bListFilterActive = bState;
 
-  // Red if filter active, black if not
-  SetTextColor(m_bListFilterActive ? RGB(168, 0, 0) : RGB(0, 0, 0));
+  // Red if filter active, default if not
+  SetTextColor(m_bListFilterActive ? RGB(168, 0, 0) : ::GetSysColor(COLOR_WINDOWTEXT));
 }
 
 BOOL CPWListCtrlX::OnEraseBkgnd(CDC* pDC)

--- a/src/ui/Windows/PWTreeCtrl.cpp
+++ b/src/ui/Windows/PWTreeCtrl.cpp
@@ -2296,8 +2296,8 @@ void CPWTreeCtrlX::SetFilterState(bool bState)
 {
   m_bTreeFilterActive = bState;
 
-  // Red if filter active, black if not
-  SetTextColor(m_bTreeFilterActive ? RGB(168, 0, 0) : RGB(0, 0, 0));
+  // Red if filter active, default if not
+  SetTextColor(m_bTreeFilterActive ? RGB(168, 0, 0) : ::GetSysColor(COLOR_WINDOWTEXT));
 }
 
 BOOL CPWTreeCtrlX::OnEraseBkgnd(CDC* pDC)

--- a/src/ui/Windows/PasswordSubsetDlg.cpp
+++ b/src/ui/Windows/PasswordSubsetDlg.cpp
@@ -334,7 +334,7 @@ void CPasswordSubsetDlg::OnCopy()
   m_csWarningMsg.LoadString(IDS_PASSWORDCOPIED);
 
   m_stcWarningMsg.SetWindowText(m_csWarningMsg);
-  m_stcWarningMsg.SetColour(RGB(0, 0, 0));
+  m_stcWarningMsg.SetColour(::GetSysColor(COLOR_WINDOWTEXT));
   m_stcWarningMsg.Invalidate();
 }
 

--- a/src/ui/Windows/ProgressPieCtrl.cpp
+++ b/src/ui/Windows/ProgressPieCtrl.cpp
@@ -24,7 +24,7 @@ CProgressPieCtrl::CProgressPieCtrl()
   m_common(this),
   m_clrBackground(::GetSysColor(COLOR_3DFACE)),
   m_backgroundBrush(m_clrBackground),
-  m_clrText(RGB(0, 0, 0))
+  m_clrText(::GetSysColor(COLOR_WINDOWTEXT))
 {
 }
 

--- a/src/ui/Windows/ViewReport.cpp
+++ b/src/ui/Windows/ViewReport.cpp
@@ -32,7 +32,7 @@ CViewReport::CViewReport(CWnd* pParent /*=NULL*/,
 
   m_dwDatasize = (DWORD)(m_pString.length() * sizeof(wchar_t));
 
-  m_backgroundcolour = RGB(255, 255, 255);
+  m_backgroundcolour = ::GetSysColor(COLOR_WINDOW);
   m_backgroundbrush.CreateSolidBrush(m_backgroundcolour);
   m_textcolor = ::GetSysColor(COLOR_WINDOWTEXT);
 }

--- a/src/ui/Windows/VirtualKeyboard/VKeyBoardDlg.cpp
+++ b/src/ui/Windows/VirtualKeyboard/VKeyBoardDlg.cpp
@@ -2150,9 +2150,14 @@ HBRUSH CVKeyBoardDlg::OnCtlColor(CDC* pDC, CWnd *pWnd, UINT nCtlColor)
   switch (nCtlColor) {
     case CTLCOLOR_STATIC:
     case CTLCOLOR_DLG:
-      // Black text on white background - except passphrase if visible
-      pDC->SetTextColor(RGB(nID == IDC_STATIC_VKPASSPHRASE ? 255 : 0, 0, 0));
-      pDC->SetBkColor(RGB(255, 255, 255));
+      // default text and background, except passphrase if visible
+      if (nID == IDC_STATIC_VKPASSPHRASE)
+      {
+        pDC->SetTextColor(RGB(255, 0, 0));
+      } else {
+        pDC->SetTextColor(::GetSysColor(COLOR_WINDOWTEXT));
+      }
+      pDC->SetBkColor(::GetSysColor(COLOR_WINDOW));
       return (HBRUSH)(m_pBkBrush.GetSafeHandle());
     default:
       return hbr;


### PR DESCRIPTION
instead of hardcoding black and white.

Resolves #1439 