### PR TITLE
[macOS] Add coretest to the macOS workflow

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -54,7 +54,7 @@ jobs:
       
     - name: Install dependencies for creating dmg
       # gettext is already installed in the runner image
-      run: brew install create-dmg
+      run: brew install create-dmg googletest
 
     - name: Install tools for Yubikey build
       run: brew install autoconf automake libtool
@@ -118,6 +118,10 @@ jobs:
     - name: Build pwsafe
       working-directory: ${{ github.workspace }}
       run: xcodebuild -project Xcode/pwsafe-xcode6.xcodeproj -scheme pwsafe -configuration $XCODE_CONFIG
+
+    - name: Build and run coretest
+      working-directory: src/test
+      run: make -f Makefile.macos
 
     - name: Install language files and create dmg
       working-directory: install/macosx

--- a/README.MAC.DEVELOPERS.md
+++ b/README.MAC.DEVELOPERS.md
@@ -268,6 +268,15 @@ Product => Show Build Folder in Finder
 From the command line:
 xcodebuild -project pwsafe-xcode6.xcodeproj -configuration <Debug|Release> -showBuildSettings | grep TARGET_BUILD_DIR
 ```
+## Run unit tests
+To run the unit tests, you need to have googletest installed.  The makefile expects to use the Homebrew version.  You also need
+to provide the path to the wx-config command.  If you're using the Homebrew wxWidgets installation, it should be able to find it.
+Otherwise, provide the full path to the command in your wxWidgets build directory.
+```
+brew install googletest
+cd src/test         #under the main pwsafe directory
+make -f Makefile.macos [WX_CONFIG=<path to the wx-config command>]
+```
 
 ## Build installation package
 This procedure will build a .dmg file for the Universal Binary or the current machine's architecture, 

--- a/src/test/Makefile.macos
+++ b/src/test/Makefile.macos
@@ -1,0 +1,80 @@
+#
+# Coretest makefile for macOS
+#
+
+# The Xcode configuration: Debug or Release
+CONFIG ?= Release
+
+# Following sets the location of the wx-config command
+# WX_BUILD_DIR is set by the GitHub workflow
+# Override this to use a local build
+ifdef WX_BUILD_DIR
+WX_CONFIG := $(WX_BUILD_DIR)/bin/wx-config
+else ifdef HOMEBREW_PREFIX
+WX_CONFIG := $(HOMEBREW_PREFIX)/bin/wx-config
+endif
+
+# Get the location of the Xcode built libraries (core and os)
+XRELDIR := $(shell xcodebuild -project ../../Xcode/pwsafe-xcode6.xcodeproj -showBuildSettings -scheme pwsafe -configuration $(CONFIG) | awk '/TARGET_BUILD_DIR =/{print $$3}')
+
+BUILD		:= $(CONFIG)
+
+TESTSRC         := coretest.cpp $(wildcard *Test.cpp)
+
+OBJPATH         = ../../obj/$(BUILD)
+LIBPATH         = $(XRELDIR)
+BINPATH         = ./bin
+INCPATH         = ..
+
+# Assumes Googletest was installed via Homebrew
+# brew install googletest
+GTEST_DIR     = $(HOMEBREW_PREFIX)/include/googletest/googletest
+GTEST_HEADERS = $(HOMEBREW_PREFIX)/include/gtest/*.h $(HOMEBREW_PREFIX)/include/gtest/internal/*.h
+GTEST_SRCS_   = $(GTEST_DIR)/src/*.cc $(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
+GTEST_OBJ = $(OBJPATH)/gtest-all.o
+
+#destination related macros
+TESTOBJ	 = $(addprefix $(OBJPATH)/,$(subst .cpp,.o,$(TESTSRC)))
+TEST	 = $(BINPATH)/coretest
+OBJS     = $(TESTOBJ) $(GTEST_OBJ)
+
+CXXFLAGS += -DUNICODE -Wall -I$(INCPATH) -I$(INCPATH)/core -std=c++17 -I $(HOMEBREW_PREFIX)/include
+LDFLAGS  += -L$(LIBPATH) -lcore -los 
+
+ifeq ($(CONFIG),Debug)
+LDFLAGS += `$(WX_CONFIG) --debug=yes --unicode=yes --libs`
+else ifeq ($(CONFIG),Release)
+LDFLAGS += `$(WX_CONFIG) --debug=no --unicode=yes --libs`
+endif
+
+# rules
+.PHONY: all clean test run setup
+
+$(OBJPATH)/%.o : %.c
+	$(CC) -g  $(CFLAGS)   -c $< -o $@
+
+$(OBJPATH)/%.o : %.cpp
+	$(CXX) -g $(CXXFLAGS) -c $< -o $@
+
+all : setup test
+
+$(GTEST_OBJ): $(GTEST_SRCS_) $(GTEST_HEADERS)
+	$(CXX) -g $(CPPFLAGS) -I$(GTEST_DIR) $(CXXFLAGS) -c -o $@ \
+	$(GTEST_DIR)/src/gtest-all.cc
+
+
+run test : $(TEST)
+	$(TEST)
+
+$(TEST): $(LIB) $(OBJS)
+	$(CXX) -g $(CXXFLAGS) $(filter %.o,$^) $(LDFLAGS) -o $@
+
+clean:
+	rm -f *~ $(OBJPATH)/*.o $(TEST) $(DEPENDFILE)
+
+setup:
+	@mkdir -p $(OBJPATH) $(LIBPATH) $(BINPATH)
+	@echo "Xcode build location: $(XRELDIR)"
+	@echo "WX_CONFIG location: $(WX_CONFIG)"
+	@echo
+	@[ -x $(WX_CONFIG) ] || echo "ERROR: wx-config not found: Need to define the path to the wx-config command (WX_CONFIG variable)\n"


### PR DESCRIPTION
This PR adds building and running coretest (unit tests) to the macos-latest.yml workflow.
Tested on: (And passed!)
macOS M1Max Sequoia 15.3, Xcode 16.2, wx 3.2.4 and 3.2.6 (local builds)
and the current macOS 14/Xcode 15 GitHub environment.