### PR TITLE
Split min hash iterations

### DIFF
--- a/src/core/PWSfileV4.cpp
+++ b/src/core/PWSfileV4.cpp
@@ -85,7 +85,7 @@ PWSfileV4::CKeyBlocks& PWSfileV4::CKeyBlocks::operator=(const PWSfileV4::CKeyBlo
 
 PWSfileV4::PWSfileV4(const StringX &filename, RWmode mode, VERSION version)
   : PWSfile(filename, mode, version),
-    m_effectiveFileLength(0), m_nHashIters(MIN_HASH_ITERATIONS)
+    m_effectiveFileLength(0), m_nHashIters(MIN_V4_HASH_ITERATIONS)
 {
   m_IV = m_ipthing;
   m_terminal = nullptr;
@@ -121,8 +121,8 @@ int PWSfileV4::Open(const StringX &passkey)
     // Nonce is used to detect end of keyblocks
     static_assert(int(NONCELEN) == int(SHA256::HASHLEN), "can't call HashRandom256");
     HashRandom256(m_nonce); // Generate nonce
-    if (m_nHashIters < MIN_HASH_ITERATIONS) // here we silently upgrade files to the new MIN_HASH_ITERATIONS value
-      m_nHashIters = MIN_HASH_ITERATIONS;
+    if (m_nHashIters < MIN_V4_HASH_ITERATIONS) // here we silently upgrade files to the new MIN_V4_HASH_ITERATIONS value
+      m_nHashIters = MIN_V4_HASH_ITERATIONS;
     if (!m_keyblocks.GetKeys(passkey, m_nHashIters, m_key, m_ell)) {
       PWSfile::Close();
       return WRONG_PASSWORD;
@@ -405,8 +405,8 @@ void PWSfileV4::StretchKey(const unsigned char *salt, unsigned long saltLen,
   * by the hash-function-based key stretching algorithm PBKDF2, with SHA-256
   * as the hash function, and N iterations.
   */
-  if (N < MIN_HASH_ITERATIONS) {
-    PWSTRACE(L"File's ITER value %d is below current minimum %d. It will be updated when file is saved", N, MIN_HASH_ITERATIONS);
+  if (N < MIN_V4_HASH_ITERATIONS) {
+    PWSTRACE(L"File's ITER value %d is below current minimum %d. It will be updated when file is saved", N, MIN_V4_HASH_ITERATIONS);
   }
   size_t passLen = 0;
   unsigned char *pstr = nullptr;

--- a/src/core/PWSfileV4.h
+++ b/src/core/PWSfileV4.h
@@ -52,7 +52,7 @@ public:
   size_t ReadContent(Fish *fish, unsigned char *cbcbuffer,
                      unsigned char *&content, size_t clen);
 
-  uint32 GetNHashIters() const {return m_nHashIters;}
+  uint32 GetNHashIters() const {return m_nHashIters * HASH_FACTOR;} // we're fine with rounding errors
   void SetNHashIters(uint32 N) {m_nHashIters = N / HASH_FACTOR;}
   
   // Following for low-level details that changed between format versions

--- a/src/core/PWSfileV4.h
+++ b/src/core/PWSfileV4.h
@@ -53,7 +53,7 @@ public:
                      unsigned char *&content, size_t clen);
 
   uint32 GetNHashIters() const {return m_nHashIters;}
-  void SetNHashIters(uint32 N) {m_nHashIters = N;}
+  void SetNHashIters(uint32 N) {m_nHashIters = N / HASH_FACTOR;}
   
   // Following for low-level details that changed between format versions
   virtual size_t timeFieldLen() const {return 5;} // Experimental
@@ -69,7 +69,7 @@ public:
     ~CKeyBlocks();
     CKeyBlocks & operator=(const CKeyBlocks &that);
     bool AddKeyBlock(const StringX &current_passkey, const StringX &new_passkey,
-                     uint nHashIters = MIN_HASH_ITERATIONS);
+                     uint nHashIters = MIN_V4_HASH_ITERATIONS);
     bool RemoveKeyBlock(const StringX &passkey); // fails if m_keyblocks.size() <= 1...
     // ... or if passkey doesn't match.
   private:
@@ -78,7 +78,7 @@ public:
     // V4 Format constants:
     enum {PWSaltLength = 32,KWLEN = (KLEN + 8)};
     struct KeyBlock { // See formatV4.txt
-    KeyBlock() : m_nHashIters(MIN_HASH_ITERATIONS) {}
+    KeyBlock() : m_nHashIters(MIN_V4_HASH_ITERATIONS) {}
       KeyBlock(const KeyBlock &kb);
       KeyBlock &operator=(const KeyBlock &kb);
       unsigned char m_salt[PWSaltLength];
@@ -105,6 +105,8 @@ public:
 
  private:
   enum  {NONCELEN = 32};
+  static constexpr uint32 HASH_FACTOR = 7; // Since number of hash iterations is defined for V3, this represents how much V4 hash is slower than V3. Otherwise, V4 is too slow for comfort.
+  static constexpr uint32 MIN_V4_HASH_ITERATIONS = MIN_HASH_ITERATIONS / HASH_FACTOR;
   CKeyBlocks m_keyblocks;
   // Following set by CKeyBlocks::GetKeys(), call before writing database
   unsigned char m_key[KLEN]; // K


### PR DESCRIPTION
1. Define the  min (default) number of hash iterations for V4 files as a fixed fraction of the V3 value, to keep the times comparable.
2. Speedup the FileV3Test.AttachmentTest by using a single file, rather than 8.