### PR TITLE
Fixed IsTextField treatment of DATA_ATT_... fields

### DIFF
--- a/src/core/ItemData.cpp
+++ b/src/core/ItemData.cpp
@@ -521,6 +521,11 @@ StringX CItemData::GetFieldValue(FieldType ft) const
     case TOTPSTARTTIME:
       str = GetTotpStartTime();
       break;
+    case DATA_ATT_MTIME:
+      str = GetTime(DATA_ATT_MTIME, PWSUtil::TMC_LOCALE);
+      break;
+    case DATA_ATT_CONTENT:
+      break;
     default:
       ASSERT(0);
     }

--- a/src/core/ItemData.h
+++ b/src/core/ItemData.h
@@ -412,7 +412,7 @@ inline bool CItemData::IsTextField(unsigned char t)
     t == KBSHORTCUT || t == ATTREF || t == BASEUUID || t == ALIASUUID ||
     t == SHORTCUTUUID ||
     t == TOTPCONFIG || t == TOTPLENGTH || t == TOTPSTARTTIME || t == TOTPTIMESTEP ||
-    t == DATA_ATT_TITLE || t == DATA_ATT_MEDIATYPE || t == DATA_ATT_FILENAME ||
+    t == DATA_ATT_MTIME || t == DATA_ATT_CONTENT ||
     t >= LAST_DATA);
 }
 #endif /* __ITEMDATA_H */


### PR DESCRIPTION
Looks like I missed the ! at line 407 of ItemData.h for the new attachment fields.. 🙃

Also added the two non-text fields to CItemData::GetFieldValue for completeness.
