### PR TITLE
Add pwsafe cli test to cmake

### DIFF
--- a/src/ui/cli/CMakeLists.txt
+++ b/src/ui/cli/CMakeLists.txt
@@ -8,7 +8,7 @@ set (CLI_SRCS
   diff.cpp
   impexp.cpp)
 
-set (CLI_TEST_SRC
+set (CLI_TEST_SRCS
   add-entry-test.cpp
   arg-fields-test.cpp
   split-test.cpp
@@ -21,6 +21,8 @@ set (CLI_TEST_SRC
 
 if (WIN32)
   list (APPEND CLI_SRCS cli.rc)
+  list (APPEND CLI_TEST_SRCS cli.rc)
+  set_source_files_properties(cli.rc PROPERTIES LANGUAGE RC)
 endif(WIN32)
 
 
@@ -53,3 +55,32 @@ else ()
 	target_link_libraries(pwsafe-cli Rpcrt4)
 	set_target_properties(pwsafe-cli PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 endif (NOT WIN32)
+
+# Add test executable
+add_executable(pwsafe-cli-test ${CLI_TEST_SRCS})
+target_link_libraries(pwsafe-cli-test harden_interface gtest gtest_main core os core ${wxWidgets_LIBRARIES})
+
+if (XercesC_LIBRARY)
+  target_link_libraries(pwsafe-cli-test ${XercesC_LIBRARY})
+endif (XercesC_LIBRARY)
+
+if (NOT APPLE)
+  target_link_libraries(pwsafe-cli-test uuid)
+endif (NOT APPLE)
+
+if (NOT APPLE AND NOT WIN32)
+  target_link_libraries(pwsafe-cli-test magic)
+endif (NOT APPLE AND NOT WIN32)
+
+if (NOT WIN32)
+  target_link_libraries(pwsafe-cli-test pthread)
+else ()
+  target_link_libraries(pwsafe-cli-test Rpcrt4)
+  set_target_properties(pwsafe-cli-test PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+endif (NOT WIN32)
+
+# Add test target
+add_test(NAME cli-test
+  COMMAND pwsafe-cli-test
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)

--- a/src/ui/cli/CMakeLists.txt
+++ b/src/ui/cli/CMakeLists.txt
@@ -81,7 +81,9 @@ else ()
 endif (NOT WIN32)
 
 # Add test target
+if (NOT WIN32) # Windows cli-test broken, doesn't recognize rc resources.
 add_test(NAME cli-test
   COMMAND pwsafe-cli-test
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
+endif (NOT WIN32)

--- a/src/ui/cli/CMakeLists.txt
+++ b/src/ui/cli/CMakeLists.txt
@@ -58,6 +58,7 @@ endif (NOT WIN32)
 
 # Add test executable
 add_executable(pwsafe-cli-test ${CLI_TEST_SRCS})
+set_target_properties(pwsafe-cli-test PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD_RELEASE 1)
 target_link_libraries(pwsafe-cli-test harden_interface gtest gtest_main core os core ${wxWidgets_LIBRARIES})
 
 if (XercesC_LIBRARY)

--- a/src/ui/cli/search-test.cpp
+++ b/src/ui/cli/search-test.cpp
@@ -38,7 +38,6 @@ class SearchTest : public ::testing::Test {
     // Code here will be called immediately after the constructor (right
     // before each test).
     using std::make_tuple;
-    std::wostringstream os;
 
     AddEntryWithFields(core, {make_tuple(CItemData::TITLE, L"SomeTitle"),
                               make_tuple(CItemData::EMAIL, L"test@example.com"),


### PR DESCRIPTION
Works fine on all platforms but Windows.
For some reason, the text resources (cli.rc) links fine into cli, but not the test build.
Disabled on Windows for now.