### PR TITLE
[wx] Minor correction in German translation

### DIFF
--- a/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
@@ -6404,7 +6404,7 @@ msgstr "YubiKey hineinstecken"
 
 #: /home/ronys/git/pwsafe/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp:197
 msgid "&Change"
-msgstr "&Änderungsdatum"
+msgstr "&Ändern"
 
 #: /home/ronys/git/pwsafe/src/ui/wxWidgets/SafeCombinationChangeDlg.cpp:268
 msgid "The old master password is not correct"


### PR DESCRIPTION
With the last update of the translation, an error seems to have occurred in the labeling of the Change button in the password change dialog.