### PR TITLE
[wx] Make message dialog child of Add-Edit dialog

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -3762,7 +3762,7 @@ bool AddEditPropSheetDlg::SyncAndQueryCancel(bool showDialog) {
     if (showDialog) {
       wxGenericMessageDialog dialog(
         this,
-        _("One or more values have been changed.\nDo you want to discard the changes?"), wxEmptyString,
+        _("One or more values have been changed.\nDo you want to discard the changes?"), _("Warning"),
         wxOK | wxCANCEL | wxCANCEL_DEFAULT | wxICON_EXCLAMATION
       );
       dialog.SetOKLabel(_("Discard"));

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -3760,7 +3760,7 @@ bool AddEditPropSheetDlg::SyncAndQueryCancel(bool showDialog) {
   }
   else if (!(Validate() && TransferDataFromWindow()) || GetChanges() != Changes::None) {
     if (showDialog) {
-      wxMessageDialog dialog(
+      wxGenericMessageDialog dialog(
         this,
         _("One or more values have been changed.\nDo you want to discard the changes?"), wxEmptyString,
         wxOK | wxCANCEL | wxCANCEL_DEFAULT | wxICON_EXCLAMATION
@@ -3779,7 +3779,7 @@ bool AddEditPropSheetDlg::SyncAndQueryCancel(bool showDialog) {
 
 void AddEditPropSheetDlg::OnCancel(wxCommandEvent& WXUNUSED(evt))
 {
-  if (SyncAndQueryCancel(true) && IsShown()) {
+  if (SyncAndQueryCancel(true)) {
     EndModal(wxID_CANCEL);
   }
 }

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -3761,7 +3761,7 @@ bool AddEditPropSheetDlg::SyncAndQueryCancel(bool showDialog) {
   else if (!(Validate() && TransferDataFromWindow()) || GetChanges() != Changes::None) {
     if (showDialog) {
       wxMessageDialog dialog(
-        nullptr,
+        this,
         _("One or more values have been changed.\nDo you want to discard the changes?"), wxEmptyString,
         wxOK | wxCANCEL | wxCANCEL_DEFAULT | wxICON_EXCLAMATION
       );
@@ -3779,7 +3779,7 @@ bool AddEditPropSheetDlg::SyncAndQueryCancel(bool showDialog) {
 
 void AddEditPropSheetDlg::OnCancel(wxCommandEvent& WXUNUSED(evt))
 {
-  if (SyncAndQueryCancel(true)) {
+  if (SyncAndQueryCancel(true) && IsShown()) {
     EndModal(wxID_CANCEL);
   }
 }


### PR DESCRIPTION
I created this as a draft because it still needs to be tested in combination with the auto-lock functionality. It seems to work well with these changes in my environment, but a different environment might exhibit different behavior.

Related to #1470 