### PR TITLE
[wx gh1472] - Add/Edit Go button now respects [alt] browser

### DIFF
--- a/docs/ReleaseNotesWX.md
+++ b/docs/ReleaseNotesWX.md
@@ -8,6 +8,13 @@ https://pwsafe.org/. Details about changes to older releases may be found in the
 In the following, SFxxxx refers to Bug Reports, Feature Requests and Service Requests in PasswordSafe SourceForge Project tickets, and GHxxxx refers to issues in the PasswordSafe GitHub project.
 
 
+PasswordSafe 1.21.1 Release ???
+===============================
+
+Bugs fixed in 1.21.1
+--------------------
+[GH1472](https://github.com/pwsafe/pwsafe/issues/1472) 'Go' button in Add/Edit window now respects "alt" browser specification.
+
 
 PasswordSafe 1.21.0 Release 28 March 2025
 =========================================
@@ -15,6 +22,9 @@ PasswordSafe 1.21.0 Release 28 March 2025
 * In this release, PasswordSafe will significantly increase the standard (default) unlock difficulty of PasswordSafe databases. This may cause a noticeable slowdown when reading and writing databases.
  This is necessary to maintain the same level of security on today's hardware as when PasswordSafe was originally released.
 * Authenticator codes (One-time passwords, OTP, TOTP) can be configured and used via the UI.
+
+Bugs fixed in 1.21.0
+--------------------
 * [GH1317](https://github.com/pwsafe/pwsafe/issues/1317) Aliases can now be created from new or edited entries.
 * [GH1408](https://github.com/pwsafe/pwsafe/issues/1408) Time fields (such as password modification time) are now copied over correctly in sync operations between databases.
 

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -30,6 +30,8 @@
 
 #include "core/PWCharPool.h"
 #include "core/PWHistory.h"
+#include "core/PWSAuxParse.h"
+
 #include "os/media.h"
 #include "os/run.h"
 
@@ -1749,10 +1751,15 @@ void AddEditPropSheetDlg::ItemFieldsToPropSheet()
 
 void AddEditPropSheetDlg::OnGoButtonClick(wxCommandEvent& WXUNUSED(evt))
 {
-  if (Validate() && TransferDataFromWindow() && !m_Url.IsEmpty())
-    ::wxLaunchDefaultBrowser(m_Url, wxBROWSER_NEW_WINDOW);
-}
+  if (Validate() && TransferDataFromWindow() && !m_Url.IsEmpty()) {
+    std::vector<size_t> vactionverboffsets;
+    const StringX sxAutotype = PWSAuxParse::GetAutoTypeString(m_Item, m_Core, vactionverboffsets);
+    bool bDoAutotype = !sxAutotype.empty();
 
+    GetPwSafe()->LaunchBrowser(m_Url, sxAutotype, vactionverboffsets, bDoAutotype);
+  }
+}
+  
 /*!
  * wxEVT_COMMAND_BUTTON_CLICKED event handler for ID_BUTTON_GENERATE
  */

--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -958,7 +958,7 @@ void PasswordSafeFrame::DoBrowse(CItemData &item, bool bAutotype)
 
 bool PasswordSafeFrame::LaunchBrowser(const wxString &csURL, const StringX & WXUNUSED(sxAutotype),
                              const std::vector<size_t> & WXUNUSED(vactionverboffsets),
-                             bool WXUNUSED(bDoAutotype))
+                             bool WXUNUSED(bDoAutotype)) const
 {
   /*
    * This is a straight port of DBoxMain::LaunchBrowser.  See the comments in that function
@@ -1032,7 +1032,7 @@ bool PasswordSafeFrame::LaunchBrowser(const wxString &csURL, const StringX & WXU
 #endif
 
   if (!rc) {
-    wxMessageBox(errMsg, wxTheApp->GetAppName(), wxOK|wxICON_STOP, this);
+    wxMessageBox(errMsg, wxTheApp->GetAppName(), wxOK|wxICON_STOP, const_cast<PasswordSafeFrame*>(this));
   }
   return rc;
 }

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -653,6 +653,9 @@ public:
   /// Get top dialog (shown or hidden)
   wxTopLevelWindow* GetTopWindow() const;
   static void DisplayFileWriteError(int rc, const StringX &fname);
+  
+  bool LaunchBrowser(const wxString &csURL, const StringX &sxAutotype,
+    const std::vector<size_t> &vactionverboffsets, bool bDoAutotype) const;
 
 
 ////@begin PasswordSafeFrame member variables
@@ -725,8 +728,6 @@ private:
                               const bool bTitleRenamed, wxString &timeStr,
                               const CItemData::EntryType et,
                               std::vector<StringX> &vs_added);
-  bool LaunchBrowser(const wxString &csURL, const StringX &sxAutotype,
-                     const std::vector<size_t> &vactionverboffsets, bool bDoAutotype);
 
   // Do* member functions for right-click and menu-accessible actions
   void DoCopyPassword(CItemData &item);

--- a/version.wx
+++ b/version.wx
@@ -5,5 +5,5 @@
 
 VER_MAJOR = 1
 VER_MINOR = 21
-VER_REV = 0
+VER_REV = 1
 #VER_SPECIAL = pre


### PR DESCRIPTION
Addresses #1472 

Also alias should be handled correctly, as well as prep for autotype.

Since 1.21.0 was just released, bumping version to 1.21.1