### PR TITLE
Removed 'const' attribute from IsYubiInserted

### DIFF
--- a/src/os/unix/PWYubi.cpp
+++ b/src/os/unix/PWYubi.cpp
@@ -43,7 +43,7 @@ PWYubi::~PWYubi()
   pthread_mutex_unlock(&s_mutex);
 }
 
-bool PWYubi::IsYubiInserted() const
+bool PWYubi::IsYubiInserted()
 {
   bool retval = false;
   pthread_mutex_lock(&s_mutex);

--- a/src/os/unix/PWYubi.h
+++ b/src/os/unix/PWYubi.h
@@ -16,7 +16,7 @@ class PWYubi {
 public:
   PWYubi();
   ~PWYubi();
-  bool IsYubiInserted() const;
+  bool IsYubiInserted();
   bool GetSerial(unsigned int &serial) const;
   bool WriteSK(const unsigned char *sk, size_t sklen);
 
@@ -38,7 +38,7 @@ public:
   const std::wstring &GetErrStr() const {return m_ykerrstr;}
 private:
   void report_error() const;
-  mutable bool m_isInited;
+  bool m_isInited;
   static bool s_yubiDetected;
   static pthread_mutex_t s_mutex;
   mutable std::wstring m_ykerrstr;

--- a/src/ui/wxWidgets/YubiCfgDlg.cpp
+++ b/src/ui/wxWidgets/YubiCfgDlg.cpp
@@ -366,6 +366,6 @@ void YubiCfgDlg::yubiRemoved(void)
 
 bool YubiCfgDlg::IsYubiInserted() const
 {
-  const PWYubi yubi;
+  PWYubi yubi;
   return yubi.IsYubiInserted();
 }

--- a/src/ui/wxWidgets/YubiMixin.cpp
+++ b/src/ui/wxWidgets/YubiMixin.cpp
@@ -66,7 +66,7 @@ void YubiMixin::yubiRemoved(void)
 
 bool YubiMixin::IsYubiInserted() const
 {
-  const PWYubi yubi;
+  PWYubi yubi;
   return yubi.IsYubiInserted();
 }
 


### PR DESCRIPTION
The IsYubiInserted de-initializes the object if no key is inserted, which is IMHO not to be expected from a const method.

With this PR applied, it is (more) clear that the object changes significantly.

The 'mutable' on the ivar allowed this behavior, removed that keyword too.