### PR TITLE
[macOS] Add file type associations

### DIFF
--- a/Xcode/pwsafe-template.plist
+++ b/Xcode/pwsafe-template.plist
@@ -4,6 +4,41 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeIconSystemGenerated</key>
+			<integer>1</integer>
+			<key>CFBundleTypeName</key>
+			<string>Password Safe Database</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.pwsafe.pwsafe.safe</string>
+			</array>
+			<key>NSDocumentClass</key>
+			<string>Document</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeIconSystemGenerated</key>
+			<integer>1</integer>
+			<key>CFBundleTypeName</key>
+			<string>Password Safe Backup</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.pwsafe.pwsafe.backup</string>
+			</array>
+			<key>NSDocumentClass</key>
+			<string>Document</string>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
@@ -26,5 +61,56 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.contents</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Password Safe Database</string>
+			<key>UTTypeIcons</key>
+			<dict>
+				<key>UTTypeIconBadgeName</key>
+				<string>AppIcon</string>
+			</dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.pwsafe.pwsafe.safe</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>psafe3</string>
+					<string>psafe4</string>
+					<string>dat</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.contents</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Password Safe Backup</string>
+			<key>UTTypeIcons</key>
+			<dict>
+				<key>UTTypeIconBadgeName</key>
+				<string>AppIcon</string>
+			</dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.pwsafe.pwsafe.backup</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>ibak</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Xcode/pwsafe-template.plist
+++ b/Xcode/pwsafe-template.plist
@@ -26,6 +26,22 @@
 			<key>CFBundleTypeIconSystemGenerated</key>
 			<integer>1</integer>
 			<key>CFBundleTypeName</key>
+			<string>Password Safe v1 or v2</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.pwsafe.pwsafe.v1v2</string>
+			</array>
+			<key>NSDocumentClass</key>
+			<string>Document</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeIconSystemGenerated</key>
+			<integer>1</integer>
+			<key>CFBundleTypeName</key>
 			<string>Password Safe Backup</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
@@ -84,6 +100,28 @@
 				<array>
 					<string>psafe3</string>
 					<string>psafe4</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.contents</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Password Safe v1 or v2</string>
+			<key>UTTypeIcons</key>
+			<dict>
+				<key>UTTypeIconBadgeName</key>
+				<string>AppIcon</string>
+			</dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.pwsafe.pwsafe.v1v2</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
 					<string>dat</string>
 				</array>
 			</dict>

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -372,7 +372,6 @@
 		E0A70B9621C8FF8900A2FEA8 /* PolicyManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PolicyManager.cpp; sourceTree = "<group>"; };
 		E0A70B9721C8FF8900A2FEA8 /* PolicyManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PolicyManager.h; sourceTree = "<group>"; };
 		E0A70B9A21C905A500A2FEA8 /* libcurl.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcurl.tbd; path = usr/lib/libcurl.tbd; sourceTree = SDKROOT; };
-		E0C3C4512379CD8300715124 /* CoreAlias.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CoreAlias.cpp; sourceTree = "<group>"; };
 		E0C3C42F2379B2C200715124 /* AES.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AES.cpp; path = crypto/AES.cpp; sourceTree = "<group>"; };
 		E0C3C4302379B2C200715124 /* AES.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AES.h; path = crypto/AES.h; sourceTree = "<group>"; };
 		E0C3C4312379B2C200715124 /* bitops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bitops.h; path = crypto/bitops.h; sourceTree = "<group>"; };
@@ -393,6 +392,7 @@
 		E0C3C44A2379CA2A00715124 /* CryptKeyEntryDlg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CryptKeyEntryDlg.cpp; sourceTree = "<group>"; };
 		E0C3C44B2379CA2A00715124 /* CryptKeyEntryDlg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CryptKeyEntryDlg.h; sourceTree = "<group>"; };
 		E0C3C44D2379CA7300715124 /* MenuFileHandlers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MenuFileHandlers.cpp; sourceTree = "<group>"; };
+		E0C3C4512379CD8300715124 /* CoreAlias.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CoreAlias.cpp; sourceTree = "<group>"; };
 		E60F25D612C4ACEB001E63C4 /* ExternalKeyboardButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ExternalKeyboardButton.cpp; sourceTree = "<group>"; };
 		E60F25D712C4ACEB001E63C4 /* ExternalKeyboardButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExternalKeyboardButton.h; sourceTree = "<group>"; };
 		E6112A61131D720E00AA1454 /* ExpiredList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ExpiredList.cpp; sourceTree = "<group>"; };
@@ -1590,10 +1590,7 @@
 			children = (
 				E6EE83EA11E87E9800B01518 /* XML */,
 				E0C3C42D2379B2A700715124 /* crypto */,
-				E0A70B9621C8FF8900A2FEA8 /* PolicyManager.cpp */,
-				E0A70B9721C8FF8900A2FEA8 /* PolicyManager.h */,
-				E6F8DC201D132657007DFBEC /* RUEList.cpp */,
-				E6F8DC211D132657007DFBEC /* RUEList.h */,
+				E683B216150481DF0013D588 /* pugixml */,
 				E6EE839411E87E9700B01518 /* CheckVersion.cpp */,
 				E6EE839511E87E9700B01518 /* CheckVersion.h */,
 				E6EE839611E87E9700B01518 /* Command.cpp */,
@@ -1602,6 +1599,7 @@
 				E6EE83A211E87E9700B01518 /* core_st.cpp */,
 				E6EE83A311E87E9700B01518 /* core_st.h */,
 				E6EE839F11E87E9700B01518 /* core.h */,
+				E0C3C4512379CD8300715124 /* CoreAlias.cpp */,
 				E6EE839D11E87E9700B01518 /* coredefs.h */,
 				E6EE839E11E87E9700B01518 /* CoreImpExp.cpp */,
 				E6DDC6FF1389120E00F0C0D1 /* CoreOtherDB.cpp */,
@@ -1618,8 +1616,9 @@
 				E6EE83AA11E87E9700B01518 /* ItemField.h */,
 				E6EE83AC11E87E9700B01518 /* Match.cpp */,
 				E6EE83AD11E87E9700B01518 /* Match.h */,
+				E0A70B9621C8FF8900A2FEA8 /* PolicyManager.cpp */,
+				E0A70B9721C8FF8900A2FEA8 /* PolicyManager.h */,
 				E6EE83AF11E87E9700B01518 /* Proxy.h */,
-				E683B216150481DF0013D588 /* pugixml */,
 				E6EE83B011E87E9700B01518 /* PWCharPool.cpp */,
 				E6EE83B111E87E9700B01518 /* PWCharPool.h */,
 				E6EE83B211E87E9700B01518 /* PWHistory.cpp */,
@@ -1642,7 +1641,6 @@
 				E6EE83C111E87E9700B01518 /* PWSfileV3.h */,
 				A2FE258B1C5ACF7500210C36 /* PWSfileV4.cpp */,
 				A2FE258C1C5ACF7500210C36 /* PWSfileV4.h */,
-				E0C3C4512379CD8300715124 /* CoreAlias.cpp */,
 				E6EE83C211E87E9700B01518 /* PWSFilters.cpp */,
 				E6EE83C311E87E9700B01518 /* PWSFilters.h */,
 				E698275814C01B7D0043C243 /* PWSLog.cpp */,
@@ -1656,6 +1654,8 @@
 				A2FE25941C5ACFBD00210C36 /* PWStime.h */,
 				E6EE83C911E87E9700B01518 /* Report.cpp */,
 				E6EE83CA11E87E9700B01518 /* Report.h */,
+				E6F8DC201D132657007DFBEC /* RUEList.cpp */,
+				E6F8DC211D132657007DFBEC /* RUEList.h */,
 				E6299FB91D07161E00D03FD1 /* SearchUtils.h */,
 				E6EE83CF11E87E9700B01518 /* StringX.cpp */,
 				E6EE83D011E87E9700B01518 /* StringX.h */,

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -720,7 +720,7 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
 #ifdef __WXMAC__
 // On macOS, this enables file unlock and UI restore upon left-click of the dock icon.
 // Not to be confused with the system tray (menu bar) icon.
-void PWSafeApp::MacNewFile()
+void PWSafeApp::MacReopenApp()
 {
   GetPasswordSafeFrame()->UnlockSafe(true, false);
 }

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -75,7 +75,7 @@ public:
 
 ////@begin PWSafeApp event handler declarations
 #ifdef __WXMAC__
-  virtual void MacNewFile() wxOVERRIDE;
+  virtual void MacReopenApp() wxOVERRIDE;
 #endif // __WXMAC__
 ////@end PWSafeApp event handler declarations
 


### PR DESCRIPTION
This adds the file type associations to Info.plist so the pwsafe icon will be used for .psafe3, .psafe4, and .ibak files.  Also, some minor clean-up.
Note: If you double-click on a pwsafe file type it will launch the app, but the name will not be pre-populated in the password dialog.  It's complicated...maybe a project for the future. :-)