### PR TITLE
[wx] Remove an unnecessary  parameter that causes a debug message

### DIFF
--- a/src/ui/wxWidgets/CryptKeyEntryDlg.cpp
+++ b/src/ui/wxWidgets/CryptKeyEntryDlg.cpp
@@ -53,7 +53,7 @@ CryptKeyEntryDlg::CryptKeyEntryDlg(Mode mode)
     }
 
     BoxSizer1 = new wxBoxSizer(wxVERTICAL);
-    BoxSizer1->Add(StaticTextDescription, 0, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    BoxSizer1->Add(StaticTextDescription, 0, wxALL|wxALIGN_LEFT, 5);
     FlexGridSizer1 = new wxFlexGridSizer(0, 2, 0, 0);
     FlexGridSizer1->AddGrowableCol(1);
     StaticTextKey1 = new wxStaticText(this, wxID_ANY, _("Enter Key:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));


### PR DESCRIPTION
Using a debug builds of wxWidgets 3.2.4 and 3.2.7 on macOS:
Running pwsafe from the command line with the -d or -e options caused a debug message to pop-up because of an unnecessary, and inconsistent, parameter. (See screenshot.)  Click continue and the program continues normally.  As the message says, the fix is to remove it.

![Screenshot 2025-04-06 at 6 31 44 PM](https://github.com/user-attachments/assets/588931c4-e26e-4aca-aaad-5d74bbcad0f0)
