### PR TITLE
[macOS] Support launching the app by clicking a file

### DIFF
--- a/Xcode/pwsafe-template.plist
+++ b/Xcode/pwsafe-template.plist
@@ -123,6 +123,7 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>dat</string>
+					<string>bak</string>
 				</array>
 			</dict>
 		</dict>

--- a/Xcode/pwsafe-template.plist
+++ b/Xcode/pwsafe-template.plist
@@ -8,7 +8,7 @@
 	<array>
 		<dict>
 			<key>CFBundleTypeIconSystemGenerated</key>
-			<integer>1</integer>
+			<integer>0</integer>
 			<key>CFBundleTypeName</key>
 			<string>Password Safe Database</string>
 			<key>CFBundleTypeRole</key>
@@ -19,28 +19,10 @@
 			<array>
 				<string>org.pwsafe.pwsafe.safe</string>
 			</array>
-			<key>NSDocumentClass</key>
-			<string>Document</string>
 		</dict>
 		<dict>
 			<key>CFBundleTypeIconSystemGenerated</key>
-			<integer>1</integer>
-			<key>CFBundleTypeName</key>
-			<string>Password Safe v1 or v2</string>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>LSHandlerRank</key>
-			<string>Alternate</string>
-			<key>LSItemContentTypes</key>
-			<array>
-				<string>org.pwsafe.pwsafe.v1v2</string>
-			</array>
-			<key>NSDocumentClass</key>
-			<string>Document</string>
-		</dict>
-		<dict>
-			<key>CFBundleTypeIconSystemGenerated</key>
-			<integer>1</integer>
+			<integer>0</integer>
 			<key>CFBundleTypeName</key>
 			<string>Password Safe Backup</string>
 			<key>CFBundleTypeRole</key>
@@ -51,8 +33,6 @@
 			<array>
 				<string>org.pwsafe.pwsafe.backup</string>
 			</array>
-			<key>NSDocumentClass</key>
-			<string>Document</string>
 		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
@@ -100,30 +80,6 @@
 				<array>
 					<string>psafe3</string>
 					<string>psafe4</string>
-				</array>
-			</dict>
-		</dict>
-		<dict>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>public.data</string>
-				<string>public.contents</string>
-			</array>
-			<key>UTTypeDescription</key>
-			<string>Password Safe v1 or v2</string>
-			<key>UTTypeIcons</key>
-			<dict>
-				<key>UTTypeIconBadgeName</key>
-				<string>AppIcon</string>
-			</dict>
-			<key>UTTypeIdentifier</key>
-			<string>org.pwsafe.pwsafe.v1v2</string>
-			<key>UTTypeTagSpecification</key>
-			<dict>
-				<key>public.filename-extension</key>
-				<array>
-					<string>dat</string>
-					<string>bak</string>
 				</array>
 			</dict>
 		</dict>

--- a/docs/ReleaseNotesWX.md
+++ b/docs/ReleaseNotesWX.md
@@ -17,7 +17,7 @@ Bugs fixed in 1.21.1
 
 New features in 1.21.1
 ----------------------
-* macOS: File type associations are now supported for .psafe3 and .ibak files.  The proper icon will be used in Finder and Password Safe can be launched by double-clicking a file.
+* macOS: File type associations are now supported for .psafe3 and .ibak files.  The Pwsafe icon will be used in Finder and the app can be launched by double-clicking a file.
 
 
 PasswordSafe 1.21.0 Release 28 March 2025

--- a/docs/ReleaseNotesWX.md
+++ b/docs/ReleaseNotesWX.md
@@ -15,6 +15,10 @@ Bugs fixed in 1.21.1
 --------------------
 [GH1472](https://github.com/pwsafe/pwsafe/issues/1472) 'Go' button in Add/Edit window now respects "alt" browser specification.
 
+New features in 1.21.1
+----------------------
+* macOS: File type associations are now supported for .psafe3 and .ibak files.  The proper icon will be used in Finder and Password Safe can be launched by double-clicking a file.
+
 
 PasswordSafe 1.21.0 Release 28 March 2025
 =========================================

--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -242,11 +242,16 @@ void PasswordSafeFrame::OnOpenClick(wxCommandEvent& WXUNUSED(evt))
   int rc = DoOpen(_("Open Password Database"));
 
   if (rc == PWScore::SUCCESS) {
-    m_core.ResumeOnDBNotification();
-    CreateMenubar(); // Recreate the menu with updated list of most recently used DBs
-    UpdateSearchBarVisibility();
-    m_AuiManager.Update();
+    FinishGoodOpen();
   }
+}
+
+void PasswordSafeFrame::FinishGoodOpen()
+{
+  m_core.ResumeOnDBNotification();
+  CreateMenubar(); // Recreate the menu with updated list of most recently used DBs
+  UpdateSearchBarVisibility();
+  m_AuiManager.Update();
 }
 
 /*!

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -141,9 +141,8 @@ static const wxCmdLineEntryDesc cmdLineDesc[] = {
    wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL},
 #endif
   {wxCMD_LINE_PARAM, nullptr, nullptr, STR("database"),
-   wxCMD_LINE_VAL_STRING,
-   (wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE)},
-  {wxCMD_LINE_NONE, nullptr, nullptr, nullptr, wxCMD_LINE_VAL_NONE, 0}
+   wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},   // We only really use one param
+  wxCMD_LINE_DESC_END
 };
 
 #undef STR
@@ -344,14 +343,15 @@ bool PWSafeApp::OnInit()
     return false;
 
   // Parse command line options:
-  wxString filename, user, host, cfg_file;
+  wxString cmd_filename, user, host, cfg_file;
   bool cmd_ro = cmdParser.Found(wxT("r"));
 
-  bool cmd_encrypt = cmdParser.Found(wxT("e"), &filename);
-  bool cmd_decrypt = cmdParser.Found(wxT("d"), &filename);
-  bool cmd_closed = cmdParser.Found(wxT("c"));
-  bool cmd_silent = cmdParser.Found(wxT("s"));
-  bool cmd_minimized = cmdParser.Found(wxT("m"));
+  m_cmd_closed = cmdParser.Found(wxT("c"));
+  m_cmd_silent = cmdParser.Found(wxT("s"));
+  m_cmd_minimized = cmdParser.Found(wxT("m"));
+
+  bool cmd_encrypt = cmdParser.Found(wxT("e"), &cmd_filename);
+  bool cmd_decrypt = cmdParser.Found(wxT("d"), &cmd_filename);
   bool cmd_user = cmdParser.Found(wxT("u"), &user);
   bool cmd_host = cmdParser.Found(wxT("h"), &host);
   bool cmd_cfg = cmdParser.Found(wxT("g"), &cfg_file);
@@ -359,24 +359,24 @@ bool PWSafeApp::OnInit()
   long int yubi_polling_interval;
   bool cmd_yubi_polling_interval = cmdParser.Found(wxT("yubi-polling-interval"), &yubi_polling_interval);
 #endif
-  bool file_in_cmd = false;
+  m_file_in_cmd = false;
   size_t count = cmdParser.GetParamCount();
   if (count == 1) {
-    filename = cmdParser.GetParam();
-    file_in_cmd = true;
+    cmd_filename = cmdParser.GetParam();
+    m_file_in_cmd = true;
   }
   else if (count > 1) {
     cmdParser.Usage();
     return false;
   }
   // check for mutually exclusive options
-  if ((cmd_encrypt && cmd_decrypt) || (cmd_closed && cmd_silent && cmd_minimized)) {
+  if ((cmd_encrypt && cmd_decrypt) || (m_cmd_closed && m_cmd_silent && m_cmd_minimized)) {
     cmdParser.Usage();
     return false;
   }
 
   // Process encryption/decryption command line arguments
-  if ((cmd_encrypt || cmd_decrypt) && !filename.IsEmpty()) {
+  if ((cmd_encrypt || cmd_decrypt) && !cmd_filename.IsEmpty()) {
 
     auto processCryption = [&](CryptKeyEntryDlg::Mode mode, std::function<bool(const stringT &fn, const StringX &passwd, stringT &errmess)> func) {
       stringT errstr;
@@ -384,7 +384,7 @@ bool PWSafeApp::OnInit()
       CryptKeyEntryDlg dialog(mode);
 
       if (dialog.ShowModal() == wxID_OK) {
-        if (!func(tostdstring(filename), dialog.getCryptKey(), errstr)) {
+        if (!func(tostdstring(cmd_filename), dialog.getCryptKey(), errstr)) {
           wxMessageDialog messageBox(
             nullptr, errstr, _("Error"), wxOK | wxICON_ERROR
           );
@@ -436,19 +436,19 @@ bool PWSafeApp::OnInit()
 
   // if filename passed in command line, it takes precedence
   // over that in preference:
-  if (filename.empty()) {
-    filename =  prefs->GetPref(PWSprefs::CurrentFile).c_str();
+  if (cmd_filename.empty()) {
+    cmd_filename =  prefs->GetPref(PWSprefs::CurrentFile).c_str();
   } else {
-    recentDatabases().AddFileToHistory(filename);
+    recentDatabases().AddFileToHistory(cmd_filename);
   }
-  m_core.SetCurFile(tostringx(filename));
+  m_core.SetCurFile(tostringx(cmd_filename));
   m_core.SetApplicationNameAndVersion(tostdstring(progName),
                                       MAKELONG(MINORVERSION, MAJORVERSION));
 
   static wxSingleInstanceChecker appInstance;
   if (!prefs->GetPref(PWSprefs::MultipleInstances) &&
-        (appInstance.Create(wxT("pwsafe.lck"), towxstring(pws_os::getuserprefsdir())) &&
-         appInstance.IsAnotherRunning()))
+      (appInstance.Create(wxT("pwsafe.lck"), towxstring(pws_os::getuserprefsdir())) &&
+       appInstance.IsAnotherRunning()))
   {
     wxMessageBox(_("Another instance of Password Safe is already running"), _("Password Safe"),
                           wxOK|wxICON_INFORMATION);
@@ -462,10 +462,10 @@ bool PWSafeApp::OnInit()
   // here if we're the child
   recentDatabases().Load();
 
-  if (cmd_closed || cmd_minimized) {
+  if (m_cmd_closed || m_cmd_minimized) {
     m_core.SetCurFile(L"");
   }
-  if (cmd_silent) {
+  if (m_cmd_silent) {
     if ( IsTaskBarIconAvailable() ) {
       // start silent implies use system tray.
       // Note that if UseSystemTray is already true, then pwsafe will try to run silently anyway
@@ -483,11 +483,11 @@ bool PWSafeApp::OnInit()
 
   if (!isHelpActivated) { // set on language activation by ActivateHelp
     std::wcerr << L"Could not initialize help subsystem." << std::endl;
-    if (!prefs->GetPref(PWSprefs::IgnoreHelpLoadError) && !cmd_silent) {
+    if (!prefs->GetPref(PWSprefs::IgnoreHelpLoadError) && !m_cmd_silent) {
 #if wxCHECK_VERSION(2,9,2)
       wxRichMessageDialog dlg(nullptr,
-        _("Could not initialize help subsystem. Help will not be available."),
-        _("Password Safe: Error initializing help"), wxCENTRE|wxOK|wxICON_EXCLAMATION);
+                              _("Could not initialize help subsystem. Help will not be available."),
+                              _("Password Safe: Error initializing help"), wxCENTRE|wxOK|wxICON_EXCLAMATION);
       dlg.ShowCheckBox(_("Don't show this warning again"));
       dlg.ShowModal();
       if (dlg.IsCheckBoxChecked()) {
@@ -496,12 +496,28 @@ bool PWSafeApp::OnInit()
       }
 #else
       wxMessageBox(_("Could not initialize help subsystem. Help will not be available."),
-      _("Password Safe: Error initializing help"), wxOK | wxICON_ERROR);
+                   _("Password Safe: Error initializing help"), wxOK | wxICON_ERROR);
 #endif
     }
   }
 
-  if (!cmd_closed && !cmd_silent && !cmd_minimized) {
+/*
+ * On macOS, Finder GUI file actions, such as double-clicking a file to open it, are sent
+ * to the app via calls to MacOpenFiles() and MacNewFile().  However, those messages
+ * are not processed until OnInit() returns.  This hack splits OnInit() into two parts,
+ * InitPart2() is called from those functions so that MacOpenFiles() has a chance
+ * to set the file name before the password entry dialog is displayed.
+ * All other information needed is stored in the PWSafeApp object.
+ * On Linux/Unix, this is still one big happy function.
+ */
+#ifdef __WXMAC__
+  return true;
+}
+
+bool PWSafeApp::InitPart2() {
+#endif //__WXMAC__
+
+  if (!m_cmd_closed && !m_cmd_silent && !m_cmd_minimized) {
     // Get the file, r/w mode and password from user
     // Note that file may be new
     DestroyWrapper<SafeCombinationEntryDlg> initWindowWrapper(nullptr, m_core);
@@ -545,17 +561,17 @@ bool PWSafeApp::OnInit()
     }
   }
 
-  if (!cmd_silent)
+  if (!m_cmd_silent)
     m_frame->Show();
-  if (cmd_minimized)
+  if (m_cmd_minimized)
     m_frame->Iconize();
-  else if (cmd_silent) {
+  else if (m_cmd_silent) {
     // Hide UI enumerates top-level windows and its children and hide them,
     // so we need to set top windows first and only then call hideUI
     SetTopWindow(m_frame);
     wxSafeYield();
     m_frame->HideUI(false);
-    if (file_in_cmd) {
+    if (m_file_in_cmd) {
        // set locked status if file was passed from command line
        m_frame->SetTrayStatus(true);
     }
@@ -570,6 +586,7 @@ bool PWSafeApp::OnInit()
     m_frame->ShowTrayIcon();
 
   m_frame->Register(); // register modal dialog hook
+  m_initComplete = true;
   return true;
 }
 
@@ -718,11 +735,40 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
 }
 
 #ifdef __WXMAC__
-// On macOS, this enables file unlock and UI restore upon left-click of the dock icon.
+// macOS specific functions for UI interactions...
+
+// This enables file unlock and UI restore upon left-click of the dock icon.
 // Not to be confused with the system tray (menu bar) icon.
 void PWSafeApp::MacReopenApp()
 {
-  GetPasswordSafeFrame()->UnlockSafe(true, false);
+//  (void)wxMessageBox("We're here!", "MacReopenApp", wxICON_INFORMATION | wxOK );
+  if (m_initComplete)
+    GetPasswordSafeFrame()->UnlockSafe(true, false);
+}
+
+// This is called when a file, of a type associated with the app, is double-clicked
+// or drag-and-dropped onto the dock icon.  We need to set the current file name before
+// showing the SafeCombinationEntryDlg dialog.  (Which happens in InitPart2().  If
+// InitPart2() does not create the PasswordSafeFrame, (i.e. the user clicked cancel)
+// the the framework will call OnExit() for us.
+void PWSafeApp::MacOpenFiles(const wxArrayString& fileNames) {
+  StringX filename;
+  if (m_initComplete || fileNames.IsEmpty())
+    return;
+
+//  wxString msg = wxString::Format("MacOpenFiles entered with %zd names, the first one is: %s", fileNames.GetCount(), fileNames[0].c_str());
+//  (void)wxMessageBox("We're here!", msg, wxICON_INFORMATION | wxOK );
+
+  filename = fileNames[0];
+  m_core.SetCurFile(filename);
+  InitPart2();
+}
+
+// This is called when the app is started by itself (not by clicking a file)
+// Just finish the init.
+void PWSafeApp::MacNewFile() {
+//  (void)wxMessageBox("We're here!", "MacNewFile", wxICON_INFORMATION | wxOK );
+  InitPart2();
 }
 #endif // __WXMAC__
 
@@ -732,21 +778,22 @@ void PWSafeApp::MacReopenApp()
 
 int PWSafeApp::OnExit()
 {
-  m_idleTimer->Stop();
-  recentDatabases().Save();
-  PWSprefs *prefs = PWSprefs::GetInstance();
-  if (m_core.IsDbFileSet()) {
-    prefs->SetPref(PWSprefs::CurrentFile, m_core.GetCurFile());
-    // Don't leave dangling locks!
-    m_core.SafeUnlockCurFile();
+  if (m_initComplete) {
+    m_idleTimer->Stop();
+    recentDatabases().Save();
+    PWSprefs *prefs = PWSprefs::GetInstance();
+    if (m_core.IsDbFileSet()) {
+      prefs->SetPref(PWSprefs::CurrentFile, m_core.GetCurFile());
+      // Don't leave dangling locks!
+      m_core.SafeUnlockCurFile();
+    }
+    // Save Application related preferences
+    prefs->SaveApplicationPreferences();
+    // Save shortcuts, if changed
+    PWSMenuShortcuts::GetShortcutsManager()->SaveUserShortcuts();
+    PWSMenuShortcuts::DestroyShortcutsManager();
   }
-  // Save Application related preferences
-  prefs->SaveApplicationPreferences();
-  // Save shortcuts, if changed
-  PWSMenuShortcuts::GetShortcutsManager()->SaveUserShortcuts();
 
-  PWSMenuShortcuts::DestroyShortcutsManager();
-  
 ////@begin PWSafeApp cleanup
   return wxApp::OnExit();
 ////@end PWSafeApp cleanup

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -742,7 +742,6 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
 // Not to be confused with the system tray (menu bar) icon.
 void PWSafeApp::MacReopenApp()
 {
-//  (void)wxMessageBox("We're here!", "MacReopenApp", wxOK );
   if (m_initComplete)
     GetPasswordSafeFrame()->UnlockSafe(true, false);
 }
@@ -756,10 +755,6 @@ void PWSafeApp::MacOpenFiles(const wxArrayString& fileNames) {
   StringX filename;
   if (fileNames.IsEmpty())
     return;
-
-//  wxString msg = wxString::Format("MacOpenFiles entered with %zd names, the first one is: %s",
-//                                  fileNames.GetCount(), fileNames[0].c_str());
-//  (void)wxMessageBox("We're here!", msg, wxICON_INFORMATION | wxOK );
 
   // Really, we can only open one file at a time, so just use the first one.
   filename = fileNames[0];
@@ -787,7 +782,6 @@ void PWSafeApp::MacOpenFiles(const wxArrayString& fileNames) {
 // This is called when the app is started by itself (not by clicking a data file)
 // Just finish the init.
 void PWSafeApp::MacNewFile() {
-//  (void)wxMessageBox("We're here!", "MacNewFile", wxOK );
   wxMutexLocker lock(m_MacFileEventMutex);
   if (lock.IsOk()) {
     InitPart2();

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -128,7 +128,7 @@ private:
   bool m_cmd_minimized;
   bool m_file_in_cmd = false;
   bool m_initComplete = false;
-  bool InitPart2();
+  void FinishInit();
 
 public:
   RecentDbList &recentDatabases();

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -75,7 +75,10 @@ public:
 
 ////@begin PWSafeApp event handler declarations
 #ifdef __WXMAC__
+  bool InitPart2();
   virtual void MacReopenApp() wxOVERRIDE;
+  virtual void MacNewFile() wxOVERRIDE;
+  virtual void MacOpenFiles(const wxArrayString& fileNames) wxOVERRIDE;
 #endif // __WXMAC__
 ////@end PWSafeApp event handler declarations
 
@@ -119,6 +122,12 @@ private:
   wxString helpFileNamePath;
   bool isHelpActivated;
   bool ActivateHelp(wxLanguage language);
+
+  bool m_cmd_closed;
+  bool m_cmd_silent;
+  bool m_cmd_minimized;
+  bool m_file_in_cmd = false;
+  bool m_initComplete = false;
 
 public:
   RecentDbList &recentDatabases();

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -75,7 +75,6 @@ public:
 
 ////@begin PWSafeApp event handler declarations
 #ifdef __WXMAC__
-  bool InitPart2();
   virtual void MacReopenApp() wxOVERRIDE;
   virtual void MacNewFile() wxOVERRIDE;
   virtual void MacOpenFiles(const wxArrayString& fileNames) wxOVERRIDE;
@@ -128,6 +127,7 @@ private:
   bool m_cmd_minimized;
   bool m_file_in_cmd = false;
   bool m_initComplete = false;
+  bool InitPart2();
 
 public:
   RecentDbList &recentDatabases();

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -78,6 +78,7 @@ public:
   virtual void MacReopenApp() wxOVERRIDE;
   virtual void MacNewFile() wxOVERRIDE;
   virtual void MacOpenFiles(const wxArrayString& fileNames) wxOVERRIDE;
+  wxMutex m_MacFileEventMutex;
 #endif // __WXMAC__
 ////@end PWSafeApp event handler declarations
 

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -677,6 +677,7 @@ private:
   int NewFile(StringX &fname);
   int DoOpen(const wxString& title);
   int Open(const wxString &fname); // prompt for password, try to Load.
+  void FinishGoodOpen();
   int SaveIfChanged();
   int SaveAs(void);
   int Save(SaveType savetype = SaveType::INVALID);


### PR DESCRIPTION
On macOS, when an app is launched by double-clicking a file, the file name is not passed on the command line, as it is in Unix/Linux.  Instead, the file name(s) are passed in event messages which wxWidgets passes to the app by calling these Mac-only functions:
MacNewFile() - When the app icon itself is clicked to launch the program (No file name is passed.)
MacOpenFiles() - When one or more files are double-clicked (we only use the first one in the list)
This is also called if a file is double-clicked while the program is running, in which case it's handled the same as using the File->Open menu item.

However, the framework does not call those functions until OnInit() returns, so MacOpenFiles() does not have a chance to override the default file name displayed in the password entry dialog.

This PR splits OnInit() into two parts. When the first part (OnInit()) returns "true", the event is processed and one of the above functions will call the second part, FinishInit().  On non-macOS builds, OnInit() calls FinishInit() directly, so there should be no change in functionality.
 
Although there is no intended change in function for non-macOS builds, some code changes are in effect.  Some minimal testing has been done on Linux to check for regressions, including command line option processing.  

Testing was done on:
macOS M1Max Sequoia 15.4, Xcode 16.3, wx 3.2.4 and 3.2.7 (local builds)
Fedora 41 ARM64 VMware,      Xfce/X11,      gcc 14.2.1, wx 3.2.6, GTK 3.24.43
Fedora 41 ARM64 VMware,      KDE/Wayland,   gcc 14.2.1, wx 3.2.6, GTK 3.24.43
Ubuntu 24.04.2 ARM64 VMware, Gnome/Wayland, gcc 13.3.0, wx 3.2.4, GTK 3.24.41

EDIT: InitPart2() changed to FinishInit() per review comment.