### PR TITLE
Mac: Fallback to default locale instead of throwing

### DIFF
--- a/src/os/mac/utf8conv.cpp
+++ b/src/os/mac/utf8conv.cpp
@@ -32,8 +32,17 @@ class Startup {
 public:
   Startup() {
     char *sl = setlocale(LC_ALL, "");
-    if (sl == NULL)
-      throw "Couldn't initialize locale - bailing out";
+    if (sl == NULL) {
+      // According to setlocale(3):
+      // An argument of "" will determine the name of the new locale taking into account the environment variables LANG and LC_*.  If these environment variables yield a locale that is invalid, NULL will be returned and the current locale will remain unchanged.
+      // Apparently these environment variables are setup incorrectly, let's try some sane defaults
+      sl = setlocale(LC_ALL, "C.UTF-8");
+      if (sl == NULL)
+        sl = setlocale(LC_ALL, "en_US.UTF-8");
+    }
+    // If s1 is still NULL, all three setlocale calls failed.
+    // According to setlocale(3): By default, C programs start in the "C" locale.
+    // Continue using the "C" locale. UTF8 will not work.
   }
 };
 


### PR DESCRIPTION
Throwing when setlocale fails is not really helping the user. This PR addresses that by providing fallback logic, inspired by the unix implementation.

Different from the unix implementation, there is no output written to the console, as I don't think many Mac users will look at that, and also, that's not something a core lib should be doing.

Should we store the failure in the Startup global so the application can query that and provide an alert to the user after launching?