### PR TITLE
macOS: Slight changes to the Options Prop Sheet

### DIFF
--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -277,6 +277,9 @@ void OptionsPropertySheetDlg::CreateControls()
 
 wxPanel* OptionsPropertySheetDlg::CreateHeaderPanel(wxWindow* parent, const wxString& title)
 {
+#ifdef __WXMAC__
+  auto headerPanel = new wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(605, -1));
+#else
   auto headerPanel = new wxPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize);
   auto bgColor = headerPanel->GetBackgroundColour();
 
@@ -288,6 +291,7 @@ wxPanel* OptionsPropertySheetDlg::CreateHeaderPanel(wxWindow* parent, const wxSt
 
   wxColor::ChangeLightness(&red, &green, &blue, alpha);
   headerPanel->SetBackgroundColour(wxColor(red, green, blue));
+#endif
 
   auto sizer = new wxBoxSizer(wxVERTICAL);
   headerPanel->SetSizer(sizer);


### PR DESCRIPTION
I'd like to request some changes to the Options dialog on macOS.  
1. I've been doing some work involving the System properties and the horizontal scroll bar is getting annoying. 
- Set a fixed width big enough for all the icons.
2. In dark mode, the dark background around the page title doesn't look very good.
- Use the system default background.  That has the slight advantage of picking-up the desktop color tint. (Matching the rest of the dialog background.) It's a Mac thing.

The change is ifdef'ed, so it only affects macOS.

Current image:
![Screenshot 2025-05-19 at 7 31 34 AM](https://github.com/user-attachments/assets/c2c19b60-3415-440c-8cd2-5eb1c0d0cf1c)

Proposed version:
![Screenshot 2025-05-19 at 7 13 20 AM](https://github.com/user-attachments/assets/249d3f15-f7e3-4e3d-b3cf-9e713d921c20)
![Screenshot 2025-05-19 at 7 12 42 AM](https://github.com/user-attachments/assets/d59c465d-d227-4866-97f9-67c4b8014d80)
