### PR TITLE
Correct some MRU list issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ pwsafe*.msi
 /.vs
 *.VC.db
 .vscode
+*.swp
 *dmg

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -212,6 +212,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		579723522DDD5E5A001582BE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E6ADB7F0119569CC004E2BE5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E6ADB80211956A93004E2BE5;
+			remoteInfo = core;
+		};
+		579723542DDD5E5A001582BE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E6ADB7F0119569CC004E2BE5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E6ADB91B11956DD0004E2BE5;
+			remoteInfo = os;
+		};
 		E66D29361D02B50400C9BCBF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E6ADB7F0119569CC004E2BE5 /* Project object */;
@@ -257,6 +271,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		579723672DDD5E5A001582BE /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 		E66D292D1D02B49B00C9BCBF /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -293,10 +316,47 @@
 		572D9E202DC4920900AF81D4 /* StatusBar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StatusBar.h; sourceTree = "<group>"; };
 		572D9E212DC4920900AF81D4 /* StrengthMeter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StrengthMeter.h; sourceTree = "<group>"; };
 		572D9E222DC4920900AF81D4 /* StrengthMeter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StrengthMeter.cpp; sourceTree = "<group>"; };
+		573ED8DF2DDD61DB00177684 /* filter_for_test.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = filter_for_test.xml; sourceTree = "<group>"; };
+		573ED8E02DDD61DB00177684 /* image1.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = image1.jpg; sourceTree = "<group>"; };
+		573ED8E12DDD61DB00177684 /* import-text-unit-test1.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "import-text-unit-test1.txt"; sourceTree = "<group>"; };
+		573ED8E22DDD61DB00177684 /* import-text-unit-test2.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = "import-text-unit-test2.csv"; sourceTree = "<group>"; };
+		573ED8E32DDD61DB00177684 /* import-text-unit-test3.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = "import-text-unit-test3.csv"; sourceTree = "<group>"; };
+		573ED8E42DDD61DB00177684 /* import-text-unit-test4.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = "import-text-unit-test4.csv"; sourceTree = "<group>"; };
+		573ED8E52DDD61DB00177684 /* import-text-unit-test5.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = "import-text-unit-test5.csv"; sourceTree = "<group>"; };
+		573ED8E62DDD61DB00177684 /* text1.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = text1.txt; sourceTree = "<group>"; };
+		573ED8E92DDD61DB00177684 /* AESTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AESTest.cpp; path = ../AESTest.cpp; sourceTree = "<group>"; };
+		573ED8EA2DDD61DB00177684 /* AliasShortcutTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AliasShortcutTest.cpp; path = ../AliasShortcutTest.cpp; sourceTree = "<group>"; };
+		573ED8EB2DDD61DB00177684 /* AuxParseTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AuxParseTest.cpp; path = ../AuxParseTest.cpp; sourceTree = "<group>"; };
+		573ED8EC2DDD61DB00177684 /* Base32Test.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Base32Test.cpp; path = ../Base32Test.cpp; sourceTree = "<group>"; };
+		573ED8ED2DDD61DB00177684 /* BlowFishTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = BlowFishTest.cpp; path = ../BlowFishTest.cpp; sourceTree = "<group>"; };
+		573ED8EF2DDD61DB00177684 /* CommandsTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CommandsTest.cpp; path = ../CommandsTest.cpp; sourceTree = "<group>"; };
+		573ED8F02DDD61DB00177684 /* coretest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = coretest.cpp; path = ../coretest.cpp; sourceTree = "<group>"; };
+		573ED8F52DDD61DB00177684 /* FileEncDecTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FileEncDecTest.cpp; path = ../FileEncDecTest.cpp; sourceTree = "<group>"; };
+		573ED8F62DDD61DB00177684 /* FileV3Test.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FileV3Test.cpp; path = ../FileV3Test.cpp; sourceTree = "<group>"; };
+		573ED8F72DDD61DB00177684 /* FileV4Test.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FileV4Test.cpp; path = ../FileV4Test.cpp; sourceTree = "<group>"; };
+		573ED8F92DDD61DB00177684 /* HMAC_SHA1Test.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = HMAC_SHA1Test.cpp; path = ../HMAC_SHA1Test.cpp; sourceTree = "<group>"; };
+		573ED8FA2DDD61DB00177684 /* HMAC_SHA256Test.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = HMAC_SHA256Test.cpp; path = ../HMAC_SHA256Test.cpp; sourceTree = "<group>"; };
+		573ED8FB2DDD61DB00177684 /* ImportTextTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ImportTextTest.cpp; path = ../ImportTextTest.cpp; sourceTree = "<group>"; };
+		573ED8FC2DDD61DB00177684 /* ItemAttTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ItemAttTest.cpp; path = ../ItemAttTest.cpp; sourceTree = "<group>"; };
+		573ED8FD2DDD61DB00177684 /* ItemDataTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ItemDataTest.cpp; path = ../ItemDataTest.cpp; sourceTree = "<group>"; };
+		573ED8FE2DDD61DB00177684 /* ItemFieldTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ItemFieldTest.cpp; path = ../ItemFieldTest.cpp; sourceTree = "<group>"; };
+		573ED8FF2DDD61DB00177684 /* KeyWrapTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = KeyWrapTest.cpp; path = ../KeyWrapTest.cpp; sourceTree = "<group>"; };
+		573ED9012DDD61DB00177684 /* Makefile.macos */ = {isa = PBXFileReference; lastKnownFileType = text; name = Makefile.macos; path = ../Makefile.macos; sourceTree = "<group>"; };
+		573ED9022DDD61DB00177684 /* MRUListTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MRUListTest.cpp; path = ../MRUListTest.cpp; sourceTree = "<group>"; };
+		573ED9032DDD61DB00177684 /* OSTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = OSTest.cpp; path = ../OSTest.cpp; sourceTree = "<group>"; };
+		573ED9042DDD61DB00177684 /* SHA1Test.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SHA1Test.cpp; path = ../SHA1Test.cpp; sourceTree = "<group>"; };
+		573ED9052DDD61DB00177684 /* SHA256Test.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SHA256Test.cpp; path = ../SHA256Test.cpp; sourceTree = "<group>"; };
+		573ED9062DDD61DB00177684 /* StringXTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = StringXTest.cpp; path = ../StringXTest.cpp; sourceTree = "<group>"; };
+		573ED9072DDD61DB00177684 /* TestCommon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TestCommon.h; path = ../TestCommon.h; sourceTree = "<group>"; };
+		573ED9082DDD61DB00177684 /* TOTPTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = TOTPTest.cpp; path = ../TOTPTest.cpp; sourceTree = "<group>"; };
+		573ED9092DDD61DB00177684 /* TwoFishTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = TwoFishTest.cpp; path = ../TwoFishTest.cpp; sourceTree = "<group>"; };
+		573ED90A2DDD61DB00177684 /* UtilTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UtilTest.cpp; path = ../UtilTest.cpp; sourceTree = "<group>"; };
+		573ED90B2DDD61DB00177684 /* ValidateTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ValidateTest.cpp; path = ../ValidateTest.cpp; sourceTree = "<group>"; };
 		574370962A3CE21800B46A7D /* pwsafe-template.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "pwsafe-template.plist"; sourceTree = "<group>"; };
 		575412A92B14265800507BC5 /* ubuntu-latest.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; name = "ubuntu-latest.yml"; path = "../.github/workflows/ubuntu-latest.yml"; sourceTree = "<group>"; };
 		575412AA2B14265800507BC5 /* macos-latest.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; name = "macos-latest.yml"; path = "../.github/workflows/macos-latest.yml"; sourceTree = "<group>"; };
 		575412AB2B14265800507BC5 /* codeql-analysis.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; name = "codeql-analysis.yml"; path = "../.github/workflows/codeql-analysis.yml"; sourceTree = "<group>"; };
+		5797236C2DDD5E5A001582BE /* coretest */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = coretest; sourceTree = BUILT_PRODUCTS_DIR; };
 		579BDA4E2C55F0A1004C727B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		57C329E72A070EFD00454292 /* ReleaseNotesWX.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = ReleaseNotesWX.md; path = ../docs/ReleaseNotesWX.md; sourceTree = "<group>"; };
 		57C329E82A0715F500454292 /* ReleaseNotes.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = ReleaseNotes.md; path = ../docs/ReleaseNotes.md; sourceTree = "<group>"; };
@@ -875,6 +935,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		5797235E2DDD5E5A001582BE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E66D292C1D02B49B00C9BCBF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -910,6 +977,59 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		573ED8E72DDD61DB00177684 /* data */ = {
+			isa = PBXGroup;
+			children = (
+				573ED8DF2DDD61DB00177684 /* filter_for_test.xml */,
+				573ED8E02DDD61DB00177684 /* image1.jpg */,
+				573ED8E12DDD61DB00177684 /* import-text-unit-test1.txt */,
+				573ED8E22DDD61DB00177684 /* import-text-unit-test2.csv */,
+				573ED8E32DDD61DB00177684 /* import-text-unit-test3.csv */,
+				573ED8E42DDD61DB00177684 /* import-text-unit-test4.csv */,
+				573ED8E52DDD61DB00177684 /* import-text-unit-test5.csv */,
+				573ED8E62DDD61DB00177684 /* text1.txt */,
+			);
+			name = data;
+			path = ../data;
+			sourceTree = "<group>";
+		};
+		573ED9292DDD629000177684 /* coretest */ = {
+			isa = PBXGroup;
+			children = (
+				573ED8E72DDD61DB00177684 /* data */,
+				573ED8E92DDD61DB00177684 /* AESTest.cpp */,
+				573ED8EA2DDD61DB00177684 /* AliasShortcutTest.cpp */,
+				573ED8EB2DDD61DB00177684 /* AuxParseTest.cpp */,
+				573ED8EC2DDD61DB00177684 /* Base32Test.cpp */,
+				573ED8ED2DDD61DB00177684 /* BlowFishTest.cpp */,
+				573ED8EF2DDD61DB00177684 /* CommandsTest.cpp */,
+				573ED8F02DDD61DB00177684 /* coretest.cpp */,
+				573ED8F52DDD61DB00177684 /* FileEncDecTest.cpp */,
+				573ED8F62DDD61DB00177684 /* FileV3Test.cpp */,
+				573ED8F72DDD61DB00177684 /* FileV4Test.cpp */,
+				573ED8F92DDD61DB00177684 /* HMAC_SHA1Test.cpp */,
+				573ED8FA2DDD61DB00177684 /* HMAC_SHA256Test.cpp */,
+				573ED8FB2DDD61DB00177684 /* ImportTextTest.cpp */,
+				573ED8FC2DDD61DB00177684 /* ItemAttTest.cpp */,
+				573ED8FD2DDD61DB00177684 /* ItemDataTest.cpp */,
+				573ED8FE2DDD61DB00177684 /* ItemFieldTest.cpp */,
+				573ED8FF2DDD61DB00177684 /* KeyWrapTest.cpp */,
+				573ED9012DDD61DB00177684 /* Makefile.macos */,
+				573ED9022DDD61DB00177684 /* MRUListTest.cpp */,
+				573ED9032DDD61DB00177684 /* OSTest.cpp */,
+				573ED9042DDD61DB00177684 /* SHA1Test.cpp */,
+				573ED9052DDD61DB00177684 /* SHA256Test.cpp */,
+				573ED9062DDD61DB00177684 /* StringXTest.cpp */,
+				573ED9072DDD61DB00177684 /* TestCommon.h */,
+				573ED9082DDD61DB00177684 /* TOTPTest.cpp */,
+				573ED9092DDD61DB00177684 /* TwoFishTest.cpp */,
+				573ED90A2DDD61DB00177684 /* UtilTest.cpp */,
+				573ED90B2DDD61DB00177684 /* ValidateTest.cpp */,
+			);
+			name = coretest;
+			path = ../src/test/coretest;
+			sourceTree = "<group>";
+		};
 		575412A82B14261800507BC5 /* Workflows */ = {
 			isa = PBXGroup;
 			children = (
@@ -1340,6 +1460,7 @@
 				E6EE837D11E87CD200B01518 /* os */,
 				E6ADB9A411957099004E2BE5 /* wxWidgets */,
 				E66D29301D02B49B00C9BCBF /* pwsafe-cli */,
+				573ED9292DDD629000177684 /* coretest */,
 				E6ADB80411956A93004E2BE5 /* Products */,
 				E69B800911F61CF20084F6C4 /* Carbon.framework */,
 				E6B1448112B26CEE00415AAE /* OpenGL.framework */,
@@ -1358,6 +1479,7 @@
 				E6ADB91C11956DD0004E2BE5 /* libos.a */,
 				E6ADB99E1195706A004E2BE5 /* pwsafe.app */,
 				E66D292F1D02B49B00C9BCBF /* pwsafe-cli */,
+				5797236C2DDD5E5A001582BE /* coretest */,
 			);
 			indentWidth = 2;
 			name = Products;
@@ -1731,6 +1853,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		579723502DDD5E5A001582BE /* coretest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 579723682DDD5E5A001582BE /* Build configuration list for PBXNativeTarget "coretest" */;
+			buildPhases = (
+				579723552DDD5E5A001582BE /* Sources */,
+				5797235E2DDD5E5A001582BE /* Frameworks */,
+				579723672DDD5E5A001582BE /* CopyFiles */,
+				5797236D2DDD5E83001582BE /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				579723512DDD5E5A001582BE /* PBXTargetDependency */,
+				579723532DDD5E5A001582BE /* PBXTargetDependency */,
+			);
+			name = coretest;
+			productName = "pwsafe-cli";
+			productReference = 5797236C2DDD5E5A001582BE /* coretest */;
+			productType = "com.apple.product-type.tool";
+		};
 		E66D292E1D02B49B00C9BCBF /* pwsafe-cli */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E66D29351D02B49B00C9BCBF /* Build configuration list for PBXNativeTarget "pwsafe-cli" */;
@@ -1839,6 +1981,7 @@
 				E6ADB99D1195706A004E2BE5 /* pwsafe */,
 				E690B53012980BDD007EA508 /* Help Files */,
 				E66D292E1D02B49B00C9BCBF /* pwsafe-cli */,
+				579723502DDD5E5A001582BE /* coretest */,
 			);
 		};
 /* End PBXProject section */
@@ -1860,6 +2003,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		5797236D2DDD5E83001582BE /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(TARGETNAME)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export HOMEBREW_PREFIX=/opt/homebrew\nmake -C ../src/test -f Makefile.macos xcodebuild\n";
+		};
 		E690B54212980CFC007EA508 /* Default English Help */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1895,6 +2057,7 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "make -C .. -f Makefile.macos src/ui/wxWidgets/version.h Xcode/pwsafe.plist\n";
+			showEnvVarsInLog = 0;
 		};
 		E6CFEF1811EA41FB001402D8 /* Generate core_st */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1916,6 +2079,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		579723552DDD5E5A001582BE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E66D292B1D02B49B00C9BCBF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2111,6 +2281,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		579723512DDD5E5A001582BE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E6ADB80211956A93004E2BE5 /* core */;
+			targetProxy = 579723522DDD5E5A001582BE /* PBXContainerItemProxy */;
+		};
+		579723532DDD5E5A001582BE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E6ADB91B11956DD0004E2BE5 /* os */;
+			targetProxy = 579723542DDD5E5A001582BE /* PBXContainerItemProxy */;
+		};
 		E66D29371D02B50400C9BCBF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = E6ADB80211956A93004E2BE5 /* core */;
@@ -2293,6 +2473,79 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = "Debug-no-yubi";
+		};
+		579723692DDD5E5A001582BE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E69541311A01150D00BC85E1 /* pwsafe-debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = "pwsafe-cli.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				ENABLE_HARDENED_RUNTIME = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					../src/core,
+					../src,
+				);
+				MACOSX_DEPLOYMENT_TARGET = "$(inherited)";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		5797236A2DDD5E5A001582BE /* Debug-no-yubi */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E69541311A01150D00BC85E1 /* pwsafe-debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = "pwsafe-cli.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				ENABLE_HARDENED_RUNTIME = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					../src/core,
+					../src,
+				);
+				MACOSX_DEPLOYMENT_TARGET = "$(inherited)";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Debug-no-yubi";
+		};
+		5797236B2DDD5E5A001582BE /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E69541321A01150D00BC85E1 /* pwsafe-release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = "pwsafe-cli.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					../src/core,
+					../src,
+				);
+				MACOSX_DEPLOYMENT_TARGET = "$(inherited)";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
 		};
 		E66D29331D02B49B00C9BCBF /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2604,6 +2857,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		579723682DDD5E5A001582BE /* Build configuration list for PBXNativeTarget "coretest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				579723692DDD5E5A001582BE /* Debug */,
+				5797236A2DDD5E5A001582BE /* Debug-no-yubi */,
+				5797236B2DDD5E5A001582BE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		E66D29351D02B49B00C9BCBF /* Build configuration list for PBXNativeTarget "pwsafe-cli" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -1565,6 +1565,7 @@
 		E6EE837D11E87CD200B01518 /* os */ = {
 			isa = PBXGroup;
 			children = (
+				E6C1253511E1B2BA00D22D92 /* mac */,
 				570781692B0C4CD30082EB6E /* PWYubi.cpp */,
 				570781682B0C4CD30082EB6E /* PWYubi.h */,
 				E6889E011EE4640F0023E376 /* cleanup.cpp */,
@@ -1585,7 +1586,6 @@
 				E6EE838B11E87DAC00B01518 /* sleep.h */,
 				E6EE838C11E87DAC00B01518 /* typedefs.h */,
 				E6EE838D11E87DAC00B01518 /* utf8conv.h */,
-				E6C1253511E1B2BA00D22D92 /* mac */,
 			);
 			indentWidth = 2;
 			name = os;
@@ -1681,11 +1681,11 @@
 				E6EE83E311E87E9800B01518 /* UTF8Conv.h */,
 				E6EE83E411E87E9800B01518 /* Util.cpp */,
 				E6EE83E511E87E9800B01518 /* Util.h */,
+				E6EE845611E87E9800B01518 /* Validate.cpp */,
 				E6EE83E811E87E9800B01518 /* VerifyFormat.cpp */,
 				E6EE83E911E87E9800B01518 /* VerifyFormat.h */,
 				E6EE841911E87E9800B01518 /* XMLprefs.cpp */,
 				E6EE841A11E87E9800B01518 /* XMLprefs.h */,
-				E6EE845611E87E9800B01518 /* Validate.cpp */,
 			);
 			indentWidth = 4;
 			name = core;

--- a/Xcode/pwsafe-xcode6.xcodeproj/xcshareddata/xcschemes/coretest.xcscheme
+++ b/Xcode/pwsafe-xcode6.xcodeproj/xcshareddata/xcschemes/coretest.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "579723502DDD5E5A001582BE"
+               BuildableName = "coretest"
+               BlueprintName = "coretest"
+               ReferencedContainer = "container:pwsafe-xcode6.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "YES"
+      customWorkingDirectory = "$(PROJECT_DIR)/../src/test"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "579723502DDD5E5A001582BE"
+            BuildableName = "coretest"
+            BlueprintName = "coretest"
+            ReferencedContainer = "container:pwsafe-xcode6.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "579723502DDD5E5A001582BE"
+            BuildableName = "coretest"
+            BlueprintName = "coretest"
+            ReferencedContainer = "container:pwsafe-xcode6.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/core/PWSprefs.cpp
+++ b/src/core/PWSprefs.cpp
@@ -262,7 +262,6 @@ PWSprefs::PWSprefs() : m_pXML_Config(nullptr)
   m_PSSrect.top = m_PSSrect.bottom = m_PSSrect.left = m_PSSrect.right = -1;
   m_PSSrect.changed = false;
 
-  m_MRUitems.resize(m_int_prefs[MaxMRUItems].maxVal);
   InitializePreferences();
 }
 
@@ -457,9 +456,7 @@ unsigned int PWSprefs::SetMRUList(const std::vector<stringT> &MRUFiles, int max_
   if (cleanMRU.size() > static_cast<std::size_t>(max_MRU))
     cleanMRU.erase(cleanMRU.begin() + max_MRU, cleanMRU.end());
 
-  bool changed = (cleanMRU != m_MRUitems);
-
-  if (changed) {
+  if (cleanMRU != m_MRUitems) {
     m_MRUitems = cleanMRU;
     m_prefs_changed[APP_PREF] = true;
   }
@@ -1489,14 +1486,12 @@ bool PWSprefs::LoadProfileFromFile()
   m_PrefLayout = m_pXML_Config->Get(m_csHKCU_PREF, _T("Layout"), L"");
 
   // Load most recently used file list
-  if (m_MRUitems.size() < m_intValues[MaxMRUItems])
-    m_MRUitems.resize(m_intValues[MaxMRUItems]);
-  for (i = m_intValues[MaxMRUItems]; i > 0; i--) {
-    Format(csSubkey, L"Safe%02d", i);
+  m_MRUitems.clear();
+  for (unsigned int idx = 1; idx <= m_intValues[MaxMRUItems]; idx++) {
+    Format(csSubkey, L"Safe%02u", idx);
     auto value = m_pXML_Config->Get(m_csHKCU_MRU, csSubkey, L"");
-    if (!value.empty())
-    {
-      m_MRUitems[i-1] = value;
+    if (!value.empty()) {
+      m_MRUitems.push_back(value);
     }
   }
 
@@ -1648,10 +1643,8 @@ void PWSprefs::SaveApplicationPreferences()
     // Now put back the ones we want
     stringT csSubkey;
     for (auto item : m_MRUitems) {
-      if (!item.empty()) {
-        Format(csSubkey, L"Safe%02d", ++j);
-        m_pXML_Config->Set(m_csHKCU_MRU, csSubkey, item);
-      }
+      Format(csSubkey, L"Safe%02d", ++j);
+      m_pXML_Config->Set(m_csHKCU_MRU, csSubkey, item);
     }
 
     // Since we may have changed the MRU - update timestamp in config file

--- a/src/core/PWSprefs.h
+++ b/src/core/PWSprefs.h
@@ -272,6 +272,9 @@ public:
 
   void ClearUnknownPrefs(); // Clear unknown preferences vectors
 
+  // This is a helper for the SetMRUList/GetMRUList unit tests
+  void PrepForUnitTests(bool testing = true) { m_ConfigOption = testing ? CF_FILE_RW : CF_NONE; }
+
 private:
   PWSprefs();
   ~PWSprefs();

--- a/src/os/mac/file.cpp
+++ b/src/os/mac/file.cpp
@@ -61,7 +61,7 @@ static char *createFileSystemRepresentation(const stringT &filename)
   CFIndex maxBufLen = CFStringGetMaximumSizeOfFileSystemRepresentation(str);
   char *buffer = new char[maxBufLen];
 
-  bool res = CFStringGetFileSystemRepresentation(str, buffer, maxBufLen);
+  [[maybe_unused]] bool res = CFStringGetFileSystemRepresentation(str, buffer, maxBufLen);
   assert(res);
 
   CFRelease(str);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -3,7 +3,7 @@ set (TEST_SRCS
   FileV4Test.cpp ItemDataTest.cpp SHA256Test.cpp SHA1Test.cpp CommandsTest.cpp ItemFieldTest.cpp
   StringXTest.cpp coretest.cpp HMAC_SHA256Test.cpp HMAC_SHA1Test.cpp KeyWrapTest.cpp TwoFishTest.cpp
   AuxParseTest.cpp UtilTest.cpp FileEncDecTest.cpp ImportTextTest.cpp TOTPTest.cpp Base32Test.cpp
-  ValidateTest.cpp)
+  ValidateTest.cpp MRUListTest.cpp)
 
 if (WIN32)
   list (APPEND TEST_SRCS ../core/core.rc2)

--- a/src/test/MRUListTest.cpp
+++ b/src/test/MRUListTest.cpp
@@ -1,0 +1,267 @@
+/*
+* Copyright (c) 2003-2025 Rony Shapiro <ronys@pwsafe.org>.
+* All rights reserved. Use of the code is allowed under the
+* Artistic License 2.0 terms, as specified in the LICENSE file
+* distributed with this code, or available from
+* http://www.opensource.org/licenses/artistic-license-2.0.php
+*/
+// MRUListTest.cpp: Unit test for the Set/Get MRU List and the RecentDbList class
+
+#ifdef WIN32
+#include "../ui/Windows/stdafx.h"
+#endif
+
+#include "core/PWSprefs.h"
+#include "gtest/gtest.h"
+
+// A fixture for factoring common code across tests
+class MRUListTest : public ::testing::Test
+{
+protected:
+  MRUListTest();
+
+  std::vector<stringT> MRUFiles;
+};
+
+MRUListTest::MRUListTest()
+{
+  MRUFiles.push_back(L"filename1");
+  MRUFiles.push_back(L"filename2");
+  MRUFiles.push_back(L"filename3");
+  MRUFiles.push_back(L"filename4");
+  MRUFiles.push_back(L"filename5");
+}
+
+
+TEST_F(MRUListTest, MRUList)
+{
+  unsigned int is, ig;
+  std::vector<stringT> MRURet, v4, v0;
+  
+  PWSprefs *prefs = PWSprefs::GetInstance();
+  prefs->SetPref(PWSprefs::MaxMRUItems, 10);
+
+  // Basic Set/Get
+  is = prefs->SetMRUList(MRUFiles, 10);
+  ig = prefs->GetMRUList(MRURet);
+  EXPECT_EQ(is, 5);
+  EXPECT_EQ(ig, 5);
+  EXPECT_EQ(MRUFiles, MRURet);
+
+  // Test max_MRU parameter of SetMRUList
+  is = prefs->SetMRUList(MRUFiles, 6);
+  ig = prefs->GetMRUList(MRURet);
+  EXPECT_EQ(is, 5);
+  EXPECT_EQ(ig, 5);
+  EXPECT_EQ(MRUFiles, MRURet);
+
+  v4 = MRUFiles;
+  v4.pop_back();
+  v4.pop_back();
+  is = prefs->SetMRUList(MRUFiles, 3);
+  ig = prefs->GetMRUList(MRURet);
+  EXPECT_EQ(is, 3);
+  EXPECT_EQ(ig, 3);
+  EXPECT_EQ(v4, MRURet);
+
+  v0.clear();
+  is = prefs->SetMRUList(MRUFiles, 0);
+  ig = prefs->GetMRUList(MRURet);
+  EXPECT_EQ(is, 0);
+  EXPECT_EQ(ig, 0);
+  EXPECT_EQ(v0, MRURet);
+
+  // Test MaxMRUItems limit in GetMRUList
+  prefs->SetPref(PWSprefs::MaxMRUItems, 3);
+  is = prefs->SetMRUList(MRUFiles, 10);
+  ig = prefs->GetMRUList(MRURet);
+  EXPECT_EQ(is, 5);
+  EXPECT_EQ(ig, 3);
+  EXPECT_EQ(v4, MRURet);
+
+  prefs->SetPref(PWSprefs::MaxMRUItems, 0);
+  is = prefs->SetMRUList(MRUFiles, 10);
+  ig = prefs->GetMRUList(MRURet);
+  EXPECT_EQ(is, 5);
+  EXPECT_EQ(ig, 0);
+  EXPECT_EQ(v0, MRURet);
+
+  // Test removing *.ibak from the list
+  prefs->SetPref(PWSprefs::MaxMRUItems, 10);
+  v4 = MRUFiles;
+  MRUFiles.push_back(L"Filename.bak");
+  MRUFiles.push_back(L"Filename.ibak~");
+  MRUFiles.push_back(L"Filename.ibak");
+  MRUFiles.push_back(L"Filename.ibak~");
+  is = prefs->SetMRUList(MRUFiles, 10);
+  ig = prefs->GetMRUList(MRURet);
+  EXPECT_EQ(is, 5);
+  EXPECT_EQ(ig, 5);
+  EXPECT_EQ(v4, MRURet);
+}
+
+#ifndef WIN32
+#include "ui/wxWidgets/RecentDbList.h"
+
+class RecentDBTest : public ::testing::Test
+{
+protected:
+  RecentDBTest();
+
+  std::vector<stringT> MRUFiles;
+  wxArrayString StrList;
+};
+
+RecentDBTest::RecentDBTest()
+{
+  MRUFiles.push_back(L"filename1");
+  MRUFiles.push_back(L"filename2");
+  MRUFiles.push_back(L"filename3");
+  MRUFiles.push_back(L"filename4");
+  MRUFiles.push_back(L"filename5");
+
+  StrList.Add(L"filename1");
+  StrList.Add(L"filename2");
+  StrList.Add(L"filename3");
+  StrList.Add(L"filename4");
+  StrList.Add(L"filename5");
+}
+
+
+TEST_F(RecentDBTest, RecentList)
+{
+  int is, ig;
+  wxArrayString GotStrings;
+  std::vector<stringT> MRURet;
+
+  PWSprefs *prefs = PWSprefs::GetInstance();
+  prefs->SetPref(PWSprefs::MaxMRUItems, 10);
+  is = prefs->SetMRUList(MRUFiles, 10);
+  EXPECT_EQ(is, 5);
+
+  // Initialize after setting MaxMRUItems
+  RecentDbList rdb;
+  is = rdb.GetMaxFiles();
+  EXPECT_EQ(is, 10);
+  EXPECT_EQ(rdb.GetCount(), 0);
+
+  // Load the list from the Prefs and get the list of strings
+  rdb.Load();
+  rdb.GetAll(GotStrings);
+  EXPECT_EQ(rdb.GetCount(), 5);
+  EXPECT_EQ(GotStrings.size(), 5);
+  EXPECT_EQ(StrList, GotStrings);
+
+  // Add a new name to the top of the list
+  GotStrings.clear();
+  StrList.Insert("NewFilename1", 0);
+
+  rdb.AddFileToHistory("NewFilename1");
+  rdb.GetAll(GotStrings);
+  EXPECT_EQ(rdb.GetCount(), 6);
+  EXPECT_EQ(GotStrings.size(), 6);
+  EXPECT_EQ(StrList, GotStrings);
+
+  // Remove a name from the list
+  GotStrings.clear();
+  StrList.Remove("filename1");
+
+  rdb.RemoveFile("filename1");
+  rdb.GetAll(GotStrings);
+  EXPECT_EQ(rdb.GetCount(), 5);
+  EXPECT_EQ(GotStrings.size(), 5);
+  EXPECT_EQ(StrList, GotStrings);
+
+  // Save the modified list to Prefs
+  auto pos = MRUFiles.begin();
+  auto pos2 = MRUFiles.insert(pos, L"NewFilename1");
+  MRUFiles.erase(++pos2);
+
+  rdb.Save();
+  ig = prefs->GetMRUList(MRURet);
+  EXPECT_EQ(ig, 5);
+  EXPECT_EQ(MRUFiles, MRURet);
+  
+  // Clear the list
+  GotStrings.clear();
+  rdb.Clear();
+  rdb.GetAll(GotStrings);
+  EXPECT_EQ(rdb.GetCount(), 0);
+  EXPECT_EQ(GotStrings.size(), 0);
+}
+
+TEST_F(RecentDBTest, RecentListLimit)
+{
+  int is;
+  wxArrayString GotStrings;
+
+  PWSprefs *prefs = PWSprefs::GetInstance();
+  prefs->SetPref(PWSprefs::MaxMRUItems, 4);
+  is = prefs->SetMRUList(MRUFiles, 10);
+  EXPECT_EQ(is, 5);
+
+  // Initialize after MacMRUItems is set
+  RecentDbList rdb;
+  is = rdb.GetMaxFiles();
+  EXPECT_EQ(is, 4);
+
+  // Test limiting to 4
+  StrList.Remove("filename5");
+  GotStrings.clear();
+  rdb.Load();
+  rdb.GetAll(GotStrings);
+  EXPECT_EQ(rdb.GetCount(), 4);
+  EXPECT_EQ(GotStrings.size(), 4);
+  EXPECT_EQ(StrList, GotStrings);
+
+  // Add to the top, remove from the bottom
+  StrList.Insert("NewName1", 0);
+  StrList.Remove("filename4");
+  GotStrings.clear();
+
+  rdb.AddFileToHistory("NewName1");
+  rdb.GetAll(GotStrings);
+  EXPECT_EQ(rdb.GetCount(), 4);
+  EXPECT_EQ(GotStrings.size(), 4);
+  EXPECT_EQ(StrList, GotStrings);
+}
+
+TEST_F(RecentDBTest, RecentListLimit0)
+{
+  int is, ig;
+  wxArrayString GotStrings;
+  std::vector<stringT> MRURet;
+
+  PWSprefs *prefs = PWSprefs::GetInstance();
+  prefs->SetPref(PWSprefs::MaxMRUItems, 0);
+  is = prefs->SetMRUList(MRUFiles, 10);
+  ig = prefs->GetMRUList(MRURet);
+  EXPECT_EQ(is, 5);
+  EXPECT_EQ(ig, 0);
+
+  // Initialize after MacMRUItems is set
+  RecentDbList rdb;
+  is = rdb.GetMaxFiles();
+  EXPECT_EQ(is, 0);
+
+  // Test limiting to 0
+  GotStrings.clear();
+  rdb.Load();
+  rdb.GetAll(GotStrings);
+  EXPECT_EQ(rdb.GetCount(), 0);
+  EXPECT_EQ(GotStrings.size(), 0);
+
+  // Add should not be allowed
+  GotStrings.clear();
+
+  rdb.AddFileToHistory("NewName1");
+  rdb.GetAll(GotStrings);
+  EXPECT_EQ(rdb.GetCount(), 0);
+  EXPECT_EQ(GotStrings.size(), 0);
+
+  rdb.Save();
+  ig = prefs->GetMRUList(MRURet);
+  EXPECT_EQ(ig, 0);
+  EXPECT_EQ(MRURet.size(), 0);
+}
+#endif //WIN32

--- a/src/test/Makefile.macos
+++ b/src/test/Makefile.macos
@@ -2,6 +2,13 @@
 # Coretest makefile for macOS
 #
 
+TARGET = coretest
+
+# CONFIGURATION and TARGET_BUILD_DIR are set when executed by Xcode
+# WX_BUILD_DIR is set by the GitHub build workflow
+# HOMEBREW_PREFIX is used to locate googletest
+# When run from the command line, you can provide these variables or use the defaults
+
 # The Xcode configuration: Debug or Release
 ifdef CONFIGURATION
 CONFIG := $(CONFIGURATION)
@@ -18,7 +25,7 @@ endif
 
 # Following sets the location of the wx-config command
 # WX_BUILD_DIR is set by the GitHub workflow
-# Override this to use a local build
+# For command line use, make sure wx-config is in your PATH
 ifdef WX_BUILD_DIR
 WX_CONFIG := $(WX_BUILD_DIR)/bin/wx-config
 else
@@ -26,7 +33,7 @@ WX_CONFIG := $(shell which wx-config)
 endif
 
 
-TESTSRC         := coretest.cpp $(wildcard *Test.cpp)
+TESTSRC         := $(TARGET).cpp $(wildcard *Test.cpp)
 
 OBJPATH         = ../../obj/$(CONFIG)
 LIBPATH         = $(XRELDIR)
@@ -42,8 +49,8 @@ GTEST_OBJ     = $(OBJPATH)/gtest-all.o
 
 #destination related macros
 TESTOBJ	 = $(addprefix $(OBJPATH)/,$(subst .cpp,.o,$(TESTSRC)))
-TEST	 = $(BINPATH)/coretest
-OBJS     = $(TESTOBJ) $(GTEST_OBJ)
+TEST	 = $(BINPATH)/$(TARGET)
+OBJS     = $(TESTOBJ) $(GTEST_OBJ) $(XRELDIR)/libcore.a $(XRELDIR)/libos.a
 
 CXXFLAGS += -DUNICODE -Wall -I$(INCPATH) -I$(INCPATH)/core -std=c++17 -I $(HOMEBREW_PREFIX)/include -Wno-overloaded-virtual
 LDFLAGS  += -L$(LIBPATH) -lcore -los 
@@ -74,13 +81,21 @@ $(GTEST_OBJ): $(GTEST_SRCS) $(GTEST_HEADERS)
 run test : $(TEST)
 	$(TEST)
 
-build: $(TEST)
+build: setup $(TEST)
+
+xcodebuild: setup $(XRELDIR)/$(TARGET)
+
+$(XRELDIR)/$(TARGET): $(TEST)
+	cp $(TEST) $(XRELDIR)
 
 $(TEST): $(OBJS)
 	$(CXX) -g $(CXXFLAGS) $(filter %.o,$^) $(LDFLAGS) -o $@
 
 clean:
 	rm -f *~ $(OBJPATH)/*.o $(TEST)
+ifdef TARGET_BUILD_DIR
+	rm -f $(TARGET_BUILD_DIR)/$(TARGETNAME)
+endif
 
 setup:
 	@mkdir -p $(OBJPATH) $(BINPATH)

--- a/src/test/Makefile.macos
+++ b/src/test/Makefile.macos
@@ -3,25 +3,32 @@
 #
 
 # The Xcode configuration: Debug or Release
+ifdef CONFIGURATION
+CONFIG := $(CONFIGURATION)
+else
 CONFIG ?= Release
+endif
+
+# Get the location of the Xcode built libraries (core and os)
+ifdef TARGET_BUILD_DIR
+XRELDIR := $(TARGET_BUILD_DIR)
+else
+XRELDIR := $(shell xcodebuild -project ../../Xcode/pwsafe-xcode6.xcodeproj -showBuildSettings -scheme pwsafe -configuration $(CONFIG) | awk '/TARGET_BUILD_DIR =/{print $$3}')
+endif
 
 # Following sets the location of the wx-config command
 # WX_BUILD_DIR is set by the GitHub workflow
 # Override this to use a local build
 ifdef WX_BUILD_DIR
 WX_CONFIG := $(WX_BUILD_DIR)/bin/wx-config
-else ifdef HOMEBREW_PREFIX
-WX_CONFIG := $(HOMEBREW_PREFIX)/bin/wx-config
+else
+WX_CONFIG := $(shell which wx-config)
 endif
 
-# Get the location of the Xcode built libraries (core and os)
-XRELDIR := $(shell xcodebuild -project ../../Xcode/pwsafe-xcode6.xcodeproj -showBuildSettings -scheme pwsafe -configuration $(CONFIG) | awk '/TARGET_BUILD_DIR =/{print $$3}')
-
-BUILD		:= $(CONFIG)
 
 TESTSRC         := coretest.cpp $(wildcard *Test.cpp)
 
-OBJPATH         = ../../obj/$(BUILD)
+OBJPATH         = ../../obj/$(CONFIG)
 LIBPATH         = $(XRELDIR)
 BINPATH         = ./bin
 INCPATH         = ..
@@ -30,25 +37,27 @@ INCPATH         = ..
 # brew install googletest
 GTEST_DIR     = $(HOMEBREW_PREFIX)/include/googletest/googletest
 GTEST_HEADERS = $(HOMEBREW_PREFIX)/include/gtest/*.h $(HOMEBREW_PREFIX)/include/gtest/internal/*.h
-GTEST_SRCS_   = $(GTEST_DIR)/src/*.cc $(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
-GTEST_OBJ = $(OBJPATH)/gtest-all.o
+GTEST_SRCS    = $(GTEST_DIR)/src/*.cc $(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
+GTEST_OBJ     = $(OBJPATH)/gtest-all.o
 
 #destination related macros
 TESTOBJ	 = $(addprefix $(OBJPATH)/,$(subst .cpp,.o,$(TESTSRC)))
 TEST	 = $(BINPATH)/coretest
 OBJS     = $(TESTOBJ) $(GTEST_OBJ)
 
-CXXFLAGS += -DUNICODE -Wall -I$(INCPATH) -I$(INCPATH)/core -std=c++17 -I $(HOMEBREW_PREFIX)/include
+CXXFLAGS += -DUNICODE -Wall -I$(INCPATH) -I$(INCPATH)/core -std=c++17 -I $(HOMEBREW_PREFIX)/include -Wno-overloaded-virtual
 LDFLAGS  += -L$(LIBPATH) -lcore -los 
 
 ifeq ($(CONFIG),Debug)
-LDFLAGS += `$(WX_CONFIG) --debug=yes --unicode=yes --libs`
+CXXFLAGS += $(shell $(WX_CONFIG) --debug=yes --unicode=yes --cxxflags)
+LDFLAGS  += $(shell $(WX_CONFIG) --debug=yes --unicode=yes --libs)
 else ifeq ($(CONFIG),Release)
-LDFLAGS += `$(WX_CONFIG) --debug=no --unicode=yes --libs`
+CXXFLAGS += $(shell $(WX_CONFIG) --debug=no --unicode=yes --cxxflags)
+LDFLAGS  += $(shell $(WX_CONFIG) --debug=no --unicode=yes --libs)
 endif
 
 # rules
-.PHONY: all clean test run setup
+.PHONY: all clean test run setup build
 
 $(OBJPATH)/%.o : %.c
 	$(CC) -g  $(CFLAGS)   -c $< -o $@
@@ -58,23 +67,25 @@ $(OBJPATH)/%.o : %.cpp
 
 all : setup test
 
-$(GTEST_OBJ): $(GTEST_SRCS_) $(GTEST_HEADERS)
+$(GTEST_OBJ): $(GTEST_SRCS) $(GTEST_HEADERS)
 	$(CXX) -g $(CPPFLAGS) -I$(GTEST_DIR) $(CXXFLAGS) -c -o $@ \
 	$(GTEST_DIR)/src/gtest-all.cc
-
 
 run test : $(TEST)
 	$(TEST)
 
-$(TEST): $(LIB) $(OBJS)
+build: $(TEST)
+
+$(TEST): $(OBJS)
 	$(CXX) -g $(CXXFLAGS) $(filter %.o,$^) $(LDFLAGS) -o $@
 
 clean:
-	rm -f *~ $(OBJPATH)/*.o $(TEST) $(DEPENDFILE)
+	rm -f *~ $(OBJPATH)/*.o $(TEST)
 
 setup:
-	@mkdir -p $(OBJPATH) $(LIBPATH) $(BINPATH)
+	@mkdir -p $(OBJPATH) $(BINPATH)
+	@echo
 	@echo "Xcode build location: $(XRELDIR)"
 	@echo "WX_CONFIG location: $(WX_CONFIG)"
 	@echo
-	@[ -x $(WX_CONFIG) ] || echo "ERROR: wx-config not found: Need to define the path to the wx-config command (WX_CONFIG variable)\n"
+	@[[ -n "$(WX_CONFIG)" && -x "$(WX_CONFIG)" ]] || { echo "ERROR: wx-config not found: Need to define the path to the wx-config command (WX_CONFIG variable)\n"; exit 1; }

--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -138,6 +138,7 @@ int PasswordSafeFrame::New()
   m_sysTray->SetTrayStatus(SystemTray::TrayStatus::UNLOCKED);
   m_RUEList.ClearEntries();
   wxGetApp().recentDatabases().AddFileToHistory(towxstring(cs_newfile));
+  CreateMenubar(); // Recreate the menu with updated list of most recently used DBs
   ResetFilters();
   GetSearchBarPane().Hide(); // There is nothing to search for in an empty database
   m_AuiManager.Update();

--- a/src/ui/wxWidgets/MenuManageHandlers.cpp
+++ b/src/ui/wxWidgets/MenuManageHandlers.cpp
@@ -81,6 +81,8 @@ void PasswordSafeFrame::DoPreferencesClick()
   bool showMenuSeprator = prefs->GetPref(PWSprefs::ShowMenuSeparator);
   bool autoAdjColWidth = prefs->GetPref(PWSprefs::AutoAdjColWidth);
   bool toolbarShowText = prefs->GetPref(PWSprefs::ToolbarShowText);
+  bool MRUOnFileMenu = prefs->GetPref(PWSprefs::MRUOnFileMenu);
+  unsigned int maxMRUItems = prefs->GetPref(PWSprefs::MaxMRUItems);
   const StringX sxOldDBPrefsString(prefs->Store());
   DestroyWrapper<OptionsPropertySheetDlg> windowWrapper(this, m_core);
   OptionsPropertySheetDlg* window = windowWrapper.Get();
@@ -108,7 +110,15 @@ void PasswordSafeFrame::DoPreferencesClick()
       DoLayout();
       SendSizeEvent();
     }
-    
+
+    bool resizeMRU = (maxMRUItems != prefs->GetPref(PWSprefs::MaxMRUItems));
+    if (resizeMRU) {
+      wxGetApp().ResizeRecentDatabases();
+    }
+    if (resizeMRU || (MRUOnFileMenu != prefs->GetPref(PWSprefs::MRUOnFileMenu))) {
+      CreateMenubar();
+    }
+
     StringX sxNewDBPrefsString(prefs->Store(true));
     // Update system tray icon if visible so changes show up immediately
     if (m_sysTray && prefs->GetPref(PWSprefs::UseSystemTray))

--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -889,7 +889,7 @@ wxPanel* OptionsPropertySheetDlg::CreateSystemPanel(const wxString& title)
 
   itemBoxSizer114->Add(system_MaxMRUItemsSB, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  wxStaticText* itemStaticText117 = new wxStaticText( itemPanel104, wxID_STATIC, _("databases"), wxDefaultPosition, wxDefaultSize, 0 );
+  wxStaticText* itemStaticText117 = new wxStaticText( itemPanel104, wxID_STATIC, _("databases (Change requires restart)"), wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer114->Add(itemStaticText117, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
   wxCheckBox* system_MRUOnFileMenuCB = new wxCheckBox( itemPanel104, ID_CHECKBOX32, _("Recent Databases on File Menu rather than as a sub-menu"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -889,7 +889,7 @@ wxPanel* OptionsPropertySheetDlg::CreateSystemPanel(const wxString& title)
 
   itemBoxSizer114->Add(system_MaxMRUItemsSB, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
-  wxStaticText* itemStaticText117 = new wxStaticText( itemPanel104, wxID_STATIC, _("databases (Change requires restart)"), wxDefaultPosition, wxDefaultSize, 0 );
+  wxStaticText* itemStaticText117 = new wxStaticText( itemPanel104, wxID_STATIC, _("databases"), wxDefaultPosition, wxDefaultSize, 0 );
   itemBoxSizer114->Add(itemStaticText117, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
   wxCheckBox* system_MRUOnFileMenuCB = new wxCheckBox( itemPanel104, ID_CHECKBOX32, _("Recent Databases on File Menu rather than as a sub-menu"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -869,6 +869,16 @@ RecentDbList &PWSafeApp::recentDatabases()
   return *m_recentDatabases;
 }
 
+void PWSafeApp::ResizeRecentDatabases()
+{
+  if (m_recentDatabases != nullptr) {
+    m_recentDatabases->Save();
+    delete m_recentDatabases;
+    m_recentDatabases = new RecentDbList;
+    m_recentDatabases->Load();
+  }
+}
+
 void PWSafeApp::SaveFrameCoords(void)
 {
   if (m_frame->IsMaximized()) {

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -132,6 +132,7 @@ private:
 
 public:
   RecentDbList &recentDatabases();
+  void ResizeRecentDatabases();
   uint32 GetHashIters() const { return m_core.GetHashIters(); }
   bool ActivateLanguage(wxLanguage language, bool tryOnly);
   wxLanguage GetSystemLanguage();

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -826,8 +826,10 @@ void PasswordSafeFrame::CreateControls()
   itemBoxSizer83->Layout();
 
   const RecentDbList& rdb = wxGetApp().recentDatabases();
-  Connect(rdb.GetBaseId(), rdb.GetBaseId() + rdb.GetMaxFiles() - 1, wxEVT_COMMAND_MENU_SELECTED,
+  if (rdb.GetMaxFiles() > 0) {
+    Connect(rdb.GetBaseId(), rdb.GetBaseId() + rdb.GetMaxFiles() - 1, wxEVT_COMMAND_MENU_SELECTED,
             wxCommandEventHandler(PasswordSafeFrame::OnOpenRecentDB));
+  }
 
   m_AuiManager.AddPane(panel, wxAuiPaneInfo().
     Name(wxT("mainview")).Caption(wxT("Main View")).

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -528,6 +528,12 @@ void PasswordSafeFrame::CreateMenubar()
 
   menuBar->Freeze();
 
+  // Remove any prior menu references from the recent DB list
+  auto& rdb = wxGetApp().recentDatabases();
+  for (auto item : rdb.GetMenus()) {
+    rdb.RemoveMenu(dynamic_cast<wxMenu *>(item));
+  }
+
   // Removing all existing menu items is necessary for language switching
   while (menuBar->GetMenuCount()) {
     delete menuBar->Remove(0);
@@ -554,16 +560,17 @@ void PasswordSafeFrame::CreateMenubar()
     menuFile->Append(ID_LOCK_SAFE, _("&Lock\tCtrl+J"), wxEmptyString, wxITEM_NORMAL);
   }
 
-  if (wxGetApp().recentDatabases().GetCount() > 0) {
-
+  if (rdb.GetCount() > 0) {
     // Most recently used DBs listed directly on File menu
     if (PWSprefs::GetInstance()->GetPref(PWSprefs::MRUOnFileMenu)) {
-      wxGetApp().recentDatabases().AddFilesToMenu(menuFile);
+      rdb.UseMenu(menuFile);
+      rdb.AddFilesToMenu(menuFile);
     }
     // Most recently used DBs listed as submenu of File menu
     else {
       auto recentDatabasesMenu = new wxMenu;
-      wxGetApp().recentDatabases().AddFilesToMenu(recentDatabasesMenu);
+      rdb.UseMenu(recentDatabasesMenu);
+      rdb.AddFilesToMenu(recentDatabasesMenu);
       menuFile->AppendSeparator();
       menuFile->Append(ID_RECENTSAFES, _("&Recent Databases..."), recentDatabasesMenu);
     }

--- a/src/ui/wxWidgets/RecentDbList.h
+++ b/src/ui/wxWidgets/RecentDbList.h
@@ -49,12 +49,14 @@ public:
     void Load() {
       PWSprefs* prefs = PWSprefs::GetInstance();
       const auto nExpected = prefs->GetPref(PWSprefs::MaxMRUItems);
-      std::vector<stringT> mruList(nExpected);
+      std::vector<stringT> mruList;
       const auto nFound = prefs->GetMRUList(mruList);
       wxASSERT(nExpected >= nFound);
-      for (unsigned int idx = 0; idx < nFound; ++idx) {
-        if (!mruList[idx].empty())
-          AddFileToHistory(towxstring(mruList[idx]));
+
+      // wxFileHistory::AddFileToHistory() appears to add to the begining of the list,
+      // so we iterate backward to keep the order the same.
+      for (auto iter = mruList.rbegin(); iter != mruList.rend(); iter++) {
+        AddFileToHistory(towxstring(*iter));
       }
     }
 

--- a/src/ui/wxWidgets/RecentDbList.h
+++ b/src/ui/wxWidgets/RecentDbList.h
@@ -54,9 +54,9 @@ public:
 
     void Load() {
       PWSprefs* prefs = PWSprefs::GetInstance();
-      const auto nExpected = prefs->GetPref(PWSprefs::MaxMRUItems);
+      [[maybe_unused]] const auto nExpected = prefs->GetPref(PWSprefs::MaxMRUItems);
       std::vector<stringT> mruList;
-      const auto nFound = prefs->GetMRUList(mruList);
+      [[maybe_unused]] const auto nFound = prefs->GetMRUList(mruList);
       wxASSERT(nExpected >= nFound);
 
       // wxFileHistory::AddFileToHistory() appears to add to the begining of the list,

--- a/src/ui/wxWidgets/RecentDbList.h
+++ b/src/ui/wxWidgets/RecentDbList.h
@@ -22,7 +22,13 @@ class RecentDbList : public wxFileHistory
 {
 public:
     RecentDbList() : wxFileHistory(PWSprefs::GetInstance()->GetPref(PWSprefs::MaxMRUItems))
-    {} 
+    {}
+
+    // Calling wxFileHistory::AddFileToHistory() crashes if maxFiles is initialized to 0.
+    void AddFileToHistory(const wxString& file) {
+      if (GetMaxFiles() > 0)
+        wxFileHistory::AddFileToHistory(file);
+    }
 
     void RemoveFile(const wxString& file) {
       for (size_t idx = 0, max = GetCount(); idx < max; ++idx) {
@@ -56,7 +62,7 @@ public:
       // wxFileHistory::AddFileToHistory() appears to add to the begining of the list,
       // so we iterate backward to keep the order the same.
       for (auto iter = mruList.rbegin(); iter != mruList.rend(); iter++) {
-        AddFileToHistory(towxstring(*iter));
+        wxFileHistory::AddFileToHistory(towxstring(*iter));
       }
     }
 


### PR DESCRIPTION
Related to: #1365, #1369, #1371, and #1382

This PR addresses several issues with the Most Recently Used file list:
1. [WX, core] The list is not always kept in MRU order. (A regression left over from #1382)
2. [WX] The config file is re-written on every exit, even if nothing has changed, because the old and new MRU lists are never considered equal.
3. [WX] When a file is opened via the menu, the MRU list in the File menu does not update until the window is minimized/restored.
4. [WX] Debug check failure in wxFileHistory::AddFileToHistory() if the maximum MRU entries option is set to 0. (MaxMRUItems)
5. [WX] Changes to the MRU related settings do not always take effect until a restart or minimize/restore.
6. Added some unit tests for the PWSprefs and RecentDbList MRU list functions

Discussion 1 and 2
The original issue #1365, reported a crash on Manjaro Linux because of attempting to index entries that were not pre-allocated.  The previous fix was to pre-allocate the maximum possible number of entries, but that had side effects.
This rework eliminates the use of pre-allocating and subscripting m_MRUitems by taking advantage of the dynamic behavior of std::vector and iterators.
1. Fixed by iterating in reverse when adding the list to the wxFileHistory object in RecentDbList::Load().
2. Pre-allocating m_MRUitems to the maximum size caused it to never compare equal to the current list in PWSprefs::SetMRUList().  Eliminating the “empty slots” naturally corrected that.

Discussion 3
The wxFileHistory class has the ability to update the menu automatically when a file name is added or removed. It just needed to be hooked-up.

Discussion 4
A runtime check in wxWidgets failed when using a debug build, and maxFiles is set to 0, because it tries to remove the oldest entry, which doesn’t exist.  Fixed it by overriding AddFileToHistory() to check GetMaxFiles() before adding an entry.
```
In filehistorycmn.cpp: RemoveFileFromHistory()
    wxCHECK_RET( i < numFiles,
                 wxT("invalid index in wxFileHistoryBase::RemoveFileFromHistory") );
```

Discussion 5 
Added logic to delete and recreate the recent list if MaxMRUItems changes

Discussion 6
Needed to add a helper function PWSprefs::PrepForUnitTests() because the state of private m_ConfigOption depends on whether or not a pwsafe.cfg file was found when PWSprefs initialized, affecting the behavior of the Set/GetMRUList functions.  I had everything working on my system, but the GitHub workflow failed.  Arghhhh!

Tested on:
```
macOS M1Max Sequoia 15.5,    Xcode 16.3,    wx 3.2.4 and 3.2.8 (local builds)
Ubuntu 24.04.2 ARM64 VMware, Gnome/Wayland, gcc 13.3.0, wx 3.2.4, GTK 3.24.41
Fedora 42 ARM64 VMware,      Xfce/X11,      gcc 15.0.1, wx 3.2.6, GTK 3.24.49
Windows 11 ARM 24H2 VMware, Visual Studio 2022 17.41.0
```