### PR TITLE
Improve access denied detection

### DIFF
--- a/src/core/PWSfile.cpp
+++ b/src/core/PWSfile.cpp
@@ -23,6 +23,7 @@ PWSfile *PWSfile::MakePWSfile(const StringX &a_filename, const StringX &passkey,
                               Asker *pAsker, Reporter *pReporter)
 {
   PWSfile *retval = nullptr;
+  FILE *fd = nullptr;
 
   if (mode == Read && !pws_os::FileExists(a_filename.c_str())) {
     status = CANT_OPEN_FILE;
@@ -64,6 +65,14 @@ PWSfile *PWSfile::MakePWSfile(const StringX &a_filename, const StringX &passkey,
         ASSERT(0);
         //[[fallthrough]];
       case UNKNOWN_VERSION:
+        // Return more meaningful status code if read access to the file is denied
+        fd = pws_os::FOpen(a_filename.c_str(), _T("rb"));
+        if (fd == nullptr) {
+          status = CANT_OPEN_FILE;
+          break;
+        }
+        pws_os::FClose(fd, false);
+        //[[fallthrough]];
       default:
         status = FAILURE;
       } // inner switch


### PR DESCRIPTION
This will show a more helpful error message ("can't open file" instead of "failure") to the user in case the file cannot be opened for whatever reason (could be permission issue for example).

Note: use a release build to test this change, otherwise an assert stops the program in an earlier stage.