### PR TITLE
[wx] Replace variable length array with unique_ptr

### DIFF
--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -555,9 +555,9 @@ bool ImagePanel::LoadFromAttachment(const CItemAtt& itemAttachment, wxWindow* pa
     return false;
   }
 
-  unsigned char buffer[size];
+  std::unique_ptr<unsigned char[]> buffer(new unsigned char[size]);
 
-  if (!itemAttachment.GetContent(buffer, size)) {
+  if (!itemAttachment.GetContent(buffer.get(), size)) {
     wxMessageDialog(
       parent,
       _("An error occurred while trying to get the image data from database item.\n"
@@ -568,7 +568,7 @@ bool ImagePanel::LoadFromAttachment(const CItemAtt& itemAttachment, wxWindow* pa
     return false;
   }
 
-  wxMemoryInputStream stream(&buffer, size);
+  wxMemoryInputStream stream(buffer.get(), size);
 
   if (!LoadFromMemory(stream)) {
     wxMessageDialog(

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -549,7 +549,7 @@ ImagePanel::~ImagePanel()
 
 bool ImagePanel::LoadFromAttachment(const CItemAtt& itemAttachment, wxWindow* parent, const wxString& messageBoxTitle)
 {
-  auto size = itemAttachment.GetContentSize();
+  const auto size = itemAttachment.GetContentSize();
 
   if (size <= 0) {
     return false;


### PR DESCRIPTION
This warning started to appear with Apple Clang 17 (Xcode 16):
```
.../Xcode/pwsafe/src/ui/wxWidgets/wxUtilities.cpp:558:24: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
  558 |   unsigned char buffer[size];
      |                        ^~~~
.../Xcode/pwsafe/src/ui/wxWidgets/wxUtilities.cpp:558:24: note: read of non-const variable 'size' is not allowed in a constant expression
.../Xcode/pwsafe/src/ui/wxWidgets/wxUtilities.cpp:552:8: note: declared here
  552 |   auto size = itemAttachment.GetContentSize();
      |        ^
1 warning generated.
```

If I understand smart pointers properly, this should maintain the original intent while being standards compliant (c++11 and up)