### PR TITLE
[wx] Expand the text field on resize of AddEditPropSheetDlg

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -432,7 +432,7 @@ wxPanel* AddEditPropSheetDlg::CreateBasicPanel()
   m_BasicSizer->Add(m_BasicNotesTextCtrl, wxGBPosition(/*row:*/ 18, /*column:*/ 0), wxGBSpan(/*rowspan:*/ 1, /*columnspan:*/ 6), wxEXPAND, 0);
 
   m_BasicSizer->AddGrowableCol(2);  // Growable text entry fields
-  m_BasicSizer->AddGrowableRow(15); // Growable notes field
+  m_BasicSizer->AddGrowableRow(18); // Growable notes field
 
   m_BasicTitleTextCtrl->SetValidator(wxGenericValidator(&m_Title));
   m_BasicUsernameTextCtrl->SetValidator(wxGenericValidator(&m_User));


### PR DESCRIPTION
I noticed this problem crept into 1.21: If I vertically stretch the add/edit dialog, it grows in the wrong place.

Version 1.21 and current master:
![Screenshot 2025-06-12 at 12 28 55 PM](https://github.com/user-attachments/assets/cc7efd2c-3e9d-479d-8acf-50cf4035655c)
Version 1.20 and after this PR is applied to master:
![Screenshot 2025-06-12 at 12 37 26 PM](https://github.com/user-attachments/assets/6a773eef-9f25-4890-965a-bc4097ec6c1b)
