### PR TITLE
[wx] wxWidgets 3.3.0 compatibility 

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -29,7 +29,7 @@ jobs:
       # "WX_DEBUG_FLAG: --enable-debug --enable-debug_info"
       # "XCODE_CONFIG:  Debug"
       # "XCODE_CONFIG:  Debug-no-yubi"
-      WX_VERS:          3.2.4
+      WX_VERS:          3.3.0
       WX_SRC_DIR:       ${{ github.workspace }}/wxWidgets
       WX_BUILD_DIR:     ${{ github.workspace }}/wxWidgets/static-release
       WX_ARCH:          "arm64,x86_64"
@@ -39,7 +39,7 @@ jobs:
       XCODE_CONFIG:     Release
       XCODE_DIR:        ${{ github.workspace }}/xcderived
       XCODE_PROD:       ${{ github.workspace }}/xcderived/Build/Products
-      FORCE_REBUILD_WX: 7
+      FORCE_REBUILD_WX: 1
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -107,7 +107,7 @@ jobs:
         mkdir -p $WX_BUILD_DIR
         cd $WX_SRC_DIR
         # use built-in versions of jpeg, tiff, png, and regex (pcre2) libs to avoid linking with those in /usr/local/opt
-        ./configure --enable-universal_binary=$WX_ARCH --prefix=$WX_BUILD_DIR --disable-shared --enable-unicode --with-macosx-version-min=$MACOS_VER_MIN --with-libpng=builtin --with-libjpeg=builtin --with-libtiff=builtin --with-regex=builtin --without-liblzma $WX_DEBUG_FLAG
+        ./configure --enable-universal_binary=$WX_ARCH --prefix=$WX_BUILD_DIR --disable-shared --with-macosx-version-min=$MACOS_VER_MIN --with-libpng=builtin --with-libjpeg=builtin --with-libtiff=builtin --with-regex=builtin --without-liblzma $WX_DEBUG_FLAG
         make -j $HOST_NCPU
         cd locale; make allmo; cd ..
         sudo make install

--- a/src/core/StringX.cpp
+++ b/src/core/StringX.cpp
@@ -156,7 +156,7 @@ template<class T> void LoadAString(T &s, int id)
   cs.LoadString(id);
   s = cs;
 #else
-  s = _(core_st[id]).c_str();
+  s = core_st[id];
 #endif
 }
 

--- a/src/ui/wxWidgets/DragBarCtrl.cpp
+++ b/src/ui/wxWidgets/DragBarCtrl.cpp
@@ -141,7 +141,7 @@ struct DragbarToolInfo {
   {
     return (id == ID_DRAGBAR_DND) ?
       _("Drag this image onto another window to paste the selected element or tree.") :
-      wxString::Format(_("Drag this image onto another window to paste the '%s' field."), _(name));
+      wxString::Format(_("Drag this image onto another window to paste the '%s' field."), name);
   }
 };
 

--- a/src/ui/wxWidgets/MenuViewHandlers.cpp
+++ b/src/ui/wxWidgets/MenuViewHandlers.cpp
@@ -226,7 +226,7 @@ void PasswordSafeFrame::RunShowReport(int iAction)
   }
   else {
     wxString tcAction = CReport::ReportNames.find(iAction)->second;
-    wxMessageBox(_(tcAction) + _(L" file \'") + rpt.GetFileName() + _(L"' not readable"), _("View Report"), wxOK|wxICON_ERROR);
+    wxMessageBox(tcAction + _(L" file \'") + rpt.GetFileName() + _(L"' not readable"), _("View Report"), wxOK|wxICON_ERROR);
   }
 }
 

--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -355,7 +355,7 @@ wxPanel* OptionsPropertySheetDlg::CreateBackupsPanel(const wxString& title)
   itemStaticBoxSizer7->Add(itemBoxSizer15, 0, wxEXPAND|wxALL, 0);
   wxArrayString Backup_SuffixCBStrings;
   for (int i = 0; i < int(sizeof(BACKUP_SUFFIX)/sizeof(BACKUP_SUFFIX[0])); ++i) {
-    Backup_SuffixCBStrings.Add(_(BACKUP_SUFFIX[i]));
+    Backup_SuffixCBStrings.Add(BACKUP_SUFFIX[i]);
   }
   m_Backups_SuffixCB = new wxComboBox( itemPanel2, ID_COMBOBOX2, wxEmptyString, wxDefaultPosition, wxSize(itemPanel2->ConvertDialogToPixels(wxSize(140, -1)).x, -1), Backup_SuffixCBStrings, wxCB_READONLY );
   itemBoxSizer15->Add(m_Backups_SuffixCB, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
@@ -545,7 +545,7 @@ wxPanel* OptionsPropertySheetDlg::CreateMiscellaneousPanel(const wxString& title
   wxArrayString m_Misc_DoubleClickActionCBStrings;
   wxArrayString m_Misc_ShiftDoubleClickActionCBStrings;
   for (int i = 0; i < int(sizeof(DCAStrings)/sizeof(DCAStrings[0])); ++i) {
-    wxString tmp = _(DCAStrings[i]);
+    wxString tmp = DCAStrings[i];
     m_Misc_DoubleClickActionCBStrings.Add(tmp);
     m_Misc_ShiftDoubleClickActionCBStrings.Add(tmp);
   }
@@ -1016,12 +1016,12 @@ void OptionsPropertySheetDlg::PrefsToPropSheet()
   if (m_DoubleClickAction < 0 ||
       m_DoubleClickAction >= int(sizeof(DCAStrings)/sizeof(DCAStrings[0])))
     m_DoubleClickAction = 0;
-  m_Misc_DoubleClickActionCB->SetValue(_(DCAStrings[m_DoubleClickAction]));
+  m_Misc_DoubleClickActionCB->SetValue(DCAStrings[m_DoubleClickAction]);
   m_ShiftDoubleClickAction = prefs->GetPref(PWSprefs::ShiftDoubleClickAction);
   if (m_ShiftDoubleClickAction < 0 ||
       m_ShiftDoubleClickAction >= int(sizeof(DCAStrings)/sizeof(DCAStrings[0])))
     m_ShiftDoubleClickAction = 0;
-  m_Misc_ShiftDoubleClickActionCB->SetValue(_(DCAStrings[m_ShiftDoubleClickAction]));
+  m_Misc_ShiftDoubleClickActionCB->SetValue(DCAStrings[m_ShiftDoubleClickAction]);
   m_Misc_AutotypeMinimize = prefs->GetPref(PWSprefs::MinimizeOnAutotype);
   m_Misc_AutotypeString = prefs->GetPref(PWSprefs::DefaultAutotypeString).c_str();
   if (m_Misc_AutotypeString.empty())
@@ -1081,7 +1081,7 @@ void OptionsPropertySheetDlg::PrefsToPropSheet()
 static int DCAStr2Int(const wxString &str)
 {
   for (int i = 0; i < int(sizeof(DCAStrings)/sizeof(DCAStrings[0])); ++i)
-    if (str == _(DCAStrings[i])) {
+    if (str == DCAStrings[i]) {
       return i;
     }
   ASSERT(0);

--- a/src/ui/wxWidgets/PWFiltersEditor.cpp
+++ b/src/ui/wxWidgets/PWFiltersEditor.cpp
@@ -141,7 +141,7 @@ wxString pwFiltersFTChoiceRenderer::getFieldTypeString(int ft)
 {
   std::map<int, wxString>::const_iterator iter = FieldTypeString.find(ft);
   ASSERT(iter != FieldTypeString.end());
-  return _(iter->second);
+  return iter->second;
 }
 
 /*!
@@ -369,11 +369,11 @@ wxSize pwFiltersFTChoiceRenderer::GetBestSize(wxGrid& WXUNUSED(grid), wxGridCell
   
     /* C++17 like
     for(const auto& [key, value] : FieldTypeString) {
-      m_bestSize.IncTo(DoGetBestSize(attr, dc, _(value)));
+      m_bestSize.IncTo(DoGetBestSize(attr, dc, value));
     }
      */
     for(const auto& kv : FieldTypeString) {
-      m_bestSize.IncTo(DoGetBestSize(attr, dc, _(kv.second)));
+      m_bestSize.IncTo(DoGetBestSize(attr, dc, kv.second));
     }
   }
   return m_bestSize;

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -864,8 +864,10 @@ RecentDbList &PWSafeApp::recentDatabases()
   // we create an instance of m_recentDatabases
   // as late as possible in order to make
   // sure that prefs' is set correctly (user, machine, etc.)
-  if (m_recentDatabases == nullptr)
+  if (m_recentDatabases == nullptr) {
     m_recentDatabases = new RecentDbList;
+    m_recentDatabases->SetMenuPathStyle(wxFH_PATH_SHOW_ALWAYS);
+  }
   return *m_recentDatabases;
 }
 
@@ -875,6 +877,7 @@ void PWSafeApp::ResizeRecentDatabases()
     m_recentDatabases->Save();
     delete m_recentDatabases;
     m_recentDatabases = new RecentDbList;
+    m_recentDatabases->SetMenuPathStyle(wxFH_PATH_SHOW_ALWAYS);
     m_recentDatabases->Load();
   }
 }

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -851,7 +851,7 @@ void PasswordSafeFrame::AddLanguageMenu(wxMenu* parent)
   wxLanguage system_language = wxGetApp().GetSystemLanguage();
 
   for (auto &item : m_languages) {
-    wxString lang_name = _(get<1>(item.second));
+    wxString lang_name = get<1>(item.second);
     if (get<0>(item.second) == system_language) {
       lang_name = L"[ " + lang_name + L" ]";
     }
@@ -3016,7 +3016,7 @@ void PasswordSafeFrame::UpdateStatusBar()
       menu->SetItemLabel(m_core.IsReadOnly() ? _("Change to R/W") : _("Change to R-O"));
   }
   else { // no open file
-    m_statusBar->SetStatusText(_(PWSprefs::GetDCAdescription(-1)), StatusBar::Field::DOUBLECLICK);
+    m_statusBar->SetStatusText(PWSprefs::GetDCAdescription(-1), StatusBar::Field::DOUBLECLICK);
     m_statusBar->SetStatusText(wxEmptyString, StatusBar::Field::CLIPBOARDACTION);
     m_statusBar->SetStatusText(wxEmptyString, StatusBar::Field::MODIFIED);
     m_statusBar->SetStatusText(wxEmptyString, StatusBar::Field::READONLY);
@@ -3098,7 +3098,7 @@ void PasswordSafeFrame::UpdateSelChanged(const CItemData *pci)
     if (dca == -1)
       dca = PWSprefs::GetInstance()->GetPref(PWSprefs::DoubleClickAction);
   }
-  m_statusBar->SetStatusText(_(PWSprefs::GetDCAdescription(dca)), StatusBar::Field::DOUBLECLICK);
+  m_statusBar->SetStatusText(PWSprefs::GetDCAdescription(dca), StatusBar::Field::DOUBLECLICK);
 }
 
 void PasswordSafeFrame::ChangeFontPreference(const PWSprefs::StringPrefs fontPreference)

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -530,8 +530,9 @@ void PasswordSafeFrame::CreateMenubar()
 
   // Remove any prior menu references from the recent DB list
   auto& rdb = wxGetApp().recentDatabases();
-  for (auto item : rdb.GetMenus()) {
-    rdb.RemoveMenu(dynamic_cast<wxMenu *>(item));
+  auto menuVect = rdb.GetMenus().AsVector<wxMenu *>();
+  for (auto item : menuVect) {
+    rdb.RemoveMenu(item);
   }
 
   // Removing all existing menu items is necessary for language switching

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -227,7 +227,7 @@ SafeCombinationCtrl* wxUtilities::CreateLabeledSafeCombinationCtrl(wxWindow* par
   auto *sizer = new wxBoxSizer(wxVERTICAL);
   parent->GetSizer()->Add(sizer, 0, wxBOTTOM|wxLEFT|wxRIGHT|wxEXPAND, 12);
 
-  auto *labelCtrl = new wxStaticText(parent, wxID_STATIC, _(label), wxDefaultPosition, wxDefaultSize, 0);
+  auto *labelCtrl = new wxStaticText(parent, wxID_STATIC, label, wxDefaultPosition, wxDefaultSize, 0);
   sizer->Add(labelCtrl, 0, wxBOTTOM|wxALIGN_LEFT, 5);
 
   auto *safeCombinationCtrl = new SafeCombinationCtrl(parent, id, password, wxDefaultPosition, wxDefaultSize);


### PR DESCRIPTION
Related to #1516 

This is a first draft to fix some wx3.3.0 compatibility issues. The story so far...

1. Removed inappropriate use of _().  This fixed failures in coretest and pwsafe-cli-test.
2. Fixed a crash in PasswordSafeFrame::CreateMenubar().  It was removing items from a wxList while iterating over a reference to the same object.  I'm not sure why it works in 3.2 but not 3.3, but it's probably bad form in any case.
3. The default path style for the recent file list changed.  It turns out that in 3.2 the default didn't match the documentation, in 3.3 it does.

I'm marking it draft for now because I have only tested it on macOS with 3.3.0 and 3.2.8.  I wanted to put it out for review and more testing on Linux and with other languages.  Also, the first commit needs to be reverted before merging so 3.3.0 won't be used for production.

@frankspace: Do you still have a 3.3.0 package to build against?