### PR TITLE
[wx] Refresh view after adding an entry

### DIFF
--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -111,6 +111,7 @@ void PasswordSafeFrame::OnAddClick(wxCommandEvent& WXUNUSED(evt))
   int rc = ShowModalAndGetResult<AddEditPropSheetDlg>(this, m_core, AddEditPropSheetDlg::SheetType::ADD, nullptr, selectedGroup);
   if (rc == wxID_OK) {
     UpdateStatusBar();
+    Show();
   }
 }
 


### PR DESCRIPTION
Here is an obscure edge case I encountered:

1. Select tree view
2. Select menu View->Subviews->[any subview] If none are available, change something then select the subview.
3. Switch back to the normal view
4. Add a new entry

Result: The new entry is not displayed until the window is refreshed (e.g. Minimized then restored). The new entry is added to the DB, just not displayed.  This PR adds a call to Show() to force a refresh.

This change is somewhat related to #1433 in that, for the example given, g1 and g2 no longer collapse.  However, I could not make g3 expand if it was empty.  Not even by calling Expand() explicitly.

Tested on:
macOS M1Max Sequoia 15.5,    Xcode 16.4,    wx 3.2.4 and 3.2.8 (local builds)
