### PR TITLE
[wx] Flag text for translation

### DIFF
--- a/src/ui/wxWidgets/PasswordSafeSearch.cpp
+++ b/src/ui/wxWidgets/PasswordSafeSearch.cpp
@@ -706,7 +706,7 @@ SearchPointer& SearchPointer::operator++()
     m_currentIndex++;
     if (m_currentIndex == m_indices.end()) {
       m_currentIndex = m_indices.begin();
-      PrintLabel(_("Search hit bottom, continuing at top").c_str());
+      PrintLabel(_("Search hit bottom, continuing at top.").c_str());
     }
     else {
       PrintLabel();
@@ -724,7 +724,7 @@ SearchPointer& SearchPointer::operator--()
   if (!m_indices.empty()) {
     if (m_currentIndex == m_indices.begin()) {
       m_currentIndex = --m_indices.end();
-      PrintLabel(_("Search hit top, continuing at bottom").c_str());
+      PrintLabel(_("Search hit top, continuing at bottom.").c_str());
     }
     else {
       m_currentIndex--;
@@ -749,10 +749,9 @@ void SearchPointer::PrintLabel(const TCHAR* prefix /*= 0*/)
   else {
     // need a const object so we get both args to distance() as const iterators
     const SearchIndices& idx = m_indices;
-    m_label.Clear();
-    m_label << std::distance(idx.begin(), m_currentIndex)+1 << '/' << m_indices.size() << _(" matches");
+    m_label.Printf(_("%td/%zu matches"), std::distance(idx.begin(), m_currentIndex)+1, m_indices.size());
     if (prefix) {
-      m_label = wxString(prefix) + wxT(".  ") + m_label;
+      m_label = wxString(prefix) + "  " + m_label;
     }
   }
 }

--- a/src/ui/wxWidgets/PasswordSafeSearch.cpp
+++ b/src/ui/wxWidgets/PasswordSafeSearch.cpp
@@ -227,6 +227,7 @@ void PasswordSafeSearch::OnDoSearchT(Iter begin, Iter end, Accessor afn)
 
   UpdateView();
   txtCtrl->SelectNone();
+  txtCtrl->SetInsertionPointEnd();
 
   // Replace the "Find" menu item under Edit menu by "Find Next" and "Find Previous"
   wxMenu* editMenu = nullptr;
@@ -674,6 +675,7 @@ void PasswordSafeSearch::Activate()
   }
 
   UpdateStatusAreaWidth();
+  wxDynamicCast(FindControl(ID_FIND_EDITBOX), wxSearchCtrl)->SelectAll();
 }
 
 void PasswordSafeSearch::SetFocusIntoEditField()

--- a/src/ui/wxWidgets/PasswordSafeSearch.cpp
+++ b/src/ui/wxWidgets/PasswordSafeSearch.cpp
@@ -750,7 +750,7 @@ void SearchPointer::PrintLabel(const TCHAR* prefix /*= 0*/)
     // need a const object so we get both args to distance() as const iterators
     const SearchIndices& idx = m_indices;
     m_label.Clear();
-    m_label << std::distance(idx.begin(), m_currentIndex)+1 << '/' << m_indices.size() << wxT(" matches");
+    m_label << std::distance(idx.begin(), m_currentIndex)+1 << '/' << m_indices.size() << _(" matches");
     if (prefix) {
       m_label = wxString(prefix) + wxT(".  ") + m_label;
     }


### PR DESCRIPTION
Resolves #1543 

Questions:
1. Should the ".  " inserted at line 755 be moved to the strings passed as prefix arguments, so it can be accounted for in their translation?
2. Should the string arguments to wxCHECK_RET, and other debug macros, be flagged for translation?
