### PR TITLE
[wx] Add a warning about clipboard history utilities

### DIFF
--- a/help/default/html/edit_menu.html
+++ b/help/default/html/edit_menu.html
@@ -99,7 +99,8 @@ in reverse order, from last to earliest.</p>
 <p>Clear the clipboard's memory. This clears the clipboard of
 anything that was pasted there by <b>Password Safe</b> (password, username, notes, etc.).
 If the current contents of the clipboard did not come from <b>Password Safe</b>, then
-this will have no effect.</p>
+this will have no effect. <b>WARNING: Password Safe</b> can only clear the main clipboard.
+Clipboard history utilities may still hold any information that has been copied.</p>
 
 <h3>Copy User Name to Clipboard</h3>
 

--- a/src/core/PWSprefs.cpp
+++ b/src/core/PWSprefs.cpp
@@ -81,7 +81,7 @@ const PWSprefs::boolPref PWSprefs::m_bool_prefs[NumBoolPrefs] = {
   {_T("PWUseSymbols"), true, ptDatabase},                   // database
   {_T("PWUseHexDigits"), false, ptDatabase},                // database
   {_T("PWUseEasyVision"), false, ptDatabase},               // database
-  {_T("dontaskquestion"), false, ptApplication},            // application
+  {_T("dontaskquestion"), true, ptApplication},             // application
   {_T("deletequestion"), false, ptApplication},             // application
   {_T("DCShowsPassword"), false, ptApplication},            // application
   {_T("DontAskMinimizeClearYesNo"), true, ptObsolete},      // obsolete in 3.13 - replaced by 2 separate entries

--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -414,8 +414,8 @@ void PasswordSafeFrame::DoCopyPassword(CItemData &item)
 {
   if (PWSprefs::GetInstance()->GetPref(PWSprefs::DontAskQuestion)) {
     wxRichMessageDialog dialog(this, 
-      _("Pressing OK will copy the password of the selected item\nto the clipboard. The clipboard will be securely cleared\nwhen Password Safe is closed.\n\nPressing Cancel stops the password from being copied."), 
-      _("Clear Clipboard"), 
+      _("Pressing OK will copy the password of the selected item\nto the clipboard. The clipboard will be securely cleared\nwhen Password Safe is closed.\n \nWARNING: Password Safe can only clear the main clipboard.\nClipboard history utilities may still hold any information that\nhas been copied.\n \nPressing Cancel stops the password from being copied."),
+      _("Copy Password"),
       wxOK | wxCANCEL | wxICON_INFORMATION);
 
     dialog.ShowCheckBox(_("&Don't remind me again"));


### PR DESCRIPTION
Lately I've been thinking about clipboard history utilities.  Specifically, clearing the clipboard does not remove information from them.  I can't think of anything we can do about that, so I added a warning to the pop-up confirmation message and the help file.  I also changed the default for the DontAskQuestion preference so a new user, or one who has never changed that option, will see the message at least once.

Note: The meaning of DontAskQuestion is backward.  The code treats it as "Do Ask Question".  I didn't change the code or the parameter so as to remain compatible with existing config files.

<img width="541" height="380" alt="Screenshot 2025-07-30 at 5 24 37 PM" src="https://github.com/user-attachments/assets/5cd52f85-534f-404c-b140-3922aea2ff21" />
