### PR TITLE
[NSIS] Fix CLI uninstallation and updated Slovak translation

### DIFF
--- a/install/windows/I18N/pwsafe_sk.lng
+++ b/install/windows/I18N/pwsafe_sk.lng
@@ -23,10 +23,10 @@
 LangString RESERVE_TITLE ${LANG_SLOVAK} "Vyberte typ inštalácie"
 
 ; RESERVE_FIELD1 "Regular (uses Registry, suitable for home or single user PC)"
-LangString RESERVE_FIELD1 ${LANG_SLOVAK} "Štandardná (používa registre, vhodná pre domáci počítač alebo počítač s 1 používateľom)"
+LangString RESERVE_FIELD1 ${LANG_SLOVAK} "Štandardná (používa register, vhodná pre domáci počítač alebo počítač s 1 používateľom)"
 
 ; RESERVE_FIELD2 "Green (for Disk-on-Key; does not use host Registry)"
-LangString RESERVE_FIELD2 ${LANG_SLOVAK} "Prenosná (pre použitie na USB kľúči; nepoužíva Windows registre)"
+LangString RESERVE_FIELD2 ${LANG_SLOVAK} "Prenosná (pre použitie na USB kľúči; nepoužíva register Windows)"
 
 ; PROGRAM_FILES "Program Files"
 LangString PROGRAM_FILES ${LANG_SLOVAK} "Súbory programu"
@@ -78,10 +78,10 @@ LangString TEXT_GC_SUBTITLE ${LANG_SLOVAK} "Vyberte Štandardnú pre použitie n
 LangString PSWINI_TITLE ${LANG_SLOVAK} "Vyberte typ inštalácie"
 
 ; PSWINI_TEXT1 "Regular (uses Registry, suitable for home or single user PC)"
-LangString PSWINI_TEXT1 ${LANG_SLOVAK} "Štandardná (používa registre, vhodná pre domáci počítač alebo počítač s 1 používateľom)"
+LangString PSWINI_TEXT1 ${LANG_SLOVAK} "Štandardná (používa register, vhodná pre domáci počítač alebo počítač s 1 používateľom)"
 
 ; PSWINI_TEXT2 "Green (for Disk-on-Key; does not use host Registry)"
-LangString PSWINI_TEXT2 ${LANG_SLOVAK} "Prenosná (pre použitie na USB kľúč; nepoužíva registre Windows)"
+LangString PSWINI_TEXT2 ${LANG_SLOVAK} "Prenosná (pre použitie na USB kľúč; nepoužíva register Windows)"
 
 ;--------------------------------
 ; checks and warnings
@@ -112,7 +112,7 @@ LangString CHINESE_TW_SUPPORT ${LANG_SLOVAK} "čínsky (tradičný)"
 ; GERMAN_SUPPORT "German"
 LangString GERMAN_SUPPORT ${LANG_SLOVAK} "nemecký"
 ; SPANISH_SUPPORT "Spanish"
-LangString SPANISH_SUPPORT ${LANG_SLOVAK} "španielský"
+LangString SPANISH_SUPPORT ${LANG_SLOVAK} "španielsky"
 ; SWEDISH_SUPPORT "Swedish"
 LangString SWEDISH_SUPPORT ${LANG_SLOVAK} "švédsky"
 ; DUTCH_SUPPORT "Dutch"
@@ -124,7 +124,7 @@ LangString RUSSIAN_SUPPORT ${LANG_SLOVAK} "ruský"
 ; POLISH_SUPPORT "Polish"
 LangString POLISH_SUPPORT ${LANG_SLOVAK} "poľský"
 ; ITALIAN_SUPPORT "Italian"
-LangString ITALIAN_SUPPORT ${LANG_SLOVAK} "talianský"
+LangString ITALIAN_SUPPORT ${LANG_SLOVAK} "taliansky"
 ; DANISH_SUPPORT "Danish"
 LangString DANISH_SUPPORT ${LANG_SLOVAK} "dánsky"
 ; KOREAN_SUPPORT "Korean"

--- a/install/windows/pwsafe.nsi
+++ b/install/windows/pwsafe.nsi
@@ -797,6 +797,7 @@ Section "Uninstall"
   Delete "$INSTDIR\Uninstall.exe"
   ; Delete all installed files in the directory
   Delete "$INSTDIR\pwsafe.exe"
+  Delete "$INSTDIR\pwsafe-cli.exe"
   Delete "$INSTDIR\pws_at.dll"
   Delete "$INSTDIR\pws_osk.dll"
   Delete "$INSTDIR\pwsafe.chm"


### PR DESCRIPTION
1. Minor fixes to Slovak translation for NSIS installer.
2. pwsafe-cli.exe is not deleted during uninstallation on Windows, when selected to install via NSIS. This also prevents the "C:\Program Files\Password Safe" folder from being deleted from disk. See attached screenshots.

<img width="499" height="388" alt="pwsafe_3 69-bug-CLI-01" src="https://github.com/user-attachments/assets/c0c98113-8931-4b27-8e4f-223b35a8a72f" />
<img width="1016" height="507" alt="pwsafe_3 69-bug-CLI-02" src="https://github.com/user-attachments/assets/4f172537-fe90-4109-9f09-20e015334f44" />
