### PR TITLE
[i18n] view-report-fix (wx)

### DIFF
--- a/src/ui/wxWidgets/ViewReportDlg.cpp
+++ b/src/ui/wxWidgets/ViewReportDlg.cpp
@@ -50,7 +50,7 @@ ViewReportDlg::ViewReportDlg(wxWindow *parent, CReport* pRpt, bool fromFile) :
 
   if (!reportText.IsEmpty()) {
     std::replace_if(reportText.begin(), reportText.end(),
-                   [](wxUniChar ch) { return !isprint(ch) && !isspace(ch); },
+                   [](wxUniChar ch) { return !wxIsprint(ch) && !wxIsspace(ch); },
                    wxT(' '));
   }
   


### PR DESCRIPTION
After PR #1588 that fixed issue #1557 (Blank window when viewing reports on Linux), the Reports get displayed now but the program treats "non-English" chars incorrectly and replaces them by space.
This PR is to fix that by using locale-aware functions that are part of wxWidgets.
See attached screenshots.

Left image is OK. Right: German "ä ü ß" and Slovak "Ú č é" disappeared.

<img width="328" height="286" alt="pwsafe_1 22-wxWidgets-bug-View_Report-04" src="https://github.com/user-attachments/assets/4a5b8dd0-7dfb-4327-be4c-22424858150d" />

<img width="328" height="286" alt="pwsafe_1 22-wxWidgets-bug-View_Report-05" src="https://github.com/user-attachments/assets/a969ac6c-4ecd-46c6-aab5-f048423096f8" />
