### PR TITLE
[i18n] View-reports-fix (Windows)

### DIFF
--- a/src/ui/Windows/MainView.cpp
+++ b/src/ui/Windows/MainView.cpp
@@ -3820,7 +3820,7 @@ static bool GetDriveAndDirectory(const StringX &cs_infile, CString &cs_drive,
 
 void DboxMain::OnViewReports()
 {
-  CString cs_filename, cs_path, csAction;
+  CString cs_filename, cs_path, csAction, csButton;
   CString cs_directory, cs_drive;
 
   if (!GetDriveAndDirectory(m_core.GetCurFile(), cs_drive, cs_directory))
@@ -3841,12 +3841,13 @@ void DboxMain::OnViewReports()
   };
 
   for (int i = 0; i < sizeof(Reports) / sizeof(Reports[0]); i++) {
-    csAction.LoadString(Reports[i]);
+    csAction = CReport::ReportNames.find(Reports[i])->second;
+    csButton.LoadString(Reports[i]);
     cs_filename.Format(IDSC_REPORTFILENAME, static_cast<LPCWSTR>(cs_drive),
                        static_cast<LPCWSTR>(cs_directory),
                        static_cast<LPCWSTR>(csAction));
     if (::_tstat(cs_filename, &statbuf) == 0) {
-      gmb.AddButton(Reports[i], csAction);
+      gmb.AddButton(Reports[i], csButton);
       bReportExists = true;
     }
   }


### PR DESCRIPTION
The PR #1538 fixing issue #1531 (View Reports looks for wrong files for non-English languages) provided only a partial fix: opening the correct file name in Notepad.
However, the step before that - the dialog that should display button for each Report found on disk is never created when using non-English languages.
This PR is to fix that part.

See attached screenshots, for German.
<img width="823" height="609" alt="pwsafe_3 69-bug-ViewReports-Lang_DE-01" src="https://github.com/user-attachments/assets/24981ea9-4c29-45f9-bd86-38165a60c78a" />
<img width="787" height="421" alt="pwsafe_3 69-bug-ViewReports-Lang_DE-02" src="https://github.com/user-attachments/assets/67a8f02c-dcbf-479c-8446-d8dd6aac5f35" />
