### PR TITLE
Import Text Report - Fix unknown headers formatting

### DIFF
--- a/src/core/CoreImpExp.cpp
+++ b/src/core/CoreImpExp.cpp
@@ -1027,7 +1027,7 @@ int PWScore::ImportPlaintextFile(const StringX &ImportedPrefix,
     Format(cs_error, IDSC_IMPORTHDR, numCols);
     rpt.WriteLine(cs_error);
     LoadAString(cs_error, bImportPSWDsOnly ? IDSC_IMPORTKNOWNHDRS2 : IDSC_IMPORTKNOWNHDRS);
-    rpt.WriteLine(cs_error, bImportPSWDsOnly);
+    rpt.WriteLine(cs_error);
     for (auto fieldName = foundFields.begin(); fieldName != foundFields.end(); ++fieldName)
     {
       if (*fieldName == CItemData::EngFieldName(CItem::UNKNOWNFIELDS))
@@ -1044,7 +1044,8 @@ int PWScore::ImportPlaintextFile(const StringX &ImportedPrefix,
     }
     for (const auto &unknownColumn : unknownColumns)
     {
-      rpt.WriteLine(unknownColumn);
+      Format(cs_error, L"\t%ls ", unknownColumn.c_str());
+      rpt.WriteLine(cs_error);
     }
     rpt.WriteLine();
     rpt.WriteLine();

--- a/src/core/CoreImpExp.cpp
+++ b/src/core/CoreImpExp.cpp
@@ -1038,12 +1038,13 @@ int PWScore::ImportPlaintextFile(const StringX &ImportedPrefix,
 
     if (!unknownColumns.empty())
     {
+      rpt.WriteLine();
       LoadAString(cs_error, IDSC_UNKNOWNHDRS);
-      rpt.WriteLine(cs_error, false);
+      rpt.WriteLine(cs_error);
     }
     for (const auto &unknownColumn : unknownColumns)
     {
-      rpt.WriteLine(unknownColumn, false);
+      rpt.WriteLine(unknownColumn);
     }
     rpt.WriteLine();
     rpt.WriteLine();


### PR DESCRIPTION
This PR is to fix formatting Report for the Import Text function, in case there are unknown headers in the import file.
The list of unknown columns is not formatted before displaying (no delimiter), so we need to add CRLF after each item as well.
Tested on Windows and Linux, it should work on macOS too.

See attached screenshots how it gets improved.
<img width="628" height="681" alt="pwsafe_3 69-bug-ImportText-01" src="https://github.com/user-attachments/assets/f980b668-c2f3-4d77-981a-76ee80fa33e3" />
<img width="529" height="756" alt="pwsafe_3 69-bug-ImportText-02" src="https://github.com/user-attachments/assets/ffdd2e4a-ea0d-43c7-ad03-2e3b073a90ec" />
