### PR TITLE
[wx] Fix PasswordPolicyDlg Help

### DIFF
--- a/src/ui/wxWidgets/HelpMap.h
+++ b/src/ui/wxWidgets/HelpMap.h
@@ -29,6 +29,7 @@ DLG_HELP(AdvancedSelectionDlg<FindDlgType>,             html/searching.html)
 
 //The help for Manage Password Policies dialog
 DLG_HELP(ManagePasswordPoliciesDlg,                     html/named_password_policies.html)
+DLG_HELP(PasswordPolicyDlg,                             html/password_policies.html)
 
 #ifndef NO_YUBI
 //The Yubikey Configuration dialog
@@ -44,7 +45,6 @@ DLG_HELP(YubiCfgDlg,                                    html/manage_menu.html#yu
 PROPSHEET_HELP(OptionsPropertySheetDlg,            _("Backups"),          html/backups_tab.html)
 PROPSHEET_HELP(OptionsPropertySheetDlg,            _("Display"),          html/display_tab.html)
 PROPSHEET_HELP(OptionsPropertySheetDlg,            _("Miscellaneous"),    html/misc_tab.html)
-PROPSHEET_HELP(OptionsPropertySheetDlg,            _("Password Policy"),  html/password_policies.html)
 PROPSHEET_HELP(OptionsPropertySheetDlg,            _("Password History"), html/password_history_tab.html)
 PROPSHEET_HELP(OptionsPropertySheetDlg,            _("Security"),         html/security_tab.html)
 PROPSHEET_HELP(OptionsPropertySheetDlg,            _("System"),           html/system_tab.html)

--- a/src/ui/wxWidgets/PasswordPolicyDlg.cpp
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.cpp
@@ -32,6 +32,12 @@
 ////@end XPM images
 
 /*!
+ * PasswordPolicyDlg type definition
+ */
+
+IMPLEMENT_CLASS( PasswordPolicyDlg, wxDialog )
+
+/*!
  * PasswordPolicyDlg event table definition
  */
 

--- a/src/ui/wxWidgets/PasswordPolicyDlg.h
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.h
@@ -79,6 +79,7 @@ class wxSpinCtrl;
 
 class PasswordPolicyDlg : public QueryCancelDlg
 {
+  DECLARE_DYNAMIC_CLASS( PasswordPolicyDlg )
   DECLARE_EVENT_TABLE()
 
 public:


### PR DESCRIPTION
The PasswordPolicyDlg class does not have the wxWidgets’ RTTI macro specified, so the GetHelpMap() function fails to find the HTML Help page assigned to the dialog.
The RTTI system knows only the nearest base that declares the RTTI info — in this case, wxDialog.
Also, the password_policies.html page is assigned to a non-existing property sheet in Options in HelpMap.h.
This PR is to fix both the issues.

Main Menu > Manage > Password Policies.
Click New or Edit, click Help.
See attached screenshots, hope it helps.

E.g. English: This Help page should be displayed once fixed.
<img width="962" height="618" alt="pwsafe_1 22-wxWidgets-bug-Password_Policy-04" src="https://github.com/user-attachments/assets/6f0a1f93-fedd-4331-86e8-fc58ec9d8044" />

<img width="719" height="775" alt="pwsafe_1 22-wxWidgets-bug-Password_Policy-01" src="https://github.com/user-attachments/assets/a93fe410-d9f1-4780-b1d1-40b7e90072f9" />

<img width="489" height="562" alt="pwsafe_1 22-wxWidgets-bug-Password_Policy-03" src="https://github.com/user-attachments/assets/41c3372a-cee8-41d7-ad3a-c943f76dc188" />


