### PR TITLE
[wx] Modernization of encryption/decryption key entry dialog

### DIFF
--- a/src/ui/wxWidgets/CryptKeyEntryDlg.cpp
+++ b/src/ui/wxWidgets/CryptKeyEntryDlg.cpp
@@ -96,7 +96,7 @@ void CryptKeyEntryDlg::CreateControls()
 
     auto *showHideButtonKey = new wxBitmapButton(this, wxID_ANY, wxBitmap(eye_xpm), wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
     showHideButtonKey->SetToolTip(_("Show key"));
-    showHideButtonKey->Bind(wxEVT_BUTTON, [&, showHideButtonKey](wxCommandEvent& event) {
+    showHideButtonKey->Bind(wxEVT_BUTTON, [&, hBoxSizer1, showHideButtonKey](wxCommandEvent& event) {
       UpdatePasswordTextCtrl(hBoxSizer1, m_TextCtrlKey1, m_TextCtrlKey1->GetValue(), nullptr, isCryptKeyHidden ? 0 : wxTE_PASSWORD);
       showHideButtonKey->SetBitmapLabel(wxBitmap(isCryptKeyHidden ? eye_close_xpm : eye_xpm));
       showHideButtonKey->SetToolTip(isCryptKeyHidden ? _("Hide key") : _("Show key"));
@@ -117,7 +117,7 @@ void CryptKeyEntryDlg::CreateControls()
 
       auto *showHideButtonVerificationKey = new wxBitmapButton(this, wxID_ANY, wxBitmap(eye_xpm), wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
       showHideButtonVerificationKey->SetToolTip(_("Show verification key"));
-      showHideButtonVerificationKey->Bind(wxEVT_BUTTON, [&, showHideButtonVerificationKey](wxCommandEvent& event) {
+      showHideButtonVerificationKey->Bind(wxEVT_BUTTON, [&, hBoxSizer2, showHideButtonVerificationKey](wxCommandEvent& event) {
         UpdatePasswordTextCtrl(hBoxSizer2, m_TextCtrlKey2, m_TextCtrlKey2->GetValue(), nullptr, isCryptVerificationKeyHidden ? 0 : wxTE_PASSWORD);
         showHideButtonVerificationKey->SetBitmapLabel(wxBitmap(isCryptVerificationKeyHidden ? eye_close_xpm : eye_xpm));
         showHideButtonVerificationKey->SetToolTip(isCryptVerificationKeyHidden ? _("Hide verification key") : _("Show verification key"));

--- a/src/ui/wxWidgets/CryptKeyEntryDlg.h
+++ b/src/ui/wxWidgets/CryptKeyEntryDlg.h
@@ -40,6 +40,11 @@ public:
 
 protected:
 
+  void CreateControls();
+  bool IsEncryptionMode() const {
+    return m_Mode == Mode::ENCRYPT;
+  }
+
   //(*Handlers(CryptKeyEntryDialog)
   void OnOk(wxCommandEvent& event);
   void OnCancel(wxCommandEvent& event);
@@ -50,9 +55,12 @@ protected:
   //*)
 
   //(*Declarations(CryptKeyEntryDialog)
-  wxTextCtrl* TextCtrlKey1;
-  wxTextCtrl* TextCtrlKey2;
+  wxTextCtrl* m_TextCtrlKey1;
+  wxTextCtrl* m_TextCtrlKey2;
   //*)
+
+  bool isCryptKeyHidden = true;
+  bool isCryptVerificationKeyHidden = true;
 
   Mode m_Mode;
   StringX m_CryptKey;

--- a/src/ui/wxWidgets/ViewReportDlg.cpp
+++ b/src/ui/wxWidgets/ViewReportDlg.cpp
@@ -63,7 +63,7 @@ ViewReportDlg::ViewReportDlg(wxWindow *parent, CReport* pRpt, bool fromFile) :
   wxASSERT_MSG(bs, wxT("Could not create an empty wxStdDlgButtonSizer"));
 
   if(fromFile) {
-    auto deleteButton = new wxButton(this, wxID_APPLY, _("&Delete"));
+    auto deleteButton = new wxButton(this, wxID_REMOVE, _("&Delete"));
     deleteButton->SetToolTip(_("Delete report file"));
     bs->Add(deleteButton);
   }
@@ -84,7 +84,7 @@ ViewReportDlg::ViewReportDlg(wxWindow *parent, CReport* pRpt, bool fromFile) :
   bs->Realize();
 
   Bind(wxEVT_BUTTON, &ViewReportDlg::OnSave, this, wxID_SAVE);
-  Bind(wxEVT_BUTTON, &ViewReportDlg::OnDelete, this, wxID_APPLY);
+  Bind(wxEVT_BUTTON, &ViewReportDlg::OnDelete, this, wxID_REMOVE);
   Bind(wxEVT_BUTTON, &ViewReportDlg::OnCopy, this, wxID_COPY);
   Bind(wxEVT_BUTTON, &ViewReportDlg::OnClose, this, wxID_CLOSE);
 


### PR DESCRIPTION
To better reflect the application in question, the Password Safe logo has been added to the key entry dialog. Furthermore, the title bar displays the functionality being called (encryption/decryption), the application name, and the version.

#### Current Version
<img width="315" height="178" alt="EncryptionCurrent" src="https://github.com/user-attachments/assets/5e4eae98-ccf3-4c93-9062-2dcc987005e5" />
<img width="315" height="140" alt="DecryptionCurrent" src="https://github.com/user-attachments/assets/1cf6cc0f-d6b0-418a-8fbd-4ec971e7a5c4" />

#### New Version
<img width="516" height="262" alt="EncryptionKeyNew" src="https://github.com/user-attachments/assets/7e01f1e3-1834-4681-b99c-3b1b0c6010a1" />
<img width="516" height="201" alt="DecryptionKeyNew" src="https://github.com/user-attachments/assets/833d2c6b-5e2d-417b-b071-a238af91b729" />

#### ViewReportDlg
The last commit (7d74e7c) addresses the review [comment](https://github.com/pwsafe/pwsafe/pull/1592#discussion_r2264444158) of @dskrvk in #1592.
