### PR TITLE
[wx] Fix Main Toolbar's Help button action

### DIFF
--- a/src/ui/wxWidgets/HelpMap.h
+++ b/src/ui/wxWidgets/HelpMap.h
@@ -20,7 +20,7 @@ DLG_HELP(ImportXmlDlg,                                  html/import.html#XML)
 DLG_HELP(SafeCombinationEntryDlg,                       html/create_new_db.html)
 
 //The Contents page from main toolbar
-DLG_HELP(wxToolBar,                                     html/Welcome.html)
+DLG_HELP(wxAuiToolBar,                                  html/Welcome.html)
 
 //AdvancedSelectionDlg template
 DLG_HELP(AdvancedSelectionDlg<ExportFullXml>,           html/export.html#xml)


### PR DESCRIPTION
Linux/macOS: The GetHelpMap() method fails to find the HTML Help page assigned to the main toolbar as the object is of different wxWidgets class (wxAuiToolBar).

<img width="700" height="473" alt="pwsafe_1 22-wxWidgets-bug-Toolbar_Help-01" src="https://github.com/user-attachments/assets/9247332b-ff0b-4d6d-a58a-5b613a13f15d" />

The "Welcome" Help page is displayed once fixed (example for English).

<img width="792" height="526" alt="pwsafe_1 22-wxWidgets-bug-Toolbar_Help-02" src="https://github.com/user-attachments/assets/5b1681b6-52d3-47b7-9b1b-6dc281c2de1c" />
