### PR TITLE
[wx] Fix: DBv4 file saved with DBv3 extension when using Save As

### DIFF
--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -445,18 +445,18 @@ int PasswordSafeFrame::SaveAs()
   if(cf.empty()) {
     cf = wxT("pwsafe"); // reasonable default for first time user
   }
-  wxString v3FileName = towxstring(PWSUtil::GetNewFileName(cf.c_str(), DEFAULT_SUFFIX));
+  wxString NewFileName = towxstring(PWSUtil::GetNewFileName(cf.c_str(), curver == PWSfile::V40 ? V4_SUFFIX : V3_SUFFIX));
 
   wxString title = (!m_core.IsDbFileSet()? _("Choose a name for the current (Untitled) database:") :
                                     _("Choose a new name for the current database:"));
-  wxFileName filename(v3FileName);
+  wxFileName filename(NewFileName);
   wxString dir = filename.GetPath();
   if (dir.empty())
     dir = towxstring(PWSdirs::GetSafeDir());
 
   //filename cannot have the path
   wxFileDialog fd(this, title, dir, filename.GetFullName(),
-                  _("Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|*.*;*"),
+                  curver == PWSfile::V40 ? _("Password Safe Databases (*.psafe4)|*.psafe4|All files (*.*; *)|*.*;*") : _("Password Safe Databases (*.psafe3; *.dat)|*.psafe3;*.dat|All files (*.*; *)|*.*;*"),
                    wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
 
   if (fd.ShowModal() != wxID_OK) {


### PR DESCRIPTION
If I export a v3 file as a v4 DB, it gets saved with the same filename with the "psafe4" extension.
Then, when using the Save As command for this new v4 file, the default file extension is "psafe3" instead of "psafe4".
The default file name filter is also set to "*.psafe3".
This leads to unintentional overwriting the initial v3 file instead of creating a copy of existing v4 file.

<img width="834" height="589" alt="pwsafe_1 22-wxWidgets-bug-SaveAs-02" src="https://github.com/user-attachments/assets/f45eaf8a-32b2-47b2-a6f9-caab48a39a6e" />
<img width="617" height="190" alt="pwsafe_1 22-wxWidgets-bug-SaveAs-03" src="https://github.com/user-attachments/assets/2c842e14-e69f-4e17-98f6-39416d0ba86c" />
<img width="614" height="574" alt="pwsafe_1 22-wxWidgets-bug-SaveAs-04" src="https://github.com/user-attachments/assets/155ece7b-7d99-43f9-a633-a898753dc28b" />

<br>
After the fix is applied:
<br><br>
<img width="834" height="589" alt="pwsafe_1 22-wxWidgets-bug-SaveAs-05" src="https://github.com/user-attachments/assets/608b484e-213e-4eb9-b5c2-590d6b929697" />
