### PR TITLE
[wx] Fix FreeBSD and OpenBSD version check

### DIFF
--- a/src/core/SysInfo.cpp
+++ b/src/core/SysInfo.cpp
@@ -44,7 +44,7 @@ bool SysInfo::IsUnderPw2go()
 // The wxWidgets UI is used for Linux and macOS
 bool SysInfo::IsWXUI()
 {
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
   return true;
 #else
   return false;


### PR DESCRIPTION
Both OSes report the latest version that is applicable to Windows, not wxWidgets.
Menu > Help > About
Check for the latest version:
Current 1.22
Latest 3.69

This PR is to provide fix for FreeBSD and OpenBSD:
The CheckLatestVersion method in src/core/CheckVersion.cpp parsing https://pwsafe.org/latest.xml evaluates the OS as running a non-wx version and thus checks for the PC/Windows version number.
        if ((SysInfo::IsWXUI()  && variant == _T("Linux")) ||
            (!SysInfo::IsWXUI() && variant == _T("PC"))) {

Attached you can find screenshots before and after the fix:
<img width="1140" height="636" alt="pwsafe_1 22-wxWidgets-bug-BSD-VersionCheck-01" src="https://github.com/user-attachments/assets/f4a31266-7e3c-428c-9872-ceff6262a9d5" />
<img width="1107" height="670" alt="pwsafe_1 22-wxWidgets-bug-BSD-VersionCheck-02" src="https://github.com/user-attachments/assets/bf54b344-8cf1-4a61-80f1-b444866ad530" />
<img width="1131" height="629" alt="pwsafe_1 22-wxWidgets-bug-BSD-VersionCheck-03" src="https://github.com/user-attachments/assets/c4f7834e-32b0-4934-bc6c-4a4a9495fcc9" />
<img width="1095" height="665" alt="pwsafe_1 22-wxWidgets-bug-BSD-VersionCheck-04" src="https://github.com/user-attachments/assets/4b4c64fb-7cbe-4a9e-b1f4-5faad0e24982" />
