### PR TITLE
[wx] Add Tooltip to Options when System Tray support is unavailable

### DIFF
--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -839,6 +839,7 @@ wxPanel* OptionsPropertySheetDlg::CreateSystemPanel(const wxString& title)
   itemBoxSizer105->Add(CreateHeaderPanel(itemPanel104, title), 0, wxEXPAND|wxALL, 5);
 
   wxStaticBox* itemStaticBoxSizer106Static = new wxStaticBox(itemPanel104, wxID_ANY, _("System Tray"));
+  wxUtilities::NotifyIfUnsupported(wxUtilities::Feature::SystemTray, itemStaticBoxSizer106Static);
   auto *itemStaticBoxSizer106 = new wxStaticBoxSizer(itemStaticBoxSizer106Static, wxVERTICAL);
   itemBoxSizer105->Add(itemStaticBoxSizer106, 0, wxEXPAND|wxALL, 5);
   m_System_UseSystemTrayCB = new wxCheckBox( itemPanel104, ID_CHECKBOX30, _("Put icon in System Tray"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -355,6 +355,15 @@ void wxUtilities::DisableIfUnsupported(enum Feature feature, wxWindow* window)
   }
 }
 
+void wxUtilities::NotifyIfUnsupported(enum Feature feature, wxWindow* window)
+{
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+  if (feature == SystemTray && !IsTaskBarIconAvailable()) {
+    window->SetToolTip(_("Not supported by the current Windowing System (e.g. Wayland), or you may need to install a Desktop Environment extension to enable System Tray support."));
+  }
+#endif
+}
+
 // Wrapper for wxTaskBarIcon::IsAvailable() that doesn't crash
 // on Fedora or Ubuntu
 bool IsTaskBarIconAvailable()

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -433,7 +433,7 @@ typedef wxTextDataObject wxTextDataObjectEx;
 
 namespace wxUtilities
 {
-  enum Feature { Autotype };
+  enum Feature { Autotype, SystemTray };
   enum WindowSystem {
     Undefined,    // Only used to identify the first pass through WhatWindowSystem()
     Unknown,
@@ -463,6 +463,13 @@ namespace wxUtilities
    * @param control the control to disable.
    */
   void DisableIfUnsupported(enum Feature feature, wxWindow* window);
+
+  /**
+   * @brief Shows a tooltip for the specified feature(s).
+   *
+   * @param Specify the target control.
+   */
+  void NotifyIfUnsupported(enum Feature feature, wxWindow* window);
 }
 
 // Wrapper for wxTaskBarIcon::IsAvailable() that doesn't crash


### PR DESCRIPTION
This PR is to add Tooltip with details for the System Tray settings in Options when the feature is unavailable, providing hints about how to resolve the issue.

Like the AutoType feature, System Tray support in Linux/UNIX does not work on Wayland.
Additionally, System Tray icon is not available in Desktop Environments like Gnome on X11, unless user installs an extension that adds the feature back to the system (but who knows about this?).
While settings for AutoType shows a tooltip with details ("Not supported by Wayland"), the settings for System Tray provides no info on why the feature is unavailable.

Todo:
.PO files need to be updated with a translated message:
"Not supported by the current Windowing System (e.g. Wayland), or you may need to install a Desktop Environment extension to enable System Tray support."

Tested in:
-Debian/FreeBSD/OpenBSD with Gnome where X11 is the default one or it can be selected instead of Wayland on the login screen.
  Gnome extensions tested: "AppIndicator and KStatusNotifierItem Support" and "Tray Icons: Reloaded".
  Password Safe does not need to be restarted after the extension is installed and enabled.
-Mint with Cinnamon on Wayland/X11
-Kubuntu with Plasma on Wayland/X11

Attached you can find some screenshots.
<img width="668" height="696" alt="pwsafe_1 22-wxWidgets-feat-SystemTray-01" src="https://github.com/user-attachments/assets/4452363f-0a2c-433b-8a5c-c44e21b1d2dd" />

ToolTip added - Debian on Wayland:

<img width="1366" height="768" alt="pwsafe_1 22-wxWidgets-feat-SystemTray-02" src="https://github.com/user-attachments/assets/1a67d3f6-6995-4218-8b0e-358ac04e0a2f" />

ToolTip added - Mint on Wayland:

<img width="1271" height="781" alt="pwsafe_1 22-wxWidgets-feat-SystemTray-03" src="https://github.com/user-attachments/assets/9b9f9193-1852-40f7-8ca0-e7137e87a8ed" />

Debian on X11 with a Gnome extension for System Tray:

<img width="1263" height="804" alt="pwsafe_1 22-wxWidgets-feat-SystemTray-04" src="https://github.com/user-attachments/assets/b025717c-fae1-4d05-91b9-adbd2e19fc39" />

Mint on X11:

<img width="1270" height="769" alt="pwsafe_1 22-wxWidgets-feat-SystemTray-05" src="https://github.com/user-attachments/assets/18dc762f-4e25-4847-84d4-3738f6933a30" />
