### PR TITLE
[wx] Fix minimize to System Tray on Linux

### DIFF
--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -585,8 +585,14 @@ void PWSafeApp::FinishInit() {
   } else {
     SetTopWindow(m_frame);
   }
-  if (PWSprefs::GetInstance()->GetPref(PWSprefs::UseSystemTray))
-    m_frame->ShowTrayIcon();
+  if (PWSprefs::GetInstance()->GetPref(PWSprefs::UseSystemTray)) {
+    if ( IsTaskBarIconAvailable() ) {
+      m_frame->ShowTrayIcon();
+    }
+    else {
+      PWSprefs::GetInstance()->SetPref(PWSprefs::UseSystemTray, false, false);
+    }
+  }
 
   m_frame->Register(); // register modal dialog hook
   m_initComplete = true;


### PR DESCRIPTION
This PR provides a fix to make the program's window minimize to Task Bar (so it’s Alt+Tab-able) in case System Tray becomes not available.

Issue: In many Linux distros, when the System Tray support becomes unavailable (e.g. due to migration to Wayland), Password Safe's window on locking the database behaves like it disappears:
In this case, there’s no Tray or Task Bar icon for user to click to restore the window.
Since the minimized window is unmapped/hidden, it also doesn’t show up in Alt+Tab or when using the compositor's task switcher.
Then, user can only kill existing process of Password Safe and start the program again.
A confused user would most probably launch Password Safe again trying to open the same database, only to be prompted with an error message: "Lock is done by yourself".

Some scenarios when this can happen:
1. Some distros provide a Wayland or Xorg session to choose from on the login screen. A user using pwsafe with System Tray logs out of Xorg session and logs in to Wayland session.
2. The OS gets upgraded with Wayland as the default display server, and an Xorg session may not be available anymore as it's deprecated.
3. The desktop environment extension providing support for System Tray is disabled or uninstalled.
4. User migrates from OS with System Tray support to OS without it, including the pwsafe config file.
5. New version of Password Safe gets installed, overwriting the application's .desktop file where a workaround for System Tray was configured (as described in README.LINUX.md).
  In all cases, the UseSystemTray=1 settings is saved in pwsafe.cfg.
  On startup, Password Safe assumes System Tray is still available, based on settings in pwsafe.cfg.
  Database is locked manually, or after the timeout specified in Options > Security.

Somewhat related issues on Github:
https://github.com/pwsafe/pwsafe/issues/1322
https://github.com/pwsafe/pwsafe/issues/1339
https://github.com/pwsafe/pwsafe/issues/1093
https://github.com/pwsafe/pwsafe/issues/1223

Attached you can find some screenshots (Debian on X11 -> Wayland).

<img width="1274" height="792" alt="pwsafe_1 22-wxWidgets-bug-SysTrayLock-01" src="https://github.com/user-attachments/assets/d90587b4-61a0-4fb7-98dd-2f5e69e4eea4" />
<img width="1366" height="768" alt="pwsafe_1 22-wxWidgets-bug-SysTrayLock-02" src="https://github.com/user-attachments/assets/8b81e2d5-4f2e-46d1-b415-895218549d37" />
<img width="1366" height="768" alt="pwsafe_1 22-wxWidgets-bug-SysTrayLock-03" src="https://github.com/user-attachments/assets/105a6eb5-9412-49de-9833-876b2fc62171" />
<img width="525" height="401" alt="pwsafe_1 22-wxWidgets-bug-SysTrayLock-04" src="https://github.com/user-attachments/assets/39a1324e-2bff-4fc3-93b6-92ed6167f844" />

After the fix:

<img width="1366" height="768" alt="pwsafe_1 22-wxWidgets-bug-SysTrayLock-05" src="https://github.com/user-attachments/assets/02d85423-8253-46cf-af5f-e7d31a40acd5" />
