### PR TITLE
Deb13 support

### DIFF
--- a/Misc/setup-linux-dev-env.sh
+++ b/Misc/setup-linux-dev-env.sh
@@ -77,14 +77,14 @@ case "$DISTRO" in
         elif test \( \( "$DISTRO" = "ubuntu" -o "$DISTRO" = "pop" \) -a "$RELEASE" -ge 20 \) -o \
          \( "$DISTRO" = "debian" -a "$RELEASE" -eq 11 \) ; then
             LIBWXDEV="libwxgtk3.0-gtk3-dev"
-        elif test \( "$DISTRO" = "debian"  -a "$RELEASE" -eq 12 \) ; then
+        elif test \( "$DISTRO" = "debian"  -a "$RELEASE" -ge 12 \) ; then
             LIBWXDEV="libwxgtk3.2-dev"
         elif test \( "$DISTRO" = "debian"  -a "$RELEASE" -eq 0 \) ; then
             LIBWXDEV="libwxgtk3.2-dev"
         elif test \( "$DISTRO" = "linuxmint"  -a "$RELEASE" -eq 22 \) ; then
             LIBWXDEV="libwxgtk3.2-dev"
         else
-            LIBWXDEV="libwxgtk3.0-dev"
+            LIBWXDEV="libwxgtk3.2-dev"
         fi
         apt-get install -qy cmake fakeroot g++ gettext git libgtest-dev \
             libcurl4-openssl-dev libqrencode-dev  libssl-dev libuuid1 \

--- a/src/core/PWSfileV1V2.h
+++ b/src/core/PWSfileV1V2.h
@@ -40,6 +40,7 @@ protected:
 
 private:
   PWSfileV1V2& operator=(const PWSfileV1V2&) = delete; // Do not implement
+  using PWSfile::ReadCBC;
   size_t ReadCBC(unsigned char &type, StringX &data);
   // crypto stuff for reading/writing files:
   unsigned char m_salt[SaltLength];

--- a/src/test/ItemFieldTest.cpp
+++ b/src/test/ItemFieldTest.cpp
@@ -23,9 +23,9 @@ public:
 virtual unsigned int GetBlockSize() const {return 8;}
   // Following encrypt/decrypt a single block
   // (blocksize dependent on cipher)
-  virtual void Encrypt(const unsigned char *pt, unsigned char *ct)
+  virtual void Encrypt(const unsigned char *pt, unsigned char *ct) const
   {memcpy(ct, pt, GetBlockSize());}
-  virtual void Decrypt(const unsigned char *ct, unsigned char *pt)
+  virtual void Decrypt(const unsigned char *ct, unsigned char *pt) const
   {memcpy(pt, ct, GetBlockSize());}
 };
 


### PR DESCRIPTION
Initial support for Debian 13:
- Fetch right version of wx in setup env script
- Fixed a couple of compiler warnings

TODO: Modify scripts to install and use debsign (from devscripts) instead of dpkg-sig