### PR TITLE
Update documenation to build flatpak with Freedesktop 25.08

### DIFF
--- a/README.LINUX.FLATPAK.md
+++ b/README.LINUX.FLATPAK.md
@@ -1,7 +1,7 @@
-## Introduction
+## End-users
 Flatpak is a universal installation package format for Linux. You can install Password Safe as a flatpak from Flathub: https://flathub.org/apps/org.pwsafe.pwsafe
 
-## Short Guide
+## Developers
 This guide was tested on Ubuntu and Fedora, but should also works for other Linux distributions.
 
 If you want to build flatpak by yourself, then do the following:


### PR DESCRIPTION
Documentation part of fix for [Upgrade flatpak Freedesktop SDK v23.08 to v24.08 #1482](https://github.com/pwsafe/pwsafe/issues/1482).