### PR TITLE
flatpak add donation and contact info to metainfo file

### DIFF
--- a/install/metainfo/org.pwsafe.pwsafe.metainfo.xml
+++ b/install/metainfo/org.pwsafe.pwsafe.metainfo.xml
@@ -59,5 +59,7 @@
   <url type="bugtracker">https://github.com/pwsafe/pwsafe/issues</url>
   <url type="translate">https://explore.transifex.com/passwordsafe/passwordsafe/</url>
   <url type="faq">https://pwsafe.org/faq.shtml</url>
+  <url type="contact">https://pwsafe.org/contact.php</url>
+  <url type="donation">https://sourceforge.net/p/passwordsafe/donate/</url>
   <content_rating type="oars-1.1"/>
 </component>


### PR DESCRIPTION
Flathub.org now supports two more interesting info this PR adds:
- donate bottom (at the top right of web page for individual flatpak)

<img width="608" height="226" alt="image" src="https://github.com/user-attachments/assets/8e3098ed-6625-43e6-9e8d-881d60df0c46" />

- contact info (on bottom of web page when Links is clicked)
<img width="385" height="176" alt="image" src="https://github.com/user-attachments/assets/fb88870c-a663-410c-b9f2-883c791c4b78" />

---

To have above two info published on Flathub.org:
- This commit has to be merged into "upstream" repository (from the point of Flathub downstream repo), so into current repository github.com/pwsafe/pwsafe/
- New flatpak version must be published on downstream repository github.com/flathub/org.pwsafe.pwsafe
- Then Password Safe specific web site on flathub.org/en/apps/org.pwsafe.pwsafe will automatically be updated.

SUGGESTION: Accept this commit to current repository and when new version of flatpak will be released this info will be automatically published on Flathub.org web site.