### PR TITLE
[wx] Update filter status of tree view

### DIFF
--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -111,7 +111,6 @@ void PasswordSafeFrame::OnAddClick(wxCommandEvent& WXUNUSED(evt))
   int rc = ShowModalAndGetResult<AddEditPropSheetDlg>(this, m_core, AddEditPropSheetDlg::SheetType::ADD, nullptr, selectedGroup);
   if (rc == wxID_OK) {
     UpdateStatusBar();
-    Show();
   }
 }
 

--- a/src/ui/wxWidgets/MenuViewHandlers.cpp
+++ b/src/ui/wxWidgets/MenuViewHandlers.cpp
@@ -392,6 +392,7 @@ void PasswordSafeFrame::ApplyFilters()
 {
   m_FilterManager.CreateGroups();
   // Update and setting of filter state is not needed here, as update is done at the end of RefreshView()
+  m_tree->SetFilterActive(m_bFilterActive);
   RefreshViews();
 }
 


### PR DESCRIPTION
This PR reverts the changes of #1521 to prevent multiple rebuilds of the tree view.

When a new entry is added to the database, the core already informs the user interface about the need for an update. Therefore, an additional call to "Show" should not be necessary to trigger a rebuild of the tree view.

The password frame instance and the tree view each manage their own status regarding an active filter. This pull request synchronizes both statuses in the PasswordSafe::ApplyFilters method so that the tree view's update mechanism correctly takes the filter status into account (see also TreeCtrl::UpdateGUI). The list view, on the other hand, does not have its own status regarding an active filter.

The reason for the behavior in #1521 was that the filter status in the tree view was activated when switching to a sub-view, but was not deactivated when switching back to the normal view.