### PR TITLE
[wx] Fix handling of empty groups after drag and drop

### DIFF
--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -1462,7 +1462,7 @@ void TreeCtrl::OnEndDrag(wxTreeEvent& evt)
 
     wxTreeItemId itemDst = evt.GetItem();
     auto parentOfDragItem = GetItemParent(m_drag_item);
-    auto sxSrcGroupName = tostringx(GetItemText(parentOfDragItem));
+    auto sxSrcGroupName = tostringx(GetItemGroup(m_drag_item));
     StringX sxDstGroupName;
     bool dragItemLeavesEmptyGroup = (ItemIsGroup(parentOfDragItem) && GetChildrenCount(parentOfDragItem) == 1);
     bool isDestinationEmptyGroup = false;
@@ -1485,7 +1485,7 @@ void TreeCtrl::OnEndDrag(wxTreeEvent& evt)
           itemDst = GetItemParent(itemDst);
         }
         else {                                    // On group, the group needs to be removed, if it is an empty group
-          sxDstGroupName = tostringx(GetItemText(itemDst));
+          sxDstGroupName = tostringx(GetItemGroup(itemDst));
           isDestinationEmptyGroup = m_core.IsEmptyGroup(sxDstGroupName);
         }
         if(IsDescendant(itemDst, m_drag_item)) {  // Do not drag and drop into the moved tree
@@ -1501,8 +1501,10 @@ void TreeCtrl::OnEndDrag(wxTreeEvent& evt)
       // If the drag'd item leaves an empty group in the tree
       // the group needs to be created as such in the database.
       if (dragItemLeavesEmptyGroup) {
+        auto emptyGroups = m_core.GetEmptyGroups();
+        emptyGroups.push_back(sxSrcGroupName);
         commands->Add(
-          DBEmptyGroupsCommand::Create(&m_core, sxSrcGroupName, DBEmptyGroupsCommand::EG_ADD)
+          DBEmptyGroupsCommand::Create(&m_core, emptyGroups, DBEmptyGroupsCommand::EG_REPLACEALL)
         );
       }
       // If the destination was an empty group in the tree it is not empty now


### PR DESCRIPTION
This PR uses the 'Empty Group Command' EG_REPLACEALL to add a non-empty group to the list of empty groups. This resolves the issue originally described in #1293 . However, I'm not sure if there are cases where this might be problematic.

The changes in this PR also correct the incorrect addressing of subgroups, so the full path is used instead of just the subgroup name.

Resolves #1293