### PR TITLE
[wx] Fix typos in the code

### DIFF
--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -704,7 +704,7 @@ StringX TreeCtrlBase::GroupNameOfItem(const CItemData &item)
     }
     
     if (gt == 0) {
-      group = L"Undefind Time Value";
+      group = L"Undefined Time Value";
     }
     else {
       TCHAR datetime_str[80];


### PR DESCRIPTION
I went through the source code and focused on string literals that may contain grammatical errors and typos. Here are the issues I found:

<img width="647" height="497" alt="pwsafe_1 23-wxWidgets-bug-Typos-01" src="https://github.com/user-attachments/assets/1ac84f79-a7b4-409d-b9a5-3ffb49825873" />
