### PR TITLE
[wx] Fix - DBv3-att - Filtering out entries shows no results

### DIFF
--- a/src/core/PWSFilters.cpp
+++ b/src/core/PWSFilters.cpp
@@ -1605,7 +1605,7 @@ bool PWSFilterManager::PassesPWPFiltering(const CItemData *pci) const
 bool PWSFilterManager::PassesAttFiltering(const CItemData *pci, const PWScore &core) const
 {
   bool thistest_rc;
-  const bool bPresent = pci->HasAttRef();
+  const bool bPresent = pci->HasAttachment();
   bool bValue(false);
 
   


### PR DESCRIPTION
Great idea to add support for attachments to v3 Safes, however there are still some issues to be resolved.
One of them is: Filtering out entries with attachments shows no results in a DBv3 Safe in wxWidgets version, it works in a DBv4 Safe.

As I can see, HasAttachment() was updated recently to be both V3 and V4 compatible, hence using it in this PR.

Attached you can find some screenshots from Linux.

<img width="799" height="725" alt="pwsafe_1 23-wxWidgets-bug-V3-Filter-Att-02" src="https://github.com/user-attachments/assets/0fc7abe3-c0d5-4b07-809d-af8295225f77" />
<img width="800" height="722" alt="pwsafe_1 23-wxWidgets-bug-V3-Filter-Att-03" src="https://github.com/user-attachments/assets/05609811-d9db-46dd-a817-22e56e9e4441" />
<img width="808" height="732" alt="pwsafe_1 23-wxWidgets-bug-V3-Filter-Att-04" src="https://github.com/user-attachments/assets/1a99021f-1874-46ba-ba52-dfd6f355e8f7" />
