### PR TITLE
[wx] Fix Help on Attachment tab in Add-Edit dialog

### DIFF
--- a/src/ui/wxWidgets/HelpMap.h
+++ b/src/ui/wxWidgets/HelpMap.h
@@ -54,6 +54,7 @@ PROPSHEET_HELP(AddEditPropSheetDlg, _("Basic"),            html/entering_pwd.htm
 PROPSHEET_HELP(AddEditPropSheetDlg, _("Dates and Times"),  html/entering_pwd_date.html)
 PROPSHEET_HELP(AddEditPropSheetDlg, _("Password Policy"),  html/entering_pwd_pp.html)
 PROPSHEET_HELP(AddEditPropSheetDlg, _("Additional"),       html/entering_pwd_add.html)
+PROPSHEET_HELP(AddEditPropSheetDlg, _("Attachment"),       html/entering_pwd_att.html)
 
 DLG_HELP(EditShortcutDlg,                  html/edit_menu.html)
 


### PR DESCRIPTION
This PR is to fix this issue: Help button on the Attachment tab of the in Add-Edit dialog does not show the Help page.

Attached you can find a screenshot from Linux. 
Note: works only with languages having the newly introduced html/entering_pwd_att.html file.

<img width="834" height="760" alt="pwsafe_1 23-wxWidgets-bug-Att-Help-01" src="https://github.com/user-attachments/assets/c9338007-2fc0-42d2-b1c9-bb2079a605bc" />
