### PR TITLE
[wx] Fix - DBv3 - View Attachment not available

### DIFF
--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -601,7 +601,7 @@ void PasswordSafeFrame::OnViewAttachment(wxCommandEvent& WXUNUSED(evt))
     return;
   }
 
-  if (!item->HasAttRef()) {
+  if (!item->HasAttachment()) {
     return;
   }
 
@@ -610,9 +610,16 @@ void PasswordSafeFrame::OnViewAttachment(wxCommandEvent& WXUNUSED(evt))
 
 void PasswordSafeFrame::DoViewAttachment(CItemData* item)
 {
-  ASSERT(m_core.HasAtt(item->GetAttUUID()));
-
-  CItemAtt itemAttachment = m_core.GetAtt(item->GetAttUUID());
+  CItemAtt itemAttachment;
+  if (item->HasAttRef()) { // PWSfile::V40
+    ASSERT(m_core.HasAtt(item->GetAttUUID()));
+    itemAttachment = m_core.GetAtt(item->GetAttUUID());
+  }
+  else if (m_core.GetReadFileVersion() == PWSfile::V30 && item->HasAttachment()) {
+    itemAttachment.SetMediaType(item->GetAttMediaType());
+    const std::vector<unsigned char> content = item->GetAttContent();
+    itemAttachment.SetContent(content.data(), content.size());
+  }
 
   // Shouldn't be here if no content
   if (!itemAttachment.HasContent()) {

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -649,7 +649,7 @@ void PasswordSafeFrame::CreateMenubar()
   menuEdit->Append(ID_AUTOTYPE, _("Perform Auto&type\tCtrl+T"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_CREATESHORTCUT, _("Create &Shortcut"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_GOTOBASEENTRY, _("Go to Base entry"), wxEmptyString, wxITEM_NORMAL);
-  if (m_core.GetReadFileVersion() == PWSfile::V40) {
+  if (m_core.GetReadFileVersion() >= PWSfile::V30) {
     menuEdit->Append(ID_VIEWATTACHMENT, _("View Attachment"), wxEmptyString, wxITEM_NORMAL);
   }
   menuBar->Append(menuEdit, _("&Edit"));
@@ -1955,7 +1955,7 @@ void PasswordSafeFrame::OnContextMenu(const CItemData* item)
     else {
       itemEditMenu.Append(ID_EDITBASEENTRY,  _("&Edit Base entry"));
     }
-    if (item->HasAttRef()) {
+    if (item->HasAttachment()) {
       itemEditMenu.Append(ID_VIEWATTACHMENT, _("View Attachment"));
     }
     if (!item->IsShortcut()) {
@@ -2392,7 +2392,7 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
       break;
 
     case ID_VIEWATTACHMENT:
-      evt.Enable(isUnlocked && pci && pci->HasAttRef());
+      evt.Enable(isUnlocked && pci && pci->HasAttachment());
       break;
 
     case ID_GOTOBASEENTRY:


### PR DESCRIPTION
Issue: The View Attachment command in DBv3 Safes is not available both from Edit menu as well as the context menu of entries having an attachment.
It works in a DBv4 Safe though. After the fix it works in both DBv3 and DBv4.

Attached you can find some screenshots from Linux.
<img width="873" height="617" alt="pwsafe_1 23-wxWidgets-bug-V3-View-Att-01" src="https://github.com/user-attachments/assets/9f70d47d-4d58-4e98-a0ea-905b20134433" />
<img width="870" height="633" alt="pwsafe_1 23-wxWidgets-bug-V3-View-Att-02" src="https://github.com/user-attachments/assets/c7de7045-6b08-4359-bede-3c95100c15b3" />
