### PR TITLE
[win] Fix - DBv3-att - Attachment fields in Filter and Properties

### DIFF
--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -3079,7 +3079,7 @@ void PWScore::GetDBProperties(st_DBProperties &st_dbp)
   if (GetReadFileVersion() >= PWSfile::V40)
     Format(st_dbp.numattachments, L"%d", m_attlist.size());
   else
-    st_dbp.numattachments = L"N/A";
+    Format(st_dbp.numattachments, L"%d", GetNumAtts());
 
   time_t twls = m_hdr.m_whenlastsaved;
   if (twls == 0) {

--- a/src/ui/Windows/filter/PWFilterLC.cpp
+++ b/src/ui/Windows/filter/PWFilterLC.cpp
@@ -1721,7 +1721,7 @@ void CPWFilterLC::SetUpComboBoxData()
         m_vFcbx_data.push_back(stf);
 
         // Only add attachment fields if DB has attachments
-        if (m_bCanHaveAttachments && m_psMediaTypes != NULL && !m_psMediaTypes->empty()) {
+        if (m_bCanHaveAttachments && m_psMediaTypes != NULL) {
           cs_temp.LoadString(IDS_ATTACHMENTS);
           stf.cs_text = cs_temp + L" -->";  // Normal 3 dots hard to see
           stf.ftype = FT_ATTACHMENT;


### PR DESCRIPTION
This PR is to fix 2 issues on Windows:

1. DBv3 Safe with attachments - the Attachment fields are not included in Filters.
Root cause: Media Type items are not populated from attachments due to a bug (will be fixed later). The wx version is not affected as it does not check whether Media Types set is empty.
It works in a DBv4 Safe.

2. DBv3 Safe with attachments - File Properties not showing number of attachments.
Main menu > File > Properties shows N/A for the number of attachments.
It works in a DBv4 Safe.

Attached you can find some screenshots.
<img width="545" height="519" alt="pwsafe_3 70 01-bug-V3-Filter-Att-01" src="https://github.com/user-attachments/assets/71297080-1b27-4547-8765-a2a8c56a34a6" />
<img width="545" height="535" alt="pwsafe_3 70 01-bug-V3-Filter-Att-02" src="https://github.com/user-attachments/assets/5cc03017-2a80-4bfe-a0a1-4f955ab8f3c4" />
<img width="761" height="551" alt="pwsafe_3 70 01-bug-V3-Properties-01" src="https://github.com/user-attachments/assets/841465cd-8aeb-4724-9d92-3bd1da7d7c86" />
<img width="761" height="551" alt="pwsafe_3 70 01-bug-V3-Properties-02" src="https://github.com/user-attachments/assets/edd1275e-68b3-425e-987a-b897f9ff0cb8" />
