### PR TITLE
[win] Fix - Wrong field name in Filter

### DIFF
--- a/src/ui/Windows/filter/ManageFiltersDlg.cpp
+++ b/src/ui/Windows/filter/ManageFiltersDlg.cpp
@@ -1191,7 +1191,7 @@ CString CManageFiltersDlg::GetFieldTypeName(FieldType ft)
   
     case AT_PRESENT:       nID = IDS_PRESENT; break;
     case AT_TITLE:         nID = IDS_FILETITLE; break;
-    case AT_CTIME:         nID = IDS_FILENAME; break;
+    case AT_CTIME:         nID = IDS_CTIME; break;
     case AT_MEDIATYPE:     nID = IDS_FILEMEDIATYPE; break;
     case AT_FILENAME:      nID = IDS_FILENAME; break;
     case AT_FILEPATH:      nID = IDS_FILEPATH; break;


### PR DESCRIPTION
Issue: On Windows, the name for the "Date Added" field is wrong once added to a filter.
Attached you can find some screenshots.

<img width="999" height="709" alt="pwsafe_3 70 01-bug-V3-Filter-DateAdded-01" src="https://github.com/user-attachments/assets/59bad0a5-f8a0-4f0d-8012-cf6bae93838e" />
<img width="998" height="710" alt="pwsafe_3 70 01-bug-V3-Filter-DateAdded-02" src="https://github.com/user-attachments/assets/dd78400a-ff44-4206-89a3-32450fcd9d47" />
