### PR TITLE
[win] Fix - DBv3-att - View attachment not working

### DIFF
--- a/src/ui/Windows/MainEdit.cpp
+++ b/src/ui/Windows/MainEdit.cpp
@@ -2370,11 +2370,19 @@ void DboxMain::OnViewAttachment()
   CItemData *pci = getSelectedItem();
   ASSERT(pci != NULL);
 
-  if (!pci->HasAttRef())
+  if (!pci->HasAttachment())
     return;
 
-  ASSERT(m_core.HasAtt(pci->GetAttUUID()));
-  CItemAtt att = m_core.GetAtt(pci->GetAttUUID());
+  CItemAtt att;
+  if (pci->HasAttRef()) { // PWSfile::V40
+    ASSERT(m_core.HasAtt(pci->GetAttUUID()));
+    att = m_core.GetAtt(pci->GetAttUUID());
+  }
+  else if (m_core.GetReadFileVersion() == PWSfile::V30 && pci->HasAttachment()) {
+    att.SetMediaType(pci->GetAttMediaType());
+    const std::vector<unsigned char> content = pci->GetAttContent();
+    att.SetContent(content.data(), content.size());
+  }
 
   // Shouldn't be here if no content
   if (!att.HasContent())


### PR DESCRIPTION
Issue: On Windows, the View attachment command in DBv3 Safes does not open window with an image or a dialog saying that Preview is unavailable for other file formats.
It works in a DBv4 Safe, this PR is to make it compatible with both DBv3 and DBv4.

This PR is similar to PR #1651 that was for wx.
