### PR TITLE
Fix - DBv3-att - Filtering by Attachment fields not working

### DIFF
--- a/src/core/PWSFilters.cpp
+++ b/src/core/PWSFilters.cpp
@@ -1656,7 +1656,15 @@ bool PWSFilterManager::PassesAttFiltering(const CItemData *pci, const PWScore &c
           break;
         case PWSMatch::MT_STRING:
           if (bPresent) {
-            const CItemAtt &att = core.GetAtt(pci->GetAttUUID());
+            CItemAtt att;
+            if (pci->HasAttRef()) { // PWSfile::V40
+              att = core.GetAtt(pci->GetAttUUID());
+            }
+            else if (core.GetReadFileVersion() == PWSfile::V30 && pci->HasAttachment()) {
+              att.SetTitle(pci->GetAttTitle());
+              att.SetFileName(pci->GetAttFileName());
+              att.SetMediaType(pci->GetAttMediaType());
+            }
 
             thistest_rc = att.Matches(st_fldata.fstring.c_str(), static_cast<int>(ft),
               st_fldata.fcase ? -ifunction : ifunction);
@@ -1667,7 +1675,18 @@ bool PWSFilterManager::PassesAttFiltering(const CItemData *pci, const PWScore &c
           break;
         case PWSMatch::MT_DATE:
           if (bPresent) {
-            const CItemAtt &att = core.GetAtt(pci->GetAttUUID());
+            CItemAtt att;
+            if (pci->HasAttRef()) { // PWSfile::V40
+              att = core.GetAtt(pci->GetAttUUID());
+            }
+            else if (core.GetReadFileVersion() == PWSfile::V30 && pci->HasAttachment()) {
+              time_t mtime = 0;
+              if (pci->GetAttModificationTime(mtime) != 0) {
+                att.SetFileMTime(mtime);
+                att.SetFileCTime(mtime);
+                att.SetFileATime(mtime);
+              }
+            }
 
             time_t t1(st_fldata.fdate1), t2(st_fldata.fdate2);
             if (st_fldata.fdatetype == 1 /* Relative */) {

--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -3520,8 +3520,18 @@ std::set<StringX> PWScore::GetAllMediaTypes() const
   std::set<StringX> sMediaTypes;
 
   // Find media types of all our attachments, put them in a set:
-  for (auto att_iter = m_attlist.begin(); att_iter != m_attlist.end(); att_iter++) {
-    sMediaTypes.insert(att_iter->second.GetMediaType());
+  if (GetReadFileVersion() == PWSfile::V30) {
+    for (auto pw_iter = m_pwlist.begin(); pw_iter != m_pwlist.end(); pw_iter++) {
+      const CItemData &ci = pw_iter->second;
+      if (ci.HasAttachment()) {
+        sMediaTypes.insert(ci.GetAttMediaType());
+      }
+    }
+  }
+  else { // PWSfile::V40
+    for (auto att_iter = m_attlist.begin(); att_iter != m_attlist.end(); att_iter++) {
+      sMediaTypes.insert(att_iter->second.GetMediaType());
+    }
   }
   return sMediaTypes;
 }


### PR DESCRIPTION
This PR is to fix 2 issues:
1. DBv3 Safe with attachments - Media Type items not populated for Filters.
2. DBv3 Safe with attachments - Filtering by Attachment fields provides no results.
While the "Attachment is present" criteria works (fixed by PR #1649), other fields like Title, Media Type, File Name and Dates are getting ignored.

It affects both Windows and wx versions.
It works in a DBv4 Safe.
Attached you can find some screenshots from Linux.
<img width="868" height="637" alt="pwsafe_1 23-wxWidgets-bug-V3-Filter-MediaTypes-01" src="https://github.com/user-attachments/assets/141b530a-1904-40e1-9b72-b84e572c9868" />
<img width="869" height="629" alt="pwsafe_1 23-wxWidgets-bug-V3-Filter-MediaTypes-02" src="https://github.com/user-attachments/assets/6cf7f165-c64b-487e-bcad-1856893a48f3" />
<img width="1162" height="669" alt="pwsafe_1 23-wxWidgets-bug-V3-Filter-Att-Fields-01" src="https://github.com/user-attachments/assets/161331eb-a38b-422a-91e5-4be70c5dc9c5" />
<img width="1162" height="669" alt="pwsafe_1 23-wxWidgets-bug-V3-Filter-Att-Fields-02" src="https://github.com/user-attachments/assets/dd5c3a0b-fda4-40ec-8b67-ed31b26604cc" />
