### PR TITLE
[wx] Fix - Clear list of recently opened databases

### DIFF
--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -287,7 +287,7 @@ void PasswordSafeFrame::OnClearRecentHistory(wxCommandEvent& WXUNUSED(evt))
     wxICON_EXCLAMATION|wxOK|wxCANCEL|wxCANCEL_DEFAULT
   );
   dialog.SetOKLabel(_("Clear"));
-  if (dialog.ShowModal() == wxOK) {
+  if (dialog.ShowModal() == wxID_OK) {
     wxGetApp().recentDatabases().Clear();
     CreateMenubar(); // Recreate the menu with cleared list of most recently used DBs
   }


### PR DESCRIPTION
For this command in wx version, a confirmation dialog was introduced by PR #1638.
However, the command does not perform anything in case user hits "Clear" to confirm the action.
Reason: The return value of the modal dialog is not evaluated properly.
