### PR TITLE
Increase max usable hash iters

### DIFF
--- a/src/core/PWSfile.h
+++ b/src/core/PWSfile.h
@@ -32,7 +32,7 @@
 #define MIN_HASH_ITERATIONS 262144 
 // MAX_USABLE_HASH_ITERS is a guesstimate on what's acceptable to a user
 // with a reasonably powerful CPU. Real limit's 2^32-1.
-#define MAX_USABLE_HASH_ITERS (1 << 24)
+#define MAX_USABLE_HASH_ITERS (1 << 25)
 
 #define V3_SUFFIX      _T("psafe3")
 #define V4_SUFFIX      _T("psafe4")


### PR DESCRIPTION
I think the current max is a bit conservative:

My personal safe is set to 32M iterations, which unlocks with sub-second delay on my iPhone 15 and Mac. Increasing the max in this PR to keep my safe within bounds when opened with Password Safe.

A more paranoid person might even be willing to accept a few seconds delay on opening a safe for increased security, but I thought it might be better not to push my luck in this PR 😄 so I just upped the max to 32M.

More recent Apple hardware is marketed to be 20% faster than mine. Haven't had the chance to try one of those.