### PR TITLE
[wx] Fix - Disable changing attachment of protected entries

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -937,8 +937,13 @@ void AddEditPropSheetDlg::InitAttachmentTab()
         DisableAttachmentControls();
       }
       else {
-        // Attachment must be removed before a new one can be imported again.
-        DisableImport();
+        if (m_Item.IsProtected()) {
+          EnableExport(); // Disable all controls except the Export button
+        }
+        else {
+          // Attachment must be removed before a new one can be imported again.
+          DisableImport();
+        }
       }
     }
     else {
@@ -982,8 +987,13 @@ void AddEditPropSheetDlg::InitAttachmentTab()
         DisableAttachmentControls();
       }
       else {
-        // Attachment must be removed before a new one can be imported again.
-        DisableImport();
+        if (m_Item.IsProtected()) {
+          EnableExport(); // Disable all controls except the Export button
+        }
+        else {
+          // Attachment must be removed before a new one can be imported again.
+          DisableImport();
+        }
       }
     }
     else {
@@ -1148,6 +1158,14 @@ void AddEditPropSheetDlg::EnableImport()
 {
   m_AttachmentButtonImport->Enable();
   m_AttachmentButtonExport->Disable();
+  m_AttachmentButtonRemove->Disable();
+  m_AttachmentTitle->Disable();
+}
+
+void AddEditPropSheetDlg::EnableExport()
+{
+  m_AttachmentButtonImport->Disable();
+  m_AttachmentButtonExport->Enable();
   m_AttachmentButtonRemove->Disable();
   m_AttachmentTitle->Disable();
 }

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.h
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.h
@@ -310,6 +310,7 @@ private:
   void HideImagePreview(const wxString &reason = _("No preview available"));
   wxString GetMimeTypeExtension(const stringT &mimeTypeDescription);
   void EnableImport();
+  void EnableExport();
   void DisableImport();
   void DisableAttachmentControls();
 


### PR DESCRIPTION
This PR disables Attachment tab controls for protected entries to match the Windows version's behavior.

Version: Password Safe 1.23
Issue: If an entry is protected, the Attachment tab controls are not disabled. User can delete the attachment, import a new one and change title. Naturally, all changes are lost after closing the dialog as the entry is protected.
Tested on Debian/FreeBSD/OpenBSD.

Attached you can find some screenshots from both Windows and Linux.

Windows:

<img width="562" height="882" alt="pwsafe_1 23-wxWidgets-bug-Protected-Edit-Att-03" src="https://github.com/user-attachments/assets/1acc64e6-67d8-45c5-9fa5-713affc4123c" />

Linux:

<img width="866" height="731" alt="pwsafe_1 23-wxWidgets-bug-Protected-Edit-Att-01" src="https://github.com/user-attachments/assets/705014d8-44cc-4652-9804-07942d99e61d" />

When fixed:

<img width="950" height="731" alt="pwsafe_1 23-wxWidgets-bug-Protected-Edit-Att-02" src="https://github.com/user-attachments/assets/90b223ef-8d4a-4fb1-8a0a-280ffcf9c882" />


