### PR TITLE
[win] Fix - Clear list of recently opened databases

### DIFF
--- a/src/ui/Windows/ThisMfcApp.cpp
+++ b/src/ui/Windows/ThisMfcApp.cpp
@@ -1273,18 +1273,19 @@ void ThisMfcApp::ClearMRU()
   }
 
   // Recent databases are on the popup menu off the main File menu
-  CMenu *pPopupMenu = pFile_Submenu->GetSubMenu(FindMenuItem(pFile_Submenu, ID_MENUITEM_LOCK) + 2);
-  if (pPopupMenu != NULL)  // Look for MRU first entry
-    pos = FindMenuItem(pPopupMenu, ID_FILE_MRU_ENTRY1);
-  else
-    return;
-
-  if (pos > -1) {
-    // Recent databases are on a popup menu - remove them
-    for (int nID = numMRU; nID > 1; nID--)
-      pPopupMenu->RemoveMenu(ID_FILE_MRU_ENTRY1 + nID - 1, MF_BYCOMMAND);
-
-    return;
+  int pos2 = FindMenuItem(pFile_Submenu, ID_MENUITEM_LOCK);
+  ASSERT(pos2 != -1);
+  if (pos2 > -1) {
+    CMenu *pPopupMenu = pFile_Submenu->GetSubMenu(pos2 + 2);
+    if (pPopupMenu != NULL) {
+      pos = FindMenuItem(pPopupMenu, ID_FILE_MRU_ENTRY1); // Look for MRU first entry
+      if (pos > -1) {
+        // Recent databases are on a popup menu - remove them
+        for (int nID = numMRU; nID > 1; nID--)
+          pPopupMenu->RemoveMenu(ID_FILE_MRU_ENTRY1 + nID - 1, MF_BYCOMMAND);
+        return;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Version: Password Safe 3.70.1

Options > System: Uncheck "Recent Databases on File Menu rather than as a sub-menu."
Command: Main menu > File > Clear Recently Opened list
Issue: Regardless of how many items are in the list, only the first item is removed. This issue does not occur when recent databases are displayed directly on the File menu.
Reason: The sub-menu is not referenced correctly.

Attached you can find some screenshots.

<img width="611" height="765" alt="pwsafe_3 70 01-bug-Clear-MRU-01" src="https://github.com/user-attachments/assets/6ca28f95-c7bf-4832-9394-c11f64b590cb" />
<img width="714" height="563" alt="pwsafe_3 70 01-bug-Clear-MRU-02" src="https://github.com/user-attachments/assets/a88f2698-0259-4c4a-90df-f0865d86fbbf" />
<img width="714" height="559" alt="pwsafe_3 70 01-bug-Clear-MRU-03" src="https://github.com/user-attachments/assets/11466a14-ae65-46d8-91c3-a540c79fd478" />
