### PR TITLE
[win] Fix - GetAttachmentSymbol() return value mismatch

### DIFF
--- a/src/ui/Windows/Fonts.cpp
+++ b/src/ui/Windows/Fonts.cpp
@@ -575,9 +575,9 @@ std::wstring Fonts::GetProtectedSymbol(const PWSFont font)
 std::wstring Fonts::GetAttachmentSymbol(const PWSFont font)
 {
   if (font == TREELIST) {
-    return m_bProtectSymbolSupportedTreeList ? m_sAttachment : L"+";
+    return m_bAttachmentSymbolSupportedTreeList ? m_sAttachment : L"+";
   } else {
-    return m_bProtectSymbolSupportedAddEdit ? m_sAttachment : L"+";
+    return m_bAttachmentSymbolSupportedAddEdit ? m_sAttachment : L"+";
   }
 }
 


### PR DESCRIPTION
Version: Password Safe 3.70.1

Issue:
I noticed the GetAttachmentSymbol function currently uses "ProtectSymbol" variables, but based on the surrounding logic and naming, it appears "AttachmentSymbol" was intended. Most probably a copy&paste error.
The current implementation works because m_bProtectSymbolSupportedXY and m_bAttachmentSymbolSupportedXY are both True in practice, but this assumption is implicit. If m_bProtectSymbolSupportedXY and m_bAttachmentSymbolSupportedXY ever diverge, this function would silently behave incorrectly.
