### PR TITLE
[wx] Simplify sorting by expiration date

### DIFF
--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -308,7 +308,7 @@ bool PWSafeApp::OnInit()
   setlocale(LC_CTYPE, "");
 #endif
   setlocale(LC_TIME, "");
-  
+
   //Used by help subsystem
   wxFileSystem::AddHandler(new wxArchiveFSHandler);
 

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -138,6 +138,7 @@ public:
   wxLanguage GetSystemLanguage();
   wxLanguage GetSelectedLanguage();
   PasswordSafeFrame* GetPasswordSafeFrame() { return m_frame; }
+  wxString GetLocaleShortDateFormat() const { return m_locale ? m_locale->GetInfo(wxLOCALE_SHORT_DATE_FMT) : wxString(); }
 };
 
 /*!


### PR DESCRIPTION
Follow up of #1655 

@dskrvk Thanks for the hint about wxDateTime::ParseFormat. This significantly simplifies the implementation. What do you think about the new solution?