### PR TITLE
Rename program name PasswordSafe to Password Safe in desktop file

### DIFF
--- a/install/desktop/pwsafe.desktop
+++ b/install/desktop/pwsafe.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=PasswordSafe
+Name=Password Safe
 Comment=Manage passwords
 Exec=pwsafe %f
 Icon=pwsafe


### PR DESCRIPTION
We have renamed PasswordSafe in lots of places, but there is still pwsafe.desktop file where PasswordSafe without space between "Password Safe".

Pressing Super key and type in Password and it displays icon with PasswordSafe
<img width="178" height="164" alt="image" src="https://github.com/user-attachments/assets/0fdcd363-8905-4d2b-bea3-48f993f61361" />

The same in dash:
<img width="200" height="77" alt="image" src="https://github.com/user-attachments/assets/a689980b-461c-4825-90fb-01a7534d2de5" />

This PR is to rename "PasswordSafe" to "Password Safe", because it is much easier to read two separate words then one combined one.

Also additional argument is other program e.g. "LibreOffice Writer", "VLC media player" etc all have spaces in name, because it is just easier to read text with spaces.

---

Flatpak will also benefit this change, when new Password Safe flatpak version is released in the future.