### PR TITLE
[wx] Change font to default and better align the option category title in 'Options Dialog'

### DIFF
--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -280,7 +280,7 @@ wxPanel* OptionsPropertySheetDlg::CreateHeaderPanel(wxWindow* parent, const wxSt
 #ifdef __WXMAC__
   auto headerPanel = new wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(605, -1));
 #else
-  auto headerPanel = new wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(-1, 40));
+  auto headerPanel = new wxPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize);
   auto bgColor = headerPanel->GetBackgroundColour();
 
   auto red   = bgColor.Red();
@@ -297,7 +297,7 @@ wxPanel* OptionsPropertySheetDlg::CreateHeaderPanel(wxWindow* parent, const wxSt
   headerPanel->SetSizer(sizer);
 
   const int FONT_SIZE = 16;
-  auto headerTitle = new wxStaticText(headerPanel, wxID_ANY, title, wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE_HORIZONTAL);
+  auto headerTitle = new wxStaticText(headerPanel, wxID_ANY, title, wxDefaultPosition, wxSize(-1, 2 * FONT_SIZE), wxALIGN_CENTRE_HORIZONTAL);
   headerTitle->SetOwnFont(
     wxFont(FONT_SIZE, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_ITALIC, wxFONTWEIGHT_BOLD)
   );


### PR DESCRIPTION
Minor improvement to the option category title in options properties dialog.

On Master
<img width="478" height="51" alt="OptionsTitle" src="https://github.com/user-attachments/assets/fb15560a-f5c0-4753-a9bb-b097546b2197" />

On this branch
<img width="478" height="51" alt="OptionsTitleNew" src="https://github.com/user-attachments/assets/5cac964f-33d5-41fb-ad22-cf6ac8a51aba" />
