### PR TITLE
[wx] Release allocated memory for command if DnD is terminated in Tree view

### DIFF
--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -1568,6 +1568,7 @@ void TreeCtrl::OnEndDrag(wxTreeEvent& evt)
             evt.Veto();
             wxMessageBox(_("Duplicate group name (use Shift to overrule)"), _("Duplicate group name"), wxOK|wxICON_ERROR);
             m_drag_item = nullptr;
+            delete commands;
             return;
           }
         }


### PR DESCRIPTION
#### Prerequisites
 * Create group g1
 * Create group g1.g2
 * Create group g2

#### Scenario
 * Move g2 to g1 via drag-and-drop in Tree view

#### Result
The memory reserved for the created multi-command will not be released if the drag-and-drop action is prematurely terminated.

Valgrind confirms this:
> ==9894== 128 bytes in 1 blocks are definitely lost in loss record 12,377 of 13,784
> ==9894==    at 0x4846FA3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
> ==9894==    by 0x28599B: MultiCommands::Create(CommandInterface*) (Command.h:551)
> ==9894==    by 0x3F0375: TreeCtrl::OnEndDrag(wxTreeEvent&) (TreeCtrl.cpp:1504)