### PR TITLE
[wx] Recalculate List row height on changing font size

### DIFF
--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1309,6 +1309,7 @@ void PasswordSafeFrame::ShowGrid(bool show)
         m_grid->AddItem(iter->second, i++);
     }
     
+    m_grid->AutoSizeRows(); // Forces row height recalculation based on font size
     if(PWSprefs::GetInstance()->GetPref(PWSprefs::AutoAdjColWidth)) {
       m_grid->AutoSizeColumns(false);
       m_grid->Layout();
@@ -3128,6 +3129,7 @@ void PasswordSafeFrame::ChangeFontPreference(const PWSprefs::StringPrefs fontPre
       }
       else {
         m_grid->SetDefaultCellFont(newFont);
+        m_grid->AutoSizeRows(); // Forces row height recalculation based on font size
         m_grid->Refresh(); // Updates the grid items font
       }
     }


### PR DESCRIPTION
This PR fixes row height in List view on changing font size.
Partially related to issue #1603.

Version: Password Safe 1.23
Issue: When font is changed, the Grid widget does not recalculate its row height.

Steps to reproduce:
1. Change the font size for Tree/List while in List view - the row height does not change.
2. Change the font size while in Tree view and switch to List view - the row height does not change.

Tested on Debian/Fedora/Kubuntu/FreeBSD/OpenBSD/macOS.

Attached you can find some screenshots from Linux.
<img width="752" height="661" alt="pwsafe_1 23-wxWidgets-bug-Font_Size-Change-02" src="https://github.com/user-attachments/assets/b7ba369a-570b-44b2-a0bd-343976118a6b" />
<img width="752" height="661" alt="pwsafe_1 23-wxWidgets-bug-Font_Size-Change-03" src="https://github.com/user-attachments/assets/5d7e9fe0-2741-478e-91a1-011f456c8323" />
