### PR TITLE
Added field 0x30 (JSON object)

### DIFF
--- a/docs/formatV3.txt
+++ b/docs/formatV3.txt
@@ -190,7 +190,7 @@ password change             0x13        time_t        Y              [5]
 End of Entry                0xff        [empty]       Y              [17]
 
 [1] The version number of the database format. For example, the value
-0x0310 is stored in little-endian format, that is, 0x10, 0x03.
+0x0311 is stored in little-endian format, that is, 0x11, 0x03.
 PasswordSafe V3.01 introduced Format 0x0300
 PasswordSafe V3.03 introduced Format 0x0301
 PasswordSafe V3.09 introduced Format 0x0302
@@ -705,6 +705,8 @@ For example, to encode the following custom fields:
 * WiFi Password: bobsyouruncle (sensitive field)
 One would use
     010009WiFi SSID020004Test00000001000DWiFi Password02000Cbobsyouruncle0300011
+
+This field was introduced in format version 0x0311
 
 4. Extensibility
 

--- a/docs/formatV4.txt
+++ b/docs/formatV4.txt
@@ -1,4 +1,4 @@
-PasswordSafe database format description version 4.01
+PasswordSafe database format description version 4.02
 -----------------------------------------------------
 
 Copyright (c) 2013-2026 Rony Shapiro <ronys@pwsafe.org>.
@@ -261,7 +261,7 @@ password change             0x13        time_t        Y              [5]
 End of Entry                0xff        [empty]       Y              [17]
 
 [1] The version number of the database format. For this version, the value
-is 0x0401 (stored in little-endian format, that is, 0x01, 0x04).
+is 0x0402 (stored in little-endian format, that is, 0x02, 0x04).
 PasswordSafe V3.69 introduced Format 0x0401
 
 [2] A universally unique database identifier is needed in order to
@@ -694,6 +694,8 @@ For example, to encode the following custom fields:
 * WiFi Password: bobsyouruncle (sensitive field)
 One would use
     010009WiFi SSID020004Test00000001000DWiFi Password02000Cbobsyouruncle0300011
+
+This field was introduced in format version 0x0402
 
 3.4 Attachments
 


### PR DESCRIPTION
Since PWSafe file format is used by other password managers, there are often custom fields defined (e.g. 0x20 QR Code, etc.). However, this means that every time some other application is expanded it needs to add entry to fields even though it's highly unlikely that PWSafe will ever implement it due to a different focus or philosophy.

 Possible alternative is using dedicated implementation-specific fields but these have no format specified and might contain different data between different applications leading to wrong data parsing or crashes.

I propose adding a new field (`JSON Object 0x30`) that would contain a valid JSON thus at least removing potential for crashes. In addition, even if application doesn't recognize the object, it could just show it to the user as-is and allow for cross-readability of custom fields.

For my application I already have three scenarios where this would fit without forcing a new field type:

1. Android lock pattern - e.g., `L` shaped unlock pattern could be described with
~~~json
{
    "app-id": {
        "type": "pattern",
        "pattern": "74123"
    }
}
~~~

2. Field with custom name:
~~~json
{
    "app-id": {
        "type": "text",
        "caption": "SWIFT Code",
        "text": "CHASUS01"
    }
}
~~~

3. Field with custom tooltip text:
~~~json
{
    "app-id": {
        "type": "text",
        "caption": "VPN PIN", "text": "1234",
        "tooltip": "Type it on second page after password has been confirmed"
    }
}
~~~

PS: Added namespace in examples as suggested by @huven.