### PR TITLE
Add vcs-browser parameter to metainfo.xml file

### DIFF
--- a/install/metainfo/org.pwsafe.pwsafe.metainfo.xml
+++ b/install/metainfo/org.pwsafe.pwsafe.metainfo.xml
@@ -61,5 +61,6 @@
   <url type="faq">https://pwsafe.org/faq.shtml</url>
   <url type="contact">https://pwsafe.org/contact.php</url>
   <url type="donation">https://sourceforge.net/p/passwordsafe/donate/</url>
+  <url type="vcs-browser">https://github.com/pwsafe/pwsafe/</url>
   <content_rating type="oars-1.1"/>
 </component>


### PR DESCRIPTION
In Flathub repository to create flatpak I see warning is produced to add additional info into upstream metafile.xml file.
For example see:  https://github.com/flathub/org.pwsafe.pwsafe/pull/23
<img width="1073" height="185" alt="image" src="https://github.com/user-attachments/assets/d418e859-05c9-474f-9f41-4a2c25ff6314" />

Checking [documentation:](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html?__goaway_challenge=meta-refresh&__goaway_id=3a398f5f74d91103639d5b152abb936f&__goaway_referer=https%3A%2F%2Fdocs.flatpak.org%2F) 

<img width="779" height="59" alt="image" src="https://github.com/user-attachments/assets/7510dfe4-ccd0-49d2-8036-450f8a62ccfd" />

This PR adds required metainfo. This info is not required currently, but it is smart to add it now, because in the future this may be obligated setting and we can fix this issue now when it is just a recommendation.
