### PR TITLE
[wx] Enable virtual keyboard on Wayland

### DIFF
--- a/help/default_wx/html/create_new_db.html
+++ b/help/default_wx/html/create_new_db.html
@@ -159,6 +159,9 @@ by clicking on the <span><img alt="Symbol virtual keyboard" src="images/vk_small
 keyboard, can be put in in this way. So you can build your desired master password.
 Even pieces of the master password can be built this way.</p>
 
+<p>Linux: This functionality depends on the Display Server in use such as X.Org/X11 or Wayland (it may be necessary to run the program with the XWayland compatibility layer enabled by setting the "GDK_BACKEND=x11" environment variable).<br>
+macOS: Virtual keyboard support must be enabled in System Settings under Accessibility > Keyboard > Accessibility Keyboard.</p>
+
 <center>
 <br>
 <img alt="Input a password with a virtual keyboard" src="images/virtual_keyboard.jpg">

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -336,6 +336,24 @@ enum wxUtilities::WindowSystem wxUtilities::WhatWindowSystem()
   return wsType;
 }
 
+bool IsXWaylandEnabled()
+{
+  bool XWayland = false;
+  wxOperatingSystemId osid = wxGetOsVersion();
+
+  if (osid & wxOS_UNIX) { // Includes Linux
+    wxString GDK_BACKEND_VAR = wxEmptyString;
+    if (wxGetEnv(wxT("GDK_BACKEND"), &GDK_BACKEND_VAR)) { // provides 'x11' or 'wayland'
+      if (!GDK_BACKEND_VAR.IsEmpty()) {
+        if (GDK_BACKEND_VAR == wxT("x11")) {
+          XWayland = true;
+        }
+      }
+    }
+  }
+  return XWayland;
+}
+
 bool wxUtilities::IsVirtualKeyboardSupported()
 {
 #ifdef __WINDOWS__
@@ -343,7 +361,15 @@ bool wxUtilities::IsVirtualKeyboardSupported()
 #elif defined __WXOSX__
   return true;
 #else
-  return (wxUtilities::WhatWindowSystem() == wxUtilities::X11);
+  if (wxUtilities::WhatWindowSystem() == wxUtilities::X11) {
+    return true;
+  }
+  else if (wxUtilities::WhatWindowSystem() == wxUtilities::Wayland && IsXWaylandEnabled()) {
+    return true;
+  }
+  else {
+    return false;
+  }
 #endif
 }
 


### PR DESCRIPTION
Issue: In many modern distros having Wayland as the default display server, Password Safe does not show the virtual keyboard icon.

This PR is to enable virtual keyboard (xvkbd) on Wayland in Linux/BSD when the X11/Xorg backend through the XWayland compatibility layer is enabled.

Tested on Debian(GNOME)/Mint(Cinnamon)/Kubuntu/FreeBSD(KDE) with Wayland.

<img width="1442" height="967" alt="pwsafe_1 23-wxWidgets-xvkbd-Wayland-01" src="https://github.com/user-attachments/assets/cce2ab24-2959-48cd-a511-83f3415f961a" />

