### PR TITLE
Preserve passkey fields in CItemData plaintext serialization

### DIFF
--- a/src/core/ItemData.cpp
+++ b/src/core/ItemData.cpp
@@ -2559,6 +2559,35 @@ void CItemData::SerializePlainText(vector<char> &v,
     }
   }
 
+  // Passkey fields
+  {
+    const FieldType passkeyfts[] = {
+      PASSKEY_CRED_ID,
+      PASSKEY_RP_ID,
+      PASSKEY_USER_HANDLE,
+      PASSKEY_ALGO_ID,
+      PASSKEY_PRIVATE_KEY,
+      PASSKEY_SIGN_COUNT
+    };
+    std::vector<unsigned char> field;
+
+    for (auto ft : passkeyfts) {
+      if (ft == PASSKEY_RP_ID) {
+        if (IsFieldSet(ft))
+          push(v, ft, GetField(ft));
+        continue;
+      }
+
+      field.clear();
+      GetField(ft, field);
+      if (!field.empty()) {
+        push(v, ft, static_cast<uint32>(field.size()),
+             reinterpret_cast<char *>(field.data()));
+        trashMemory(field.data(), field.size());
+      }
+    }
+  }
+
   // Unknown fields
   for (auto vi_IterURFE = m_URFL.begin();
        vi_IterURFE != m_URFL.end();

--- a/src/test/ItemDataTest.cpp
+++ b/src/test/ItemDataTest.cpp
@@ -70,6 +70,12 @@ void ItemDataTest::SetUp()
   fullItem.SetShiftDCA(iSDCA);
   fullItem.SetXTimeInt(xTimeInt);
   fullItem.SetKBShortcut(kbs);
+  fullItem.SetPasskeyCredentialID(VectorX<unsigned char>(64, 1));
+  fullItem.SetPasskeyRelyingPartyID(_T("example.com"));
+  fullItem.SetPasskeyUserHandle(VectorX<unsigned char>(32, 2));
+  fullItem.SetPasskeyAlgorithmID(-7);
+  fullItem.SetPasskeyPrivateKey(VectorX<unsigned char>(512, 3));
+  fullItem.SetPasskeySignCount(0);
 }
 
 // And now the tests...
@@ -131,6 +137,12 @@ TEST_F(ItemDataTest, Getters_n_Setters)
   EXPECT_EQ(iSDCA, fullItem.GetShiftDCA(iVal16));
   EXPECT_EQ(xTimeInt, fullItem.GetXTimeInt(iVal32));
   EXPECT_EQ(kbs, fullItem.GetKBShortcut(iVal32));
+  EXPECT_EQ(StringX(_T("example.com")), fullItem.GetPasskeyRelyingPartyID());
+  EXPECT_EQ(-7, fullItem.GetPasskeyAlgorithmID());
+  EXPECT_EQ(0U, fullItem.GetPasskeySignCount());
+  EXPECT_EQ(VectorX<unsigned char>(64, 1), fullItem.GetPasskeyCredentialID());
+  EXPECT_EQ(VectorX<unsigned char>(32, 2), fullItem.GetPasskeyUserHandle());
+  EXPECT_EQ(VectorX<unsigned char>(512, 3), fullItem.GetPasskeyPrivateKey());
   EXPECT_FALSE(fullItem.IsProtected()); // default value
 
   fullItem.SetProtected(true); // modify


### PR DESCRIPTION
## Summary

Include passkey entry fields in `CItemData` plaintext serialization so they
survive serialize/deserialize round-trips.

This fixes loss of passkey data in flows that use the plaintext entry
serialization path, including Windows cross-safe drag and drop.

## Changes

- serialize all six passkey fields in `CItemData::SerializePlainText()`
- keep the existing field-type handling in `DeSerializePlainText()`
- extend `ItemDataTest.PlainTextSerialization` to cover passkey fields

## Notes

- entries without passkey fields are unaffected
- binary, text, and 4-byte passkey field types are preserved as-is