### PR TITLE
[wx] Enable AutoType on Linux/BSD under Wayland

### DIFF
--- a/help/default_wx/html/autotype.html
+++ b/help/default_wx/html/autotype.html
@@ -52,7 +52,9 @@ for your machine.</p>
 command specified in the entry's <a href="run_command.html">Run Cmd</a> 
 field. This is a very convenient combination.</p> 
 
-<p><b>Note:</b> <i>On Linux, AutoType functionality depends on the Display Server used, such as Wayland or X.Org/X11.</i></p>
+<p><b>Note:</b> <i>On Linux, AutoType functionality depends on the Display Server used, such as Wayland or X.Org/X11.
+Under Wayland, you may need to run the target application using the X11 backend via the Xwayland compatibility layer.
+Enabling the 'Use alternate AutoType method' option in Options > System may also help for some applications.</i></p>
 
 <p><b>Note:</b> <i>If an entry has been selected due to a Find action, then
 the menu item "Perform AutoType" (and its shortcut if still defined) will use

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -455,11 +455,11 @@ wxPanel* AddEditPropSheetDlg::CreateAdditionalPanel()
   mainSizer->Add(vBoxSizer, 1, wxEXPAND|wxALL, 10);
 
   auto *itemStaticText41 = new wxStaticText(panel, wxID_STATIC, _("Autotype"), wxDefaultPosition, wxDefaultSize, 0);
-  wxUtilities::DisableIfUnsupported(wxUtilities::Feature::Autotype, itemStaticText41);
+  wxUtilities::NotifyIfUnsupported(wxUtilities::Feature::Autotype, itemStaticText41);
   vBoxSizer->Add(itemStaticText41, 0, wxALIGN_LEFT|wxBOTTOM, 5);
 
   auto *itemTextCtrl42 = new wxTextCtrl(panel, ID_TEXTCTRL_AUTOTYPE, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
-  wxUtilities::DisableIfUnsupported(wxUtilities::Feature::Autotype, itemTextCtrl42);
+  wxUtilities::NotifyIfUnsupported(wxUtilities::Feature::Autotype, itemTextCtrl42);
   vBoxSizer->Add(itemTextCtrl42, 0, wxALIGN_LEFT|wxEXPAND|wxBOTTOM, 12);
 
   auto *itemStaticText43 = new wxStaticText(panel, wxID_STATIC, _("Run Command"), wxDefaultPosition, wxDefaultSize, 0);

--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -568,22 +568,22 @@ wxPanel* OptionsPropertySheetDlg::CreateMiscellaneousPanel(const wxString& title
   itemFlexGridSizer50->Add(m_Misc_ShiftDoubleClickActionCB, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
   wxStaticBox* itemStaticBoxSizer56Static = new wxStaticBox(itemPanel44, wxID_ANY, _("Autotype"));
-  wxUtilities::DisableIfUnsupported(wxUtilities::Feature::Autotype, itemStaticBoxSizer56Static);
+  wxUtilities::NotifyIfUnsupported(wxUtilities::Feature::Autotype, itemStaticBoxSizer56Static);
   auto *itemStaticBoxSizer56 = new wxStaticBoxSizer(itemStaticBoxSizer56Static, wxVERTICAL);
   itemBoxSizer45->Add(itemStaticBoxSizer56, 0, wxEXPAND|wxALL, 5);
   wxCheckBox* misc_AutotypeMinimizeCB = new wxCheckBox( itemPanel44, ID_CHECKBOX23, _("Minimize after Autotype"), wxDefaultPosition, wxDefaultSize, 0 );
-  wxUtilities::DisableIfUnsupported(wxUtilities::Feature::Autotype, misc_AutotypeMinimizeCB);
+  wxUtilities::NotifyIfUnsupported(wxUtilities::Feature::Autotype, misc_AutotypeMinimizeCB);
   misc_AutotypeMinimizeCB->SetValue(false);
   itemStaticBoxSizer56->Add(misc_AutotypeMinimizeCB, 0, wxALIGN_LEFT|wxALL, 5);
 
   auto *itemBoxSizer58 = new wxBoxSizer(wxHORIZONTAL);
   itemStaticBoxSizer56->Add(itemBoxSizer58, 0, wxEXPAND|wxALL, 0);
   wxStaticText* itemStaticText59 = new wxStaticText( itemPanel44, wxID_STATIC, _("Default Autotype string:"), wxDefaultPosition, wxDefaultSize, 0 );
-  wxUtilities::DisableIfUnsupported(wxUtilities::Feature::Autotype, itemStaticText59);
+  wxUtilities::NotifyIfUnsupported(wxUtilities::Feature::Autotype, itemStaticText59);
   itemBoxSizer58->Add(itemStaticText59, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
   wxTextCtrl* misc_AutotypeStringTXT = new wxTextCtrl( itemPanel44, ID_TEXTCTRL11, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-  wxUtilities::DisableIfUnsupported(wxUtilities::Feature::Autotype, misc_AutotypeStringTXT);
+  wxUtilities::NotifyIfUnsupported(wxUtilities::Feature::Autotype, misc_AutotypeStringTXT);
   itemBoxSizer58->Add(misc_AutotypeStringTXT, 2, wxEXPAND|wxALL, 5);
   itemBoxSizer58->AddStretchSpacer();
 

--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -1413,7 +1413,6 @@ void OptionsPropertySheetDlg::OnPWHistApply(wxCommandEvent& WXUNUSED(evt))
 void OptionsPropertySheetDlg::OnUpdateUI(wxUpdateUIEvent& evt)
 {
   bool dbIsReadOnly = m_core.IsReadOnly();
-  const bool isWayland = (wxUtilities::WhatWindowSystem() == wxUtilities::Wayland);
 
   switch (evt.GetId()) {
   /////////////////////////////////////////////////////////////////////////////
@@ -1451,7 +1450,7 @@ void OptionsPropertySheetDlg::OnUpdateUI(wxUpdateUIEvent& evt)
       evt.Enable(!dbIsReadOnly);
       break;
     case ID_TEXTCTRL11:
-      evt.Enable(!dbIsReadOnly && !isWayland);
+      evt.Enable(!dbIsReadOnly);
       break;
     case ID_CHECKBOX24:
       evt.Enable(!dbIsReadOnly);

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -57,7 +57,6 @@
 #include "ToolbarButtons.h"
 #include "TreeCtrl.h"
 #include "ViewReportDlg.h"
-#include "wxUtilities.h"
 #include "DnDFile.h"
 #include "core/Report.h"
 
@@ -2234,7 +2233,6 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
   const bool isTreeViewGroupSelected = isTreeView && m_tree->IsGroupSelected();
   const bool isTreeViewEmpty         = isTreeView && !m_tree->HasItems(); // excludes the invisible root item
   const bool isTreeViewItemSelected  = isTreeView && m_tree->HasSelection();
-  const bool isWayland               = (wxUtilities::WhatWindowSystem() == wxUtilities::Wayland);
   const bool isUnlocked              = !IsLocked();
 
   pci = GetSelectedEntry();
@@ -2379,7 +2377,7 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
       break;
 
     case ID_AUTOTYPE:
-      evt.Enable(isUnlocked && !isWayland && !isTreeViewGroupSelected && pci);
+      evt.Enable(isUnlocked && !isTreeViewGroupSelected && pci);
       break;
 
     case ID_EDIT:

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -376,8 +376,8 @@ bool wxUtilities::IsVirtualKeyboardSupported()
 void wxUtilities::DisableIfUnsupported(enum Feature feature, wxWindow* window)
 {
   if (feature == Autotype && WhatWindowSystem() == Wayland) {
-    window->Disable();
-    window->SetToolTip(_("Not supported by Wayland"));
+//    window->Disable();
+    window->SetToolTip(_("Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."));
   }
 }
 

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -373,16 +373,11 @@ bool wxUtilities::IsVirtualKeyboardSupported()
 #endif
 }
 
-void wxUtilities::DisableIfUnsupported(enum Feature feature, wxWindow* window)
-{
-  if (feature == Autotype && WhatWindowSystem() == Wayland) {
-//    window->Disable();
-    window->SetToolTip(_("Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."));
-  }
-}
-
 void wxUtilities::NotifyIfUnsupported(enum Feature feature, wxWindow* window)
 {
+  if (feature == Autotype && WhatWindowSystem() == Wayland) {
+    window->SetToolTip(_("Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."));
+  }
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
   if (feature == SystemTray && !IsTaskBarIconAvailable()) {
     window->SetToolTip(_("Not supported by the current Windowing System (e.g. Wayland), or you may need to install a Desktop Environment extension to enable System Tray support."));

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -458,13 +458,6 @@ namespace wxUtilities
   bool IsVirtualKeyboardSupported();
 
   /**
-   * @brief Disables a control for the specified feature(s).
-   * 
-   * @param control the control to disable.
-   */
-  void DisableIfUnsupported(enum Feature feature, wxWindow* window);
-
-  /**
    * @brief Shows a tooltip for the specified feature(s).
    *
    * @param Specify the target control.


### PR DESCRIPTION
Issue: Many modern Linux distros are moving to Wayland as the default display server (protocol that is implemented by the desktop environment and its compositor).
For example, GNOME 50 (released March 2026) has officially dropped native X11 session support (Xwayland remains supported, allowing legacy X11 applications to run within a Wayland session). Some Wayland-only distros like Fedora 44 and Ubuntu 26.04 with GNOME 50 are scheduled to be released imminently.
Currently, Password Safe disables the AutoType feature when Wayland is detected. Users may encounter this change in several scenarios:
1. Some distros (still) offer a Wayland or Xorg session to choose from on the login screen. A user logs out of an Xorg session and logs into a Wayland session.
2. The OS gets upgraded with Wayland as the default display server, and an Xorg session may no longer be available.
3. A user migrates to a newer/different distro where Wayland is the default or the only available display server.

Fortunately, the AutoType feature works just fine on Wayland, with minimal one-time tweaking the one or two apps people use it typically with:
-inside web browsers
-Remote Desktop/VNC/SSH/VPN clients connecting to remote systems
-SMB/FTP connections within file managers
Note: Password Safe itself does not need to be started with Xwayland enabled (by setting the GDK_BACKEND=x11 environment variable).

This PR enables AutoType controls in Linux/BSD on Wayland and updates the tooltip in the Add/Edit dialog as well as in Options > Misc. It's up to the user to look for details in Help and search for solution for a specific app on the internet.

Tested on Debian (GNOME)/Mint (Cinnamon)/Fedora (KDE)/Kubuntu/FreeBSD (KDE) with Wayland, with the following apps:

Native X11 apps or apps using X11 by default:
Tor browser (set MOZ_ENABLE_WAYLAND=1 to use Wayland)
Double Commander (SMB/FTP connections)
Apps that can run in Xwayland mode:
Chrome: google-chrome --ozone-platform=x11
Firefox: env MOZ_ENABLE_WAYLAND=0 firefox (--nosocket=wayland --socket=x11 for flatpak version/env DISABLE_WAYLAND=1 for snap version)
Apps requiring Xwayland and the "Use alternate AutoType method" option enabled in Options > System:
another instance of Password Safe :-)
Remmina (RDP/VNC/SSH client)
Filezilla

Note: wxUtilities::DisableIfUnsupported should eventually be renamed to something like NotifyIfConditionallySupported.

As usual, some fancy screenshots:
<img width="1660" height="860" alt="pwsafe_1 23-wxWidgets-feat-AutoType-Wayland-01" src="https://github.com/user-attachments/assets/24e37c45-6104-4e23-968d-067503b8d630" />
<img width="1800" height="902" alt="pwsafe_1 23-wxWidgets-feat-AutoType-Wayland-02" src="https://github.com/user-attachments/assets/cf1592e2-0786-4799-8e69-63b936f75991" />
<img width="724" height="492" alt="pwsafe_1 23-wxWidgets-feat-AutoType-Wayland-03" src="https://github.com/user-attachments/assets/e378eb9c-84b5-4b3c-ab18-2bfa8a03391a" />
<img width="950" height="503" alt="pwsafe_1 23-wxWidgets-feat-AutoType-Wayland-04" src="https://github.com/user-attachments/assets/b72eaf9e-7a01-4bb3-965c-6c4ca3480815" />

