### PR TITLE
[wx] Enable display scaling for virtual keyboard on Linux

### DIFF
--- a/help/default_wx/html/view_menu.html
+++ b/help/default_wx/html/view_menu.html
@@ -174,12 +174,8 @@
     <img alt="Change Fonts" src="images/change_font_menu.jpg">
 
     <p>Select a different font for displaying entries in the List or Tree
-        views, and for displaying passwords in the Add and Edit Entry dialog
-        boxes. You can also specify the font to use in the Virtual Keyboard.
-        Note that this font must be able to display Unicode characters. Supported
-        fonts include: "Arial Unicode MS" (which comes with Microsoft's Office suite),
-        "Arial Unicode" and "Lucida Sans Unicode", although you may select another using
-        the appropriate menu item.</p>
+        views, and for displaying passwords and notes in the Add and Edit Entry dialog boxes. 
+        Note that this font must be able to display Unicode characters.</p>
 
     <h3>Reports</h3>
 

--- a/src/ui/wxWidgets/ExternalKeyboardButton.cpp
+++ b/src/ui/wxWidgets/ExternalKeyboardButton.cpp
@@ -27,6 +27,7 @@
 #include "wxUtilities.h"
 
 #include "graphics/vkbd.xpm"
+#include <wx/display.h>
 
 ExternalKeyboardButton::ExternalKeyboardButton( wxWindow* parent, 
                                                 wxWindowID id, 
@@ -66,9 +67,27 @@ void ExternalKeyboardButton::HandleCommandEvent(wxCommandEvent& evt)
   GdkWindow* window = widget->window;
   int xwinid = GDK_WINDOW_XWINDOW(window);
 #endif
-  wxString command = wxString(wxT("xvkbd"));
+  int screenW = 0;
+  int screenH = 0;
+  int width = 0;
+  int height = 0;
+  double scaleFactor = 1;
+  wxSize screenSize = ::wxGetClientDisplayRect().GetSize();
+  screenW = screenSize.GetWidth();
+  screenH = screenSize.GetHeight();
+  scaleFactor = wxDisplay().GetScaleFactor();
+  if (screenW != 0 && screenH != 0) {
+    width = std::round(screenW * 0.6 * scaleFactor);
+    height = std::round(screenH * 0.3 * scaleFactor);
+  }
+  wxString geometry = wxString::Format("%dx%d", width, height);
+  wxString command;
+  if (width != 0 && height != 0)
+    command = wxString::Format("xvkbd -geometry %s %s", geometry, "-xrm 'xvkbd.Font: variable'");
+  else
+    command = wxT("xvkbd");
 
-  if (!pws_os::ProgramExists(tostdstring(command))) {
+  if (!pws_os::ProgramExists(tostdstring("xvkbd"))) {
     wxMessageBox(_("Could not launch xvkbd.  Please make sure it's installed and in your PATH"), 
                   _("Could not launch external onscreen keyboard"), wxOK | wxICON_ERROR);
     return;


### PR DESCRIPTION
This PR is to enable display scaling for xvkbd on high-DPI displays in Linux/BSD, as it does not natively support DPI-aware scaling.
While xvkbd allows window resizing, the key labels do not automatically scale, making the font appear too small.
Tested on Linux (GNOME/Cinnamon/KDE) and BSD.
Also updated English Help - removed Windows specific text on virtual keyboard font.

<img width="1078" height="1099" alt="pwsafe_1 23-wxWidgets-feat-xvkbd-scaling-01" src="https://github.com/user-attachments/assets/d86414b2-9e21-4f38-be27-b739826da502" />
<br />
<img width="1563" height="1311" alt="pwsafe_1 23-wxWidgets-feat-xvkbd-scaling-02" src="https://github.com/user-attachments/assets/20d34f81-044e-4300-a927-798c20164097" />
