### PR TITLE
[wx] Fix missing Run Command menu item and add some tooltips

### DIFF
--- a/help/default_wx/html/run_command.html
+++ b/help/default_wx/html/run_command.html
@@ -241,6 +241,11 @@ open ssh://${user}@${url}
 open smb://${user}@${url}/sharename
 </pre>
 </li>
+<li>On macOS, this will open a new instance of <b>Password Safe</b> with the specified database (use "\p\n" AutoType string to unlock it):
+<pre>
+open -n -a pwsafe ${dbdir}/database.psafe3
+</pre>
+</li>
 <li>On Linux, this will open a new instance of <b>Password Safe</b> with the specified database (Thanks to Dave for this one):
 <pre> ${autotype}(\p\n)"/usr/bin/pwsafe" \UNC\path\to\database.psafe3</pre></li>
 <ul>

--- a/help/default_wx/html/run_command.html
+++ b/help/default_wx/html/run_command.html
@@ -11,7 +11,7 @@
 <h1>Run Command</h1>
 
 <p>An entry's 'Run Command' field can contain a command that will
-be run when the Run Command action is selected. Anything that you can do on Linux in the "Run" dialog (Alt+F2) can be used here.</p>
+be run when the Run Command action is selected. On Linux, anything that you can do in the "Run" dialog (Alt+F2) can be used here.</p>
 
 <p>In addition, <b>Password Safe</b> is able to pass arguments to the command
 such as the entry's username, password, etc., as described below. This
@@ -226,12 +226,22 @@ variable.</p>
 
 <h3>Examples</h3>
 <ul>
-<li>The following Run Command will cause to connect to remote host via RDP giving the entry's username, password and URL:
+<li>On Linux, the following Run Command will cause to connect to remote host via RDP giving the entry's username, password and URL:
 <pre>
 remmina -c rdp://${user}:${password}@${url}
 </pre>
 </li>
-<li>This will open a new instance of <b>Password Safe</b> with the specified database (Thanks to Dave for this one):
+<li>On macOS, this launches Terminal and opens SSH connection to remote host using the entry's username and hostname (copy and paste the password to authenticate):
+<pre>
+open ssh://${user}@${url}
+</pre>
+</li>
+<li>On macOS, this connects to a remote Shared folder via SMB using the entry's username and URL (copy and paste the password to authenticate):
+<pre>
+open smb://${user}@${url}/sharename
+</pre>
+</li>
+<li>On Linux, this will open a new instance of <b>Password Safe</b> with the specified database (Thanks to Dave for this one):
 <pre> ${autotype}(\p\n)"/usr/bin/pwsafe" \UNC\path\to\database.psafe3</pre></li>
 <ul>
 <li>Make sure Manage&nbsp;&rarr;&nbsp;Options&nbsp;&rarr;&nbsp;System "Allow multiple instances" is checked for this to work</li>

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -504,8 +504,7 @@ wxScrolledWindow* AddEditPropSheetDlg::CreateAdditionalPanel()
   StringX sx_dats = PWSprefs::GetInstance()->GetPref(PWSprefs::DefaultAutotypeString);
   if (sx_dats.empty())
     sx_dats = DEFAULT_AUTOTYPE;
-  wxString AutoTypeLabel = _("Autotype") + _T(' ') + _T('(') + _("default") + _T(':') + _T(' ') + towxstring(sx_dats) + _T(')');
-  auto *itemStaticText41 = new wxStaticText(panel, wxID_STATIC, AutoTypeLabel, wxDefaultPosition, wxDefaultSize, 0);
+  auto *itemStaticText41 = new wxStaticText(panel, wxID_STATIC, wxString::Format(_("Autotype (default string: %s)"), towxstring(sx_dats)), wxDefaultPosition, wxDefaultSize, 0);
   wxUtilities::NotifyIfUnsupported(wxUtilities::Feature::Autotype, itemStaticText41);
   vBoxSizer->Add(itemStaticText41, 0, wxALIGN_LEFT|wxBOTTOM, 5);
 

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -501,7 +501,11 @@ wxScrolledWindow* AddEditPropSheetDlg::CreateAdditionalPanel()
   auto *vBoxSizer = new wxBoxSizer(wxVERTICAL);
   mainSizer->Add(vBoxSizer, 1, wxEXPAND|wxALL, 10);
 
-  auto *itemStaticText41 = new wxStaticText(panel, wxID_STATIC, _("Autotype"), wxDefaultPosition, wxDefaultSize, 0);
+  StringX sx_dats = PWSprefs::GetInstance()->GetPref(PWSprefs::DefaultAutotypeString);
+  if (sx_dats.empty())
+    sx_dats = DEFAULT_AUTOTYPE;
+  wxString AutoTypeLabel = _("Autotype") + _T(' ') + _T('(') + _("default") + _T(':') + _T(' ') + towxstring(sx_dats) + _T(')');
+  auto *itemStaticText41 = new wxStaticText(panel, wxID_STATIC, AutoTypeLabel, wxDefaultPosition, wxDefaultSize, 0);
   wxUtilities::NotifyIfUnsupported(wxUtilities::Feature::Autotype, itemStaticText41);
   vBoxSizer->Add(itemStaticText41, 0, wxALIGN_LEFT|wxBOTTOM, 5);
 
@@ -513,6 +517,7 @@ wxScrolledWindow* AddEditPropSheetDlg::CreateAdditionalPanel()
   vBoxSizer->Add(itemStaticText43, 0, wxALIGN_LEFT|wxBOTTOM, 5);
 
   auto *itemTextCtrl44 = new wxTextCtrl(panel, ID_TEXTCTRL_RUN_CMD, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
+  itemTextCtrl44->SetToolTip(_("This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."));
   vBoxSizer->Add(itemTextCtrl44, 0, wxALIGN_LEFT|wxEXPAND|wxBOTTOM, 12);
 
   auto *itemStaticText45 = new wxStaticText(panel, wxID_STATIC, _("Double-Click Action"), wxDefaultPosition, wxDefaultSize, 0);
@@ -541,6 +546,7 @@ wxScrolledWindow* AddEditPropSheetDlg::CreateAdditionalPanel()
   vBoxSizerTwoFactoryKey->Add(m_AdditionalHBoxSizerTwoFactorKey, 1, wxALIGN_LEFT|wxEXPAND|wxBOTTOM, 12);
 
   m_AdditionalTwoFactorKeyCtrl = new wxTextCtrl(panel, ID_TEXTCTRL_2FK, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PASSWORD);
+  m_AdditionalTwoFactorKeyCtrl->SetToolTip(_("Enter the authentication secret key. This is usually taken from the authenticator setup page."));
   m_AdditionalHBoxSizerTwoFactorKey->Add(m_AdditionalTwoFactorKeyCtrl, 1, wxALIGN_LEFT|wxEXPAND|wxRIGHT, 5);
 
   m_AdditionalShowHideCtrl = new wxBitmapButton(panel, ID_BUTTON_SHOWHIDE_2FK, wxUtilities::GetBitmapResource(wxT("graphics/eye.xpm")), wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
@@ -2513,6 +2519,7 @@ void AddEditPropSheetDlg::DisableAuthenticationCodeControls()
   m_BasicTotpTextLabel->Disable();
   m_BasicTotpTextCtrl->Disable();
   m_BasicTotpTextCtrl->ChangeValue(wxEmptyString);
+  m_BasicTotpTextCtrl->SetToolTip(_("Authentication code requires secret key in Additional tab."));
   m_BasicShowHideTotpCtrl->Disable();
   m_BasicTotpButton->Disable();
   m_BasicTotpButton->SetLabel(wxEmptyString);

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
@@ -10439,18 +10439,22 @@ msgstr ""
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "Godkendelseskode kræver hemmelig nøgle i fanen Yderligere."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "Indtast den hemmelige godkendelsesnøgle. Dette tages normalt fra godkendelsesopsætningssiden."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr ""
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "Autoindsæt (standart streng: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
@@ -10438,3 +10438,19 @@ msgstr ""
 
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "Godkendelseskode kræver hemmelig nøgle i fanen Yderligere."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "Indtast den hemmelige godkendelsesnøgle. Dette tages normalt fra godkendelsesopsætningssiden."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr ""
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
@@ -7526,18 +7526,22 @@ msgstr "Unbekanntes XML Tag <%ls> in <test> im Filter Nummer %d von Filter '%ls'
 #~ msgid "Quit this program"
 #~ msgstr "Programm beenden"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "Für den Authentifizierungscode ist ein geheimer Schlüssel auf der Registerkarte \"Zusätzlich\" erforderlich."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "Geben Sie den geheimen Authentifizierungsschlüssel ein. Dies wird normalerweise von der Setup-Seite des Authentifikators übernommen."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr "Wenn dieses Feld nicht leer ist, wird dessen Inhalt bei der Aktion 'Ausführen' als Kommando dem Betriebssystem übergeben. Es können Variablen wie Anwendername, Passwort, usw. mit übergeben werden."
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "Autom. Eingabe (Standardsteuerzeichen: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
@@ -7525,3 +7525,19 @@ msgstr "Unbekanntes XML Tag <%ls> in <test> im Filter Nummer %d von Filter '%ls'
 # wxString standard strings
 #~ msgid "Quit this program"
 #~ msgstr "Programm beenden"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "Für den Authentifizierungscode ist ein geheimer Schlüssel auf der Registerkarte \"Zusätzlich\" erforderlich."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "Geben Sie den geheimen Authentifizierungsschlüssel ein. Dies wird normalerweise von der Setup-Seite des Authentifikators übernommen."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr "Wenn dieses Feld nicht leer ist, wird dessen Inhalt bei der Aktion 'Ausführen' als Kommando dem Betriebssystem übergeben. Es können Variablen wie Anwendername, Passwort, usw. mit übergeben werden."
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
@@ -11168,18 +11168,22 @@ msgstr ""
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "El código de autenticación requiere una clave secreta en la pestaña Adicional."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "Introduzca la clave secreta de autenticación. Por lo general, se toma de la página de configuración del autenticador."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr "Este campo puede usarse par indicar un comando o programa a ejecutar en la acción 'Ejecutar comando' (en el menú editar o menú contextual). Password Safe puede pasar argumentos al comando, tales como el usuario, contraseña, etc."
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "Autoescritura (formato por defecto: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
@@ -11167,3 +11167,19 @@ msgstr ""
 
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "El código de autenticación requiere una clave secreta en la pestaña Adicional."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "Introduzca la clave secreta de autenticación. Por lo general, se toma de la página de configuración del autenticador."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr "Este campo puede usarse par indicar un comando o programa a ejecutar en la acción 'Ejecutar comando' (en el menú editar o menú contextual). Password Safe puede pasar argumentos al comando, tales como el usuario, contraseña, etc."
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
@@ -7308,18 +7308,22 @@ msgstr ""
 msgid "Unknown XML tag \"%ls\" in test in filter entry %d of '%ls'"
 msgstr "Tag XML inconnu \"%ls\" dans le test dans l'entrée de filtre %d de '%ls'"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "Le code d’authentification nécessite une clé secrète dans l’onglet Supplémentaire."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "Entrez la clé secrète d’authentification. Cela provient généralement de la page de configuration de l’authentificateur."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr ""
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "Autofrappe (expression par défaut: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
@@ -7307,3 +7307,19 @@ msgstr ""
 #, c-format
 msgid "Unknown XML tag \"%ls\" in test in filter entry %d of '%ls'"
 msgstr "Tag XML inconnu \"%ls\" dans le test dans l'entrée de filtre %d de '%ls'"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "Le code d’authentification nécessite une clé secrète dans l’onglet Supplémentaire."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "Entrez la clé secrète d’authentification. Cela provient généralement de la page de configuration de l’authentificateur."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr ""
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
@@ -10177,3 +10177,19 @@ msgstr ""
 
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "A hitelesítési kódhoz titkos kulcs szükséges a További lapon."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "Adja meg a hitelesítési titkos kulcsot. Ez általában a hitelesítő beállítási oldaláról származik."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr ""
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
@@ -10178,18 +10178,22 @@ msgstr ""
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "A hitelesítési kódhoz titkos kulcs szükséges a További lapon."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "Adja meg a hitelesítési titkos kulcsot. Ez általában a hitelesítő beállítási oldaláról származik."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr ""
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "Autogépelés (alapértelmezett szöveg: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_it.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_it.po
@@ -7712,18 +7712,22 @@ msgstr ""
 #~ msgid "V%d.%d.%d %s"
 #~ msgstr "V%d.%d.%d %s"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "Il codice di autenticazione richiede la chiave segreta nella scheda Avanzate."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "Inserisci la chiave segreta di autenticazione. Questa di solito è preso dalla pagina di configurazione dell'autenticatore."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr ""
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "Digitazione Automatica (stringa predefinita: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_it.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_it.po
@@ -7711,3 +7711,19 @@ msgstr ""
 
 #~ msgid "V%d.%d.%d %s"
 #~ msgstr "V%d.%d.%d %s"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "Il codice di autenticazione richiede la chiave segreta nella scheda Avanzate."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "Inserisci la chiave segreta di autenticazione. Questa di solito è preso dalla pagina di configurazione dell'autenticatore."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr ""
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ko.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ko.po
@@ -10916,18 +10916,22 @@ msgstr ""
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr ""
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr ""
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr ""
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "자동 입력 (기본 자동입력 문자열: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ko.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ko.po
@@ -10915,3 +10915,19 @@ msgstr ""
 
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr ""
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
@@ -11209,18 +11209,22 @@ msgstr ""
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "Voor de verificatiecode is een geheime sleutel vereist op het tabblad Extra."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "Voer de geheime verificatiesleutel in. Dit is meestal afkomstig van de instellingenpagina van de authenticator."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr ""
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "Automatische invoer (standaard tekst: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
@@ -11208,3 +11208,19 @@ msgstr ""
 
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "Voor de verificatiecode is een geheime sleutel vereist op het tabblad Extra."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "Voer de geheime verificatiesleutel in. Dit is meestal afkomstig van de instellingenpagina van de authenticator."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr ""
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
@@ -11209,18 +11209,22 @@ msgstr ""
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "Kod uwierzytelniający wymaga tajnego klucza w zakładce Dodatkowe."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "Wprowadź tajny klucz uwierzytelniania. Zwykle jest to pobierane ze strony konfiguracji tokena uwierzytelniającego."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr ""
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "Autouzupełnianie (domyślna fraza: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
@@ -11208,3 +11208,19 @@ msgstr ""
 
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "Kod uwierzytelniający wymaga tajnego klucza w zakładce Dodatkowe."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "Wprowadź tajny klucz uwierzytelniania. Zwykle jest to pobierane ze strony konfiguracji tokena uwierzytelniającego."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr ""
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
@@ -8465,11 +8465,6 @@ msgstr "Да: не менее %d из %ls: %ls%ls"
 #~ msgid "Attempted to write to the reading %1."
 #~ msgstr "Попытка выполнить операцию записи при чтении %1."
 
-#~ msgid "Authentication code requires secret key in Additional tab."
-#~ msgstr ""
-#~ "Для использования кодов двухфакторной аутентификации нужно указать секретный"
-#~ " ключ на вкладке «Дополнительно»."
-
 # на вкладке "«Дополнительно", перед самим ключом есть метка "ключ", поэтому
 # здесь не дублируем
 #~ msgid "Authenticator Secret"
@@ -9347,13 +9342,6 @@ msgstr "Да: не менее %d из %ls: %ls%ls"
 
 #~ msgid "Enter the Master Password to unlock the password database:"
 #~ msgstr "Введите пароль для указанного контейнера:"
-
-#~ msgid ""
-#~ "Enter the authentication secret key. This usually taken from the "
-#~ "authenticator setup page."
-#~ msgstr ""
-#~ "Укажите секретный ключ двухфакторной аутентификации. Обычно его можно "
-#~ "получить на странице настройки второго фактора."
 
 #~ msgid ""
 #~ "Enter the current master password, followed by a new one. \r\n"
@@ -12941,6 +12929,22 @@ msgstr "Да: не менее %d из %ls: %ls%ls"
 #~ msgid "v&3 format..."
 #~ msgstr "Формат v&3..."
 
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "Для использования кодов двухфакторной аутентификации нужно указать секретный ключ на вкладке «Дополнительно»."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "Укажите секретный ключ двухфакторной аутентификации. Обычно его можно получить на странице настройки второго фактора."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr "Данное поле используется для указания команды/программы, выполняемой при выборе пункта «Выполнить команду» (в меню «Правка» или контекстном меню). Password Safe может передать в качестве аргументов имя пользователя, пароль и содержимое других полей."
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""
+
 # no need to translate
 #~ msgid "whatever"
 #~ msgstr "whatever"
@@ -12957,3 +12961,4 @@ msgstr "Да: не менее %d из %ls: %ls%ls"
 #, c-format
 #~ msgid "«%s» «%s» «%s»"
 #~ msgstr "«%s» «%s» «%s»"
+

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
@@ -12929,21 +12929,25 @@ msgstr "Да: не менее %d из %ls: %ls%ls"
 #~ msgid "v&3 format..."
 #~ msgstr "Формат v&3..."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "Для использования кодов двухфакторной аутентификации нужно указать секретный ключ на вкладке «Дополнительно»."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "Укажите секретный ключ двухфакторной аутентификации. Обычно его можно получить на странице настройки второго фактора."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr "Данное поле используется для указания команды/программы, выполняемой при выборе пункта «Выполнить команду» (в меню «Правка» или контекстном меню). Password Safe может передать в качестве аргументов имя пользователя, пароль и содержимое других полей."
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "Автонабор (строка по умолчанию: %s)"
 
 # no need to translate
 #~ msgid "whatever"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sk.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sk.po
@@ -6931,3 +6931,20 @@ msgstr "Označenie databázy"
 
 msgid "The database description"
 msgstr "Popis databázy"
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr "Spustené na Waylande – uistite sa, že cieľová aplikácia používa backend Xwayland. Pre niektoré aplikácie môže byť potrebné zaškrtnúť voľbu 'Použiť alternatívnu metódu automatického dopĺňania' na karte Systém v dialógovom okne Nastavenia."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "Na generovanie overovacích kódov (TOTP tokenov) sa vyžaduje tajný kľúč na karte Doplňujúce."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "Zadajte tajný kľúč autentifikácie na generovanie jednorazových overovacích kódov/TOTP tokenov. Dá sa nájsť na webovej stránke v nastaveniach prihlásenia, kde sa zapína dvojfaktorová autentifikácia. Stránka môže ukazovať tajný kľúč priamo alebo treba naskenovať QR kód mobilom a z vygenerovanej URL adresy treba odpísať kľúč sem."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr "Toto pole možno použiť na zadanie príkazu alebo programu, ktorý sa má spustiť z menu Upraviť alebo kontextovej ponuky po kliknutí pravým tlačidlom myši. Password Safe dokáže príkazu odovzdať argumenty, ako napríklad používateľské meno alebo heslo konkrétneho záznamu."
+

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sk.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sk.po
@@ -6936,15 +6936,18 @@ msgstr "Popis databázy"
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr "Spustené na Waylande – uistite sa, že cieľová aplikácia používa backend Xwayland. Pre niektoré aplikácie môže byť potrebné zaškrtnúť voľbu 'Použiť alternatívnu metódu automatického dopĺňania' na karte Systém v dialógovom okne Nastavenia."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "Na generovanie overovacích kódov (TOTP tokenov) sa vyžaduje tajný kľúč na karte Doplňujúce."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "Zadajte tajný kľúč autentifikácie na generovanie jednorazových overovacích kódov/TOTP tokenov. Dá sa nájsť na webovej stránke v nastaveniach prihlásenia, kde sa zapína dvojfaktorová autentifikácia. Stránka môže ukazovať tajný kľúč priamo alebo treba naskenovať QR kód mobilom a z vygenerovanej URL adresy treba odpísať kľúč sem."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr "Toto pole možno použiť na zadanie príkazu alebo programu, ktorý sa má spustiť z menu Upraviť alebo kontextovej ponuky po kliknutí pravým tlačidlom myši. Password Safe dokáže príkazu odovzdať argumenty, ako napríklad používateľské meno alebo heslo konkrétneho záznamu."
 
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "Automatické dopĺňanie (predvolený reťazec: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sl.po
@@ -7226,18 +7226,22 @@ msgstr "Manjkajoča logika ali pravila XML oznaka v vnosu filtra %d od '%ls'"
 msgid "Unknown XML tag \"%ls\" in test in filter entry %d of '%ls'"
 msgstr "Neznana oznaka XML \"%ls\" v testu v vnosu filtra %d od '%ls'"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "Avtentikacijska koda zahteva skriti ključ v zavihku Dodatno."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "Vnesite avtentikacijski skrivni ključ. Le-ta je ponavadi vzet iz avtentikacijske nastavitvene strani."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr ""
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "Samodejno vtipkanje (privzet niz: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sl.po
@@ -7225,3 +7225,19 @@ msgstr "Manjkajoča logika ali pravila XML oznaka v vnosu filtra %d od '%ls'"
 #, c-format
 msgid "Unknown XML tag \"%ls\" in test in filter entry %d of '%ls'"
 msgstr "Neznana oznaka XML \"%ls\" v testu v vnosu filtra %d od '%ls'"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "Avtentikacijska koda zahteva skriti ključ v zavihku Dodatno."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "Vnesite avtentikacijski skrivni ključ. Le-ta je ponavadi vzet iz avtentikacijske nastavitvene strani."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr ""
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
@@ -11129,18 +11129,22 @@ msgstr ""
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "Autentiseringskoden kräver hemlig nyckel på fliken Ytterligare."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "Ange den hemliga autentiseringsnyckeln. Denna hämtas vanligtvis från konfigurationssidan för autentiseraren."
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr ""
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "Autoskriv (förvald autoskriftrad: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
@@ -11128,3 +11128,19 @@ msgstr ""
 
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "Autentiseringskoden kräver hemlig nyckel på fliken Ytterligare."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "Ange den hemliga autentiseringsnyckeln. Denna hämtas vanligtvis från konfigurationssidan för autentiseraren."
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr ""
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_zh.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_zh.po
@@ -10748,18 +10748,22 @@ msgstr ""
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2521
 msgid "Authentication code requires secret key in Additional tab."
 msgstr "身份验证代码需要“附加”选项卡中的密钥。"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:548
 msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
 msgstr "输入身份验证密钥。这通常取自身份验证器设置页面。"
 
-#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:519
 msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
 msgstr "该字段可被用于指定一个命令或通过操作“运行命令”运行程序（通过编辑菜单，右击弹出菜单或快捷键 Ctrl-R）。 Password Safe 可以传递自变量到命令行，如：项目的用户名，密码等。"
 
 #: ../../../ui/wxWidgets/wxUtilities.cpp:379
 msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
 msgstr ""
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
+msgid "Autotype (default string: %s)"
+msgstr "自动输入 (默认自动输入字串: %s)"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_zh.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_zh.po
@@ -10747,3 +10747,19 @@ msgstr ""
 
 #~ msgid "xxxxxx"
 #~ msgstr "xxxxxx"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:2522
+msgid "Authentication code requires secret key in Additional tab."
+msgstr "身份验证代码需要“附加”选项卡中的密钥。"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:549
+msgid "Enter the authentication secret key. This is usually taken from the authenticator setup page."
+msgstr "输入身份验证密钥。这通常取自身份验证器设置页面。"
+
+#: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:520
+msgid "This field can be used to specify a command or program to be run via the 'Run Command' action (via the Edit menu or right-click popup menu). Password Safe is able to pass arguments to the command such as the entry's username, password, etc."
+msgstr "该字段可被用于指定一个命令或通过操作“运行命令”运行程序（通过编辑菜单，右击弹出菜单或快捷键 Ctrl-R）。 Password Safe 可以传递自变量到命令行，如：项目的用户名，密码等。"
+
+#: ../../../ui/wxWidgets/wxUtilities.cpp:379
+msgid "Running on Wayland - make sure the target application is using Xwayland. For some applications, you may need to enable the 'Use alternate AutoType method' option in Options > System."
+msgstr ""

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -646,6 +646,7 @@ void PasswordSafeFrame::CreateMenubar()
   menuEdit->Append(ID_COPYURL, _("Copy URL to Clipboard\tCtrl+Alt+L"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_BROWSEURL, _("&Browse to URL\tCtrl+L"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_SENDEMAIL, _("Send &email"), wxEmptyString, wxITEM_NORMAL);
+  menuEdit->Append(ID_RUNCOMMAND, _("&Run Command"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_AUTOTYPE, _("Perform Auto&type\tCtrl+T"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_CREATESHORTCUT, _("Create &Shortcut"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_GOTOBASEENTRY, _("Go to Base entry"), wxEmptyString, wxITEM_NORMAL);


### PR DESCRIPTION
This PR is to add missing Run Command menu item and add tooltips for the Run Command and MFA fields in Add/Edit dialog.

Fix: Run Command menu item missing in Edit menu.
New: Added a tooltip for "Authentication code" field on the Basic tab in Add/Edit dialog (aligned with the Windows version).
New: Added tooltips for "Authentication Secret" (aligned with the Windows version) and "Run Command" fields on the Additional tab in Add/Edit dialog.
New: Display the default AutoType string on Additional tab in Add/Edit dialog, as configured in Options > Misc (consistent with the Windows version).

Notes:
Translations (POS) for "Authentication code" and "Authentication Secret" tooltips were taken from Windows POS files.
The tooltip and translations (POS) for "Run Command" were taken from the Help file (entering_pwd_add.html).

<img width="1238" height="902" alt="pwsafe_1 23-wxWidgets-feat-Tooltips-01" src="https://github.com/user-attachments/assets/50a691e4-9048-47dc-81a3-0351af2210b9" />
<br/>
<img width="1186" height="901" alt="pwsafe_1 23-wxWidgets-feat-Tooltips-02" src="https://github.com/user-attachments/assets/423d9c77-5cc4-40c2-9041-d5298a54da6e" />
