### PR TITLE
[macOS] Minor improvement to AutoType

### DIFF
--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -2115,7 +2115,7 @@
 			files = (
 			);
 			inputPaths = (
-				"../help/default/*",
+				"../help/default_wx/*",
 			);
 			name = "Default English Help";
 			outputPaths = (

--- a/help/default_wx/html/autotype.html
+++ b/help/default_wx/html/autotype.html
@@ -52,6 +52,9 @@ for your machine.</p>
 command specified in the entry's <a href="run_command.html">Run Cmd</a> 
 field. This is a very convenient combination.</p> 
 
+<p><b>Note:</b> <i>On macOS, in order for the system to allow AutoType, <b>pwsafe</b> must be present and enabled in
+<b>System Settings->Privacy & Security->Accessibility</b>.</i></p>
+
 <p><b>Note:</b> <i>On Linux, AutoType functionality depends on the Display Server used, such as Wayland or X.Org/X11.
 Under Wayland, you may need to run the target application using the X11 backend via the Xwayland compatibility layer.
 Enabling the 'Use alternate AutoType method' option in Options > System may also help for some applications.</i></p>

--- a/help/default_wx/html/autotype.html
+++ b/help/default_wx/html/autotype.html
@@ -53,7 +53,7 @@ command specified in the entry's <a href="run_command.html">Run Cmd</a>
 field. This is a very convenient combination.</p> 
 
 <p><b>Note:</b> <i>On macOS, in order for the system to allow AutoType, <b>pwsafe</b> must be present and enabled in
-<b>System Settings->Privacy & Security->Accessibility</b>.</i></p>
+<b>System Settings->Privacy &amp; Security->Accessibility</b>.</i></p>
 
 <p><b>Note:</b> <i>On Linux, AutoType functionality depends on the Display Server used, such as Wayland or X.Org/X11.
 Under Wayland, you may need to run the target application using the X11 backend via the Xwayland compatibility layer.

--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -804,7 +804,7 @@ void PasswordSafeFrame::DoAutotype(const StringX& sx_autotype,
 
   CKeySend ks;
 #ifdef __WXMAC__
-  if (!ks.SimulateApplicationSwitch()) {
+  if (wxGetApp().IsActive() && !ks.SimulateApplicationSwitch()) {
     wxMessageBox(_("Error switching to another application before autotyping. Switch manually within 5 seconds"),
                   wxTheApp->GetAppName(), wxOK|wxICON_ERROR, this);
     pws_os::sleep_ms(5000);


### PR DESCRIPTION
This makes "Perform Auto Type", from the context menu, work a little better.  Also added a note about permissions to the help file.

Question: In the context menu entry "Browse URL + Autotype", the Autotype part doesn't seem to be implemented.  All I see in the code is: "#ifdef NOT_YET".  I don't know what the intention was,  but couldn't it just be a call to DoAutotype() after DoBrowse() in OnBrowseUrlAndAutotype() ?  There's obviously some history here I don't get.