### PR TITLE
ItemAtt.cpp leaked memory if GetContent returned false.

### DIFF
--- a/src/core/ItemAtt.cpp
+++ b/src/core/ItemAtt.cpp
@@ -657,8 +657,8 @@ void CItemAtt::SerializePlainText(vector<char> &v)  const
         push_length(v, static_cast<uint32>(realLen));
         v.insert(v.end(), data, (data + realLen));
         trashMemory(data, length);
-        delete[] data;
       }
+      delete[] data;
     }
   }
     

--- a/src/core/PWSfile.cpp
+++ b/src/core/PWSfile.cpp
@@ -430,6 +430,7 @@ bool PWSfile::Encrypt(const stringT &fn, const StringX &passwd, stringT &errmess
 
 bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess)
 {
+  Fish *fish = nullptr;
   ulong64 file_len;
   bool status = true;
   unsigned char salt[SaltLength];
@@ -483,7 +484,6 @@ bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess
 
     unsigned char *pwd = nullptr;
     size_t passlen = 0;
-    Fish* fish = nullptr;
 
     ConvertPasskey(passwd, pwd, passlen);
     if (fread(salt, 1, SaltLength, in) != SaltLength) {

--- a/src/core/PWSfile.cpp
+++ b/src/core/PWSfile.cpp
@@ -502,6 +502,7 @@ bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess
     ivthing = new unsigned char[BS];
 
     if (fread(ivthing, 1, BS, in) != BS) {
+      delete fish;
       status = false;
       goto exit;
     }

--- a/src/core/PWSfile.cpp
+++ b/src/core/PWSfile.cpp
@@ -483,7 +483,7 @@ bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess
 
     unsigned char *pwd = nullptr;
     size_t passlen = 0;
-    Fish* fish;
+    Fish* fish = nullptr;
 
     ConvertPasskey(passwd, pwd, passlen);
     if (fread(salt, 1, SaltLength, in) != SaltLength) {
@@ -502,7 +502,6 @@ bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess
     ivthing = new unsigned char[BS];
 
     if (fread(ivthing, 1, BS, in) != BS) {
-      delete fish;
       status = false;
       goto exit;
     }
@@ -510,7 +509,6 @@ bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess
     // read first block, containing plaintext length
     size_t plaintext_length;
     if (readcbc1st(in, plaintext_length, fish, ivthing, isBigFile) != BS) {
-      delete fish;
       status = false;
       goto exit;
     }
@@ -524,7 +522,6 @@ bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess
 
     out = pws_os::FOpen(out_fn, _T("wb"));
     if (out == nullptr) {
-      delete fish;
       status = false;
       goto exit;
     }
@@ -536,7 +533,6 @@ bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess
     do {
       size_t nread = _readcbc(in, buf, BUFSIZ, fish, ivthing);
       if (ferror(in)) {
-        delete fish;
         status = false;
         goto exit;
       }
@@ -546,7 +542,6 @@ bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess
       // write plaintext
       auto nwrite = nleft > BUFSIZ ? BUFSIZ : nleft;
       if (fwrite(buf,1, nwrite, out) != nwrite) {
-        delete fish;
         status = false;
         goto exit;
       }
@@ -557,9 +552,9 @@ bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess
       // truncated ciphertext?
       status = false;
     }
-    delete fish;
   } // write decrypted
  exit:
+  delete fish;
   delete[] ivthing;
   if (!status)
     errmess = ErrorMessages();

--- a/src/ui/wxWidgets/GridCtrl.cpp
+++ b/src/ui/wxWidgets/GridCtrl.cpp
@@ -187,7 +187,8 @@ void GridCtrl::UpdateGUI(UpdateGUICommand::GUI_Action ga, const pws_os::CUUID &e
   }
   else if (ga == UpdateGUICommand::GUI_ADD_ENTRY ||
            ga == UpdateGUICommand::GUI_REFRESH_ENTRYFIELD ||
-           ga == UpdateGUICommand::GUI_REFRESH_ENTRYPASSWORD) {
+           ga == UpdateGUICommand::GUI_REFRESH_ENTRYPASSWORD ||
+           ga == UpdateGUICommand::GUI_REFRESH_ENTRY) {
     pws_os::Trace(wxT("GridCtrl - Couldn't find uuid %ls"), StringX(CUUID(entry_uuid)).c_str());
     return;
   }


### PR DESCRIPTION
PWSfile.cpp leaked memory fread(ivthing failed.
GridCtrl.cpp did not protect GUI_REFRESH_ENTRY from a null pointer dereference.

clang-analyzer found these. I am not sure how to force test cases for these.