### PR TITLE
[wx] Enable AutoType in Run Command

### DIFF
--- a/help/default_wx/html/autotype.html
+++ b/help/default_wx/html/autotype.html
@@ -53,7 +53,7 @@ command specified in the entry's <a href="run_command.html">Run Cmd</a>
 field. This is a very convenient combination.</p> 
 
 <p><b>Note:</b> <i>On macOS, in order for the system to allow AutoType, <b>pwsafe</b> must be present and enabled in
-<b>System Settings > Privacy &amp; Security > Accessibility</b>.</i>
+<b>System Settings > Privacy &amp; Security > Accessibility</b>.
 If you reinstall Password Safe and are not prompted to grant permission when using AutoType, remove and re-add pwsafe to the list manually (re-enabling it may not always work).</i></p>
 
 <p><b>Note:</b> <i>On Linux, AutoType functionality depends on the Display Server used, such as Wayland or X.Org/X11.

--- a/help/default_wx/html/autotype.html
+++ b/help/default_wx/html/autotype.html
@@ -53,7 +53,8 @@ command specified in the entry's <a href="run_command.html">Run Cmd</a>
 field. This is a very convenient combination.</p> 
 
 <p><b>Note:</b> <i>On macOS, in order for the system to allow AutoType, <b>pwsafe</b> must be present and enabled in
-<b>System Settings->Privacy &amp; Security->Accessibility</b>.</i></p>
+<b>System Settings > Privacy &amp; Security > Accessibility</b>.</i>
+If you reinstall Password Safe and are not prompted to grant permission when using AutoType, remove and re-add pwsafe to the list manually (re-enabling it may not always work).</i></p>
 
 <p><b>Note:</b> <i>On Linux, AutoType functionality depends on the Display Server used, such as Wayland or X.Org/X11.
 Under Wayland, you may need to run the target application using the X11 backend via the Xwayland compatibility layer.

--- a/help/default_wx/html/run_command.html
+++ b/help/default_wx/html/run_command.html
@@ -231,25 +231,31 @@ variable.</p>
 remmina -c rdp://${user}:${password}@${url}
 </pre>
 </li>
-<li>On macOS, this launches Terminal and opens SSH connection to remote host using the entry's username and hostname (copy and paste the password to authenticate):
+<li>On macOS, this launches Terminal and opens SSH connection to remote host using the entry's username and hostname (use AutoType or copy and paste the password to authenticate):
 <pre>
 open ssh://${user}@${url}
 </pre>
 </li>
-<li>On macOS, this connects to a remote Shared folder via SMB using the entry's username and URL (copy and paste the password to authenticate):
+<li>On macOS, this connects to a remote Shared folder via SMB using the entry's username, password (autotyped) and URL:
 <pre>
-open smb://${user}@${url}/sharename
+open smb://${user}@${url}/sharename ${a}(\p\n)
 </pre>
 </li>
-<li>On macOS, this will open a new instance of <b>Password Safe</b> with the specified database (use "\p\n" AutoType string to unlock it):
+<li>On macOS, this opens a login page in Safari and performs AutoType after 5 seconds to allow the page to load. It uses several Tab keystrokes to navigate the form and focus the Username field (without these, the user can manually focus the first field):
 <pre>
-open -n -a pwsafe ${dbdir}/database.psafe3
+open -a safari ${url} ${a}(\W5\t\t\u\t\p\n)
 </pre>
 </li>
-<li>On Linux, this will open a new instance of <b>Password Safe</b> with the specified database (Thanks to Dave for this one):
-<pre> ${autotype}(\p\n)"/usr/bin/pwsafe" \UNC\path\to\database.psafe3</pre></li>
+<li>On macOS, this will open a new instance of <b>Password Safe</b> with the specified database using the entry's AutoType string to unlock it (it should be set to "\p\n"; if it's empty, the global AutoType string is used):
+<pre>
+${a} open -n -a pwsafe ${dbdir}/database.psafe3
+</pre>
+</li>
+<li>On Linux with Wayland, this will open a new instance of <b>Password Safe</b> with the specified database (the password is autotyped):
+<pre> ${autotype}(\p\n) env GDK_BACKEND=x11 /usr/bin/pwsafe \UNC\path\to\database.psafe3</pre></li>
 <ul>
-<li>Make sure Manage&nbsp;&rarr;&nbsp;Options&nbsp;&rarr;&nbsp;System "Allow multiple instances" is checked for this to work</li>
+<li>Make sure Manage > Options > System "Allow multiple instances" is checked for this to work</li>
+<li>Enabling the "Use alternate AutoType method" option in Options > System may also be required</li>
 <li>You might also want to set the Double-Click Action for this entry to "Run Command"</li>
 </ul> 
 </ul> 

--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -1082,9 +1082,15 @@ void PasswordSafeFrame::DoRun(CItemData& item)
 
   std::vector<size_t> vactionverboffsets;
 
-  // if no autotype value in run command's $a(value), start with item's (bug #1078)
+  // if no autotype value in run command's $a(value), start with item's (bug #1078) or the default AutoType string
+  StringX sx_dats = PWSprefs::GetInstance()->GetPref(PWSprefs::DefaultAutotypeString);
+  if (sx_dats.empty())
+   sx_dats = DEFAULT_AUTOTYPE;
   if (expandedAutoType.empty()) {
-    expandedAutoType = pci->GetAutoType();
+    if (!pci->GetAutoType().empty())
+      expandedAutoType = pci->GetAutoType();
+    else
+      expandedAutoType = sx_dats;
   }
 
   const CustomFieldList customFields = effci.GetCustomFields();
@@ -1125,6 +1131,10 @@ void PasswordSafeFrame::DoRun(CItemData& item)
 
   if (runner.runcmd(expandedES, !expandedAutoType.empty())) {
     UpdateAccessTime(item);
+    if (doAutoType && !expandedAutoType.empty()) {
+      effci.SetAutoType(expandedAutoType);
+      DoAutotype(effci);
+    }
   }
 }
 


### PR DESCRIPTION
Issue: Despite specifying an AutoType string in the Run Command field in the Add/Edit dialog (as described in Help), no action is triggered.
Users must manually invoke the AutoType command, which may use a different AutoType string defined for the entry or fall back to the global string in Settings > Misc.
Change: Enable the AutoType feature for the Run Command action on Linux and macOS.
Change: Update notes in help/default_wx/html/autotype.html.
Change: Update examples in help/default_wx/html/run_command.html.
