### PR TITLE
Add override for GetName()

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -87,7 +87,7 @@ public:
     m_NameCtrl->SetFocus();
   }
 
-  wxString GetName() const { return m_NameCtrl->GetValue(); }
+  wxString GetName() const override { return m_NameCtrl->GetValue(); }
   wxString GetValue() const { return m_ValueCtrl->GetValue(); }
   bool IsSensitive() const { return m_SensitiveCtrl->GetValue(); }
 

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -87,8 +87,8 @@ public:
     m_NameCtrl->SetFocus();
   }
 
-  wxString GetName() const override { return m_NameCtrl->GetValue(); }
-  wxString GetValue() const { return m_ValueCtrl->GetValue(); }
+  wxString GetFieldName() const { return m_NameCtrl->GetValue(); }
+  wxString GetFieldValue() const { return m_ValueCtrl->GetValue(); }
   bool IsSensitive() const { return m_SensitiveCtrl->GetValue(); }
 
 private:
@@ -3897,8 +3897,8 @@ bool AddEditPropSheetDlg::EditCustomField(CustomField *field)
   }
 
   CustomField editedField;
-  editedField.SetName(tostringx(ppdlg.Get()->GetName()));
-  editedField.SetValue(tostringx(ppdlg.Get()->GetValue()));
+  editedField.SetName(tostringx(ppdlg.Get()->GetFieldName()));
+  editedField.SetValue(tostringx(ppdlg.Get()->GetFieldValue()));
   editedField.SetSensitive(ppdlg.Get()->IsSensitive());
 
   if (field == nullptr) {


### PR DESCRIPTION
A new warning appeared because this is a virtual function defined in (WX) window.h.  I don't think it hurts anything, but a different name might be better, since it's conceptually a different function.