### PR TITLE
[wx] Update English Help for Run Command and custom fields

### DIFF
--- a/help/default_wx/html/entering_pwd.html
+++ b/help/default_wx/html/entering_pwd.html
@@ -36,6 +36,7 @@ password entry:</p>
 <li><b>URL</b>: The URL (website) associated with this entry</li>
 <li><b>Email</b>: An email address associated with this entry</li>
 <li><b>Notes</b>: Free-form general notes</li>
+<li><b>Custom Fields</b>: User-defined named values that can be added to the entry as needed.</li>
 </ul>
 
 <p><i>Only the <b>Title</b> and <b>Password</b> fields are required; all others are optional.</i></p>
@@ -58,6 +59,10 @@ limited to 30,000 characters. Whilst it is possible to add more than this limit 
 warnings will be issued when the database is re-opened. The Notes field will be truncated
 to this limit if the entry is edited. However, if the entry is protected or the database is opened
 in read-only mode, then it can be viewed without any truncation.</p>
+
+<p><b>Custom Fields</b> is where you can add your own named fields to each password entry. For each custom field, you can specify a name and a value,
+   as well as specifying if the value will be displayed or displayed as "******" (masked).
+   There's no limit on the number of custom fields you can add, but each field name must be unique for the entry, and cannot be empty.</p>
 
 <p>In addition, the following fields may be set in this tab:</p>
 
@@ -123,7 +128,7 @@ by an ampersand (&amp;). The name can be one of the following strings:</li>
 <li>CC - followed by addresses to be included in the "cc" (carbon copy) section of the message.</li>
 <li>BCC - followed by addresses to be included in the "bcc" (blind carbon copy) section of the message.</li>
 </ul>
-<p>Example: user@example.com?subject=Message Title&amp;body=Message Content"</p>
+<p>Example: user@example.com?subject=Message Title&amp;body=Message Content</p>
 </ul>
 
 </small>
@@ -271,6 +276,7 @@ the entry via the Edit menu or right-click context menu.</p>
 <param name="Keyword" value="TOTP">
 <param name="Keyword" value="OTP">
 <param name="Keyword" value="Authentication Code">
+<param name="Keyword" value="Custom Fields">
 </object>
 </body>
 </html>

--- a/help/default_wx/html/run_command.html
+++ b/help/default_wx/html/run_command.html
@@ -241,9 +241,19 @@ open ssh://${user}@${url}
 open smb://${user}@${url}/sharename ${a}(\p\n)
 </pre>
 </li>
+<li>On Linux, this connects to a remote Shared folder via SMB using the entry's username, password and URL:
+<pre>
+sh -c 'echo "${p}" | gio mount smb://WORKGROUP\\;${user}@${url}; gio open smb://WORKGROUP\\;${user}@${url}'
+</pre>
+</li>
 <li>On macOS, this opens a login page in Safari and performs AutoType after 5 seconds to allow the page to load. It uses several Tab keystrokes to navigate the form and focus the Username field (without these, the user can manually focus the first field):
 <pre>
 open -a safari ${url} ${a}(\W5\t\t\u\t\p\n)
+</pre>
+</li>
+<li>On Linux with Wayland, this opens a login page in Firefox (the Snap version) and performs AutoType after 5 seconds:
+<pre>
+env MOZ_ENABLE_WAYLAND=0 DISABLE_WAYLAND=1 firefox ${url} ${a}(\W5\u\t\p\n)
 </pre>
 </li>
 <li>On macOS, this will open a new instance of <b>Password Safe</b> with the specified database using the entry's AutoType string to unlock it (it should be set to "\p\n"; if it's empty, the global AutoType string is used):
@@ -252,7 +262,7 @@ ${a} open -n -a pwsafe ${dbdir}/database.psafe3
 </pre>
 </li>
 <li>On Linux with Wayland, this will open a new instance of <b>Password Safe</b> with the specified database (the password is autotyped):
-<pre> ${autotype}(\p\n) env GDK_BACKEND=x11 /usr/bin/pwsafe \UNC\path\to\database.psafe3</pre></li>
+<pre>${autotype}(\p\n) env GDK_BACKEND=x11 /usr/bin/pwsafe \UNC\path\to\database.psafe3</pre></li>
 <ul>
 <li>Make sure Manage > Options > System "Allow multiple instances" is checked for this to work</li>
 <li>Enabling the "Use alternate AutoType method" option in Options > System may also be required</li>


### PR DESCRIPTION
This PR updates English Help:
Added text to align with recent introduction of custom fields (so that it matches Help on Windows).
Added 2 Linux examples for the Run Command so that it is on par with the macOS items:
Tested on Debian(GNOME)/Mint(Cinnamon)/Ubuntu/Kubuntu(I had to install gvfs-backends and gvfs-fuse)/FreeBSD(KDE).
