### PR TITLE
[wx] Fix - Help sometimes not available after changing language

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -405,9 +405,9 @@ void AddEditPropSheetDlg::CreateControls()
   m_PasswordPolicyOwnSymbolsTextCtrl->SetValue(m_Symbols);
 }
 
-wxScrolledWindow *AddEditPropSheetDlg::CreateScrollablePage(wxWindowID id)
+wxScrolledWindow *AddEditPropSheetDlg::CreateScrollablePage(wxWindowID id, const wxString &pageName)
 {
-  auto *page = new wxScrolledWindow(GetBookCtrl(), id, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxVSCROLL);
+  auto *page = new wxScrolledWindow(GetBookCtrl(), id, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxVSCROLL, pageName);
 #if wxCHECK_VERSION(3,1,0)
   page->SetScrollRate(0, wxWindow::FromDIP(10, page));
 #else
@@ -454,7 +454,7 @@ void AddEditPropSheetDlg::RelaxScrollablePageSizes()
 
 wxScrolledWindow* AddEditPropSheetDlg::CreateBasicPanel()
 {
-  auto *panel = CreateScrollablePage(ID_PANEL_BASIC);
+  auto *panel = CreateScrollablePage(ID_PANEL_BASIC, "Basic");
   auto *itemBoxSizer3 = new wxBoxSizer(wxVERTICAL);
   panel->SetSizer(itemBoxSizer3);
 
@@ -622,7 +622,7 @@ wxScrolledWindow* AddEditPropSheetDlg::CreateBasicPanel()
 
 wxScrolledWindow* AddEditPropSheetDlg::CreateAdditionalPanel()
 {
-  auto *panel = CreateScrollablePage(ID_PANEL_ADDITIONAL);
+  auto *panel = CreateScrollablePage(ID_PANEL_ADDITIONAL, "Additional");
   auto *mainSizer = new wxBoxSizer(wxVERTICAL);
   panel->SetSizer(mainSizer);
 
@@ -739,7 +739,7 @@ wxScrolledWindow* AddEditPropSheetDlg::CreateAdditionalPanel()
 
 wxScrolledWindow* AddEditPropSheetDlg::CreateDatesTimesPanel()
 {
-  auto *panel = CreateScrollablePage(ID_PANEL_DTIME);
+  auto *panel = CreateScrollablePage(ID_PANEL_DTIME, "Dates and Times");
   auto *itemBoxSizer60 = new wxBoxSizer(wxVERTICAL);
   panel->SetSizer(itemBoxSizer60);
 
@@ -842,7 +842,7 @@ wxScrolledWindow* AddEditPropSheetDlg::CreateDatesTimesPanel()
 
 wxScrolledWindow* AddEditPropSheetDlg::CreatePasswordPolicyPanel()
 {
-  auto *panel = CreateScrollablePage(ID_PANEL_PPOLICY);
+  auto *panel = CreateScrollablePage(ID_PANEL_PPOLICY, "Password Policy");
   auto *itemBoxSizer61 = new wxBoxSizer(wxVERTICAL);
   panel->SetSizer(itemBoxSizer61);
 
@@ -1024,7 +1024,7 @@ wxScrolledWindow* AddEditPropSheetDlg::CreateAttachmentPanel()
   ID_BUTTON_EXPORT = wxWindow::NewControlId();
   ID_BUTTON_REMOVE = wxWindow::NewControlId();
 
-  auto *panel = CreateScrollablePage(ID_PANEL_ADDITIONAL);
+  auto *panel = CreateScrollablePage(ID_PANEL_ATTACHMENT, "Attachment");
   auto *BoxSizerMain = new wxBoxSizer(wxVERTICAL);
 
   StaticBoxSizerPreview = new wxStaticBoxSizer(wxHORIZONTAL, panel, _("Preview"));

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.h
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.h
@@ -109,6 +109,7 @@ class wxNotebook;
 #define ID_CHECKBOX_RECURRING 10112
 #define ID_RADIOBUTTON_NEVER 10001
 #define ID_PANEL_PPOLICY 10087
+#define ID_PANEL_ATTACHMENT 11088
 #define ID_CHECKBOX42 10115
 #define ID_POLICYLIST 10063
 #define ID_SPINCTRL3 10117
@@ -304,7 +305,7 @@ private:
   // Creates the controls and sizers
   void CreateControls();
 
-  wxScrolledWindow *CreateScrollablePage(wxWindowID id);
+  wxScrolledWindow *CreateScrollablePage(wxWindowID id, const wxString &pageName);
   void FinalizeScrollablePage(wxScrolledWindow *page);
   void RelaxScrollablePageSizes();
 

--- a/src/ui/wxWidgets/HelpMap.h
+++ b/src/ui/wxWidgets/HelpMap.h
@@ -42,19 +42,19 @@ DLG_HELP(YubiCfgDlg,                                    html/manage_menu.html#yu
 //
 
 //Options dialog
-PROPSHEET_HELP(OptionsPropertySheetDlg,            _("Backups"),          html/backups_tab.html)
-PROPSHEET_HELP(OptionsPropertySheetDlg,            _("Display"),          html/display_tab.html)
-PROPSHEET_HELP(OptionsPropertySheetDlg,            _("Miscellaneous"),    html/misc_tab.html)
-PROPSHEET_HELP(OptionsPropertySheetDlg,            _("Password History"), html/password_history_tab.html)
-PROPSHEET_HELP(OptionsPropertySheetDlg,            _("Security"),         html/security_tab.html)
-PROPSHEET_HELP(OptionsPropertySheetDlg,            _("System"),           html/system_tab.html)
-PROPSHEET_HELP(OptionsPropertySheetDlg,            _("Shortcuts"),        html/shortcuts_tab.html)
+PROPSHEET_HELP(OptionsPropertySheetDlg,            "Backups",          html/backups_tab.html)
+PROPSHEET_HELP(OptionsPropertySheetDlg,            "Display",          html/display_tab.html)
+PROPSHEET_HELP(OptionsPropertySheetDlg,            "Miscellaneous",    html/misc_tab.html)
+PROPSHEET_HELP(OptionsPropertySheetDlg,            "Password History", html/password_history_tab.html)
+PROPSHEET_HELP(OptionsPropertySheetDlg,            "Security",         html/security_tab.html)
+PROPSHEET_HELP(OptionsPropertySheetDlg,            "System",           html/system_tab.html)
+PROPSHEET_HELP(OptionsPropertySheetDlg,            "Shortcuts",        html/shortcuts_tab.html)
 
-PROPSHEET_HELP(AddEditPropSheetDlg, _("Basic"),            html/entering_pwd.html)
-PROPSHEET_HELP(AddEditPropSheetDlg, _("Dates and Times"),  html/entering_pwd_date.html)
-PROPSHEET_HELP(AddEditPropSheetDlg, _("Password Policy"),  html/entering_pwd_pp.html)
-PROPSHEET_HELP(AddEditPropSheetDlg, _("Additional"),       html/entering_pwd_add.html)
-PROPSHEET_HELP(AddEditPropSheetDlg, _("Attachment"),       html/entering_pwd_att.html)
+PROPSHEET_HELP(AddEditPropSheetDlg, "Basic",            html/entering_pwd.html)
+PROPSHEET_HELP(AddEditPropSheetDlg, "Dates and Times",  html/entering_pwd_date.html)
+PROPSHEET_HELP(AddEditPropSheetDlg, "Password Policy",  html/entering_pwd_pp.html)
+PROPSHEET_HELP(AddEditPropSheetDlg, "Additional",       html/entering_pwd_add.html)
+PROPSHEET_HELP(AddEditPropSheetDlg, "Attachment",       html/entering_pwd_att.html)
 
 DLG_HELP(EditShortcutDlg,                  html/edit_menu.html)
 

--- a/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
+++ b/src/ui/wxWidgets/OptionsPropertySheetDlg.cpp
@@ -311,7 +311,7 @@ wxPanel* OptionsPropertySheetDlg::CreateHeaderPanel(wxWindow* parent, const wxSt
 
 wxPanel* OptionsPropertySheetDlg::CreateBackupsPanel(const wxString& title)
 {
-  wxPanel* itemPanel2 = new wxPanel( GetBookCtrl(), ID_PANEL, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+  wxPanel* itemPanel2 = new wxPanel( GetBookCtrl(), ID_PANEL, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, "Backups" );
   auto *itemBoxSizer3 = new wxBoxSizer(wxVERTICAL);
   itemPanel2->SetSizer(itemBoxSizer3);
 
@@ -418,7 +418,7 @@ wxPanel* OptionsPropertySheetDlg::CreateBackupsPanel(const wxString& title)
 
 wxPanel* OptionsPropertySheetDlg::CreateDisplayPanel(const wxString& title)
 {
-  wxPanel* itemPanel29 = new wxPanel( GetBookCtrl(), ID_PANEL1, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+  wxPanel* itemPanel29 = new wxPanel( GetBookCtrl(), ID_PANEL1, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, "Display" );
   auto *itemBoxSizer30 = new wxBoxSizer(wxVERTICAL);
   itemPanel29->SetSizer(itemBoxSizer30);
 
@@ -520,7 +520,7 @@ wxPanel* OptionsPropertySheetDlg::CreateDisplayPanel(const wxString& title)
 
 wxPanel* OptionsPropertySheetDlg::CreateMiscellaneousPanel(const wxString& title)
 {
-  wxPanel* itemPanel44 = new wxPanel( GetBookCtrl(), ID_PANEL2, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+  wxPanel* itemPanel44 = new wxPanel( GetBookCtrl(), ID_PANEL2, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, "Miscellaneous" );
   auto *itemBoxSizer45 = new wxBoxSizer(wxVERTICAL);
   itemPanel44->SetSizer(itemBoxSizer45);
 
@@ -643,7 +643,7 @@ wxPanel* OptionsPropertySheetDlg::CreateMiscellaneousPanel(const wxString& title
 
 wxPanel* OptionsPropertySheetDlg::CreatePasswordHistoryPanel(const wxString& title)
 {
-  wxPanel* itemPanel74 = new wxPanel( GetBookCtrl(), ID_PANEL4, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+  wxPanel* itemPanel74 = new wxPanel( GetBookCtrl(), ID_PANEL4, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, "Password History" );
   auto *itemBoxSizer75 = new wxBoxSizer(wxVERTICAL);
   itemPanel74->SetSizer(itemBoxSizer75);
 
@@ -728,7 +728,7 @@ wxPanel* OptionsPropertySheetDlg::CreatePasswordHistoryPanel(const wxString& tit
 
 wxPanel* OptionsPropertySheetDlg::CreateSecurityPanel(const wxString& title)
 {
-  wxPanel* itemPanel86 = new wxPanel( GetBookCtrl(), ID_PANEL5, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+  wxPanel* itemPanel86 = new wxPanel( GetBookCtrl(), ID_PANEL5, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, "Security" );
   auto *itemBoxSizer87 = new wxBoxSizer(wxVERTICAL);
   itemPanel86->SetSizer(itemBoxSizer87);
 
@@ -814,7 +814,7 @@ wxPanel* OptionsPropertySheetDlg::CreateSecurityPanel(const wxString& title)
 
 wxPanel* OptionsPropertySheetDlg::CreateShortcutsPanel(const wxString& title)
 {
-  wxPanel* itemPanel123 = new wxPanel(GetBookCtrl(), ID_PANEL7, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+  wxPanel* itemPanel123 = new wxPanel(GetBookCtrl(), ID_PANEL7, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, "Shortcuts");
   auto *itemBoxSizer155 = new wxBoxSizer(wxVERTICAL);
   itemPanel123->SetSizer(itemBoxSizer155);
 
@@ -834,7 +834,7 @@ wxPanel* OptionsPropertySheetDlg::CreateShortcutsPanel(const wxString& title)
 
 wxPanel* OptionsPropertySheetDlg::CreateSystemPanel(const wxString& title)
 {
-  wxPanel* itemPanel104 = new wxPanel( GetBookCtrl(), ID_PANEL6, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+  wxPanel* itemPanel104 = new wxPanel( GetBookCtrl(), ID_PANEL6, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, "System" );
   auto *itemBoxSizer105 = new wxBoxSizer(wxVERTICAL);
   itemPanel104->SetSizer(itemBoxSizer105);
 

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -1040,9 +1040,10 @@ void PWSafeApp::OnHelp(wxCommandEvent& evt)
     wxPropertySheetDialog* propSheet = wxDynamicCast(window, wxPropertySheetDialog);
     if (propSheet) {
       const wxString dlgName = window->GetClassInfo()->GetClassName();
-      const wxString pageName = propSheet->GetBookCtrl()->GetPageText(propSheet->GetBookCtrl()->GetSelection());
+      const wxString pageName = propSheet->GetBookCtrl()->GetPage(propSheet->GetBookCtrl()->GetSelection())->GetName();
+      const wxString pageNameTranslated = propSheet->GetBookCtrl()->GetPageText(propSheet->GetBookCtrl()->GetSelection());
       keyName = dlgName + wxT('#') + pageName;
-      msg << _("Missing help definition for page \"") << pageName
+      msg << _("Missing help definition for page \"") << pageNameTranslated
           << _("\" of \"") << dlgName
           << wxT("\".\n");
     }


### PR DESCRIPTION
Issue: After changing language, Help for property sheet dialogs does not open. Opening Help from a regular dialog window or using the Help > Get Help command works fine.
This only affects pages in Options and Add/Edit dialog.
Root cause: This is because page labels get translated on changing language but Help definitions for the pages are initialized when the program starts (with a different language).
So, after the program is restarted, a new Help map is loaded and it works OK.

Fix: Decouple localization from lookup logic for Help.
Fix: AddEditPropSheetDlg::CreateAttachmentPanel() is using ID_PANEL_ADDITIONAL for the ID (probably a copy & paste error).

<img width="1329" height="886" alt="pwsafe_1 23-wxWidgets-bug-Help-Language-01" src="https://github.com/user-attachments/assets/0ba3ef6d-c283-4976-a3dd-5a0660b05e26" />
