### PR TITLE
Fix runaway DPI font scaling

### DIFF
--- a/src/ui/Windows/Fonts.cpp
+++ b/src/ui/Windows/Fonts.cpp
@@ -54,6 +54,11 @@ static LOGFONT DragFixLogfont = {
 
 static void tweakFontSizes()
 {
+  static bool tweaked = false;
+  if (tweaked)
+    return;
+  tweaked = true;
+
   const UINT defDPI = WinUtil::defDPI;
   const UINT curDPI = WinUtil::GetDPI();
 
@@ -71,8 +76,8 @@ static void tweakFontSizes()
 
 Fonts *Fonts::GetInstance()
 {
-  tweakFontSizes();
   if (self == nullptr) {
+    tweakFontSizes();
     self = new Fonts();
   }
   return self;
@@ -191,25 +196,10 @@ void Fonts::SetTreeListFont(LOGFONT *pLF, const int iPtSz)
   }
 
   if (iPtSz == 0) {
-    // Create a new LOGFONT structure based on provided font
-    LOGFONT lf(*pLF);
-    
-    // Use WinUtil::GetDPI() for DPI scaling
-    UINT dpi = WinUtil::GetDPI();
-    
-    // Scale the font height based on DPI
-    lf.lfHeight = MulDiv(lf.lfHeight, dpi, WinUtil::defDPI);
-    
-    m_pTreeListFont->CreateFontIndirect(&lf);
+    m_pTreeListFont->CreateFontIndirect(pLF);
   } else {
     LOGFONT lf(*pLF);
-    
-    // Use WinUtil::GetDPI() for DPI scaling
-    UINT dpi = WinUtil::GetDPI();
-    
-    // Scale the point size based on DPI
-    int scaledPtSize = MulDiv(iPtSz, dpi, WinUtil::defDPI);
-    lf.lfHeight = scaledPtSize;
+    lf.lfHeight = iPtSz;
     m_pTreeListFont->CreatePointFontIndirect(&lf);
   }
 }
@@ -236,25 +226,10 @@ void Fonts::SetAddEditFont(LOGFONT *pLF, const int iPtSz)
   }
 
   if (iPtSz == 0) {
-    // Create a new LOGFONT structure based on provided font
-    LOGFONT lf(*pLF);
-    
-    // Use WinUtil::GetDPI() for DPI scaling
-    UINT dpi = WinUtil::GetDPI();
-    
-    // Scale the font height based on DPI
-    lf.lfHeight = MulDiv(lf.lfHeight, dpi, WinUtil::defDPI);
-    
-    m_pAddEditFont->CreateFontIndirect(&lf);
+    m_pAddEditFont->CreateFontIndirect(pLF);
   } else {
     LOGFONT lf(*pLF);
-    
-    // Use WinUtil::GetDPI() for DPI scaling
-    UINT dpi = WinUtil::GetDPI();
-    
-    // Scale the point size based on DPI
-    int scaledPtSize = MulDiv(iPtSz, dpi, WinUtil::defDPI);
-    lf.lfHeight = scaledPtSize;
+    lf.lfHeight = iPtSz;
     m_pAddEditFont->CreatePointFontIndirect(&lf);
   }
 
@@ -312,21 +287,10 @@ void Fonts::SetPasswordFont(LOGFONT *pLF, const int iPtSz)
   }
 
   if (iPtSz == 0 || pLF == nullptr) {
-    // Create a new LOGFONT structure based on default or provided font
-    LOGFONT lf = (pLF == nullptr ? dfltPasswordLogfont : *pLF);
-    
-    UINT dpi = WinUtil::GetDPI();
-    
-    lf.lfHeight = MulDiv(lf.lfHeight, dpi, WinUtil::defDPI);
-    
-    m_pPasswordFont->CreateFontIndirect(&lf);
+    m_pPasswordFont->CreateFontIndirect(pLF == nullptr ? &dfltPasswordLogfont : pLF);
   } else {
     LOGFONT lf(*pLF);
-    
-    UINT dpi = WinUtil::GetDPI();
-    
-    int scaledPtSize = MulDiv(iPtSz, dpi, WinUtil::defDPI);
-    lf.lfHeight = scaledPtSize;
+    lf.lfHeight = iPtSz;
     m_pPasswordFont->CreatePointFontIndirect(&lf);
   }
 }
@@ -339,16 +303,8 @@ void Fonts::ApplyPasswordFont(CWnd *pDlgItem)
 
   if (m_pPasswordFont == nullptr) {
     m_pPasswordFont = new CFont;
-    
-    // Use WinUtil::GetDPI() with the window handle for per-window DPI
-    UINT dpi = WinUtil::GetDPI(pDlgItem->GetSafeHwnd());
-    
-    // Create a scaled LOGFONT
-    LOGFONT lf = dfltPasswordLogfont;
-    lf.lfHeight = MulDiv(lf.lfHeight, dpi, WinUtil::defDPI);
-    
     // Initialize a CFont object with the DPI-aware characteristics
-    m_pPasswordFont->CreateFontIndirect(&lf);
+    m_pPasswordFont->CreateFontIndirect(&dfltPasswordLogfont);
   }
 
   pDlgItem->SetFont(m_pPasswordFont);
@@ -375,19 +331,11 @@ void Fonts::SetNotesFont(LOGFONT *pLF, const int iPtSz)
     m_pNotesFont->DeleteObject();
   }
 
-  LOGFONT lf(*pLF);
-  UINT dpi = WinUtil::GetDPI();
-
   if (iPtSz == 0) {
-    // Scale the font height based on DPI
-    lf.lfHeight = MulDiv(lf.lfHeight, dpi, WinUtil::defDPI);
-    
-    m_pNotesFont->CreateFontIndirect(&lf);
+    m_pNotesFont->CreateFontIndirect(pLF);
   } else {
-    
-    // Scale the point size based on DPI
-    int scaledPtSize = MulDiv(iPtSz, dpi, WinUtil::defDPI);
-    lf.lfHeight = scaledPtSize;
+    LOGFONT lf(*pLF);
+    lf.lfHeight = iPtSz;
     m_pNotesFont->CreatePointFontIndirect(&lf);
   }
 }


### PR DESCRIPTION
## Summary

This fixes runaway font growth in the Windows/MFC UI when running on high-DPI displays, especially at 200% scaling.

The visible symptom is that the tree/list font and password-entry font can become enormous, to the point where normal 10-12 point UI text is rendered at something closer to poster size. The issue is easiest to trigger on high-DPI systems because the existing scaling bug compounds much faster there, but the underlying problem is in the font setup code rather than in the user's display configuration.

## Root Cause

The Windows UI font setup flows through the `Fonts` singleton in `src/ui/Windows/Fonts.cpp`. The default font `LOGFONT` values are stored as static globals, for example:

- `dfltPasswordLogfont`
- `dfltTreeListFont`
- `dfltAddEditLogfont`
- `dfltNotesLogfont`
- `DragFixLogfont`

Those defaults are adjusted for DPI by `tweakFontSizes()`. The bug is that `tweakFontSizes()` was being called from `Fonts::GetInstance()` every time `GetInstance()` was invoked, and it mutates the static `LOGFONT::lfHeight` values in place.

At 200% DPI, that means a default height such as `-13` can become `-26`, then `-52`, then `-104`, and so on as the singleton is requested repeatedly during normal UI initialization and redraw paths. The singleton object itself is only created once, but the static defaults were still being repeatedly modified before returning the existing singleton.

That repeated mutation is enough to explain the enormous tree/list text and also why password-entry fields are affected: both paths use the same `Fonts` singleton and default font state.

There was a second related issue in the same area. The font setters were pre-scaling point sizes before passing them to `CFont::CreatePointFontIndirect()`. MFC's `CreatePointFontIndirect()` expects `lfHeight` to contain the point size in tenths of a point and then performs the point-to-device conversion internally. Pre-scaling those values by DPI before calling `CreatePointFontIndirect()` makes point-size based fonts too large, especially on high-DPI displays.

## What Changed

This PR keeps the fix deliberately narrow and contained to `src/ui/Windows/Fonts.cpp`.

1. `tweakFontSizes()` is now guarded so it can only adjust the static default `LOGFONT` values once.

   This preserves the existing intent of making the built-in defaults DPI-aware, while preventing repeated calls to `Fonts::GetInstance()` from compounding the default heights.

2. `Fonts::GetInstance()` now calls `tweakFontSizes()` only when the singleton is actually being initialized.

   This restores the earlier singleton behavior and avoids mutating shared default font state during routine access.

3. The `CreatePointFontIndirect()` paths no longer pre-scale `iPtSz` by DPI.

   The setters now place the stored point size directly into `lf.lfHeight`, matching the API contract expected by MFC.

4. The `CreateFontIndirect()` paths no longer make a local copy solely to apply another DPI multiplier.

   The relevant `LOGFONT` data is passed through directly. This avoids applying additional scaling on top of defaults or stored font preferences that are already represented in `LOGFONT` units.

## Validation

Validated locally on Windows 11 with the generated CMake Visual Studio project:

```text
MSBuild _build\pwsafe.vcxproj /p:Configuration=Debug /p:Platform=x64
```

The Debug x64 build completed successfully and produced:

```text
_build\Debug\pwsafe.exe
```

Finally, ran the resulting executable and got the expected font size, matching the rest of the application and system.

## Pics or it did not happen


Before:

<img width="723" height="777" alt="pwsafe-before" src="https://github.com/user-attachments/assets/00bef824-d3e0-4838-90c2-009a1dfdf0d6" />


After:

<img width="588" height="330" alt="pwsafe-after" src="https://github.com/user-attachments/assets/0e45c420-a8c2-4f8c-b1c6-5e8a92de7981" />

