### PR TITLE
Fix main window position restore scaling

### DIFF
--- a/src/ui/Windows/DboxMain.cpp
+++ b/src/ui/Windows/DboxMain.cpp
@@ -3811,19 +3811,10 @@ void DboxMain::PlaceWindow(CWnd *pWnd, CRect *pRect, UINT uiShowCmd)
   WINDOWPLACEMENT wp = {sizeof(WINDOWPLACEMENT)};
   HRGN hrgnWork = WinUtil::GetWorkAreaRegion();
 
-  auto curDPI = WinUtil::GetDPI(nullptr); // need system value
-
-  // adjust rect for current scale factor
-  CRect adjRect;
-  adjRect.bottom = MulDiv(pRect->bottom, curDPI, WinUtil::defDPI);
-  adjRect.top =    MulDiv(pRect->top, curDPI, WinUtil::defDPI);
-  adjRect.left =   MulDiv(pRect->left, curDPI, WinUtil::defDPI);
-  adjRect.right =  MulDiv(pRect->right, curDPI, WinUtil::defDPI);
-
   pWnd->GetWindowPlacement(&wp);  // Get min/max positions - then add what we know
   wp.flags = 0;
   wp.showCmd = uiShowCmd;
-  wp.rcNormalPosition = adjRect;
+  wp.rcNormalPosition = *pRect;
 
   if (!RectInRegion(hrgnWork, &wp.rcNormalPosition)) {
     if (GetSystemMetrics(SM_CMONITORS) > 1)


### PR DESCRIPTION
## Summary

Fixes #1092 - reports complaining about the window drifting down and right.

This removes the restore-time DPI scaling from the Windows main-window placement path.

The main window already saves its position and size from `GetWindowRect()`, which returns the actual window rectangle in screen coordinates. For a per-monitor-DPI-aware window, those coordinates are already in physical pixels for the current display. Feeding that saved rectangle back into `SetWindowPlacement()` should therefore use the same coordinates directly.

## Root Cause

`DboxMain::PlaceWindow()` was scaling the saved rectangle by the current DPI before assigning it to `WINDOWPLACEMENT::rcNormalPosition`.

At 200% display scaling, that means a rectangle saved as physical pixels is multiplied by 2 when restored. Once the restored larger rectangle is saved again, the next launch multiplies that already-scaled rectangle again. The visible result is that the main window drifts down and right and grows larger on every restart, with the error matching the display scale factor.

The save side uses `GetWindowRect()` in the normal move/resize paths, so the preference values are not 96-DPI logical coordinates. The restore side should not reinterpret them as if they were.

## What Changed

`PlaceWindow()` now assigns the saved rectangle directly:

```cpp
wp.rcNormalPosition = *pRect;
```

The previous `WinUtil::GetDPI()` / `MulDiv()` adjustment block was removed.

This keeps the save/restore contract simple and symmetric: save the actual window rectangle, restore that same rectangle.

## Validation

Built and tested on Windows 11 with the Debug build at 200% DPI. Also tested at 100% to ensure consistent behavior.

## Pics or it did not happen

(For the avoidance of doubt, these screenshots represent the pre-patch state of the code, post-patch the positions are identical.)


Before exiting the app:

<img width="3840" height="2160" alt="pwsafe-saveposition" src="https://github.com/user-attachments/assets/3772c163-70ed-4103-8239-b147a69b79b6" />


After reopening the app:

<img width="3840" height="2160" alt="pwsafe-restoreposition" src="https://github.com/user-attachments/assets/f88a37f0-5561-4236-8a93-f99b778945bf" />
