### PR TITLE
[wx] Implement the Browse + AutoType feature

### DIFF
--- a/help/default_wx/html/entering_pwd.html
+++ b/help/default_wx/html/entering_pwd.html
@@ -70,9 +70,7 @@ in read-only mode, then it can be viewed without any truncation.</p>
 <li><b>URL</b>: The URL associated with the entry. If this field is not empty, then the "Go" button
 is enabled. If the protocol is not specified, then "http://" is assumed
 (e.g., "www.foo.net" is the same as "http://www.foo.net"). Clicking on the <b>Go</b> button to the right
-of the <b>URL</b> field will open the default browser on the specified URL. Clicking with the Control key
-pressed (Ctrl+Click) will, in addition, invoke the <a href="autotype.html">AutoType</a>
-function on the opened browser page. See the <a href="#URL_details">following notes</a>
+of the <b>URL</b> field will open the default browser on the specified URL. See the <a href="#URL_details">following notes</a>
 for more information.</li>
 <li><b>email</b>: The email address associated with this entry. Note
 that this is meant for keeping an e-mail address associated with the
@@ -105,13 +103,8 @@ configure an alternate browser, use the
 no protocol is specified. This is useful if the alternate browser is a
 remote access application, e.g., an SSH client. [ssh] will achieve the
 same effect.</li>
-
-<li>If '[autotype]' is found before the URL, then after the
-URL has been displayed/actioned, <b>Password Safe</b> then performs the AutoType
-action using this entry's AutoType field, or the default value if not
-specified.</li>
-
 </ul>
+
 <a name="email_details"></a>
 <b>The email address is according to the standard rules (per RFC 2368):</b>
 <ul>

--- a/help/default_wx/html/misc_tab.html
+++ b/help/default_wx/html/misc_tab.html
@@ -63,9 +63,9 @@ password to the clipboard. &nbsp;The available actions are:</p>
 <li>Copy password to clipboard</li>
 <li>Copy password to clipboard, minimize</li>
 <li>Copy username to clipboard</li>
+<li>Edit/View selected entry</li>
 <li>Run Command</li>
 <li>Send email</li>
-<li>Edit/View selected entry</li>
 </ul>
 <p>Note that last item, copy password and then minimize, won't work as
 expected if the "Clear clipboard on minimize" option is selected in the
@@ -93,13 +93,12 @@ default. Of course, you can edit it if needed.<br></p>
 
 <h3><a name="AltBrowser"></a>Alternate Browser</h3>
 
-<p>The browser you specify in this field &nbsp;will be used when using the
-"Browse To URL" function for a selected entry, when the entry's URL has
-"[alt]" before the URL, e.g., "[alt]http://www.foo.net". This is
-useful, for example, if your default browser is Firefox, and you wish
-to access a website that works best with Google Chrome, in which case you
-should specify the Google Chrome as your alternate browser (typically
-"/usr/bin/google-chrome" on Linux).</p>
+<p>The browser you specify in this field will be used when using the
+"Browse To URL" and "Browse To URL + Autotype" functions for a selected entry, when the entry's URL has
+"[alt]" before the URL, e.g., "[alt]http://www.foo.net". This is useful, for example, 
+if your default browser is Firefox, and you wish to access a website that works best with Google Chrome. 
+Or, on Linux with Wayland, you may specify a startup sequence that enables the Xwayland backend for the default browser, 
+allowing Autotype to work (such as "env MOZ_ENABLE_WAYLAND=0 firefox" for Firefox).</p>
 
 
 <p>You can specify command line options to the browser via the Browser

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -2030,11 +2030,7 @@ void AddEditPropSheetDlg::ItemFieldsToPropSheet()
 void AddEditPropSheetDlg::OnGoButtonClick(wxCommandEvent& WXUNUSED(evt))
 {
   if (Validate() && TransferDataFromWindow() && !m_Url.IsEmpty()) {
-    std::vector<size_t> vactionverboffsets;
-    const StringX sxAutotype = PWSAuxParse::GetAutoTypeString(m_Item, m_Core, vactionverboffsets);
-    bool bDoAutotype = !sxAutotype.empty();
-
-    GetPwSafe()->LaunchBrowser(m_Url, sxAutotype, vactionverboffsets, bDoAutotype);
+    GetPwSafe()->LaunchBrowser(m_Url);
   }
 }
   

--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -948,24 +948,21 @@ void PasswordSafeFrame::DoBrowse(CItemData &item, bool bAutotype)
 
   if (!cs_command.IsEmpty()) {
     std::vector<size_t> vactionverboffsets;
-    StringX sxautotype = PWSAuxParse::GetAutoTypeString(*pci, m_core,
-                                                        vactionverboffsets);
-    LaunchBrowser(cs_command, sxautotype, vactionverboffsets, bAutotype);
-
+    StringX sxautotype = PWSAuxParse::GetAutoTypeString(*pci, m_core, vactionverboffsets);
+    if (LaunchBrowser(cs_command)) {
+      if (bAutotype && !sxautotype.empty()) {
+        DoAutotype(*pci);
+      }
+    }
     if (PWSprefs::GetInstance()->GetPref(PWSprefs::CopyPasswordWhenBrowseToURL)) {
       Clipboard::GetInstance()->SetData(sx_pswd);
       UpdateLastClipboardAction(CItemData::FieldType::PASSWORD);
     }
-
-    // TODO: Minimize depending on PWSprefs::MinimizeOnAutotype
-
     UpdateAccessTime(item);
   }
 }
 
-bool PasswordSafeFrame::LaunchBrowser(const wxString &csURL, const StringX & WXUNUSED(sxAutotype),
-                             const std::vector<size_t> & WXUNUSED(vactionverboffsets),
-                             bool WXUNUSED(bDoAutotype)) const
+bool PasswordSafeFrame::LaunchBrowser(const wxString &csURL) const
 {
   /*
    * This is a straight port of DBoxMain::LaunchBrowser.  See the comments in that function
@@ -980,10 +977,6 @@ bool PasswordSafeFrame::LaunchBrowser(const wxString &csURL, const StringX & WXU
   const size_t altReplacements = theURL.Replace(wxT("[alt]"), wxEmptyString);
   const size_t alt2Replacements = (theURL.Replace(wxT("[ssh]"), wxEmptyString) +
                           theURL.Replace(wxT("{alt}"), wxEmptyString));
-#ifdef NOT_YET
-  const size_t autotypeReplacements = theURL.Replace(wxT("[autotype]"), wxEmptyString);
-  const size_t no_autotype = theURL.Replace(wxT("[xa]"), wxEmptyString);
-#endif
 
   if (alt2Replacements == 0 && !isMailto && theURL.Find(wxT("://")) == wxNOT_FOUND)
     theURL = wxT("http://") + theURL;
@@ -1008,26 +1001,6 @@ bool PasswordSafeFrame::LaunchBrowser(const wxString &csURL, const StringX & WXU
 
   sxFile.Trim(false); //false => from left
 
-#ifdef NOT_YET
-  // Obey user's No Autotype flag [xa]
-  if (no_autotype > 0) {
-    m_bDoAutoType = false;
-    m_AutoType.clear();
-    m_vactionverboffsets.clear();
-  }
-  else {
-    // Either do it because they pressed the right menu/shortcut
-    // or they had specified Do Autotype flag [autotype]
-    m_bDoAutoType = bDoAutotype || autotypeReplacements > 0;
-    m_AutoType = m_bDoAutoType ? sxAutotype : wxEmptyString;
-    if (m_bDoAutoType)
-      m_vactionverboffsets = vactionverboffsets;
-  }
-#endif
-
-#ifdef NOT_YET
-  bool rc = m_runner.issuecmd(sxFile, sxParameters, !m_AutoType.empty());
-#else
   bool rc;
   if (useAltBrowser) {
     const wxString cmdLine(sxFile + wxT(" ") + sxParameters);
@@ -1036,7 +1009,6 @@ bool PasswordSafeFrame::LaunchBrowser(const wxString &csURL, const StringX & WXU
   else {
     rc= ::wxLaunchDefaultBrowser(sxFile);
   }
-#endif
 
   if (!rc) {
     wxMessageBox(errMsg, wxTheApp->GetAppName(), wxOK|wxICON_STOP, const_cast<PasswordSafeFrame*>(this));
@@ -1085,7 +1057,7 @@ void PasswordSafeFrame::DoRun(CItemData& item)
   // if no autotype value in run command's $a(value), start with item's (bug #1078) or the default AutoType string
   StringX sx_dats = PWSprefs::GetInstance()->GetPref(PWSprefs::DefaultAutotypeString);
   if (sx_dats.empty())
-   sx_dats = DEFAULT_AUTOTYPE;
+    sx_dats = DEFAULT_AUTOTYPE;
   if (expandedAutoType.empty()) {
     if (!pci->GetAutoType().empty())
       expandedAutoType = pci->GetAutoType();

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -645,6 +645,7 @@ void PasswordSafeFrame::CreateMenubar()
   menuEdit->Append(ID_COPYNOTESFLD, _("Copy &Notes to Clipboard\tCtrl+G"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_COPYURL, _("Copy URL to Clipboard\tCtrl+Alt+L"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_BROWSEURL, _("&Browse to URL\tCtrl+L"), wxEmptyString, wxITEM_NORMAL);
+  menuEdit->Append(ID_BROWSEURLPLUS, _("Browse to URL + &Autotype"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_SENDEMAIL, _("Send &email"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_RUNCOMMAND, _("&Run Command"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_AUTOTYPE, _("Perform Auto&type\tCtrl+T"), wxEmptyString, wxITEM_NORMAL);

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -667,8 +667,7 @@ public:
   wxTopLevelWindow* GetTopWindow() const;
   static void DisplayFileWriteError(int rc, const StringX &fname);
   
-  bool LaunchBrowser(const wxString &csURL, const StringX &sxAutotype,
-    const std::vector<size_t> &vactionverboffsets, bool bDoAutotype) const;
+  bool LaunchBrowser(const wxString &csURL) const;
 
 
 ////@begin PasswordSafeFrame member variables


### PR DESCRIPTION
Issue: In the wx version, this feature is not yet implemented (#ifdef NOT_YET in the code).

Tested on macOS, BSD (with both X11 and Wayland) and Linux (with both X11 and Wayland, using both native and Flatpak versions).

Test scenarios:
1. Native version on macOS, local build on BSD, or native/Flatpak version on Linux with X11:
1.1 Default browser not running
https://URL is the entry's url
The Browse + Autotype command starts the default browser and performs AutoType (using either the entry's Autotype string such as "\W5\t\t\t\u\t\p\n" or the default one specified in Options > Misc).
[alt]https://URL is the entry's url
The Browse + Autotype command starts the alternate browser and performs AutoType.
Note: This does not work with the Flatpak version due to sandboxing restrictions, unless the Flatpak is built with permission to communicate with org.freedesktop.Flatpak (e.g., Alternate browser: flatpak-spawn --host google-chrome).

2. Native version on Linux with Wayland or local build on FreeBSD with Wayland:
2.1 Start Firefox manually with Xwayland enabled: "env MOZ_ENABLE_WAYLAND=0 firefox" ("env MOZ_ENABLE_WAYLAND=0 DISABLE_WAYLAND=1 firefox" for the Snap version)
https://URL is the entry's url
The Browse + Autotype command opens a new tab in Firefox and performs AutoType.
2.2 Firefox not running
[alt]https://URL is the entry's url
Specify Alternate Browser in Options > Misc: env MOZ_ENABLE_WAYLAND=0 firefox
The Browse + Autotype command starts Firefox with Xwayland enabled and performs AutoType.

3. Flatpak version on Linux with Wayland:
3.1 Start Firefox manually with Xwayland enabled: env MOZ_ENABLE_WAYLAND=0 firefox
https://URL is the entry's url
Start Password Safe with Xwayland enabled: flatpak --nosocket=wayland --socket=x11 run org.pwsafe.pwsafe
The Browse + Autotype command opens a new tab in Firefox and performs AutoType.
[alt]https://URL is the entry's url
The Browse + Autotype command starts the alternate browser and performs AutoType.
Note: This only works if the Flatpak is built with permission to communicate with org.freedesktop.Flatpak (e.g., Alternate browser: flatpak-spawn --host google-chrome --ozone-platform=x11).

New: Implemented the "Browse to URL + Autotype" feature.
New: Added the "Browse to URL + Autotype" menu item to Edit menu (it was already in the context menu).
Change: Removed the code that would perform AutoType on the opened browser page when using the Go button in the Add/Edit dialog. Since "Browse to URL + AutoType" was not previously implemented, this behavior was undocumented, and the expected default action should be "Browse to URL" without AutoType. This is now covered by the dedicated "Browse to URL + AutoType" feature.
Change: Removed the note in English Help stating that Ctrl+Click on the Go button in Add/Edit dialog will invoke the AutoType function on the opened browser page - this is a Windows specific feature (entering_pwd.html).
Change: Updated the notes in English Help on using Alternate Browser with Autotype (misc_tab.html).

