### PR TITLE
Refine custom field specs

### DIFF
--- a/docs/formatV3.txt
+++ b/docs/formatV3.txt
@@ -672,8 +672,8 @@ These parameters were introduced in version 0x0310 (PasswordSafe V3.69).
 [32] Custom fields consist of property entries stored in the following format:
     PLVPLV...PLV S PLVPLV...PLV ... S PLVPLV...PLV
 where:
-    P = 2 hexadecimal digits indicating property ID; P = 00 is not allowed
-    L = 4 hexadecimal digits value length in bytes
+    P = 2 lowercase hexadecimal digits indicating property ID; P = 00 is not allowed
+    L = 4 lowercase hexadecimal digits value length in bytes
     V = value of the property whose interpretation depends on the P; content
         must be a valid UTF-8
     S = 6 hexadecimal digits 000000 that serve as a separator between different
@@ -704,7 +704,7 @@ For example, to encode the following custom fields:
 * WiFi SSID: Test
 * WiFi Password: bobsyouruncle (sensitive field)
 One would use
-    010009WiFi SSID020004Test00000001000DWiFi Password02000Dbobsyouruncle0300011
+    010009WiFi SSID020004Test00000001000dWiFi Password02000dbobsyouruncle0300011
 
 This field was introduced in format version 0x0311
 

--- a/docs/formatV4.txt
+++ b/docs/formatV4.txt
@@ -661,8 +661,8 @@ These parameters were introduced in version 0x0401 (PasswordSafe V3.69).
 [32] Custom fields consist of property entries stored in the following format:
     PLVPLV...PLV S PLVPLV...PLV ... S PLVPLV...PLV
 where:
-    P = 2 hexadecimal digits indicating property ID; P = 00 is not allowed
-    L = 4 hexadecimal digits value length in bytes
+    P = 2 lowercase hexadecimal digits indicating property ID; P = 00 is not allowed
+    L = 4 lowercase hexadecimal digits value length in bytes
     V = value of the property whose interpretation depends on the P; content
         must be a valid UTF-8
     S = 6 hexadecimal digits 000000 that serve as a separator between different
@@ -693,7 +693,7 @@ For example, to encode the following custom fields:
 * WiFi SSID: Test
 * WiFi Password: bobsyouruncle (sensitive field)
 One would use
-    010009WiFi SSID020004Test00000001000DWiFi Password02000Dbobsyouruncle0300011
+    010009WiFi SSID020004Test00000001000dWiFi Password02000dbobsyouruncle0300011
 
 This field was introduced in format version 0x0402
 


### PR DESCRIPTION
Clarify that hexadecimal representation is lowercase (0-9a-f), adjust example accordingly.

Resolves #1780