### PR TITLE
issues found by clang static analyzer

### DIFF
--- a/src/test/TOTPTest.cpp
+++ b/src/test/TOTPTest.cpp
@@ -79,12 +79,12 @@ TEST(TOTPTest, key_decoder_copy_move_cleanup)
 
   const unsigned char* dec_ptr = dec.get_ptr();
   RFC4648_Base32Decoder dec3(std::move(dec));
-  EXPECT_TRUE(dec.get_size() == 0);
-  EXPECT_TRUE(dec.get_ptr() == nullptr);
-  EXPECT_TRUE(dec_ptr != dec.get_ptr());
+  //EXPECT_TRUE(dec.get_size() == 0);
+  //EXPECT_TRUE(dec.get_ptr() == nullptr);
+  //EXPECT_TRUE(dec_ptr != dec.get_ptr());
   EXPECT_TRUE(dec_ptr == dec3.get_ptr());
   EXPECT_TRUE(dec3.is_decoding_successful());
-  EXPECT_TRUE(!dec.is_decoding_successful());
+  //EXPECT_TRUE(!dec.is_decoding_successful());
   EXPECT_TRUE(dec3.get_bytes() == dec2.get_bytes());
   EXPECT_TRUE(dec3.get_size() != 0);
   EXPECT_TRUE(dec2.get_size() == dec2.get_size());
@@ -106,13 +106,13 @@ TEST(TOTPTest, key_decoder_copy_move_cleanup)
 
   const unsigned char* dec2_ptr = dec2.get_ptr();
   dec3 = std::move(dec2);
-  EXPECT_TRUE(dec2.get_size() == 0);
-  EXPECT_TRUE(dec2.get_ptr() == nullptr);
-  EXPECT_TRUE(!dec2.is_decoding_successful());
-  EXPECT_TRUE(dec2.get_ptr() != dec2_ptr);
+  //EXPECT_TRUE(dec2.get_size() == 0);
+  //EXPECT_TRUE(dec2.get_ptr() == nullptr);
+  //EXPECT_TRUE(!dec2.is_decoding_successful());
+  //EXPECT_TRUE(dec2.get_ptr() != dec2_ptr);
   EXPECT_TRUE(dec3.get_ptr() == dec2_ptr);
   EXPECT_TRUE(dec3.is_decoding_successful());
-  EXPECT_TRUE(dec3.get_bytes() != dec2.get_bytes());
+  //EXPECT_TRUE(dec3.get_bytes() != dec2.get_bytes());
   EXPECT_TRUE(dec3.get_bytes() != dec4.get_bytes());
 }
 

--- a/src/test/TOTPTest.cpp
+++ b/src/test/TOTPTest.cpp
@@ -79,12 +79,8 @@ TEST(TOTPTest, key_decoder_copy_move_cleanup)
 
   const unsigned char* dec_ptr = dec.get_ptr();
   RFC4648_Base32Decoder dec3(std::move(dec));
-  //EXPECT_TRUE(dec.get_size() == 0);
-  //EXPECT_TRUE(dec.get_ptr() == nullptr);
-  //EXPECT_TRUE(dec_ptr != dec.get_ptr());
   EXPECT_TRUE(dec_ptr == dec3.get_ptr());
   EXPECT_TRUE(dec3.is_decoding_successful());
-  //EXPECT_TRUE(!dec.is_decoding_successful());
   EXPECT_TRUE(dec3.get_bytes() == dec2.get_bytes());
   EXPECT_TRUE(dec3.get_size() != 0);
   EXPECT_TRUE(dec2.get_size() == dec2.get_size());
@@ -106,13 +102,8 @@ TEST(TOTPTest, key_decoder_copy_move_cleanup)
 
   const unsigned char* dec2_ptr = dec2.get_ptr();
   dec3 = std::move(dec2);
-  //EXPECT_TRUE(dec2.get_size() == 0);
-  //EXPECT_TRUE(dec2.get_ptr() == nullptr);
-  //EXPECT_TRUE(!dec2.is_decoding_successful());
-  //EXPECT_TRUE(dec2.get_ptr() != dec2_ptr);
   EXPECT_TRUE(dec3.get_ptr() == dec2_ptr);
   EXPECT_TRUE(dec3.is_decoding_successful());
-  //EXPECT_TRUE(dec3.get_bytes() != dec2.get_bytes());
   EXPECT_TRUE(dec3.get_bytes() != dec4.get_bytes());
 }
 

--- a/src/ui/wxWidgets/PWFiltersStringDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersStringDlg.cpp
@@ -320,7 +320,7 @@ void pwFiltersStringDlg::OnSelectionChange(wxCommandEvent& WXUNUSED(event))
       m_CheckBoxFCase->Disable();
     }
     else {
-      if(m_TextCtrlValueString && m_TextCtrlValueString->GetLineLength(0)) {
+      if(m_TextCtrlValueString->GetLineLength(0)) {
         FindWindow(wxID_OK)->Enable();
       }
       else {
@@ -331,7 +331,7 @@ void pwFiltersStringDlg::OnSelectionChange(wxCommandEvent& WXUNUSED(event))
     }
   }
   else {
-    if(m_TextCtrlValueString && m_TextCtrlValueString->GetLineLength(0)) {
+    if(m_TextCtrlValueString->GetLineLength(0)) {
       FindWindow(wxID_OK)->Enable();
     }
     else {
@@ -349,7 +349,7 @@ void pwFiltersStringDlg::OnTextChange(wxCommandEvent& WXUNUSED(event))
   if (!m_controlsReady) {
     return;
   }
-  if(m_TextCtrlValueString && m_TextCtrlValueString->GetLineLength(0)) {
+  if(m_TextCtrlValueString->GetLineLength(0)) {
     FindWindow(wxID_OK)->Enable();
   }
   else {

--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -339,7 +339,8 @@ void TreeCtrl::UpdateGUI(UpdateGUICommand::GUI_Action ga, const pws_os::CUUID &e
   }
   else if (ga == UpdateGUICommand::GUI_ADD_ENTRY ||
            ga == UpdateGUICommand::GUI_REFRESH_ENTRYFIELD ||
-           ga == UpdateGUICommand::GUI_REFRESH_ENTRYPASSWORD) {
+           ga == UpdateGUICommand::GUI_REFRESH_ENTRYPASSWORD ||
+           ga == UpdateGUICommand::GUI_REFRESH_ENTRY) {
     pws_os::Trace(wxT("TreeCtrl - Couldn't find uuid %ls"), StringX(CUUID(entry_uuid)).c_str());
     return;
   }


### PR DESCRIPTION
src/test/TOTPTest.cpp referenced objects after std::move().

src/ui/wxWidgets/PWFiltersStringDlg.cpp had unnecessary tests for null m_TextCtrlValueString which is initialized in the constructor.

src/ui/wxWidgets/TreeCtrl.cpp did not protect GUI_REFRESH_ENTRY from a null pointer dereference.