### PR TITLE
consistent bold links between .md doc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ https://pwsafe.org
 Release Notes
 =============
 For information on the latest features, bugfixes and known problems,
-see [ReleaseNotes.md](docs/ReleaseNotes.md) for the Windows version and 
-[ReleaseNotesWX.md](docs/ReleaseNotesWX.md) for the Linux and Mac versions.
+see [**ReleaseNotes.md**](docs/ReleaseNotes.md) for the Windows version and
+[**ReleaseNotesWX.md**](docs/ReleaseNotesWX.md) for the Linux and Mac versions.
 
 Credits
 =======

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,5 +1,5 @@
 This note describes the new features, fixed bugs and known problems with the latest versions of Password Safe. For a short description of
-Password Safe, please see the accompanying README.md file. For more information on the product and the project, please visit
+Password Safe, please see the accompanying [**README.md**](../README.md) file. For more information on the product and the project, please visit
 https://pwsafe.org/. Details about changes to older releases may be found in the file ChangeLog.txt.
 
 In the following, SFxxxx refers to Bug Reports, Feature Requests and Service Requests in PasswordSafe SourceForge Project tickets, and GHxxxx refers to issues in the PasswordSafe GitHub project.

--- a/docs/ReleaseNotesWX.md
+++ b/docs/ReleaseNotesWX.md
@@ -1,8 +1,8 @@
 This note describes the new features, fixed bugs and known problems that are specific to versions of *Password Safe* for Mac and Linux. 
-For the Windows version, and all common changes, please see **ReleaseNotes.md**.
+For the Windows version, and all common changes, please see [**ReleaseNotes.md**](ReleaseNotes.md).
 
 For a short description of
-Password Safe, please see the accompanying **README.md** file. For more information on the product and the project, please visit
+Password Safe, please see the accompanying [**README.md**](../README.md) file. For more information on the product and the project, please visit
 https://pwsafe.org/. Details about changes to older releases may be found in the file ChangeLog.txt.
 
 In the following, SFxxxx refers to Bug Reports, Feature Requests and Service Requests in PasswordSafe SourceForge Project tickets, and GHxxxx refers to issues in the PasswordSafe GitHub project.


### PR DESCRIPTION
The three primary .md doc files have references between them. This changes those references to consistent bold links.