### PR TITLE
Parse "Build" string correctly for minidump installer

### DIFF
--- a/src/ui/Windows/ThisMfcApp.cpp
+++ b/src/ui/Windows/ThisMfcApp.cpp
@@ -103,7 +103,7 @@ ThisMfcApp::ThisMfcApp() :
 
   CString csFileVersionString, csRevision(L"");
   csFileVersionString = GetFileVersionString();
-  int revIndex = csFileVersionString.ReverseFind(L',');
+  int revIndex = csFileVersionString.ReverseFind(L'/');
   if (revIndex >= 0) {
     int len = csFileVersionString.GetLength();
     csRevision = csFileVersionString.Right(len - revIndex - 1);


### PR DESCRIPTION
This resolves an issue with the build not being displayed in the minidump dialog box title, as reported in [SF1627](https://sourceforge.net/p/passwordsafe/bugs/1627)