### PR TITLE
[wx] Change layout of custom fields dialog

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -61,6 +61,7 @@ public:
     auto *mainSizer = new wxBoxSizer(wxVERTICAL);
     auto *gridSizer = new wxFlexGridSizer(5, 1, 5, 5);
     gridSizer->AddGrowableCol(0);
+    gridSizer->AddGrowableRow(3); // multi-line text input field for the value
 
     gridSizer->Add(new wxStaticText(this, wxID_ANY, _("Name")), 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxBOTTOM, 0);
     m_NameCtrl = new wxTextCtrl(this, wxID_ANY);

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -59,23 +59,34 @@ public:
       m_OriginalName(field != nullptr ? towxstring(field->GetName()) : wxString())
   {
     auto *mainSizer = new wxBoxSizer(wxVERTICAL);
-    auto *gridSizer = new wxFlexGridSizer(2, 2, 8, 8);
-    gridSizer->AddGrowableCol(1);
+    auto *gridSizer = new wxFlexGridSizer(5, 1, 5, 5);
+    gridSizer->AddGrowableCol(0);
 
-    gridSizer->Add(new wxStaticText(this, wxID_ANY, _("Name")), 0, wxALIGN_CENTER_VERTICAL);
+    gridSizer->Add(new wxStaticText(this, wxID_ANY, _("Name")), 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxBOTTOM, 0);
     m_NameCtrl = new wxTextCtrl(this, wxID_ANY);
-    gridSizer->Add(m_NameCtrl, 1, wxEXPAND);
+    gridSizer->Add(m_NameCtrl, 1, wxALIGN_LEFT|wxBOTTOM|wxEXPAND, 7);
 
-    gridSizer->Add(new wxStaticText(this, wxID_ANY, _("Value")), 0, wxALIGN_TOP);
+    gridSizer->Add(new wxStaticText(this, wxID_ANY, _("Value")), 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxBOTTOM, 0);
     m_ValueCtrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(320, 120), wxTE_MULTILINE);
-    gridSizer->Add(m_ValueCtrl, 1, wxEXPAND);
-
-    mainSizer->Add(gridSizer, 1, wxEXPAND | wxALL, 12);
+    gridSizer->Add(m_ValueCtrl, 1, wxALIGN_LEFT|wxBOTTOM|wxEXPAND, 7);
 
     m_SensitiveCtrl = new wxCheckBox(this, wxID_ANY, _("Sensitive"));
-    mainSizer->Add(m_SensitiveCtrl, 0, wxLEFT | wxRIGHT | wxBOTTOM, 12);
+    gridSizer->Add(m_SensitiveCtrl, 0, wxALIGN_LEFT|wxBOTTOM, 7);
 
-    mainSizer->Add(CreateSeparatedButtonSizer(wxOK | wxCANCEL), 0, wxEXPAND | wxALL, 12);
+    mainSizer->Add(gridSizer, 1, wxEXPAND|wxALL, 12);
+
+    auto *stdDialogButtonSizer = new wxStdDialogButtonSizer;
+
+    mainSizer->Add(stdDialogButtonSizer, 0, wxEXPAND|wxBOTTOM, 12);
+    auto *confirmationButton = new wxButton(this, wxID_OK, field == nullptr ? _("&Add") : _("&Ok"));
+    confirmationButton->SetDefault();
+    stdDialogButtonSizer->AddButton(confirmationButton);
+
+    auto *cancelButton = new wxButton(this, wxID_CANCEL);
+    stdDialogButtonSizer->AddButton(cancelButton);
+
+    stdDialogButtonSizer->Realize();
+
     SetSizerAndFit(mainSizer);
 
     if (field != nullptr) {


### PR DESCRIPTION
This PR proposes changes to the layout of the custom fields dialog, in accordance with my review comment in #1746.

The dialog for adding/editing custom fields, as it currently appears:

<img width="389" height="317" alt="CustomFieldDlg_master" src="https://github.com/user-attachments/assets/d3e3e6e9-f2cb-4794-9d78-e5308b467881" />


The changes introduced by this PR to align the layout with other dialogs of this type:

<img width="344" height="344" alt="CustomFieldDlg_add" src="https://github.com/user-attachments/assets/cecdeebf-5310-4154-9dfb-06bc960b7007" />

<img width="344" height="344" alt="CustomFieldDlg_edit" src="https://github.com/user-attachments/assets/70417594-2699-4fa3-844b-54a9d86be569" />
