### PR TITLE
[wx] Tweaks for the Flatpak version

### DIFF
--- a/src/ui/wxWidgets/AboutDlg.cpp
+++ b/src/ui/wxWidgets/AboutDlg.cpp
@@ -123,6 +123,9 @@ void AboutDlg::CreateControls()
   rightSizer->Add(verCheckSizer, 0, wxALIGN_LEFT|wxALL, 0);
 
   wxGenericHyperlinkCtrl* latestCheckButton = new wxGenericHyperlinkCtrl(aboutDialog, ID_CHECKNEW, _("Check"), wxEmptyString, wxDefaultPosition, wxDefaultSize, wxHL_DEFAULT_STYLE);
+  if (IsRunningInFlatpak()) {
+    latestCheckButton->SetToolTip(_("Internet access required: Make sure to grant network access to the Flatpak application.\nThe '--share=network' permission is required for this check."));
+  }
   verCheckSizer->Add(latestCheckButton, 0, wxALIGN_CENTER_VERTICAL|wxTOP|wxBOTTOM|wxLEFT, 5);
 
   wxStaticText* latestStaticTextEnd = new wxStaticText(aboutDialog, wxID_STATIC, _(" for the latest version."), wxDefaultPosition, wxDefaultSize, 0);
@@ -540,7 +543,10 @@ void AboutDlg::CompareVersionData()
       wxString newer(_("Current version: "));
       newer << pwsafeVersionString << L"\n";
       newer << _("Latest version:\t") << latest.c_str() << L"\n\n";
-      newer << _("Visit the Password Safe website to download the latest version.");
+      if (IsRunningInFlatpak())
+        newer << _("Use the 'flatpak update' command or your system's software store application to update to the latest version.");
+      else
+        newer << _("Visit the Password Safe website to download the latest version.");
       const wxString cs_title(_("Newer Version Found!"));
       *m_VersionStatus << cs_title;
       wxMessageDialog dlg(this, newer, cs_title, wxOK);

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -396,7 +396,7 @@ bool IsRunningInFlatpak()
   wxGetEnv("FLATPAK_ID", &appID);
   wxGetEnv("HOME", &homeFolder);
   if (!appID.IsEmpty() && !homeFolder.IsEmpty()) {
-    return (wxDirExists(homeFolder + "/.var/app/" + appID)) ? true : false;
+    return wxDirExists(homeFolder + "/.var/app/" + appID);
   }
   else {
     return false;

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -342,13 +342,16 @@ bool IsXWaylandEnabled()
   wxOperatingSystemId osid = wxGetOsVersion();
 
   if (osid & wxOS_UNIX) { // Includes Linux
-    wxString GDK_BACKEND_VAR = wxEmptyString;
+    wxString GDK_BACKEND_VAR = wxEmptyString; // set by the native version on Linux with Wayland to fall back to using x11 backend
     if (wxGetEnv(wxT("GDK_BACKEND"), &GDK_BACKEND_VAR)) { // provides 'x11' or 'wayland'
       if (!GDK_BACKEND_VAR.IsEmpty()) {
         if (GDK_BACKEND_VAR == wxT("x11")) {
           XWayland = true;
         }
       }
+    }
+    else if (!wxGetEnv(wxT("WAYLAND_DISPLAY"), nullptr)) { // unset by the Flatpak version on Wayland when started with the "--nosocket=wayland --socket=x11" options
+      XWayland = true;
     }
   }
   return XWayland;
@@ -382,6 +385,24 @@ void wxUtilities::NotifyIfUnsupported(enum Feature feature, wxWindow* window)
   if (feature == SystemTray && !IsTaskBarIconAvailable()) {
     window->SetToolTip(_("Not supported by the current Windowing System (e.g. Wayland), or you may need to install a Desktop Environment extension to enable System Tray support."));
   }
+#endif
+}
+
+bool IsRunningInFlatpak()
+{
+#ifdef __WXGTK__
+  wxString appID;
+  wxString homeFolder;
+  wxGetEnv("FLATPAK_ID", &appID);
+  wxGetEnv("HOME", &homeFolder);
+  if (!appID.IsEmpty() && !homeFolder.IsEmpty()) {
+    return (wxDirExists(homeFolder + "/.var/app/" + appID)) ? true : false;
+  }
+  else {
+    return false;
+  }
+#else
+  return false;
 #endif
 }
 

--- a/src/ui/wxWidgets/wxUtilities.cpp
+++ b/src/ui/wxWidgets/wxUtilities.cpp
@@ -343,12 +343,8 @@ bool IsXWaylandEnabled()
 
   if (osid & wxOS_UNIX) { // Includes Linux
     wxString GDK_BACKEND_VAR = wxEmptyString; // set by the native version on Linux with Wayland to fall back to using x11 backend
-    if (wxGetEnv(wxT("GDK_BACKEND"), &GDK_BACKEND_VAR)) { // provides 'x11' or 'wayland'
-      if (!GDK_BACKEND_VAR.IsEmpty()) {
-        if (GDK_BACKEND_VAR == wxT("x11")) {
-          XWayland = true;
-        }
-      }
+    if (wxGetEnv(wxT("GDK_BACKEND"), &GDK_BACKEND_VAR) && GDK_BACKEND_VAR == wxT("x11")) { // provides 'x11' or 'wayland'
+      XWayland = true;
     }
     else if (!wxGetEnv(wxT("WAYLAND_DISPLAY"), nullptr)) { // unset by the Flatpak version on Wayland when started with the "--nosocket=wayland --socket=x11" options
       XWayland = true;

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -469,6 +469,9 @@ namespace wxUtilities
 // on Fedora or Ubuntu
 bool IsTaskBarIconAvailable();
 
+// Returns true if it's Flatpak version on Linux, false if native build
+bool IsRunningInFlatpak();
+
 /**
  * @brief Creates a taskbar icon with text overlay.
  *


### PR DESCRIPTION
This is the first attempt to tackle various aspects of the Flatpak version, and fix issues such as:

Issues:
1. On Linux with Wayland, the virtual keyboard is not detected in the Flatpak version when using the Xwayland backend.
In the native version of the application, virtual keyboard support is detected correctly.
2. Help > About > Check for the latest version fails due to missing permission (network access).
Error: Could not download version data. Could not resolve hostname
This may appear to be an issue with the update infrastructure, but it is actually caused by missing network permissions in the Flatpak sandbox.

Changes:
New: Added detection for whether the Flatpak version is running.
New: Flatpak version is running - check if the XWayland backend is enabled.
New: Flatpak version is running - display network access requirements as a tooltip for the "Check for the latest version" command in Help > About.
New: Flatpak version is running - display a different message about updating the application to the latest version.

Tested on Debian/Kubuntu/Fedora/Mint.

Attached you can see some screenshots.

<img width="1481" height="382" alt="pwsafe_1 24-wxWidgets-flatpak-Version-01" src="https://github.com/user-attachments/assets/4573ab7c-d102-4e7f-bf55-0dbb558e3ff1" />
<img width="915" height="657" alt="pwsafe_1 24-wxWidgets-flatpak-Version-02" src="https://github.com/user-attachments/assets/4f2f70d8-efe8-4b3c-8248-3c3ea272a662" />
<img width="918" height="659" alt="pwsafe_1 24-wxWidgets-flatpak-Version-03" src="https://github.com/user-attachments/assets/b812e9f9-a04a-48f3-a490-b9ba70684fe4" />
New:<br>
<img width="1102" height="648" alt="pwsafe_1 24-wxWidgets-flatpak-Version-04" src="https://github.com/user-attachments/assets/266c489e-e05c-4d84-9891-f10e31f51775" />
New:<br>
<img width="1023" height="759" alt="pwsafe_1 24-wxWidgets-flatpak-Version-05" src="https://github.com/user-attachments/assets/3d35717c-d08f-42d0-8cbc-e71c2453f67b" />
New:<br>
<img width="724" height="510" alt="pwsafe_1 24-wxWidgets-flatpak-xvkbd-01" src="https://github.com/user-attachments/assets/3af49380-079f-4586-b3cf-16a31ce3baa9" />
