### PR TITLE
[wx] Add context menu to copy the custom field value(s)

### DIFF
--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -456,6 +456,17 @@ void PasswordSafeFrame::DoCopyRunCmd(CItemData &item)
   UpdateAccessTime(item);
 }
 
+void PasswordSafeFrame::DoCopyCustomFieldValue(const StringX &fieldValue)
+{
+  auto *item = GetSelectedEntry();
+  if (item == nullptr) {
+    return;
+  }
+  Clipboard::GetInstance()->SetData(fieldValue);
+  UpdateLastClipboardAction(CItemData::FieldType::CUSTOMTEXT);
+  UpdateAccessTime(*item);
+}
+
 /*!
  * wxEVT_COMMAND_MENU_SELECTED event handler for ID_COPYUSERNAME
  */

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1892,7 +1892,7 @@ void PasswordSafeFrame::OnContextMenu(const CItemData* item)
     itemEditMenu.Append(ID_COPYURL,        _("Copy UR&L to Clipboard"));
     itemEditMenu.Append(ID_COPYEMAIL,      _("Copy email to Clipboard"));
     itemEditMenu.Append(ID_COPYRUNCOMMAND, _("Copy Run Command to Clipboard"));
-    const auto *item_data = item->IsShortcut() || item->IsAlias() ? m_core.GetBaseEntry(item) : item;
+    const auto *item_data = item->IsShortcut() ? m_core.GetBaseEntry(item) : item;
     if (item_data->IsCustomFieldsSet()) {
       auto customFieldsMenu = new wxMenu;
       auto customFields = item_data->GetCustomFields();

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1896,19 +1896,14 @@ void PasswordSafeFrame::OnContextMenu(const CItemData* item)
       auto customFieldsMenu = new wxMenu;
       auto customFields = item->GetCustomFields();
       for (auto &customField : customFields) {
-        if (customField.HasProperty(CustomField::PropertyId::PROP_NAME)) {
-          auto customFieldName = customField.GetName();
-          auto customFieldValue = customField.GetValue();
-          auto menuID = wxNewId();
-          customFieldsMenu->Append(
-            menuID,
-            wxT("<") + towxstring(customFieldName) + wxT(">")
-          );
+        auto customFieldName = customField.GetName();
+        auto customFieldValue = customField.GetValue();
+        auto menuID = wxNewId();
+        customFieldsMenu->Append(menuID, towxstring(customFieldName));
 
-          Bind(wxEVT_MENU, [&, customFieldValue](wxCommandEvent& WXUNUSED(event)) {
-            DoCopyCustomFieldValue(customFieldValue);
-          }, menuID);
-        }
+        Bind(wxEVT_MENU, [&, customFieldValue](wxCommandEvent& WXUNUSED(event)) {
+          DoCopyCustomFieldValue(customFieldValue);
+        }, menuID);
       }
       itemEditMenu.AppendSubMenu(customFieldsMenu, _("Copy Custom &Field Value..."));
     }

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1892,6 +1892,26 @@ void PasswordSafeFrame::OnContextMenu(const CItemData* item)
     itemEditMenu.Append(ID_COPYURL,        _("Copy UR&L to Clipboard"));
     itemEditMenu.Append(ID_COPYEMAIL,      _("Copy email to Clipboard"));
     itemEditMenu.Append(ID_COPYRUNCOMMAND, _("Copy Run Command to Clipboard"));
+    if (item->IsCustomFieldsSet()) {
+      auto customFieldsMenu = new wxMenu;
+      auto customFields = item->GetCustomFields();
+      for (auto &customField : customFields) {
+        if (customField.HasProperty(CustomField::PropertyId::PROP_NAME)) {
+          auto customFieldName = customField.GetName();
+          auto customFieldValue = customField.GetValue();
+          auto menuID = wxNewId();
+          customFieldsMenu->Append(
+            menuID,
+            wxT("<") + towxstring(customFieldName) + wxT(">")
+          );
+
+          Bind(wxEVT_MENU, [&, customFieldValue](wxCommandEvent& WXUNUSED(event)) {
+            DoCopyCustomFieldValue(customFieldValue);
+          }, menuID);
+        }
+      }
+      itemEditMenu.AppendSubMenu(customFieldsMenu, _("Copy Custom &Field Value..."));
+    }
     itemEditMenu.AppendSeparator();
     itemEditMenu.Append(ID_BROWSEURL,      _("&Browse to URL"));
     itemEditMenu.Append(ID_BROWSEURLPLUS,  _("Browse to URL + &Autotype"));

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1892,9 +1892,10 @@ void PasswordSafeFrame::OnContextMenu(const CItemData* item)
     itemEditMenu.Append(ID_COPYURL,        _("Copy UR&L to Clipboard"));
     itemEditMenu.Append(ID_COPYEMAIL,      _("Copy email to Clipboard"));
     itemEditMenu.Append(ID_COPYRUNCOMMAND, _("Copy Run Command to Clipboard"));
-    if (item->IsCustomFieldsSet()) {
+    const auto *item_data = item->IsShortcut() || item->IsAlias() ? m_core.GetBaseEntry(item) : item;
+    if (item_data->IsCustomFieldsSet()) {
       auto customFieldsMenu = new wxMenu;
-      auto customFields = item->GetCustomFields();
+      auto customFields = item_data->GetCustomFields();
       for (auto &customField : customFields) {
         auto customFieldName = customField.GetName();
         auto customFieldValue = customField.GetValue();

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -750,6 +750,7 @@ private:
   void DoCopyURL(CItemData &item);
   void DoCopyEmail(CItemData &item);
   void DoCopyRunCmd(CItemData &item);
+  void DoCopyCustomFieldValue(const StringX &fieldValue);
   void DoEdit(CItemData item);
   void DoAutotype(CItemData &item);
   void DoAutotype(const StringX& sx_autotype, const std::vector<size_t>& vactionverboffsets);


### PR DESCRIPTION
This PR adds a submenu containing the names of custom fields to the context menu. These submenus allow the user to copy the field values ​​to the clipboard.

Custom Fields of Item
<img width="545" height="164" alt="image" src="https://github.com/user-attachments/assets/c170efd9-522a-42e8-a658-6cfdf99bb50b" />

Context Menu of Item
<img width="337" height="336" alt="image" src="https://github.com/user-attachments/assets/57782fad-0d27-45fc-a8ce-6d5759ebdec3" />

Refers to my review comment in #1746.