### PR TITLE
docs: correct Yubico header field type

### DIFF
--- a/docs/formatV3.txt
+++ b/docs/formatV3.txt
@@ -184,7 +184,7 @@ Reserved                    0x0e        -                            [13]
 Recently Used Entries       0x0f        Text                         [14]
 Named Password Policies     0x10        Text                         [15]
 Empty Groups                0x11        Text                         [16]
-Yubico                      0x12        Text                         [18]
+Yubico                      0x12        20 bytes      Y              [18]
 Timestamp of last master
 password change             0x13        time_t        Y              [5]
 End of Entry                0xff        [empty]       Y              [17]

--- a/docs/formatV4.txt
+++ b/docs/formatV4.txt
@@ -255,7 +255,7 @@ Reserved                    0x0e        -                            [13]
 Recently Used Entries       0x0f        Text                         [14]
 Named Password Policies     0x10        Text                         [15]
 Empty Groups                0x11        Text                         [16]
-Yubico                      0x12        Text                         [18]
+Yubico                      0x12        20 bytes      Y              [18]
 Timestamp of last master
 password change             0x13        time_t        Y              [5]
 End of Entry                0xff        [empty]       Y              [17]


### PR DESCRIPTION
This updates the V3 and V4 format documentation for the Yubico `0x12` database header field.

The docs previously listed the field type as `Text`, but the core implementation stores and reads it as a fixed 20-byte binary YubiKey secret key via `HDR_YUBI_SK`. The field is now documented as `20 bytes` and marked as implemented in both format tables.

No code changes.