### PR TITLE
Treat alias passkey fields as base-owned

### DIFF
--- a/src/core/ItemData.cpp
+++ b/src/core/ItemData.cpp
@@ -587,10 +587,17 @@ StringX CItemData::GetEffectiveFieldValue(FieldType ft, const CItemData *pbci) c
       TOTPCONFIG,
       TOTPSTARTTIME,
       TOTPTIMESTEP,
-      TOTPLENGTH
+      TOTPLENGTH,
+      PASSKEY_CRED_ID,
+      PASSKEY_RP_ID,
+      PASSKEY_USER_HANDLE,
+      PASSKEY_ALGO_ID,
+      PASSKEY_PRIVATE_KEY,
+      PASSKEY_SIGN_COUNT
     };
-    // Only base_fields fields (i.e., current password and history, TOTP parameters)
-    // are taken from base entry. Everything else is from the actual entry.
+    // Only base_fields fields (i.e., current password and history,
+    // TOTP parameters, and passkey parameters) are taken from base entry.
+    // Everything else is from the actual entry.
     if (std::find(base_fields.begin(), base_fields.end(), ft) != base_fields.end())
       return pbci->GetField(ft);
     else

--- a/src/test/AliasShortcutTest.cpp
+++ b/src/test/AliasShortcutTest.cpp
@@ -15,12 +15,22 @@
 #include "core/PWSAuxParse.h"
 #include "gtest/gtest.h"
 
+#include <vector>
+
 class AliasShortcutTest : public ::testing::Test
 {
 protected:
   AliasShortcutTest() {}
   PWScore core;
   CItemData base;
+  const std::vector<CItemData::FieldType> passkey_fields = {
+    CItemData::PASSKEY_CRED_ID,
+    CItemData::PASSKEY_RP_ID,
+    CItemData::PASSKEY_USER_HANDLE,
+    CItemData::PASSKEY_ALGO_ID,
+    CItemData::PASSKEY_PRIVATE_KEY,
+    CItemData::PASSKEY_SIGN_COUNT
+  };
   void SetUp();
   void TearDown();
 };
@@ -110,18 +120,10 @@ TEST_F(AliasShortcutTest, Alias)
   EXPECT_EQ(effci.GetCustomFieldsRaw(), al.GetCustomFieldsRaw());
   EXPECT_TRUE(sx_totpauthcode.empty());
 
-  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_CRED_ID, nullptr),
-            al2.GetEffectiveFieldValue(CItemData::PASSKEY_CRED_ID, &base));
-  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_RP_ID, nullptr),
-            al2.GetEffectiveFieldValue(CItemData::PASSKEY_RP_ID, &base));
-  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_USER_HANDLE, nullptr),
-            al2.GetEffectiveFieldValue(CItemData::PASSKEY_USER_HANDLE, &base));
-  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_ALGO_ID, nullptr),
-            al2.GetEffectiveFieldValue(CItemData::PASSKEY_ALGO_ID, &base));
-  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_PRIVATE_KEY, nullptr),
-            al2.GetEffectiveFieldValue(CItemData::PASSKEY_PRIVATE_KEY, &base));
-  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_SIGN_COUNT, nullptr),
-            al2.GetEffectiveFieldValue(CItemData::PASSKEY_SIGN_COUNT, &base));
+  for (const CItemData::FieldType ft : passkey_fields) {
+    EXPECT_EQ(base.GetEffectiveFieldValue(ft, nullptr),
+              al2.GetEffectiveFieldValue(ft, &base));
+  }
 }
 
 TEST_F(AliasShortcutTest, Shortcut)
@@ -164,16 +166,8 @@ TEST_F(AliasShortcutTest, Shortcut)
   EXPECT_EQ(effci.GetCustomFieldsRaw(), base.GetCustomFieldsRaw());
   EXPECT_TRUE(sx_totpauthcode.empty());
 
-  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_CRED_ID, nullptr),
-            sc2.GetEffectiveFieldValue(CItemData::PASSKEY_CRED_ID, &base));
-  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_RP_ID, nullptr),
-            sc2.GetEffectiveFieldValue(CItemData::PASSKEY_RP_ID, &base));
-  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_USER_HANDLE, nullptr),
-            sc2.GetEffectiveFieldValue(CItemData::PASSKEY_USER_HANDLE, &base));
-  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_ALGO_ID, nullptr),
-            sc2.GetEffectiveFieldValue(CItemData::PASSKEY_ALGO_ID, &base));
-  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_PRIVATE_KEY, nullptr),
-            sc2.GetEffectiveFieldValue(CItemData::PASSKEY_PRIVATE_KEY, &base));
-  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_SIGN_COUNT, nullptr),
-            sc2.GetEffectiveFieldValue(CItemData::PASSKEY_SIGN_COUNT, &base));
+  for (const CItemData::FieldType ft : passkey_fields) {
+    EXPECT_EQ(base.GetEffectiveFieldValue(ft, nullptr),
+              sc2.GetEffectiveFieldValue(ft, &base));
+  }
 }

--- a/src/test/AliasShortcutTest.cpp
+++ b/src/test/AliasShortcutTest.cpp
@@ -43,6 +43,12 @@ void AliasShortcutTest::SetUp()
   base.SetAutoType(L"base-autotype");
   base.SetEmail(L"email@base.com");
   base.SetRunCommand(L"Run base, run");
+  base.SetPasskeyCredentialID(VectorX<unsigned char>(64, 1));
+  base.SetPasskeyRelyingPartyID(L"base-relying-party");
+  base.SetPasskeyUserHandle(VectorX<unsigned char>(32, 2));
+  base.SetPasskeyAlgorithmID(1);
+  base.SetPasskeyPrivateKey(VectorX<unsigned char>(512, 3));
+  base.SetPasskeySignCount(4);
   CustomField baseCustom;
   baseCustom.SetName(L"PIN");
   baseCustom.SetValue(L"base-pin");
@@ -63,6 +69,12 @@ TEST_F(AliasShortcutTest, Alias)
   al.SetAutoType(L"alias-autotype");
   al.SetEmail(L"email@alias.com");
   al.SetRunCommand(L"Run alias, run");
+  al.SetPasskeyCredentialID(VectorX<unsigned char>(64, 10));
+  al.SetPasskeyRelyingPartyID(L"alias-relying-party");
+  al.SetPasskeyUserHandle(VectorX<unsigned char>(32, 11));
+  al.SetPasskeyAlgorithmID(10);
+  al.SetPasskeyPrivateKey(VectorX<unsigned char>(512, 12));
+  al.SetPasskeySignCount(13);
   CustomField aliasCustom;
   aliasCustom.SetName(L"PIN");
   aliasCustom.SetValue(L"alias-pin");
@@ -97,6 +109,19 @@ TEST_F(AliasShortcutTest, Alias)
   EXPECT_EQ(effci.GetRunCommand(), al.GetRunCommand());
   EXPECT_EQ(effci.GetCustomFieldsRaw(), al.GetCustomFieldsRaw());
   EXPECT_TRUE(sx_totpauthcode.empty());
+
+  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_CRED_ID, nullptr),
+            al2.GetEffectiveFieldValue(CItemData::PASSKEY_CRED_ID, &base));
+  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_RP_ID, nullptr),
+            al2.GetEffectiveFieldValue(CItemData::PASSKEY_RP_ID, &base));
+  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_USER_HANDLE, nullptr),
+            al2.GetEffectiveFieldValue(CItemData::PASSKEY_USER_HANDLE, &base));
+  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_ALGO_ID, nullptr),
+            al2.GetEffectiveFieldValue(CItemData::PASSKEY_ALGO_ID, &base));
+  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_PRIVATE_KEY, nullptr),
+            al2.GetEffectiveFieldValue(CItemData::PASSKEY_PRIVATE_KEY, &base));
+  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_SIGN_COUNT, nullptr),
+            al2.GetEffectiveFieldValue(CItemData::PASSKEY_SIGN_COUNT, &base));
 }
 
 TEST_F(AliasShortcutTest, Shortcut)
@@ -138,4 +163,17 @@ TEST_F(AliasShortcutTest, Shortcut)
   EXPECT_EQ(effci.GetRunCommand(), base.GetRunCommand());
   EXPECT_EQ(effci.GetCustomFieldsRaw(), base.GetCustomFieldsRaw());
   EXPECT_TRUE(sx_totpauthcode.empty());
+
+  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_CRED_ID, nullptr),
+            sc2.GetEffectiveFieldValue(CItemData::PASSKEY_CRED_ID, &base));
+  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_RP_ID, nullptr),
+            sc2.GetEffectiveFieldValue(CItemData::PASSKEY_RP_ID, &base));
+  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_USER_HANDLE, nullptr),
+            sc2.GetEffectiveFieldValue(CItemData::PASSKEY_USER_HANDLE, &base));
+  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_ALGO_ID, nullptr),
+            sc2.GetEffectiveFieldValue(CItemData::PASSKEY_ALGO_ID, &base));
+  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_PRIVATE_KEY, nullptr),
+            sc2.GetEffectiveFieldValue(CItemData::PASSKEY_PRIVATE_KEY, &base));
+  EXPECT_EQ(base.GetEffectiveFieldValue(CItemData::PASSKEY_SIGN_COUNT, nullptr),
+            sc2.GetEffectiveFieldValue(CItemData::PASSKEY_SIGN_COUNT, &base));
 }


### PR DESCRIPTION
## Summary

This updates alias effective-field resolution so passkey fields are taken from the base entry, matching the existing behavior for passwords, password history, and TOTP fields.

The affected passkey fields are:

- Passkey Credential ID
- Passkey Relying Party ID
- Passkey User Handle
- Passkey Algorithm ID
- Passkey Private Key
- Passkey Sign Count

## Testing

- Added coverage to `AliasShortcutTest` verifying effective passkey field values resolve from the base entry for aliases and shortcuts.
- Ran unit tests on Linux:
  - `cli-test`
  - `Coretests`