### PR TITLE
Gorilla pwsafe import2

### DIFF
--- a/src/core/PWSfileV1V2.cpp
+++ b/src/core/PWSfileV1V2.cpp
@@ -493,6 +493,7 @@ int PWSfileV1V2::ReadRecord(CItemData &item)
             case CItemData::XTIME_INT:
               break;
             case CItemData::URL:
+              // not part of V2, but used by gorilla passwordsafe
               item.SetURL(tempdata); break;
             default:
               break;

--- a/src/core/PWSfileV1V2.cpp
+++ b/src/core/PWSfileV1V2.cpp
@@ -491,6 +491,9 @@ int PWSfileV1V2::ReadRecord(CItemData &item)
             case CItemData::RMTIME:
             case CItemData::POLICY:
             case CItemData::XTIME_INT:
+              break;
+            case CItemData::URL:
+              item.SetURL(tempdata); break;
             default:
               break;
           } // switch


### PR DESCRIPTION
gorilla passwordsafe import goes thru PWSfileV1V2.cpp, but they use CItemData::URL which is V3.