### PR TITLE
[wx] Reset Statusbar info

### DIFF
--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -141,6 +141,7 @@ int PasswordSafeFrame::New()
   CreateMenubar(); // Recreate the menu with updated list of most recently used DBs
   ResetFilters();
   GetSearchBarPane().Hide(); // There is nothing to search for in an empty database
+  ResetStatusBar();
   m_AuiManager.Update();
   // XXX TODO: Reset IdleLockTimer, as preference has reverted to default
   return PWScore::SUCCESS;
@@ -252,6 +253,7 @@ void PasswordSafeFrame::FinishGoodOpen()
   m_core.ResumeOnDBNotification();
   CreateMenubar(); // Recreate the menu with updated list of most recently used DBs
   UpdateSearchBarVisibility();
+  ResetStatusBar();
   m_AuiManager.Update();
 }
 

--- a/src/ui/wxWidgets/MenuManageHandlers.cpp
+++ b/src/ui/wxWidgets/MenuManageHandlers.cpp
@@ -351,6 +351,9 @@ void PasswordSafeFrame::OnLanguageClick(wxCommandEvent& evt)
     // Recreate search bar
     wxCHECK_RET(m_search, wxT("Search object not created so far"));
     m_search->ReCreateSearchBar();
+
+    // Recreate status bar
+    ResetStatusBar();
   } else {
     GetMenuBar()->Check( m_selectedLanguage, true );
   }

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1281,7 +1281,7 @@ int PasswordSafeFrame::Load(const StringX &passwd)
     SetTitle(wxEmptyString);
     m_sysTray->SetTrayStatus(SystemTray::TrayStatus::CLOSED);
   }
-  UpdateStatusBar();
+  ResetStatusBar();
   UpdateMenuBar();
   return status;
 }
@@ -3010,6 +3010,13 @@ void PasswordSafeFrame::ViewReport(CReport& rpt)
 void PasswordSafeFrame::OnVisitWebsite(wxCommandEvent&)
 {
   wxLaunchDefaultBrowser(L"https://pwsafe.org");
+}
+
+void PasswordSafeFrame::ResetStatusBar()
+{
+  m_statusBar->SetStatusText(wxEmptyString, StatusBar::Field::DOUBLECLICK);
+  m_LastClipboardAction = wxEmptyString;
+  UpdateStatusBar();
 }
 
 void PasswordSafeFrame::UpdateStatusBar()

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -773,6 +773,8 @@ private:
   /// Adds a language to internal list of supported languages by this application
   void AddLanguage(int menu_id, wxLanguage lang_id, const wxString& lang_name);
 
+  /// Clears some text and calls UpdateStatusBar() to apply
+  void ResetStatusBar();
   /// Update status bar - call when stuff changes:
   /// File open, double-click, modify, r-o r/w, filter...
   void UpdateStatusBar();


### PR DESCRIPTION
This PR clears stale status bar text when a new database is opened or when the application language is changed.

The main fields that are reset are:
-Double-click Action value
-Last Clipboard Action
-Number of Entries
-Filter indicator

Tested on Debian/macOS/FreeBSD.

Attached you can see some screenshots.

<img width="1324" height="483" alt="pwsafe_1 24-wxWidgets-bug-StatusBar-01" src="https://github.com/user-attachments/assets/37a7821c-2bb6-4834-bdc5-bd4db3b92549" />

