### PR TITLE
Expiry update fix

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -2,7 +2,7 @@ This note describes the new features, fixed bugs and known problems with the lat
 Password Safe, please see the accompanying [**README.md**](../README.md) file. For more information on the product and the project, please visit
 https://pwsafe.org/. Details about changes to older releases may be found in the file ChangeLog.txt.
 
-In the following, SFxxxx refers to Bug Reports, Feature Requests and Service Requests in PasswordSafe SourceForge Project tickets, and GHxxxx refers to issues in the PasswordSafe GitHub project.
+In the following, SFxxxx refers to Bug Reports, Feature Requests and Support Requests in PasswordSafe SourceForge Project tickets, and GHxxxx refers to issues in the PasswordSafe GitHub project.
 
 PasswordSafe 3.72.0pre Release June 12 2026
 ===========================================
@@ -10,7 +10,8 @@ Bugs Fixed in 3.72.0pre
 -----------------------
 * Improved font scale handling -should resolve font size issues on high resolution displays.
 * [GH1749](https://github.com/pwsafe/pwsafe/issues/1749) In the Master Password Setup window, "Show Master Password" is no longer truncated on some displays.
-* [GH1092](https://github.com/pwsafe/pwsafe/issues/1092)[SF1595](https://sourceforge.net/p/passwordsafe/bugs/1595/) Size and position of main window is now correctly restored on scaled displays.
+* [GH1092](https://github.com/pwsafe/pwsafe/issues/1092), [SF1595](https://sourceforge.net/p/passwordsafe/bugs/1595/) Size and position of main window is now correctly restored on scaled displays.
+* [SF1630](https://sourceforge.net/p/passwordsafe/bugs/1630/) Keep password expiry date when both password and password expiry are changed.
 * [SF1628](https://sourceforge.net/p/passwordsafe/bugs/1628/) Custom values can now be copied to the clipboard in read-only mode via Ctrl-C and right-click->Copy Value.
 
 New Features in 3.72.0pre

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,7 +11,7 @@ Bugs Fixed in 3.72.0pre
 * Improved font scale handling -should resolve font size issues on high resolution displays.
 * [GH1749](https://github.com/pwsafe/pwsafe/issues/1749) In the Master Password Setup window, "Show Master Password" is no longer truncated on some displays.
 * [GH1092](https://github.com/pwsafe/pwsafe/issues/1092), [SF1595](https://sourceforge.net/p/passwordsafe/bugs/1595/) Size and position of main window is now correctly restored on scaled displays.
-* [SF1630](https://sourceforge.net/p/passwordsafe/bugs/1630/) Keep password expiry date when both password and password expiry are changed.
+* [SF1630](https://sourceforge.net/p/passwordsafe/bugs/1630/) Keep password expiry date when both password and password expiry are changed; don't clear a non-recurring expiry when the passwsord's changed.
 * [SF1628](https://sourceforge.net/p/passwordsafe/bugs/1628/) Custom values can now be copied to the clipboard in read-only mode via Ctrl-C and right-click->Copy Value.
 
 New Features in 3.72.0pre

--- a/docs/ReleaseNotesWX.md
+++ b/docs/ReleaseNotesWX.md
@@ -7,6 +7,14 @@ https://pwsafe.org/. Details about changes to older releases may be found in the
 
 In the following, SFxxxx refers to Bug Reports, Feature Requests and Service Requests in PasswordSafe SourceForge Project tickets, and GHxxxx refers to issues in the PasswordSafe GitHub project.
 
+PasswordSafe 1.25.0 Release ?? ??? 2026
+========================================
+
+Bugs fixed in 1.25.0
+--------------------
+* [SF1630](https://sourceforge.net/p/passwordsafe/bugs/1630/) Don't clear a non-recurring expiry when the password's changed.
+
+
 PasswordSafe 1.24.0 Release  8 May 2026
 =======================================
 

--- a/src/core/ItemData.cpp
+++ b/src/core/ItemData.cpp
@@ -1436,25 +1436,26 @@ void CItemData::SetTitle(const StringX &title, TCHAR delimiter)
   }
 }
 
-void CItemData::UpdatePassword(const StringX &password)
+void CItemData::UpdatePassword(const StringX& password)
 {
-  // use when password changed - manages history, modification times
+  // use when password changed - manages modification history and expiration time
   UpdatePasswordHistory();
   SetPassword(password);
 
   time_t t;
-  time(&t);
+  (void)time(&t);
   SetPMTime(t);
 
   int32 xint;
   GetXTimeInt(xint);
   if (xint != 0) {
-    // convert days to seconds for time_t
+    // Recurring expiry interval: the expiry date is relative to the password
+    // change, so recompute it (convert days to seconds for time_t).
     t += (xint * 86400);
     SetXTime(t);
-  } else {
-    SetXTime(time_t(0));
   }
+  // Note: a non-recurring (absolute) expiry date is independent of the
+  // password change time, so it's deliberately left unchanged here.
 }
 
 void CItemData::UpdatePasswordHistory()

--- a/src/test/ItemDataTest.cpp
+++ b/src/test/ItemDataTest.cpp
@@ -322,6 +322,10 @@ TEST_F(ItemDataTest, UpdatePasswordExpiry)
     time_t xt;
     di.GetXTime(xt);
     EXPECT_EQ(time_t(0), xt);
+
+    int32 xint;
+    di.GetXTimeInt(xint);
+    EXPECT_EQ(0, xint);
   }
 
   // A recurring interval is relative to the password change, so the expiry

--- a/src/test/ItemDataTest.cpp
+++ b/src/test/ItemDataTest.cpp
@@ -282,6 +282,73 @@ TEST_F(ItemDataTest, PasswordHistory)
   EXPECT_EQ(emptyHeader, PWHistList::MakePWHistoryHeader(false, 0, 0));
 }
 
+TEST_F(ItemDataTest, UpdatePasswordExpiry)
+{
+  PWSprefs* prefs = PWSprefs::GetInstance();
+  prefs->SetPref(PWSprefs::SavePasswordHistory, false);
+
+  // A non-recurring (absolute) expiry date is independent of the password
+  // and must survive a password change.
+  {
+    CItemData di;
+    di.SetCTime();
+    di.SetPassword(L"first");
+
+    const time_t absXTime = time(nullptr) + 30 * 86400;
+    di.SetXTime(absXTime);
+    di.SetXTimeInt(0); // non-recurring
+
+    di.UpdatePassword(L"second");
+
+    time_t xt;
+    di.GetXTime(xt);
+    EXPECT_EQ(absXTime, xt); // unchanged
+
+    int32 xint;
+    di.GetXTimeInt(xint);
+    EXPECT_EQ(0, xint);
+  }
+
+  // An entry that never expires must continue to never expire.
+  {
+    CItemData di;
+    di.SetCTime();
+    di.SetPassword(L"first");
+    di.SetXTime(time_t(0));
+    di.SetXTimeInt(0);
+
+    di.UpdatePassword(L"second");
+
+    time_t xt;
+    di.GetXTime(xt);
+    EXPECT_EQ(time_t(0), xt);
+  }
+
+  // A recurring interval is relative to the password change, so the expiry
+  // date must be rolled forward to 'now + interval' when the password changes.
+  {
+    CItemData di;
+    di.SetCTime();
+    di.SetPassword(L"first");
+    const int32 days = 7;
+    di.SetXTime(time_t(0));
+    di.SetXTimeInt(days);
+
+    const time_t before = time(nullptr);
+    di.UpdatePassword(L"second");
+    const time_t after = time(nullptr);
+
+    time_t xt;
+    di.GetXTime(xt);
+    EXPECT_GE(xt, before + days * 86400);
+    EXPECT_LE(xt, after + days * 86400);
+
+    int32 xint;
+    di.GetXTimeInt(xint);
+    EXPECT_EQ(days, xint);
+  }
+}
+
 TEST_F(ItemDataTest, CustomFields)
 {
   const StringX raw = _T("010004Name020005Value0300012")

--- a/src/ui/Windows/AddEdit_PropertySheet.cpp
+++ b/src/ui/Windows/AddEdit_PropertySheet.cpp
@@ -448,23 +448,25 @@ BOOL CAddEdit_PropertySheet::OnApply(const int &iCID)
       if (bIsPSWDModified || m_AEMD.locXTime != m_AEMD.oldlocXTime) {
         CItemData *pciA = (m_AEMD.pci->IsAlias()) ? m_AEMD.pcore->GetBaseEntry(m_AEMD.pci) : m_AEMD.pci;
 
-        if (m_AEMD.locXTime != m_AEMD.oldlocXTime) {
-          pciA->SetXTime(m_AEMD.tttXTime);
-          m_AEMD.locXTime = pciA->GetXTimeL();
-          m_AEMD.oldlocXTime = m_AEMD.locXTime;
-        }
-
+        // Update the password first, since UpdatePassword() recomputes the expiry date.
         if (bIsPSWDModified) {
-          m_AEMD.pci->UpdatePassword(m_AEMD.realpassword); // also updates exp time if entry's recurring exp set
+          m_AEMD.pci->UpdatePassword(m_AEMD.realpassword);
           m_AEMD.locPMTime = m_AEMD.pci->GetPMTimeL();
-         if (m_AEMD.XTimeInt != 0) {
-           // if entry has a recurring password interval, then
-           // changing the password ==> updated expiry
+          if (m_AEMD.XTimeInt != 0) {
+            // if entry has a recurring password interval, then
+            // changing the password ==> updated expiry
             pciA->GetXTime(m_AEMD.tttXTime);
-            m_AEMD.locXTime = pciA->GetXTimeL();
           }
         } // bIsPSWDModified
-      }
+
+        // m_AEMD.tttXTime now holds the intended expiry date (the user's chosen
+        // date for a non-recurring entry, or the value just recomputed by
+        // UpdatePassword() for a recurring one). Apply it unconditionally so it
+        // survives the UpdatePassword() call above.
+        pciA->SetXTime(m_AEMD.tttXTime);
+        m_AEMD.locXTime = pciA->GetXTimeL();
+        m_AEMD.oldlocXTime = m_AEMD.locXTime;
+      } // bIsPSWDModified || m_AEMD.locXTime != m_AEMD.oldlocXTime)
 
       if (m_bIsModified && !bIsPSWDModified) {
         time(&t);

--- a/src/ui/Windows/AddEdit_PropertySheet.cpp
+++ b/src/ui/Windows/AddEdit_PropertySheet.cpp
@@ -448,25 +448,24 @@ BOOL CAddEdit_PropertySheet::OnApply(const int &iCID)
       if (bIsPSWDModified || m_AEMD.locXTime != m_AEMD.oldlocXTime) {
         CItemData *pciA = (m_AEMD.pci->IsAlias()) ? m_AEMD.pcore->GetBaseEntry(m_AEMD.pci) : m_AEMD.pci;
 
-        // Update the password first, since UpdatePassword() recomputes the expiry date.
+
         if (bIsPSWDModified) {
-          m_AEMD.pci->UpdatePassword(m_AEMD.realpassword);
+          m_AEMD.pci->UpdatePassword(m_AEMD.realpassword); // also updates exp time if entry's recurring exp set
           m_AEMD.locPMTime = m_AEMD.pci->GetPMTimeL();
           if (m_AEMD.XTimeInt != 0) {
             // if entry has a recurring password interval, then
             // changing the password ==> updated expiry
             pciA->GetXTime(m_AEMD.tttXTime);
+            m_AEMD.locXTime = pciA->GetXTimeL();
           }
         } // bIsPSWDModified
 
-        // m_AEMD.tttXTime now holds the intended expiry date (the user's chosen
-        // date for a non-recurring entry, or the value just recomputed by
-        // UpdatePassword() for a recurring one). Apply it unconditionally so it
-        // survives the UpdatePassword() call above.
-        pciA->SetXTime(m_AEMD.tttXTime);
-        m_AEMD.locXTime = pciA->GetXTimeL();
-        m_AEMD.oldlocXTime = m_AEMD.locXTime;
-      } // bIsPSWDModified || m_AEMD.locXTime != m_AEMD.oldlocXTime)
+        if (m_AEMD.locXTime != m_AEMD.oldlocXTime) {
+          pciA->SetXTime(m_AEMD.tttXTime);
+          m_AEMD.locXTime = pciA->GetXTimeL();
+          m_AEMD.oldlocXTime = m_AEMD.locXTime;
+        }
+      }
 
       if (m_bIsModified && !bIsPSWDModified) {
         time(&t);

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -3175,6 +3175,14 @@ Command* AddEditPropSheetDlg::NewEditEntryCommand()
     m_Item.SetXTimeInt(0);
   }
 
+  // If only the password changed, UpdatePassword() may have cleared a
+  // non-recurring expiry date - restore what the user still sees in the UI.
+  if ((changes & Changes::Password) &&
+      !(changes & (Changes::XTime | Changes::XTimeInt | Changes::XTimeNever)) &&
+    m_DatesTimesExpireOnCtrl->GetValue()) {
+    m_Item.SetXTime(NormalizeExpDate(m_DatesTimesExpiryDateCtrl->GetValue()).GetTicks());
+  }
+
   // Setting by interval
   // The date control should already be correct.  Only save the interval value if recurring is set
   if (changes & Changes::XTimeInt) {

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -3175,14 +3175,6 @@ Command* AddEditPropSheetDlg::NewEditEntryCommand()
     m_Item.SetXTimeInt(0);
   }
 
-  // If only the password changed, UpdatePassword() may have cleared a
-  // non-recurring expiry date - restore what the user still sees in the UI.
-  if ((changes & Changes::Password) &&
-      !(changes & (Changes::XTime | Changes::XTimeInt | Changes::XTimeNever)) &&
-    m_DatesTimesExpireOnCtrl->GetValue()) {
-    m_Item.SetXTime(NormalizeExpDate(m_DatesTimesExpiryDateCtrl->GetValue()).GetTicks());
-  }
-
   // Setting by interval
   // The date control should already be correct.  Only save the interval value if recurring is set
   if (changes & Changes::XTimeInt) {


### PR DESCRIPTION
Addresses https://sourceforge.net/p/passwordsafe/bugs/1630/ (Windows), as well as a related bug in wx:

1. Changing an entry's password and setting an expiration date cause the change to the expiration to be lost - Windows only
2. Changing an entry's password reset the expiration to 'never' - Windows and wx.
