### PR TITLE
[wx] Show entry count in group tooltips

### DIFF
--- a/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
@@ -10458,3 +10458,11 @@ msgstr ""
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
 msgid "Autotype (default string: %s)"
 msgstr "Autoindsæt (standart streng: %s)"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "%d indgange under gruppe"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_da.po
@@ -10460,9 +10460,6 @@ msgid "Autotype (default string: %s)"
 msgstr "Autoindsæt (standart streng: %s)"
 
 #: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "%d indgange under gruppe"
+msgid "Number of entries: %d"
+msgstr "Antal af poster: %d"
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
@@ -7547,9 +7547,6 @@ msgid "Autotype (default string: %s)"
 msgstr "Autom. Eingabe (Standardsteuerzeichen: %s)"
 
 #: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "%d Einträge unter Gruppe"
+msgid "Number of entries: %d"
+msgstr "Anzahl der Einträge: %d"
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr "%d Eintrag unter Gruppe"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_de.po
@@ -7545,3 +7545,11 @@ msgstr ""
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
 msgid "Autotype (default string: %s)"
 msgstr "Autom. Eingabe (Standardsteuerzeichen: %s)"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "%d Einträge unter Gruppe"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr "%d Eintrag unter Gruppe"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
@@ -11189,9 +11189,6 @@ msgid "Autotype (default string: %s)"
 msgstr "Autoescritura (formato por defecto: %s)"
 
 #: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "%d entradas en el grupo"
+msgid "Number of entries: %d"
+msgstr "Número de entradas: %d"
 
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr "%d entrada en el grupo"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_es.po
@@ -11187,3 +11187,11 @@ msgstr ""
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
 msgid "Autotype (default string: %s)"
 msgstr "Autoescritura (formato por defecto: %s)"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "%d entradas en el grupo"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr "%d entrada en el grupo"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
@@ -7329,9 +7329,5 @@ msgid "Autotype (default string: %s)"
 msgstr "Autofrappe (expression par défaut: %s)"
 
 #: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "%d entrées dans le groupe"
-
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr "%d entrée dans le groupe"
+msgid "Number of entries: %d"
+msgstr "Nombre d'entrées: %d"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_fr.po
@@ -7327,3 +7327,11 @@ msgstr ""
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
 msgid "Autotype (default string: %s)"
 msgstr "Autofrappe (expression par défaut: %s)"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "%d entrées dans le groupe"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr "%d entrée dans le groupe"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
@@ -10197,3 +10197,11 @@ msgstr ""
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
 msgid "Autotype (default string: %s)"
 msgstr "Autogépelés (alapértelmezett szöveg: %s)"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "%d csoport alatti bejegyzések"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr "%d csoport alatti bejegyzés"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_hu.po
@@ -10199,9 +10199,5 @@ msgid "Autotype (default string: %s)"
 msgstr "Autogépelés (alapértelmezett szöveg: %s)"
 
 #: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "%d csoport alatti bejegyzések"
-
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr "%d csoport alatti bejegyzés"
+msgid "Number of entries: %d"
+msgstr "Bejegyzések száma: %d"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_it.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_it.po
@@ -7731,3 +7731,11 @@ msgstr ""
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
 msgid "Autotype (default string: %s)"
 msgstr "Digitazione Automatica (stringa predefinita: %s)"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "%d voci nel gruppo"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr "%d voce nel gruppo"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_it.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_it.po
@@ -7733,9 +7733,5 @@ msgid "Autotype (default string: %s)"
 msgstr "Digitazione Automatica (stringa predefinita: %s)"
 
 #: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "%d voci nel gruppo"
-
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr "%d voce nel gruppo"
+msgid "Number of entries: %d"
+msgstr "Numero di voci: %d"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ko_KR.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ko_KR.po
@@ -10937,9 +10937,5 @@ msgid "Autotype (default string: %s)"
 msgstr "자동 입력 (기본 자동입력 문자열: %s)"
 
 #: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr ""
-
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr ""
+msgid "Number of entries: %d"
+msgstr "총 항목 개수: %d"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ko_KR.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ko_KR.po
@@ -10935,3 +10935,11 @@ msgstr ""
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
 msgid "Autotype (default string: %s)"
 msgstr "자동 입력 (기본 자동입력 문자열: %s)"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr ""
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr ""

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
@@ -11228,3 +11228,11 @@ msgstr ""
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
 msgid "Autotype (default string: %s)"
 msgstr "Automatische invoer (standaard tekst: %s)"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "%d vermeldingen onder groep"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr "%d vermelding onder groep"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_nl.po
@@ -11230,9 +11230,5 @@ msgid "Autotype (default string: %s)"
 msgstr "Automatische invoer (standaard tekst: %s)"
 
 #: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "%d vermeldingen onder groep"
-
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr "%d vermelding onder groep"
+msgid "Number of entries: %d"
+msgstr "Aantal elementen: %d"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
@@ -11230,9 +11230,5 @@ msgid "Autotype (default string: %s)"
 msgstr "Autouzupełnianie (domyślna fraza: %s)"
 
 #: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "%d wpisy w grupie"
-
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr "%d wpis w grupie"
+msgid "Number of entries: %d"
+msgstr "Liczba wpisów: %d"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_pl.po
@@ -11228,3 +11228,11 @@ msgstr ""
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
 msgid "Autotype (default string: %s)"
 msgstr "Autouzupełnianie (domyślna fraza: %s)"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "%d wpisy w grupie"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr "%d wpis w grupie"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
@@ -7686,13 +7686,13 @@ msgstr "Да: не менее %d из %ls: %ls%ls"
 #~ msgid "%d entries synchronized"
 #~ msgstr "Синхронизировано элементов: %d"
 
-#, c-format
-#~ msgid "%d entries under group"
-#~ msgstr "Элементов в группе: %d"
+#: src/ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "Элементов в группе: %d"
 
-#, c-format
-#~ msgid "%d entry under group"
-#~ msgstr "Элементов в группе: %d"
+#: src/ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr "Элементов в группе: %d"
 
 # в панели статуса количество элементов, урезано для сокращения размера (также
 # конфликты для разных чисел)

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_ru.po
@@ -7687,12 +7687,8 @@ msgstr "Да: не менее %d из %ls: %ls%ls"
 #~ msgstr "Синхронизировано элементов: %d"
 
 #: src/ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "Элементов в группе: %d"
-
-#: src/ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr "Элементов в группе: %d"
+msgid "Number of entries: %d"
+msgstr "Количество элементов: %d"
 
 # в панели статуса количество элементов, урезано для сокращения размера (также
 # конфликты для разных чисел)

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sk.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sk.po
@@ -2072,13 +2072,9 @@ msgstr ""
 msgid "You must save this database before it can be exported."
 msgstr "Pred exportom musíte túto databázu uložiť."
 
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:823
-msgid "Exporting database: "
-msgstr "Exportuje sa databáza: "
-
-#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:823
-msgid " to "
-msgstr " do "
+#: ../../../ui/wxWidgets/MenuFileHandlers.cpp:855
+msgid "Exporting database: %ls to %ls\r\n"
+msgstr "Exportuje sa databáza: %ls do %ls\n"
 
 #: ../../../ui/wxWidgets/MenuFileHandlers.cpp:836
 msgid "Export complete.  Do you wish to see a detailed report?"
@@ -6972,3 +6968,23 @@ msgstr "Pre tento záznam už existuje vlastné pole s týmto názvom."
 
 msgid "Custom field copied "
 msgstr "Vlastné pole skopírované "
+
+msgid "&Add"
+msgstr "Pridať"
+
+msgid "Copy Custom &Field Value..."
+msgstr "Skopíruj vlastné pole..."
+
+msgid "Internet access required: Make sure to grant network access to the Flatpak application.\nThe '--share=network' permission is required for this check."
+msgstr "Vyžaduje sa prístup na internet: Uistite sa, že ste aplikácii Flatpak povolili prístup k sieti.\nNa toto overenie je potrebné povolenie '--share=network'."
+
+msgid "Use the 'flatpak update' command or your system's software store application to update to the latest version."
+msgstr "Na aktualizáciu na najnovšiu verziu použite príkaz 'flatpak update' alebo aplikáciu typu 'softvérový obchod' vo vašom systéme."
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr "%d záznam v skupine"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "Počet záznamov v skupine: %d"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sk.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sk.po
@@ -6982,9 +6982,5 @@ msgid "Use the 'flatpak update' command or your system's software store applicat
 msgstr "Na aktualizáciu na najnovšiu verziu použite príkaz 'flatpak update' alebo aplikáciu typu 'softvérový obchod' vo vašom systéme."
 
 #: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr "%d záznam v skupine"
-
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "Počet záznamov v skupine: %d"
+msgid "Number of entries: %d"
+msgstr "Počet záznamov: %d"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sl.po
@@ -7385,3 +7385,11 @@ msgid ""
 msgstr ""
 "Pri poskusu nalaganja slik v območje predogleda je prišlo do napake. Zato "
 "slike ni mogoče prikazati v predogledu."
+
+#: /home/ronys/git/pwsafe/src/ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "%d vnosi pod skupino"
+
+#: /home/ronys/git/pwsafe/src/ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr "%d pod skupino"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sl.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sl.po
@@ -7387,9 +7387,5 @@ msgstr ""
 "slike ni mogoče prikazati v predogledu."
 
 #: /home/ronys/git/pwsafe/src/ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "%d vnosi pod skupino"
-
-#: /home/ronys/git/pwsafe/src/ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr "%d pod skupino"
+msgid "Number of entries: %d"
+msgstr "Število vnosov: %d"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
@@ -11150,9 +11150,5 @@ msgid "Autotype (default string: %s)"
 msgstr "Autoskriv (förvald autoskriftrad: %s)"
 
 #: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "%d poster under grupp"
-
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr "%d post under grupp"
+msgid "Number of entries: %d"
+msgstr "Antal poster: %d"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_sv.po
@@ -11148,3 +11148,11 @@ msgstr ""
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
 msgid "Autotype (default string: %s)"
 msgstr "Autoskriv (förvald autoskriftrad: %s)"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "%d poster under grupp"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr "%d post under grupp"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_zh_CN.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_zh_CN.po
@@ -10769,9 +10769,5 @@ msgid "Autotype (default string: %s)"
 msgstr "自动输入 (默认自动输入字串: %s)"
 
 #: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entries under group"
-msgstr "组下的%d条目"
-
-#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
-msgid "%d entry under group"
-msgstr "组下的%d条目"
+msgid "Number of entries: %d"
+msgstr "项目数量合计: %d"

--- a/src/ui/wxWidgets/I18N/pos/pwsafe_zh_CN.po
+++ b/src/ui/wxWidgets/I18N/pos/pwsafe_zh_CN.po
@@ -10767,3 +10767,11 @@ msgstr ""
 #: ../../../ui/wxWidgets/AddEditPropSheetDlg.cpp:507
 msgid "Autotype (default string: %s)"
 msgstr "自动输入 (默认自动输入字串: %s)"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entries under group"
+msgstr "组下的%d条目"
+
+#: ../../../ui/wxWidgets/TreeCtrl.cpp:1022
+msgid "%d entry under group"
+msgstr "组下的%d条目"

--- a/src/ui/wxWidgets/MenuFileHandlers.cpp
+++ b/src/ui/wxWidgets/MenuFileHandlers.cpp
@@ -142,6 +142,11 @@ int PasswordSafeFrame::New()
   ResetFilters();
   GetSearchBarPane().Hide(); // There is nothing to search for in an empty database
   ResetStatusBar();
+  if (IsTreeView()) {
+    m_tree->SetToolTip(nullptr); // Clear stale tooltip that may have been set in a previously opened database
+    m_tree->Refresh();
+    m_tree->Update();
+  }
   m_AuiManager.Update();
   // XXX TODO: Reset IdleLockTimer, as preference has reverted to default
   return PWScore::SUCCESS;

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1414,6 +1414,7 @@ void PasswordSafeFrame::ShowTree(bool show)
     m_guiInfo->SaveTreeViewInfo(m_tree);
   }
 
+  m_tree->SetToolTip(nullptr); // Clear stale entry (Notes) or group (number of entries) tooltip that may remain, for example, after deletion
   m_tree->Show(show);
   GetSizer()->Layout();
 }

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -2952,6 +2952,8 @@ void PasswordSafeFrame::LockDb()
 
   // Hide search bar to not populate any search results (see GitHub issue 375)
   GetSearchBarPane().Hide();
+  if (IsTreeView())
+    m_tree->SetToolTip(nullptr); // Clear stale entry (Notes) or group (number of entries) tooltip
   m_AuiManager.Update();
 }
 

--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -990,7 +990,7 @@ void TreeCtrlBase::SelectItem(const CUUID & uuid)
   }
 }
 
-size_t TreeCtrl::GetEntriesCount(const wxTreeItemId& item)
+size_t TreeCtrl::GetEntriesCount(const wxTreeItemId& item) const
 {
   size_t count = 0;
   auto *itemData = dynamic_cast<PWTreeItemData *>(GetItemData(item));
@@ -1017,9 +1017,9 @@ void TreeCtrl::OnGetToolTip( wxTreeEvent& evt )
     }
   }
   else if (ItemIsGroup(id)) { // we're on a group other than root, show number of entries including subgroups
-    int count = GetEntriesCount(id);
+    const size_t count = GetEntriesCount(id);
     if (count > 0) {
-      const wxString entries = (count > 1) ? wxString::Format(_("%d entries under group"), count) : wxString::Format(_("%d entry under group"), count);
+      const wxString entries = wxString::Format(_("Number of entries: %d"), count);
       evt.SetToolTip(entries);
     }
   }

--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -990,14 +990,37 @@ void TreeCtrlBase::SelectItem(const CUUID & uuid)
   }
 }
 
+size_t TreeCtrl::GetEntriesCount(const wxTreeItemId& item)
+{
+  size_t count = 0;
+  auto *itemData = dynamic_cast<PWTreeItemData *>(GetItemData(item));
+  if (itemData && GetChildrenCount(item, false) == 0)
+    ++count;
+  wxTreeItemIdValue cookie;
+  wxTreeItemId child = GetFirstChild(item, cookie);
+  while (child.IsOk()) {
+    count += GetEntriesCount(child);
+    child = GetNextChild(item, cookie);
+  }
+  return count;
+}
+
 void TreeCtrl::OnGetToolTip( wxTreeEvent& evt )
 { // Added manually
-  if (PWSprefs::GetInstance()->GetPref(PWSprefs::ShowNotesAsTooltipsInViews)) {
-    wxTreeItemId id = evt.GetItem();
-    const CItemData *ci = GetItem(id);
-    if (ci != nullptr) {
-      const wxString note = ci->GetNotes().c_str();
+  wxTreeItemId id = evt.GetItem();
+  const CItemData *ci = GetItem(id);
+  if (ci != nullptr) {
+    if (PWSprefs::GetInstance()->GetPref(PWSprefs::ShowNotesAsTooltipsInViews)) {
+      const CItemData *pci = ci->IsShortcut() ? m_core.GetBaseEntry(ci) : ci;
+      const wxString note = pci->GetNotes().c_str();
       evt.SetToolTip(note);
+    }
+  }
+  else if (ItemIsGroup(id)) { // we're on a group other than root, show number of entries including subgroups
+    int count = GetEntriesCount(id);
+    if (count > 0) {
+      const wxString entries = (count > 1) ? wxString::Format(_("%d entries under group"), count) : wxString::Format(_("%d entry under group"), count);
+      evt.SetToolTip(entries);
     }
   }
 }

--- a/src/ui/wxWidgets/TreeCtrl.h
+++ b/src/ui/wxWidgets/TreeCtrl.h
@@ -223,6 +223,8 @@ public:
   /// wxEVT_MOTION event handler for mouse events
   void OnMouseMove(wxMouseEvent& event);
 
+  size_t GetEntriesCount(const wxTreeItemId& item); // Get count of entries in a group, including subgroups
+
   void OnGetToolTip( wxTreeEvent& evt); // Added manually
 
   /// wxEVT_COMMAND_MENU_SELECTED event handler for ID_ADDGROUP

--- a/src/ui/wxWidgets/TreeCtrl.h
+++ b/src/ui/wxWidgets/TreeCtrl.h
@@ -223,7 +223,7 @@ public:
   /// wxEVT_MOTION event handler for mouse events
   void OnMouseMove(wxMouseEvent& event);
 
-  size_t GetEntriesCount(const wxTreeItemId& item); // Get count of entries in a group, including subgroups
+  size_t GetEntriesCount(const wxTreeItemId& item) const; // Get count of entries in a group, including subgroups
 
   void OnGetToolTip( wxTreeEvent& evt); // Added manually
 


### PR DESCRIPTION
This PR makes the wx version behave the same way as the Windows version with regard to entry/shortcut and group tooltips:
Shows Notes for shortcuts (if enabled in Options).
Shows the number of entries in a group tootip.

Note:
Translations (PO files) for the group tooltip were taken from the Windows PO files.

This PR also includes additional updates to the Slovak PO file:
-updated translations to align with recent changes to the Export to TXT/XML feature, custom fields and Flatpak tweaks

Tested on Debian(GNOME)/Mint(Cinnamon)/FreeBSD(KDE)/macOS.

Attached you can find some screenshots.
<img width="1250" height="571" alt="pwsafe_1 24-wxWidgets-feat-group-tooltip-01" src="https://github.com/user-attachments/assets/bd10ca0c-62b7-4f41-b7da-e36939870f1a" />
<img width="1020" height="484" alt="pwsafe_1 24-wxWidgets-feat-group-tooltip-02" src="https://github.com/user-attachments/assets/e9106931-020f-41b3-aaba-96c0a3debb55" />
<img width="1143" height="478" alt="pwsafe_1 24-wxWidgets-feat-group-tooltip-03" src="https://github.com/user-attachments/assets/22cb83e3-0b5c-49b7-8d99-4e99fbc68681" />
