### PR TITLE
[wx] Clear stale Tree tooltips when closing a database

### DIFF
--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -3397,6 +3397,8 @@ void PasswordSafeFrame::CloseDB(std::function<void(bool)> callback)
           m_core.SetReadOnly(false);
           UpdateStatusBar();
           UpdateMenuBar();
+          if (IsTreeView())
+            m_tree->SetToolTip(nullptr); // Clear stale entry (Notes) or group (number of entries) tooltip
           PWSprefs::GetInstance()->SetPref(PWSprefs::FindToolBarActive, showSearchBar);
         }
         else {

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -3394,12 +3394,12 @@ void PasswordSafeFrame::CloseDB(std::function<void(bool)> callback)
           const auto showSearchBar = PWSprefs::GetInstance()->GetPref(PWSprefs::FindToolBarActive);
           wxCommandEvent dummyEv;
           m_search->OnSearchClose(dummyEv); // fix github issue 375
+          PWSprefs::GetInstance()->SetPref(PWSprefs::FindToolBarActive, showSearchBar);
           m_core.SetReadOnly(false);
           UpdateStatusBar();
           UpdateMenuBar();
           if (IsTreeView())
             m_tree->SetToolTip(nullptr); // Clear stale entry (Notes) or group (number of entries) tooltip
-          PWSprefs::GetInstance()->SetPref(PWSprefs::FindToolBarActive, showSearchBar);
         }
         else {
           wxMessageBox(_("Can't close database. There are unsaved changes in opened dialogs."), wxTheApp->GetAppName(), wxOK | wxICON_WARNING, this);


### PR DESCRIPTION
This PR clears stale Tree tooltips when closing a database.

Steps to reproduce:
-Hover the mouse pointer over a group or an entry with Notes (When "Show Notes as Tooltips" is checked in Options).
-Close the database using the main menu, the toolbar, or by pressing Ctrl+W.
-Hover the mouse pointer over the empty area of the Tree. The previously displayed entry or group tooltip is still shown.

Note: With the introduction of group tooltips in PR #1831, this issue may occur more frequently than before.

Tested on Debian/Mint/FreeBSD/macOS.

Attached you can find some screenshots.
<img width="708" height="735" alt="pwsafe_1 24-wxWidgets-bug-tree-tooltip-01" src="https://github.com/user-attachments/assets/429bca3a-febf-448e-870d-9a83c151b1fd" />
<img width="1103" height="517" alt="pwsafe_1 24-wxWidgets-bug-tree-tooltip-02" src="https://github.com/user-attachments/assets/8ad4a616-f816-4c94-b247-76ca9b228b60" />
