### PR TITLE
Bump Xcode version in macos-cmake-latest.yml

### DIFF
--- a/.github/workflows/macos-cmake-latest.yml
+++ b/.github/workflows/macos-cmake-latest.yml
@@ -30,7 +30,7 @@ jobs:
       XCODE_CONFIG: Release
       FORCE_REBUILD_WX: 2
       WX_DEBUG_FLAG: "--disable-debug" 
-      XCODE_VER: "16.4"
+      XCODE_VER: "26.5"
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
GitHub has upgraded macos-latest to 26.x, which does not have Xcode 16.  The current version Xcode is 26.5.

Note that the macos-latest.yml workflow is explicitly using macOS 15 and Xcode 16.  This PR does not change that.