### PR TITLE
[wx] System Tray MRU not working properly

### DIFF
--- a/src/ui/wxWidgets/MenuManageHandlers.cpp
+++ b/src/ui/wxWidgets/MenuManageHandlers.cpp
@@ -120,6 +120,7 @@ void PasswordSafeFrame::DoPreferencesClick()
     }
 
     StringX sxNewDBPrefsString(prefs->Store(true));
+    m_RUEList.SetMax(prefs->GetPref(PWSprefs::MaxREItems)); // Remember last X used entries in System Tray menu
     // Update system tray icon if visible so changes show up immediately
     if (m_sysTray && prefs->GetPref(PWSprefs::UseSystemTray))
         m_sysTray->ShowIcon();

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -461,7 +461,7 @@ void PasswordSafeFrame::Init()
     SetTreeSortType(TreeSortType::GROUP);
   }
 
-  m_RUEList.SetMax(PWSprefs::GetInstance()->PWSprefs::MaxREItems);
+  m_RUEList.SetMax(PWSprefs::GetInstance()->GetPref(PWSprefs::MaxREItems));
 ////@begin PasswordSafeFrame member initialisation
   m_Toolbar = nullptr;
   m_Dragbar = nullptr;
@@ -1277,6 +1277,7 @@ int PasswordSafeFrame::Load(const StringX &passwd)
     SetTitle(m_core.GetCurFile().c_str());
     m_sysTray->SetTrayStatus(SystemTray::TrayStatus::UNLOCKED);
     m_core.ResumeOnDBNotification();
+    m_RUEList.SetRUEList(m_core.GetRUEList()); // It is populated in PWScore::ReadFile() from the file header
   } else {
     SetTitle(wxEmptyString);
     m_sysTray->SetTrayStatus(SystemTray::TrayStatus::CLOSED);

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -1277,7 +1277,7 @@ int PasswordSafeFrame::Load(const StringX &passwd)
     SetTitle(m_core.GetCurFile().c_str());
     m_sysTray->SetTrayStatus(SystemTray::TrayStatus::UNLOCKED);
     m_core.ResumeOnDBNotification();
-    m_RUEList.SetRUEList(m_core.GetRUEList()); // It is populated in PWScore::ReadFile() from the file header
+    m_RUEList.SetRUEList(m_core.GetRUEList());
   } else {
     SetTitle(wxEmptyString);
     m_sysTray->SetTrayStatus(SystemTray::TrayStatus::CLOSED);


### PR DESCRIPTION
This PR fixes several issues with the Entries MRU List in System Tray in the wx version.

Issues:
1. The "Remember last X used entries" setting in Options > System is not honored due to an incorrect reference. It always returns 10, and the value cannot be changed.
2. The feature cannot be disabled by setting the value to 0.
3. The List is stored in the database file but is not loaded when the database is opened.

Tested on Debian/Mint/macOS.

Attached you can find some screenshots.
<img width="1440" height="810" alt="pwsafe_1 24-wxWidgets-bug-SysTrayMRU-01" src="https://github.com/user-attachments/assets/6957cd0b-66ef-4e8b-857f-079a054aa4c2" />
