### PR TITLE
Fix Linux compiler warnings & treat any future ones as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,13 @@ endif (WX_WINDOWS)
 include(set-options-msvc)
 else ()
 set(CMAKE_CXX_FLAGS
-  "${CMAKE_CXX_FLAGS} -Wall -DUNICODE -DWCHAR_INCOMPATIBLE_XMLCH ${CMAKE_WXWINDOWS_CXX_FLAGS}")
+    "${CMAKE_CXX_FLAGS} -Wall -DUNICODE -DWCHAR_INCOMPATIBLE_XMLCH ${CMAKE_WXWINDOWS_CXX_FLAGS}")
+  if (NOT APPLE)
+    # TODO: with the below flag the Mac cmake-based build fails with an error:
+    #   clang: error: argument unused during compilation: '-fstack-clash-protection'
+    # it's possible check_cxx_compiler_flag is using the wrong compiler for the check?
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  endif (NOT APPLE)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
 if (USE_ASAN)
   set(CMAKE_CXX_FLAGS_DEBUG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if (UNIX)
 endif ()
 
 if (NOT WIN32)
-include(FindUnixCommands)
+  include(FindUnixCommands)
 endif (NOT WIN32)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
@@ -80,9 +80,9 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   option (NO_QR "Set ON to disable QR support" OFF)
   if (NOT NO_QR)
     CHECK_INCLUDE_FILE("qrencode.h" HAVE_LIBQRENCODE_DEV)
-    if(NOT HAVE_LIBQRENCODE_DEV)
+    if (NOT HAVE_LIBQRENCODE_DEV)
       unset(HAVE_LIBQRENCODE_DEV CACHE)
-      message( FATAL_ERROR "libqrencode-dev(el) not installed: install or select NO_QR")
+      message(FATAL_ERROR "libqrencode-dev(el) not installed: install or select NO_QR")
     endif(NOT HAVE_LIBQRENCODE_DEV)
   else (NOT NO_QR)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_QR")
@@ -93,7 +93,7 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 if (NOT WIN32 OR WX_WINDOWS)
   if (NOT WIN32)
      # help people with wxWidgets on non-standard installation
-     # quick-and-dirty since wxWdigets cmake's support is not yet loaded.
+     # quick-and-dirty since wxWidgets cmake's support is not yet loaded.
      find_program(PWSHINT_wxconfig wx-config)
      if (NOT PWSHINT_wxconfig)
        message(STATUS
@@ -117,7 +117,7 @@ endif (NOT WIN32 OR WX_WINDOWS)
 
 if (NOT WIN32)
     if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-      set( CMAKE_REQUIRED_INCLUDES "/usr/local/include" )
+      set(CMAKE_REQUIRED_INCLUDES "/usr/local/include")
     endif (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
     if (${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
 	  CHECK_INCLUDE_FILE("uuid.h" UUID_H)
@@ -128,7 +128,7 @@ if (NOT WIN32)
     message(FATAL_ERROR
       "uuid.h not found - uuid-dev / libuuid-devel not installed?")
   endif(NOT UUID_H)
-  if(NOT NO_YUBI)
+  if (NOT NO_YUBI)
     if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
       CHECK_LIBRARY_EXISTS(ykpers-1 yk_init "/usr/local/lib/" HAVE_YKPERS_H)
     else ()
@@ -136,7 +136,7 @@ if (NOT WIN32)
     endif (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
   endif(NOT NO_YUBI)
 
-  if(NOT HAVE_YKPERS_H)
+  if (NOT HAVE_YKPERS_H)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_YUBI")
     message(STATUS "Yubikey support disabled")
   endif(NOT HAVE_YKPERS_H)
@@ -200,24 +200,24 @@ add_compile_definitions(
 
 # Assume that we're either MSVC or a Unix-like
 if (MSVC)
-# Debug build looks for dlls with _D postfix, this provides it:
-set (CMAKE_DEBUG_POSTFIX "_D")
-# This copies dlls to same directory as exec upon 'install' build
-set (CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR})
+  # Debug build looks for dlls with _D postfix, this provides it:
+  set (CMAKE_DEBUG_POSTFIX "_D")
+  # This copies dlls to same directory as exec upon 'install' build
+  set (CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR})
 
-set_property (GLOBAL PROPERTY USE_FOLDERS ON)
+  set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 
-if (NO_YUBI)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_YUBI")
-endif (NO_YUBI)
+  if (NO_YUBI)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_YUBI")
+  endif (NO_YUBI)
 
-if (WX_WINDOWS)
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D __WX__")
-endif (WX_WINDOWS)
+  if (WX_WINDOWS)
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D __WX__")
+  endif (WX_WINDOWS)
 
-include(set-options-msvc)
+  include(set-options-msvc)
 else ()
-set(CMAKE_CXX_FLAGS
+  set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -Wall -DUNICODE -DWCHAR_INCOMPATIBLE_XMLCH ${CMAKE_WXWINDOWS_CXX_FLAGS}")
   if (NOT APPLE)
     # TODO: with the below flag the Mac cmake-based build fails with an error:
@@ -225,11 +225,11 @@ set(CMAKE_CXX_FLAGS
     # it's possible check_cxx_compiler_flag is using the wrong compiler for the check?
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
   endif (NOT APPLE)
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
-if (USE_ASAN)
-  set(CMAKE_CXX_FLAGS_DEBUG
-    "${CMAKE_CXX_FLAGS_DEBUG} -gdwarf-4 -O0 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address")
-endif (USE_ASAN)
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
+  if (USE_ASAN)
+    set(CMAKE_CXX_FLAGS_DEBUG
+      "${CMAKE_CXX_FLAGS_DEBUG} -gdwarf-4 -O0 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address")
+  endif (USE_ASAN)
 endif (MSVC)
 
 if (NOT NO_GTEST AND GTEST_BUILD)
@@ -260,11 +260,11 @@ if (NOT NO_GTEST AND GTEST_BUILD)
                        )
 endif(NOT NO_GTEST AND GTEST_BUILD)
 
-if( NOT CMAKE_BUILD_TYPE )
-  set( CMAKE_BUILD_TYPE Release )
-endif( NOT CMAKE_BUILD_TYPE )
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif(NOT CMAKE_BUILD_TYPE)
 
-if(HAVE_YKPERS_H)
+if (HAVE_YKPERS_H)
   if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I/usr/local/include/ykpers-1")
   else ()
@@ -316,7 +316,7 @@ if (NOT WIN32)
   add_executable(pwsafe ${PWSAFE_SRCS})
 else (NOT WIN32)
    add_executable(pwsafe WIN32 ${PWSAFE_SRCS})
-   add_dependencies( pwsafe language-dlls) # i18n dlls
+   add_dependencies(pwsafe language-dlls) # i18n dlls
    if (NOT WX_WINDOWS)
       set (PWS_DLL_LIBS "pws_at" "pws_osk")
       set_target_properties(pwsafe PROPERTIES COMPILE_DEFINITIONS
@@ -395,7 +395,7 @@ else ()
 endif (NOT WIN32)
 
 # uninstall target
-if(NOT TARGET uninstall)
+if (NOT TARGET uninstall)
   configure_file(
       "${CMAKE_CURRENT_SOURCE_DIR}/install/cmake_uninstall.cmake.in"
       "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
@@ -702,7 +702,6 @@ set (CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
      "/usr/share/locale/sv" "/usr/share/locale/sv/LC_MESSAGES"
      "/usr/share/locale/zh_CN" "/usr/share/locale/zh_CN/LC_MESSAGES"
      "/usr/share/applications" "/usr/share/pixmaps"
-     "/usr/share/icons/hicolor" "/usr/share/icons/hicolor/48x48" "/usr/share/icons/hicolor/48x48/apps"
      "/usr/share/icons" "/usr/share/icons/hicolor"
      "/usr/share/icons/hicolor/48x48" "/usr/share/icons/hicolor/48x48/apps"
     )

--- a/src/os/unix/utf8conv.cpp
+++ b/src/os/unix/utf8conv.cpp
@@ -33,18 +33,21 @@ public:
       // Couldn't get environment-specified locale, warn user
       // and punt to default "C"
       char wrnmess[] = "Couldn't load locale, falling back to default\n";
-      (void) write(STDERR_FILENO, wrnmess, sizeof(wrnmess)/sizeof(*wrnmess)-1);
+      [[maybe_unused]] const auto nbytes = write(STDERR_FILENO, wrnmess, sizeof(wrnmess)/sizeof(*wrnmess)-1);
+      ASSERT(nbytes > 0);
       sl = setlocale(LC_ALL, gl);
     }
     if (sl == nullptr) {
       // If we can't get the default, we're really FUBARed
       char errmess[] = "Couldn't initialize locale - bailing out\n";
-      (void) write(STDERR_FILENO, errmess, sizeof(errmess)/sizeof(*errmess)-1);
+      [[maybe_unused]] const auto nbytes = write(STDERR_FILENO, errmess, sizeof(errmess)/sizeof(*errmess)-1);
+      ASSERT(nbytes > 0);
       _exit(2);
     }
     if (strcmp(nl_langinfo(CODESET), "UTF-8")){
       char errmess[] = "Current locale doesn't support UTF-8\n";
-      (void) write(STDERR_FILENO, errmess, sizeof(errmess)/sizeof(*errmess)-1);
+      [[maybe_unused]] const auto nbytes = write(STDERR_FILENO, errmess, sizeof(errmess)/sizeof(*errmess)-1);
+      ASSERT(nbytes > 0);
     }
   }
 };

--- a/src/test/TOTPTest.cpp
+++ b/src/test/TOTPTest.cpp
@@ -86,10 +86,11 @@ TEST(TOTPTest, key_decoder_copy_move_cleanup)
   EXPECT_TRUE(dec2.get_size() == dec2.get_size());
 
   const unsigned char* dec3_ptr = dec3.get_ptr();
-  dec3 = dec3;
-  EXPECT_TRUE(dec3_ptr == dec3.get_ptr());
-  dec3 = std::move(dec3);
-  EXPECT_TRUE(dec3_ptr == dec3.get_ptr());
+  RFC4648_Base32Decoder& dec3ref = dec3;
+  dec3ref = dec3;
+  EXPECT_TRUE(dec3_ptr == dec3ref.get_ptr());
+  dec3ref = std::move(dec3);
+  EXPECT_TRUE(dec3_ptr == dec3ref.get_ptr());
 
   RFC4648_Base32Decoder dec4(valid_key2.c_str());
   EXPECT_TRUE(dec4.is_decoding_successful());

--- a/src/ui/cli/search.cpp
+++ b/src/ui/cli/search.cpp
@@ -226,13 +226,13 @@ int SearchInternal(PWScore &core, const UserArgs &ua, wostream &os)
     case UserArgs::ClearFields:
     {
       CItemData::FieldBits ftp = ParseFields(ua.opArg2);
-      return DoSearch<UserArgs::ClearFields>(core, ua, [&core, &ua, &ftp](const ItemPtrVec &matches) {
+      return DoSearch<UserArgs::ClearFields>(core, ua, [&core, &ftp](const ItemPtrVec &matches) {
         return ClearFieldsOfSearchResults(matches, core, ftp);
       });
     }
 
     case UserArgs::ChangePassword:
-      return DoSearch<UserArgs::ChangePassword>(core, ua, [&core, &ua](const ItemPtrVec &matches) {
+      return DoSearch<UserArgs::ChangePassword>(core, ua, [&core](const ItemPtrVec &matches) {
         return ChangePasswordOfSearchResults(matches, core);
       });
 

--- a/src/ui/cli/split-test.cpp
+++ b/src/ui/cli/split-test.cpp
@@ -90,8 +90,3 @@ TEST_F(SplitTest, IgnoresEmptyTokensBeforeAndAfterSeparator) {
 
 
 }  // namespace
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -2913,7 +2913,7 @@ uint32_t AddEditPropSheetDlg::GetChanges() const
   // symbols
   {
     const auto oldSymbols = m_Item.GetSymbols();
-    if (tostringx(m_Symbols) != oldSymbols && (!oldSymbols.empty() || m_Symbols != CPasswordCharPool::GetDefaultSymbols())) {
+    if (tostringx(m_Symbols) != oldSymbols && (!oldSymbols.empty() || m_Symbols != towxstring(CPasswordCharPool::GetDefaultSymbols()))) {
       changes |= Changes::Symbols;
     }
   }

--- a/src/ui/wxWidgets/DeleteConfirmationDlg.cpp
+++ b/src/ui/wxWidgets/DeleteConfirmationDlg.cpp
@@ -22,6 +22,7 @@
 
 #include "DeleteConfirmationDlg.h"
 #include "core/PWSprefs.h"
+#include "wxUtilities.h"
 
 #ifdef __WXMSW__
 #include <wx/msw/msvcrt.h>

--- a/src/ui/wxWidgets/PWFiltersBoolDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersBoolDlg.cpp
@@ -28,7 +28,7 @@
 #include "PWFiltersEditor.h"
 #include "PWFiltersTable.h"
 #include "PWFiltersGrid.h"
-
+#include "wxUtilities.h"
 
 //(*IdInit(pwFiltersBoolDlg)
 const PWSMatch::MatchRule pwFiltersBoolDlg::m_mrxp[PW_NUM_BOOL_ENUM] = {PWSMatch::MR_PRESENT, PWSMatch::MR_NOTPRESENT};

--- a/src/ui/wxWidgets/PWFiltersDateDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersDateDlg.cpp
@@ -29,6 +29,7 @@
 #include "PWFiltersEditor.h"
 #include "PWFiltersTable.h"
 #include "PWFiltersGrid.h"
+#include "wxUtilities.h"
 
 //(*IdInit(pwFiltersDateDlg)
 const PWSMatch::MatchRule pwFiltersDateDlg::m_mrpres[PW_NUM_PRESENT_ENUM] = {

--- a/src/ui/wxWidgets/PWFiltersIntegerDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersIntegerDlg.cpp
@@ -31,6 +31,7 @@
 #include "PWFiltersEditor.h"
 #include "PWFiltersTable.h"
 #include "PWFiltersGrid.h"
+#include "wxUtilities.h"
 
 //(*IdInit(pwFiltersIntegerDlg)
 const PWSMatch::MatchRule pwFiltersIntegerDlg::m_mrpres[PW_NUM_PRESENT_ENUM] = {

--- a/src/ui/wxWidgets/PWFiltersMediaDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersMediaDlg.cpp
@@ -28,6 +28,7 @@
 #include "PWFiltersEditor.h"
 #include "PWFiltersTable.h"
 #include "PWFiltersGrid.h"
+#include "wxUtilities.h"
 
 //(*IdInit(pwFiltersMediaTypesDlg)
 const PWSMatch::MatchRule pwFiltersMediaTypesDlg::m_mrpres[PW_NUM_PRESENT_ENUM] = {

--- a/src/ui/wxWidgets/PWFiltersPasswordDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersPasswordDlg.cpp
@@ -31,6 +31,7 @@
 #include "PWFiltersEditor.h"
 #include "PWFiltersTable.h"
 #include "PWFiltersGrid.h"
+#include "wxUtilities.h"
 
 //(*IdInit(pwFiltersPasswordDlg)
 const PWSMatch::MatchRule pwFiltersPasswordDlg::m_mrcrit[PW_NUM_PASSWORD_CRITERIA_ENUM] = {

--- a/src/ui/wxWidgets/PWFiltersStringDlg.cpp
+++ b/src/ui/wxWidgets/PWFiltersStringDlg.cpp
@@ -28,6 +28,7 @@
 #include "PWFiltersEditor.h"
 #include "PWFiltersTable.h"
 #include "PWFiltersGrid.h"
+#include "wxUtilities.h"
 
 //(*IdInit(pwFiltersStringDlg)
 const PWSMatch::MatchRule pwFiltersStringDlg::m_mrpres[PW_NUM_PRESENT_ENUM] = {

--- a/src/ui/wxWidgets/PasswordSubsetDlg.cpp
+++ b/src/ui/wxWidgets/PasswordSubsetDlg.cpp
@@ -25,6 +25,7 @@
 #include <wx/tokenzr.h>
 #include "PasswordSubsetDlg.h"
 #include "Clipboard.h"
+#include "wxUtilities.h"
 
 ////@begin XPM images
 #include "graphics/toolbar/new/copypassword.xpm"

--- a/src/ui/wxWidgets/SetFiltersDlg.cpp
+++ b/src/ui/wxWidgets/SetFiltersDlg.cpp
@@ -401,7 +401,7 @@ bool SetFiltersDlg::VerifyFilters()
 }
 
 bool SetFiltersDlg::IsChanged() const {
-  return *m_pfilters != m_origFilters || m_filterName != m_origFilters.fname;
+  return *m_pfilters != m_origFilters || m_filterName != towxstring(m_origFilters.fname);
 }
 
 bool SetFiltersDlg::SyncAndQueryCancel(bool showDialog) {

--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -1526,9 +1526,9 @@ void TreeCtrl::OnEndDrag(wxTreeEvent& evt)
 
       auto *commands = MultiCommands::Create(&m_core);
 
-      // If the drag'd item leaves an empty group in the tree
+      // If the dragged item leaves an empty group in the tree
       // the group needs to be created as such in the database.
-      if (dragItemLeavesEmptyGroup && (GetRootItem() != GetItemGroup(parentOfDragItem))) {
+      if (dragItemLeavesEmptyGroup && GetItemGroup(parentOfDragItem) != wxEmptyString) {
         auto emptyGroups = m_core.GetEmptyGroups();
         emptyGroups.push_back(tostringx(GetItemGroup(parentOfDragItem))); // parent of entry or group
         commands->Add(

--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -891,8 +891,7 @@ void TreeCtrlBase::SetItemImage(const wxTreeItemId &node,
       if (PWSprefs::GetInstance()->GetPref(PWSprefs::PreExpiryWarn)) {
         int idays = PWSprefs::GetInstance()->GetPref(PWSprefs::PreExpiryWarnDays);
         struct tm st;
-        errno_t err;
-        err = localtime_s(&st, &now);  // secure version
+        [[maybe_unused]] errno_t err = localtime_s(&st, &now);  // secure version
         ASSERT(err == 0);
         st.tm_mday += idays;
         warnexptime = mktime(&st);

--- a/src/ui/wxWidgets/wxUtilities.h
+++ b/src/ui/wxWidgets/wxUtilities.h
@@ -72,6 +72,17 @@ inline wxString& operator<<(wxString& w, const stringT& s) {
   return w << towxstring(s);
 }
 
+#if wxVERSION_NUMBER < 3106
+// these are needed to prevent compiler errors about "bitwise operation between different enumeration types" with old
+// versions of wxWidgets
+constexpr int operator|(wxAlignment a, wxDirection d) { return static_cast<int>(a) | static_cast<int>(d); }
+constexpr int operator|(wxDirection d, wxAlignment a) { return static_cast<int>(a) | static_cast<int>(d); }
+constexpr int operator|(wxStretch s, wxDirection d) { return static_cast<int>(s) | static_cast<int>(d); }
+constexpr int operator|(wxDirection d, wxStretch s) { return static_cast<int>(s) | static_cast<int>(d); }
+constexpr int operator|(wxStretch s, wxAlignment a) { return static_cast<int>(s) | static_cast<int>(a); }
+constexpr int operator|(wxAlignment a, wxStretch s) { return static_cast<int>(s) | static_cast<int>(a); }
+#endif
+
 inline void ApplyFontPreference(wxWindow* window, const PWSprefs::StringPrefs fontPreference)
 {
   switch (fontPreference)


### PR DESCRIPTION
There have been cases before when a missed compiler warning caused a bug, so this enforcement should help reduce such instances and also improve the code quality a bit. We should do this for other platforms too, but I can't verify those builds work locally. Will try and see if the Github builds succeed.