### PR TITLE
Fix infinite loop in Comparison Dialog

### DIFF
--- a/src/ui/wxWidgets/ComparisonGridTable.cpp
+++ b/src/ui/wxWidgets/ComparisonGridTable.cpp
@@ -552,16 +552,16 @@ wxPen ComparisonGrid::GetRowGridLinePen(int row)
 void ComparisonGrid::OnGridRangeSelect(wxGridRangeSelectEvent& evt)
 {
   //select grids asynchronously, or else we get in an infinite loop of selections & their notifications
-  if (evt.GetTopRow()%2 != 0 && !IsInSelection(evt.GetTopRow()-1, 0)) {
+  if (auto topRow = evt.GetTopRow(); topRow%2 != 0 && !IsInSelection(topRow-1, 0)) {
     wxCommandEvent cmdEvent(EVT_SELECT_GRID_ROW);
     cmdEvent.SetEventObject(evt.GetEventObject());
-    cmdEvent.SetInt(evt.GetTopRow()-1);
+    cmdEvent.SetInt(topRow-1);
     GetEventHandler()->AddPendingEvent(cmdEvent);
   }
-  if (evt.GetBottomRow()%2 == 0 && !IsInSelection(evt.GetTopRow()+1, 0)) {
+  if (auto bottomRow = evt.GetBottomRow(); bottomRow%2 == 0 && !IsInSelection(bottomRow+1, 0)) {
     wxCommandEvent cmdEvent(EVT_SELECT_GRID_ROW);
     cmdEvent.SetEventObject(evt.GetEventObject());
-    cmdEvent.SetInt(evt.GetBottomRow()+1);
+    cmdEvent.SetInt(bottomRow+1);
     GetEventHandler()->AddPendingEvent(cmdEvent);
   }
 }

--- a/src/ui/wxWidgets/ComparisonGridTable.cpp
+++ b/src/ui/wxWidgets/ComparisonGridTable.cpp
@@ -552,13 +552,13 @@ wxPen ComparisonGrid::GetRowGridLinePen(int row)
 void ComparisonGrid::OnGridRangeSelect(wxGridRangeSelectEvent& evt)
 {
   //select grids asynchronously, or else we get in an infinite loop of selections & their notifications
-  if (evt.GetTopRow()%2 != 0) {
+  if (evt.GetTopRow()%2 != 0 && !IsInSelection(evt.GetTopRow()-1, 0)) {
     wxCommandEvent cmdEvent(EVT_SELECT_GRID_ROW);
     cmdEvent.SetEventObject(evt.GetEventObject());
     cmdEvent.SetInt(evt.GetTopRow()-1);
     GetEventHandler()->AddPendingEvent(cmdEvent);
   }
-  if (evt.GetBottomRow()%2 == 0) {
+  if (evt.GetBottomRow()%2 == 0 && !IsInSelection(evt.GetTopRow()+1, 0)) {
     wxCommandEvent cmdEvent(EVT_SELECT_GRID_ROW);
     cmdEvent.SetEventObject(evt.GetEventObject());
     cmdEvent.SetInt(evt.GetBottomRow()+1);


### PR DESCRIPTION
https://github.com/pwsafe/pwsafe/issues/1856

Something changed in recent versions of wxWidgets that broke pwsafe's logic of always selecting 2 rows at a time. Use wxGrid's selection state data to avoid selecting a row that's already selected.