### PR TITLE
No json for ykpers

### DIFF
--- a/.github/workflows/macos-cmake-latest.yml
+++ b/.github/workflows/macos-cmake-latest.yml
@@ -73,7 +73,7 @@ jobs:
         cd yubikey-personalization
         git checkout db0c0d641d47ee52e43af94dcee603d76186b6d3
         autoreconf --install --force
-        ./configure --disable-shared --disable-documentation CFLAGS="-O2 -arch arm64 -arch x86_64 -mmacosx-version-min=$MACOS_VER_MIN"
+        ./configure --disable-shared --disable-documentation --without-json CFLAGS="-O2 -arch arm64 -arch x86_64 -mmacosx-version-min=$MACOS_VER_MIN"
         make -j $HOST_NCPU check
         sudo make install
 

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -82,7 +82,7 @@ jobs:
         cd yubikey-personalization
         git checkout db0c0d641d47ee52e43af94dcee603d76186b6d3
         autoreconf --install --force
-        ./configure --disable-shared --disable-documentation CFLAGS="-O2 -arch arm64 -arch x86_64 -mmacosx-version-min=$MACOS_VER_MIN"
+        ./configure --disable-shared --disable-documentation --without-json CFLAGS="-O2 -arch arm64 -arch x86_64 -mmacosx-version-min=$MACOS_VER_MIN"
         make -j $HOST_NCPU check
         sudo make install
 


### PR DESCRIPTION
Looks like the 20260706 runner image added a JSON library via homebrew, but only for arm64, so the builds are failing on the x86_64 part.  We didn't have it before, so we don't need it now.  Added --without-json to the configure command for yubikey-personalization.