### PR TITLE
[wx] Fix - Build fails on BSD systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,10 +220,12 @@ else ()
   set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -Wall -DUNICODE -DWCHAR_INCOMPATIBLE_XMLCH ${CMAKE_WXWINDOWS_CXX_FLAGS}")
   if (NOT APPLE)
-    # TODO: with the below flag the Mac cmake-based build fails with an error:
+    # TODO: with the below flag the Mac and BSD cmake-based builds fail with an error such as:
     #   clang: error: argument unused during compilation: '-fstack-clash-protection'
     # it's possible check_cxx_compiler_flag is using the wrong compiler for the check?
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   endif (NOT APPLE)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
   if (USE_ASAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,14 +219,12 @@ if (MSVC)
 else ()
   set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -Wall -DUNICODE -DWCHAR_INCOMPATIBLE_XMLCH ${CMAKE_WXWINDOWS_CXX_FLAGS}")
-  if (NOT APPLE)
+  if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     # TODO: with the below flag the Mac and BSD cmake-based builds fail with an error such as:
     #   clang: error: argument unused during compilation: '-fstack-clash-protection'
     # it's possible check_cxx_compiler_flag is using the wrong compiler for the check?
-    if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-    endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  endif (NOT APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
   if (USE_ASAN)
     set(CMAKE_CXX_FLAGS_DEBUG


### PR DESCRIPTION
The "Fix Linux compiler warnings & treat any future ones as errors" change in PR #1851 causes compilation to fail on BSD systems because Clang is the default compiler.

This PR provides a quick fix to restore successful compilation on FreeBSD and OpenBSD.

Tested on Debian/FreeBSD/OpenBSD.

Attached you can find some screenshots.

FreeBSD - before:
<img width="2456" height="1322" alt="pwsafe_1 24-wxWidgets-bug-FreeBSD-CMake-01" src="https://github.com/user-attachments/assets/e37b4e53-ce3f-46d4-95e2-ec12d924203e" />
FreeBSD - after (it builds successfully - warnings only):
<img width="2456" height="1322" alt="pwsafe_1 24-wxWidgets-bug-FreeBSD-CMake-02" src="https://github.com/user-attachments/assets/73e5591e-a0c6-4139-8ac5-d78815f34624" />
OpenBSD - before:
<img width="1976" height="752" alt="pwsafe_1 24-wxWidgets-bug-OpenBSD-CMake-01" src="https://github.com/user-attachments/assets/50812e76-ad6a-4f07-afc7-201c7713c419" />
OpenBSD - after (it builds successfully - warnings only):
<img width="2560" height="1600" alt="pwsafe_1 24-wxWidgets-bug-OpenBSD-CMake-02" src="https://github.com/user-attachments/assets/809e9a6b-85de-44a9-9526-8d52342e1b08" />
