### PR TITLE
[macOS] Fix compiler warnings and add -Wall -pedantic -Werror

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -73,7 +73,7 @@ jobs:
         git checkout e4334554857b0367085cbf845bf87dd92433e020
         autoreconf --install --force
         ./configure --disable-shared --disable-documentation CFLAGS="-O2 -arch arm64 -arch x86_64 -mmacosx-version-min=$MACOS_VER_MIN"
-        make -j $HOST_NCPU check
+        make --quiet -j $HOST_NCPU check
         sudo make install
 
     - name: Build ykpers from upstream
@@ -83,7 +83,7 @@ jobs:
         git checkout db0c0d641d47ee52e43af94dcee603d76186b6d3
         autoreconf --install --force
         ./configure --disable-shared --disable-documentation --without-json CFLAGS="-O2 -arch arm64 -arch x86_64 -mmacosx-version-min=$MACOS_VER_MIN"
-        make -j $HOST_NCPU check
+        make --quiet -j $HOST_NCPU check
         sudo make install
 
     - name: Cache wxWidgets build
@@ -109,7 +109,7 @@ jobs:
         cd $WX_SRC_DIR
         # use built-in versions of jpeg, tiff, png, and regex (pcre2) libs to avoid linking with those in /usr/local/opt
         ./configure --enable-universal_binary=$WX_ARCH --prefix=$WX_BUILD_DIR --disable-shared --enable-unicode --with-macosx-version-min=$MACOS_VER_MIN --with-libpng=builtin --with-libjpeg=builtin --with-libtiff=builtin --with-regex=builtin --without-liblzma $WX_DEBUG_FLAG
-        make -j $HOST_NCPU
+        make --quiet -j $HOST_NCPU
         cd locale; make allmo; cd ..
         sudo make install
         du -sh $WX_BUILD_DIR
@@ -122,7 +122,7 @@ jobs:
     
     - name: Build pwsafe and test programs
       working-directory: ${{ github.workspace }}
-      run: xcodebuild -derivedDataPath $XCODE_DIR -project Xcode/pwsafe-xcode6.xcodeproj -scheme All -configuration $XCODE_CONFIG
+      run: xcodebuild -quiet -derivedDataPath $XCODE_DIR -project Xcode/pwsafe-xcode6.xcodeproj -scheme All -configuration $XCODE_CONFIG
 
     - name: Run coretest
       working-directory: src/test

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -3341,10 +3341,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.pwsafe.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = pwsafe;
 				USER_HEADER_SEARCH_PATHS = ../src;
-				WARNING_CFLAGS = (
-					"$(inherited)",
-					"-Wno-overloaded-virtual",
-				);
 			};
 			name = Release;
 		};

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		5700B9922DF25C020067D2D9 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6C94E991FA33BA6008F0072 /* QuartzCore.framework */; };
 		5700B9932DF260210067D2D9 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3A7B67C254824C000E780B8 /* AppKit.framework */; };
 		5700B9942DF260BC0067D2D9 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6B1449312B26D7E00415AAE /* IOKit.framework */; };
-		5700B9962DF260F30067D2D9 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E69B800911F61CF20084F6C4 /* Carbon.framework */; };
 		5707816E2B0C4D030082EB6E /* YubiCfgDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5707816A2B0C4CED0082EB6E /* YubiCfgDlg.cpp */; };
 		570781702B0C4D030082EB6E /* YubiMixin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5707816C2B0C4CED0082EB6E /* YubiMixin.cpp */; };
 		570781742B0C4D330082EB6E /* PWYubi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 570781692B0C4CD30082EB6E /* PWYubi.cpp */; };
@@ -85,6 +84,13 @@
 		A2FE25921C5ACF7500210C36 /* PWSfileV4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE258B1C5ACF7500210C36 /* PWSfileV4.cpp */; };
 		A2FE25951C5ACFBD00210C36 /* PWStime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25931C5ACFBD00210C36 /* PWStime.cpp */; };
 		A6F2B3362832B0380096A7E4 /* QueryCancelDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A6F2B3342832B0380096A7E4 /* QueryCancelDlg.cpp */; };
+		AC5EDDE42FFED65D0073460C /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6B1449312B26D7E00415AAE /* IOKit.framework */; };
+		AC5EDDE52FFED6650073460C /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E69B800911F61CF20084F6C4 /* Carbon.framework */; };
+		AC5EDDE82FFED6B00073460C /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6C94E991FA33BA6008F0072 /* QuartzCore.framework */; };
+		AC5EDDE92FFED6E50073460C /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6C94E991FA33BA6008F0072 /* QuartzCore.framework */; };
+		AC5EDDEA2FFED6F20073460C /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6B1449312B26D7E00415AAE /* IOKit.framework */; };
+		AC5EDDEB2FFED6F80073460C /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E69B800911F61CF20084F6C4 /* Carbon.framework */; };
+		AC5EDDED2FFF2F630073460C /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E69B800911F61CF20084F6C4 /* Carbon.framework */; };
 		B84A41C2A9CBBC9791F9B2DF /* base32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5BE1417792CF637AD3D45F4D /* base32.cpp */; };
 		D3012934262C731500FDF023 /* PWFiltersStringDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D3012932262C731500FDF023 /* PWFiltersStringDlg.cpp */; };
 		D31B027926384D29000EAA61 /* PWFiltersMediaDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D31B027726384D29000EAA61 /* PWFiltersMediaDlg.cpp */; };
@@ -1006,6 +1012,9 @@
 			files = (
 				5762BC192DE7E26800322CA5 /* libcore.a in Frameworks */,
 				5762BC1C2DE7E26800322CA5 /* libos.a in Frameworks */,
+				AC5EDDE52FFED6650073460C /* Carbon.framework in Frameworks */,
+				AC5EDDE42FFED65D0073460C /* IOKit.framework in Frameworks */,
+				AC5EDDE82FFED6B00073460C /* QuartzCore.framework in Frameworks */,
 				5762BC1B2DE7E26800322CA5 /* AppKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1016,7 +1025,7 @@
 			files = (
 				57E951B42DE9377000DE9640 /* libcore.a in Frameworks */,
 				57E951B52DE9377500DE9640 /* libos.a in Frameworks */,
-				5700B9962DF260F30067D2D9 /* Carbon.framework in Frameworks */,
+				AC5EDDED2FFF2F630073460C /* Carbon.framework in Frameworks */,
 				5700B9942DF260BC0067D2D9 /* IOKit.framework in Frameworks */,
 				5700B9922DF25C020067D2D9 /* QuartzCore.framework in Frameworks */,
 				57E951B62DE937D200DE9640 /* AppKit.framework in Frameworks */,
@@ -1029,6 +1038,9 @@
 			files = (
 				E66D293C1D02B92F00C9BCBF /* libcore.a in Frameworks */,
 				E66D293D1D02B92F00C9BCBF /* libos.a in Frameworks */,
+				AC5EDDEB2FFED6F80073460C /* Carbon.framework in Frameworks */,
+				AC5EDDEA2FFED6F20073460C /* IOKit.framework in Frameworks */,
+				AC5EDDE92FFED6E50073460C /* QuartzCore.framework in Frameworks */,
 				5700B9932DF260210067D2D9 /* AppKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -2512,6 +2512,7 @@
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_PEDANTIC = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
@@ -2520,6 +2521,7 @@
 				GTEST_LIB = /opt/homebrew/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				ONLY_ACTIVE_ARCH = YES;
+				WARNING_CFLAGS = "-Wall";
 			};
 			name = "Debug-no-yubi";
 		};
@@ -2533,7 +2535,7 @@
 				PRODUCT_NAME = core;
 				USER_HEADER_SEARCH_PATHS = ../src/;
 				WARNING_CFLAGS = (
-					"-Wall",
+					"$(inherited)",
 					"-Wextra",
 				);
 			};
@@ -2553,7 +2555,7 @@
 				PRODUCT_NAME = os;
 				USER_HEADER_SEARCH_PATHS = ../src;
 				WARNING_CFLAGS = (
-					"-Wall",
+					"$(inherited)",
 					"-Wextra",
 				);
 			};
@@ -2614,7 +2616,6 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../src/core,
 					../src,
 				);
@@ -2642,7 +2643,6 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../src/core,
 					../src,
 					"$(GTEST_INC)",
@@ -2671,7 +2671,6 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../src/core,
 					../src,
 					"$(GTEST_INC)",
@@ -2698,7 +2697,6 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../src/core,
 					../src,
 					"$(GTEST_INC)",
@@ -2728,7 +2726,6 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../src/core,
 					../src,
 					"$(GTEST_INC)",
@@ -2757,7 +2754,6 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../src/core,
 					../src,
 					"$(GTEST_INC)",
@@ -2784,7 +2780,6 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../src/core,
 					../src,
 					"$(GTEST_INC)",
@@ -2848,6 +2843,7 @@
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_PEDANTIC = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
@@ -2856,6 +2852,7 @@
 				GTEST_LIB = /opt/homebrew/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				ONLY_ACTIVE_ARCH = YES;
+				WARNING_CFLAGS = "-Wall";
 			};
 			name = "Homebrew-Release";
 		};
@@ -2868,7 +2865,7 @@
 				PRODUCT_NAME = core;
 				USER_HEADER_SEARCH_PATHS = ../src/;
 				WARNING_CFLAGS = (
-					"-Wall",
+					"$(inherited)",
 					"-Wextra",
 				);
 			};
@@ -2887,7 +2884,7 @@
 				PRODUCT_NAME = os;
 				USER_HEADER_SEARCH_PATHS = ../src;
 				WARNING_CFLAGS = (
-					"-Wall",
+					"$(inherited)",
 					"-Wextra",
 				);
 			};
@@ -2949,7 +2946,6 @@
 				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../src/core,
 					../src,
 				);
@@ -2975,7 +2971,6 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../src/core,
 					../src,
 					"$(GTEST_INC)",
@@ -3002,7 +2997,6 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../src/core,
 					../src,
 					"$(GTEST_INC)",
@@ -3038,7 +3032,6 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../src/core,
 					../src,
 				);
@@ -3071,7 +3064,6 @@
 				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../src/core,
 					../src,
 				);
@@ -3154,6 +3146,7 @@
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_PEDANTIC = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
@@ -3162,6 +3155,7 @@
 				GTEST_LIB = /opt/homebrew/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				ONLY_ACTIVE_ARCH = YES;
+				WARNING_CFLAGS = "-Wall";
 			};
 			name = Debug;
 		};
@@ -3211,8 +3205,10 @@
 					PUGIXML_WCHAR_MODE,
 					PUGIXML_NO_XPATH,
 				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_PEDANTIC = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
@@ -3221,6 +3217,7 @@
 				GTEST_LIB = /opt/homebrew/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				ONLY_ACTIVE_ARCH = NO;
+				WARNING_CFLAGS = "-Wall";
 			};
 			name = Release;
 		};
@@ -3234,7 +3231,7 @@
 				PRODUCT_NAME = core;
 				USER_HEADER_SEARCH_PATHS = ../src/;
 				WARNING_CFLAGS = (
-					"-Wall",
+					"$(inherited)",
 					"-Wextra",
 				);
 			};
@@ -3249,7 +3246,7 @@
 				PRODUCT_NAME = core;
 				USER_HEADER_SEARCH_PATHS = ../src/;
 				WARNING_CFLAGS = (
-					"-Wall",
+					"$(inherited)",
 					"-Wextra",
 				);
 			};
@@ -3269,7 +3266,7 @@
 				PRODUCT_NAME = os;
 				USER_HEADER_SEARCH_PATHS = ../src;
 				WARNING_CFLAGS = (
-					"-Wall",
+					"$(inherited)",
 					"-Wextra",
 				);
 			};
@@ -3288,7 +3285,7 @@
 				PRODUCT_NAME = os;
 				USER_HEADER_SEARCH_PATHS = ../src;
 				WARNING_CFLAGS = (
-					"-Wall",
+					"$(inherited)",
 					"-Wextra",
 				);
 			};
@@ -3344,6 +3341,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.pwsafe.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = pwsafe;
 				USER_HEADER_SEARCH_PATHS = ../src;
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wno-overloaded-virtual",
+				);
 			};
 			name = Release;
 		};

--- a/docs/README.MAC.DEVELOPERS.md
+++ b/docs/README.MAC.DEVELOPERS.md
@@ -25,6 +25,8 @@ It is organized in the following sections:
 
 1. Install the dependencies via homebrew:
 
+Note: The default wxWidgets in Homebrew is v3.3.x. Password Safe does not yet build with that version.  wxwidgets@3.2 should work better.
+
 ```
 brew install wxwidgets yubikey-personalization googletest
 ```

--- a/docs/README.MAC.DEVELOPERS.md
+++ b/docs/README.MAC.DEVELOPERS.md
@@ -28,7 +28,7 @@ It is organized in the following sections:
 Note: The default wxWidgets in Homebrew is v3.3.x. Password Safe does not yet build with that version.  wxwidgets@3.2 should work better.
 
 ```
-brew install wxwidgets yubikey-personalization googletest
+brew install wxwidgets@3.2 yubikey-personalization googletest
 ```
 
 2. Configure the project

--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -311,80 +311,68 @@ void PasswordSafeFrame::OnDuplicateEntry(wxCommandEvent& WXUNUSED(event))
 {
   if (m_core.IsReadOnly()) // disable in read-only mode
     return;
-//  if (SelItemOk() == TRUE) {
-    CItemData *pci = GetSelectedEntry();
-    ASSERT(pci != nullptr);
-//    DisplayInfo *pdi = (DisplayInfo *)pci->GetDisplayInfo();
-//    ASSERT(pdi != nullptr);
 
-    // Get information from current selected entry
-    const StringX ci2_group = pci->GetGroup();
-    const StringX ci2_user = pci->GetUser();
-    const StringX ci2_title0 = pci->GetTitle();
-    StringX ci2_title;
+  CItemData *pci = GetSelectedEntry();
+  ASSERT(pci != nullptr);
 
-    // Find a unique "Title"
-    ItemListConstIter listpos;
-    int i = 0;
-    wxString s_copy;
-    do {
-      s_copy.clear();
-      i++;
-      s_copy << _(" Copy # ") << i;
-      ci2_title = ci2_title0 + tostringx(s_copy);
-      listpos = m_core.Find(ci2_group, ci2_title, ci2_user);
-    } while (listpos != m_core.GetEntryEndIter());
+  // Get information from current selected entry
+  const StringX ci2_group = pci->GetGroup();
+  const StringX ci2_user = pci->GetUser();
+  const StringX ci2_title0 = pci->GetTitle();
+  StringX ci2_title;
 
-    // Set up new entry
-    CItemData ci2(*pci);
-    ci2.CreateUUID();
-    ci2.SetGroup(ci2_group);
-    ci2.SetTitle(ci2_title);
-    ci2.SetUser(ci2_user);
-    ci2.SetStatus(CItemData::ES_ADDED);
+  // Find a unique "Title"
+  ItemListConstIter listpos;
+  int i = 0;
+  wxString s_copy;
+  do {
+    s_copy.clear();
+    i++;
+    s_copy << _(" Copy # ") << i;
+    ci2_title = ci2_title0 + tostringx(s_copy);
+    listpos = m_core.Find(ci2_group, ci2_title, ci2_user);
+  } while (listpos != m_core.GetEntryEndIter());
 
-    Command *pcmd = nullptr;
-    if (pci->IsDependent()) {
-      if (pci->IsAlias()) {
-        ci2.SetAlias();
-      } else {
-        ci2.SetShortcut();
-      }
+  // Set up new entry
+  CItemData ci2(*pci);
+  ci2.CreateUUID();
+  ci2.SetGroup(ci2_group);
+  ci2.SetTitle(ci2_title);
+  ci2.SetUser(ci2_user);
+  ci2.SetStatus(CItemData::ES_ADDED);
 
-      const CItemData *pbci = m_core.GetBaseEntry(pci);
-      if (pbci != nullptr) {
-        StringX cs_tmp;
-        cs_tmp = wxT("[") +
-          pbci->GetGroup() + wxT(":") +
-          pbci->GetTitle() + wxT(":") +
-          pbci->GetUser()  + wxT("]");
-        ci2.SetPassword(cs_tmp);
-        pcmd = AddEntryCommand::Create(&m_core, ci2, pbci->GetUUID());
-      }
-    } else { // not alias or shortcut
-      ci2.SetNormal();
-      pcmd = AddEntryCommand::Create(&m_core, ci2);
+  Command *pcmd = nullptr;
+  if (pci->IsDependent()) {
+    if (pci->IsAlias()) {
+      ci2.SetAlias();
+    } else {
+      ci2.SetShortcut();
     }
 
-    Execute(pcmd);
+    const CItemData *pbci = m_core.GetBaseEntry(pci);
+    if (pbci != nullptr) {
+      StringX cs_tmp;
+      cs_tmp = wxT("[") +
+        pbci->GetGroup() + wxT(":") +
+        pbci->GetTitle() + wxT(":") +
+        pbci->GetUser()  + wxT("]");
+      ci2.SetPassword(cs_tmp);
+      pcmd = AddEntryCommand::Create(&m_core, ci2, pbci->GetUUID());
+    }
+  } else { // not alias or shortcut
+    ci2.SetNormal();
+    pcmd = AddEntryCommand::Create(&m_core, ci2);
+  }
 
-//    pdi->list_index = -1; // so that InsertItemIntoGUITreeList will set new values
+  Execute(pcmd);
 
-    CUUID uuid = ci2.GetUUID();
-    auto iter = m_core.Find(uuid);
-    ASSERT(iter != m_core.GetEntryEndIter());
-    wxUnusedVar(iter); // used in assert only
-//    InsertItemIntoGUITreeList(m_core.GetEntry(iter));
-//    FixListIndexes();
-    UpdateStatusBar();
+  CUUID uuid = ci2.GetUUID();
+  auto iter = m_core.Find(uuid);
+  ASSERT(iter != m_core.GetEntryEndIter());
+  wxUnusedVar(iter); // used in assert only
+  UpdateStatusBar();
 
-//    int rc = SelectEntry(pdi->list_index);
-//    if (rc == 0) {
-//      SelectEntry(m_ctlItemList.GetItemCount() - 1);
-//    }
-//    ChangeOkUpdate();
-    m_RUEList.AddRUEntry(uuid);
-//  }
+  m_RUEList.AddRUEntry(uuid);
 }
 
 /*!

--- a/src/ui/wxWidgets/PWFiltersTypeDlg.h
+++ b/src/ui/wxWidgets/PWFiltersTypeDlg.h
@@ -104,7 +104,7 @@ private:
   CItemData::EntryType m_etype;
   // Result parameter
   PWSMatch::MatchRule *m_prule = nullptr;
-  CItemData::EntryType *m_petype = nullptr;;
+  CItemData::EntryType *m_petype = nullptr;
 
   typedef struct etypeMapItem {
     int msgText;

--- a/src/ui/wxWidgets/PasswordPolicyDlg.h
+++ b/src/ui/wxWidgets/PasswordPolicyDlg.h
@@ -261,7 +261,7 @@ private:
   wxComboBox* m_PoliciesSelectionCtrl = nullptr;
   wxTextCtrl* m_passwordCtrl = nullptr;
   wxArrayString m_Policynames;
-  wxStaticBoxSizer* m_itemStaticBoxSizer6  = nullptr;;
+  wxStaticBoxSizer* m_itemStaticBoxSizer6  = nullptr;
 
   wxString m_Symbols;
   wxString m_polname;

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -710,7 +710,12 @@ private:
   void UpdateMainToolbarSeparators(bool insert);
   void DeleteMainToolbarSeparators();
   wxAuiPaneInfo& GetMainToolbarPane();
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
   wxAuiToolBar* GetToolBar() { return m_Toolbar; }
+  void CreateStatusBar();
+#pragma GCC diagnostic pop
 
   void CreateDragBar();
   void UpdateDragbarTooltips();
@@ -724,8 +729,6 @@ private:
   wxAuiPaneInfo& GetSearchBarPane();
   PasswordSafeSearch* GetSearchBar() { return m_search; };
   void UpdateSearchBarVisibility();
-
-  void CreateStatusBar();
 
   long GetEventRUEIndex(const wxCommandEvent& evt) const;
   bool IsRUEEvent(const wxCommandEvent& evt) const;

--- a/src/ui/wxWidgets/RecentDbList.h
+++ b/src/ui/wxWidgets/RecentDbList.h
@@ -21,57 +21,57 @@
 class RecentDbList : public wxFileHistory
 {
 public:
-    RecentDbList() : wxFileHistory(PWSprefs::GetInstance()->GetPref(PWSprefs::MaxMRUItems))
-    {}
+  RecentDbList() : wxFileHistory(PWSprefs::GetInstance()->GetPref(PWSprefs::MaxMRUItems))
+  {}
 
-    // Calling wxFileHistory::AddFileToHistory() crashes if maxFiles is initialized to 0.
-    void AddFileToHistory(const wxString& file) {
-      if (GetMaxFiles() > 0)
-        wxFileHistory::AddFileToHistory(file);
-    }
+  // Calling wxFileHistory::AddFileToHistory() crashes if maxFiles is initialized to 0.
+  void AddFileToHistory(const wxString& file) {
+    if (GetMaxFiles() > 0)
+      wxFileHistory::AddFileToHistory(file);
+  }
 
-    void RemoveFile(const wxString& file) {
-      for (size_t idx = 0, max = GetCount(); idx < max; ++idx) {
-        if (GetHistoryFile(idx) == file) {
-          RemoveFileFromHistory(idx);
-          return;
-        }
+  void RemoveFile(const wxString& file) {
+    for (size_t idx = 0, max = GetCount(); idx < max; ++idx) {
+      if (GetHistoryFile(idx) == file) {
+        RemoveFileFromHistory(idx);
+        return;
       }
     }
+  }
 
-    void GetAll(wxArrayString& sa) const {
-      for (size_t idx = 0, max = GetCount(); idx < max; ++idx)
-        sa.Add(GetHistoryFile(idx));
+  void GetAll(wxArrayString& sa) const {
+    for (size_t idx = 0, max = GetCount(); idx < max; ++idx)
+      sa.Add(GetHistoryFile(idx));
+  }
+
+  using wxFileHistory::Save;
+  void Save() const {
+    std::vector<stringT> mruList;
+    for (size_t idx = 0, max = GetCount(); idx < max; ++idx) {
+      mruList.push_back(stringT(GetHistoryFile(idx)));
     }
+    PWSprefs::GetInstance()->SetMRUList(mruList, PWSprefs::GetInstance()->GetPref(PWSprefs::MaxMRUItems));
+  }
 
-    using wxFileHistory::Save;
-    void Save() const {
-      std::vector<stringT> mruList;
-      for (size_t idx = 0, max = GetCount(); idx < max; ++idx) {
-        mruList.push_back(stringT(GetHistoryFile(idx)));
-      }
-      PWSprefs::GetInstance()->SetMRUList(mruList, PWSprefs::GetInstance()->GetPref(PWSprefs::MaxMRUItems));
+  using wxFileHistory::Load;
+  void Load() {
+    PWSprefs* prefs = PWSprefs::GetInstance();
+    [[maybe_unused]] const auto nExpected = prefs->GetPref(PWSprefs::MaxMRUItems);
+    std::vector<stringT> mruList;
+    [[maybe_unused]] const auto nFound = prefs->GetMRUList(mruList);
+    wxASSERT(nExpected >= nFound);
+
+    // wxFileHistory::AddFileToHistory() appears to add to the begining of the list,
+    // so we iterate backward to keep the order the same.
+    for (auto iter = mruList.rbegin(); iter != mruList.rend(); iter++) {
+      wxFileHistory::AddFileToHistory(towxstring(*iter));
     }
+  }
 
-    using wxFileHistory::Load;
-    void Load() {
-      PWSprefs* prefs = PWSprefs::GetInstance();
-      [[maybe_unused]] const auto nExpected = prefs->GetPref(PWSprefs::MaxMRUItems);
-      std::vector<stringT> mruList;
-      [[maybe_unused]] const auto nFound = prefs->GetMRUList(mruList);
-      wxASSERT(nExpected >= nFound);
-
-      // wxFileHistory::AddFileToHistory() appears to add to the begining of the list,
-      // so we iterate backward to keep the order the same.
-      for (auto iter = mruList.rbegin(); iter != mruList.rend(); iter++) {
-        wxFileHistory::AddFileToHistory(towxstring(*iter));
-      }
-    }
-
-    void Clear() {
-      while(GetCount() > 0)
-        RemoveFileFromHistory(0);
-    }
+  void Clear() {
+    while(GetCount() > 0)
+      RemoveFileFromHistory(0);
+  }
 };
 
 #endif // _RECENTDBLIST_H_

--- a/src/ui/wxWidgets/RecentDbList.h
+++ b/src/ui/wxWidgets/RecentDbList.h
@@ -44,6 +44,7 @@ public:
         sa.Add(GetHistoryFile(idx));
     }
 
+    using wxFileHistory::Save;
     void Save() const {
       std::vector<stringT> mruList;
       for (size_t idx = 0, max = GetCount(); idx < max; ++idx) {
@@ -52,6 +53,7 @@ public:
       PWSprefs::GetInstance()->SetMRUList(mruList, PWSprefs::GetInstance()->GetPref(PWSprefs::MaxMRUItems));
     }
 
+    using wxFileHistory::Load;
     void Load() {
       PWSprefs* prefs = PWSprefs::GetInstance();
       [[maybe_unused]] const auto nExpected = prefs->GetPref(PWSprefs::MaxMRUItems);

--- a/src/ui/wxWidgets/TreeCtrl.h
+++ b/src/ui/wxWidgets/TreeCtrl.h
@@ -62,6 +62,8 @@ class TreeCtrl;
 
 typedef void (TreeCtrl:: *TreeCtrlMemberFncPtr)(void);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 class TreeCtrlTimer: public wxTimer
 {
 public:
@@ -166,6 +168,7 @@ private:
   PWScore &m_core;
   UUIDTIMapT m_item_map; // given a uuid, find the tree item pronto!
 };
+#pragma GCC diagnostic pop
 
 /*!
  * TreeCtrl class declaration


### PR DESCRIPTION
Xcode flavored Follow-on to #1851 
Tested with: macOS M1Max 15.7.7 Sequoia, Xcode 16.4, wx 3.2.10 (local build)

1. Adds -Wall and -pedantic to all targets and configurations
2. **Core** and **os** libs also have -Wextra (They've already had that for some time now.)
3. The Release configuration now has -Werror (But, not the other configs.  Release is used by the GitHub workflows.)
4. Fixed a few warning and indentation issues
5. Suppressed some hidden overload warnings, discussion follows:

Clang with -Wall reports a number of warnings that gcc apparently doesn't include in -Wall.
There were several warnings of this type spread across three header files:

```
/Users/rpowell/Documents/Xcode/pwsafe/src/ui/wxWidgets/./RecentDbList.h:48:8: error: 'RecentDbList::Save' hides overloaded virtual function [-Werror,-Woverloaded-virtual]
   48 |   void Save() const {
      |        ^
In file included from /Users/rpowell/Documents/Xcode/pwsafe/src/ui/wxWidgets/SafeCombinationEntryDlg.cpp:37:
In file included from /Users/rpowell/Documents/Xcode/pwsafe/src/ui/wxWidgets/PWSafeApp.h:29:
In file included from /Users/rpowell/Documents/Xcode/pwsafe/src/ui/wxWidgets/./RecentDbList.h:17:
In file included from /Users/rpowell/NotBackedUp/pwsafe_testing/wxWidgets/wxWidgets-3.2.10/include/wx/docview.h:22:
/Users/rpowell/NotBackedUp/pwsafe_testing/wxWidgets/wxWidgets-3.2.10/include/wx/filehistory.h:54:18: note: hidden overloaded virtual function 'wxFileHistoryBase::Save' declared here: different number of parameters (1 vs 0)
   54 |     virtual void Save(wxConfigBase& config);
      |                  ^
1 error generated.
```

Various combinations of "virtual" and "override" did not work in these cases due to there being different numbers of parameters.  Two of them were easily fixed by adding "using" statements, in other cases "using" just lead to ambiguous overloads at the call sites.  I started to rename the offending functions, but I wasn't liking it, so instead I inserted a pragma in the headers.  If there are objections to either approach, I can take another run at renaming.

```
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Woverloaded-virtual"
...
#pragma GCC diagnostic pop
```
