### PR TITLE
 Fix main window position restore double-scaling at >100% display scale

### DIFF
--- a/src/core/PWSprefs.cpp
+++ b/src/core/PWSprefs.cpp
@@ -260,8 +260,10 @@ PWSprefs::PWSprefs() : m_pXML_Config(nullptr)
   for (i = 0; i < NumStringPrefs; i++) m_stringChanged[i] = false;
 
   m_rect.top = m_rect.bottom = m_rect.left = m_rect.right = -1;
+  m_rect.dpi = 0;
   m_rect.changed = false;
   m_PSSrect.top = m_PSSrect.bottom = m_PSSrect.left = m_PSSrect.right = -1;
+  m_PSSrect.dpi = 0;
   m_PSSrect.changed = false;
 
   InitializePreferences();
@@ -749,7 +751,7 @@ bool PWSprefs::DeletePref(const StringX &name)
 }
 
 void PWSprefs::SetPrefRect(long top, long bottom,
-                           long left, long right)
+                           long left, long right, unsigned dpi)
 {
   if (m_rect.top != top) {
     m_rect.top = top; m_rect.changed = true;
@@ -762,6 +764,9 @@ void PWSprefs::SetPrefRect(long top, long bottom,
   }
   if (m_rect.right != right) {
     m_rect.right = right; m_rect.changed = true;
+  }
+  if (m_rect.dpi != dpi) {
+    m_rect.dpi = dpi; m_rect.changed = true;
   }
   if (m_rect.changed)
     m_prefs_changed[APP_PREF] = true;
@@ -1364,6 +1369,7 @@ void PWSprefs::LoadProfileFromRegistry()
   m_rect.bottom = pws_os::RegReadValue(PWS_REG_POSITION, _T("bottom"), -1);
   m_rect.left = pws_os::RegReadValue(PWS_REG_POSITION, _T("left"), -1);
   m_rect.right = pws_os::RegReadValue(PWS_REG_POSITION, _T("right"), -1);
+  m_rect.dpi = pws_os::RegReadValue(PWS_REG_POSITION, _T("dpi"), 0);
 
   // Load last Password subset window size & pos:
   m_PSSrect.top = pws_os::RegReadValue(PWS_REG_POSITION, _T("PSS_top"), -1);
@@ -1478,6 +1484,7 @@ bool PWSprefs::LoadProfileFromFile()
   m_rect.bottom = m_pXML_Config->Get(m_csHKCU_POS, _T("bottom"), -1);
   m_rect.left = m_pXML_Config->Get(m_csHKCU_POS, _T("left"), -1);
   m_rect.right = m_pXML_Config->Get(m_csHKCU_POS, _T("right"), -1);
+  m_rect.dpi = m_pXML_Config->Get(m_csHKCU_POS, _T("dpi"), 0); // 0: saved by a version without dpi support
 
   m_PSSrect.top = m_pXML_Config->Get(m_csHKCU_POS, _T("PSS_top"), -1);
   m_PSSrect.bottom = m_pXML_Config->Get(m_csHKCU_POS, _T("PSS_bottom"), -1);
@@ -1589,6 +1596,8 @@ void PWSprefs::SaveApplicationPreferences()
                               int(m_rect.left));
         pws_os::RegWriteValue(PWS_REG_POSITION, _T("right"),
                               int(m_rect.right));
+        pws_os::RegWriteValue(PWS_REG_POSITION, _T("dpi"),
+                              int(m_rect.dpi));
         break;
       case CF_FILE_RW:
       case CF_FILE_RW_NEW:
@@ -1596,6 +1605,7 @@ void PWSprefs::SaveApplicationPreferences()
         VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"bottom", static_cast<int>(m_rect.bottom)) == 0);
         VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"left", static_cast<int>(m_rect.left)) == 0);
         VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"right", static_cast<int>(m_rect.right)) == 0);
+        VERIFY(m_pXML_Config->Set(m_csHKCU_POS, L"dpi", static_cast<int>(m_rect.dpi)) == 0);
         break;
       case CF_FILE_RO:
       case CF_NONE:

--- a/src/core/PWSprefs.cpp
+++ b/src/core/PWSprefs.cpp
@@ -401,12 +401,14 @@ unsigned int PWSprefs::GetPref(IntPrefs pref_enum, unsigned int defVal,
 }
 
 void PWSprefs::GetPrefRect(long &top, long &bottom,
-                           long &left, long &right) const
+                           long &left, long &right, unsigned *dpi) const
 {
   top = m_rect.top;
   bottom = m_rect.bottom;
   left = m_rect.left;
   right = m_rect.right;
+  if (dpi != nullptr)
+    *dpi = m_rect.dpi;
 }
 
 void PWSprefs::GetPrefPSSRect(long &top, long &bottom,

--- a/src/core/PWSprefs.h
+++ b/src/core/PWSprefs.h
@@ -227,11 +227,10 @@ public:
   StringX GetAllStringPrefs(const bool bUseCopy = false);
 
   // Special cases
-  void GetPrefRect(long &top, long &bottom, long &left, long &right) const;
-  // dpi: display scale the rect was captured under, for rescaling the window
-  // at restore if it changed since; 0 = unknown (legacy config, non-MFC UI)
+  // dpi (optional out): display scale the rect was captured under, for rescaling
+  // the window at restore if it changed since; 0 = unknown (legacy config, non-MFC UI)
+  void GetPrefRect(long &top, long &bottom, long &left, long &right, unsigned *dpi = nullptr) const;
   void SetPrefRect(long top, long bottom, long left, long right, unsigned dpi = 0);
-  unsigned GetPrefRectDPI() const {return m_rect.dpi;}
   void GetPrefPSSRect(long &top, long &bottom, long &left, long &right) const;
   void SetPrefPSSRect(long top, long bottom, long left, long right);
   unsigned int GetMRUList(std::vector<stringT> &MRUFiles) const;

--- a/src/core/PWSprefs.h
+++ b/src/core/PWSprefs.h
@@ -228,7 +228,10 @@ public:
 
   // Special cases
   void GetPrefRect(long &top, long &bottom, long &left, long &right) const;
-  void SetPrefRect(long top, long bottom, long left, long right);
+  // dpi: display scale the rect was captured under, for rescaling the window
+  // at restore if it changed since; 0 = unknown (legacy config, non-MFC UI)
+  void SetPrefRect(long top, long bottom, long left, long right, unsigned dpi = 0);
+  unsigned GetPrefRectDPI() const {return m_rect.dpi;}
   void GetPrefPSSRect(long &top, long &bottom, long &left, long &right) const;
   void SetPrefPSSRect(long top, long bottom, long left, long right);
   unsigned int GetMRUList(std::vector<stringT> &MRUFiles) const;
@@ -324,7 +327,7 @@ private:
   bool m_boolValues[NumBoolPrefs];
   unsigned int m_intValues[NumIntPrefs];
   StringX m_stringValues[NumStringPrefs];
-  struct {long top, bottom, left, right; bool changed;} m_rect, m_PSSrect;
+  struct {long top, bottom, left, right; unsigned dpi; bool changed;} m_rect, m_PSSrect;
   bool m_boolChanged[NumBoolPrefs];
   bool m_intChanged[NumIntPrefs];
   bool m_stringChanged[NumStringPrefs];

--- a/src/ui/Windows/DboxMain.cpp
+++ b/src/ui/Windows/DboxMain.cpp
@@ -3813,15 +3813,19 @@ int DboxMain::OnUpdateMenuToolbar(const UINT nID)
   return iEnable;
 }
 
-void DboxMain::PlaceWindow(CWnd *pWnd, CRect *pRect, UINT uiShowCmd)
+void DboxMain::PlaceWindow(CWnd *pWnd, CRect *pRect, UINT uiShowCmd, UINT nSavedDPI)
 {
-  // Do NOT scale pRect here. It is stored verbatim from GetWindowRect()
-  // (see OnMove/OnSize) and round-trips through SetWindowPlacement() 1:1:
-  // save and restore both run on the main thread, which DoModal() has already
-  // elevated to per-monitor-V2, so the coordinates are physical on both ends.
-  // Applying a MulDiv by monitor DPI double-scales the window on displays
-  // > 100% - the regression in commit e6491bef3 that this reverts, which had
-  // itself re-broken PR #1774.
+  // pRect is stored verbatim from GetWindowRect() (see OnMove/OnSize) and
+  // round-trips through SetWindowPlacement() 1:1: save and restore both run
+  // on the main thread, which is elevated to per-monitor-V2 before the window
+  // exists, so the coordinates are physical pixels on both ends. Blanket
+  // MulDivs here double-scale the window on displays > 100% (the e6491bef3
+  // regression of PR #1774). The only valid transform is the one below: if
+  // the display scale CHANGED since the rect was saved, rescale the size -
+  // top-left stays anchored - so the window reopens at the same logical size.
+  // Its ratio is current/saved, i.e. a no-op when the scale is unchanged, and
+  // nSavedDPI == 0 (config predating the dpi attribute, or non-MFC UI) skips
+  // it entirely, restoring verbatim.
   WINDOWPLACEMENT wp = {sizeof(WINDOWPLACEMENT)};
   HRGN hrgnWork = WinUtil::GetWorkAreaRegion();
 
@@ -3829,6 +3833,16 @@ void DboxMain::PlaceWindow(CWnd *pWnd, CRect *pRect, UINT uiShowCmd)
   wp.flags = 0;
   wp.showCmd = uiShowCmd;
   wp.rcNormalPosition = *pRect;
+
+  const UINT nCurDPI = WinUtil::GetMonitorDPI(pRect);
+  if (nSavedDPI != 0 && nCurDPI != nSavedDPI) {
+    wp.rcNormalPosition.right = pRect->left + MulDiv(pRect->Width(), nCurDPI, nSavedDPI);
+    wp.rcNormalPosition.bottom = pRect->top + MulDiv(pRect->Height(), nCurDPI, nSavedDPI);
+    // If the resize grew the window past a monitor edge, slide it back into
+    // view. Deliberately not done for unscaled restores: a window saved partly
+    // off-screen is otherwise restored exactly where the user left it.
+    ClipRectToMonitor(NULL, &wp.rcNormalPosition, TRUE);
+  }
 
   if (!RectInRegion(hrgnWork, &wp.rcNormalPosition)) {
     if (GetSystemMetrics(SM_CMONITORS) > 1)

--- a/src/ui/Windows/DboxMain.cpp
+++ b/src/ui/Windows/DboxMain.cpp
@@ -3815,6 +3815,13 @@ int DboxMain::OnUpdateMenuToolbar(const UINT nID)
 
 void DboxMain::PlaceWindow(CWnd *pWnd, CRect *pRect, UINT uiShowCmd)
 {
+  // Do NOT scale pRect here. It is stored verbatim from GetWindowRect()
+  // (see OnMove/OnSize) and round-trips through SetWindowPlacement() 1:1:
+  // save and restore both run on the main thread, which DoModal() has already
+  // elevated to per-monitor-V2, so the coordinates are physical on both ends.
+  // Applying a MulDiv by monitor DPI double-scales the window on displays
+  // > 100% - the regression in commit e6491bef3 that this reverts, which had
+  // itself re-broken PR #1774.
   WINDOWPLACEMENT wp = {sizeof(WINDOWPLACEMENT)};
   HRGN hrgnWork = WinUtil::GetWorkAreaRegion();
 
@@ -3822,12 +3829,6 @@ void DboxMain::PlaceWindow(CWnd *pWnd, CRect *pRect, UINT uiShowCmd)
   wp.flags = 0;
   wp.showCmd = uiShowCmd;
   wp.rcNormalPosition = *pRect;
-
-  UINT dpi = WinUtil::GetMonitorDPI(pWnd->GetSafeHwnd());
-  wp.rcNormalPosition.left = MulDiv(pRect->left, dpi, WinUtil::defDPI);
-  wp.rcNormalPosition.top = MulDiv(pRect->top, dpi, WinUtil::defDPI);
-  wp.rcNormalPosition.right = MulDiv(pRect->right, dpi, WinUtil::defDPI);
-  wp.rcNormalPosition.bottom = MulDiv(pRect->bottom, dpi, WinUtil::defDPI);
 
   if (!RectInRegion(hrgnWork, &wp.rcNormalPosition)) {
     if (GetSystemMetrics(SM_CMONITORS) > 1)

--- a/src/ui/Windows/DboxMain.h
+++ b/src/ui/Windows/DboxMain.h
@@ -375,7 +375,7 @@ public:
   void DoAutoType(const StringX &sx_autotype, 
                   const std::vector<size_t> &vactionverboffsets);
   void UpdateLastClipboardAction(const ClipboardDataSource& cds);
-  void PlaceWindow(CWnd *pWnd, CRect *pRect, UINT uiShowCmd);
+  void PlaceWindow(CWnd *pWnd, CRect *pRect, UINT uiShowCmd, UINT nSavedDPI = 0);
   void SetDCAText(CItemData *pci = NULL);
   void OnItemSelected(NMHDR *pNotifyStruct, LRESULT *pLResult, const bool bTreeView);
   bool IsNodeModified(StringX &path) const

--- a/src/ui/Windows/MainFile.cpp
+++ b/src/ui/Windows/MainFile.cpp
@@ -266,7 +266,7 @@ BOOL DboxMain::OpenOnInit()
     GetWindowRect(&rect);
     SendMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(rect.Width(), rect.Height()));
   } else {
-    PlaceWindow(this, &rect, SW_HIDE);
+    PlaceWindow(this, &rect, SW_HIDE, PWSprefs::GetInstance()->GetPrefRectDPI());
   }
   ::DeleteObject(hrgnWork);
 

--- a/src/ui/Windows/MainFile.cpp
+++ b/src/ui/Windows/MainFile.cpp
@@ -124,6 +124,7 @@ BOOL DboxMain::OpenOnInit()
   MFCReporter r;
   CReport Rpt;
   CRect rect;
+  unsigned savedDPI = 0;
   int rc2;
   HRGN hrgnWork;
   bool go_ahead;
@@ -254,7 +255,7 @@ BOOL DboxMain::OpenOnInit()
  
 
   // Now get window sizes
-  PWSprefs::GetInstance()->GetPrefRect(rect.top, rect.bottom, rect.left, rect.right);
+  PWSprefs::GetInstance()->GetPrefRect(rect.top, rect.bottom, rect.left, rect.right, &savedDPI);
 
   hrgnWork = WinUtil::GetWorkAreaRegion();
   
@@ -266,7 +267,7 @@ BOOL DboxMain::OpenOnInit()
     GetWindowRect(&rect);
     SendMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(rect.Width(), rect.Height()));
   } else {
-    PlaceWindow(this, &rect, SW_HIDE, PWSprefs::GetInstance()->GetPrefRectDPI());
+    PlaceWindow(this, &rect, SW_HIDE, savedDPI);
   }
   ::DeleteObject(hrgnWork);
 

--- a/src/ui/Windows/MainView.cpp
+++ b/src/ui/Windows/MainView.cpp
@@ -1532,7 +1532,8 @@ void DboxMain::OnMove(int x, int y)
   if (m_bInitDone && IsWindowVisible() == TRUE && x >= 0 && y >= 0) {
     CRect rc;
     GetWindowRect(&rc);
-    PWSprefs::GetInstance()->SetPrefRect(rc.top, rc.bottom, rc.left, rc.right);
+    PWSprefs::GetInstance()->SetPrefRect(rc.top, rc.bottom, rc.left, rc.right,
+                                         WinUtil::GetDPI(m_hWnd));
   }
 }
 
@@ -1696,7 +1697,8 @@ void DboxMain::OnSize(UINT nType, int cx, int cy)
 
       if (nType == SIZE_RESTORED) {
         GetWindowRect(&rc);
-        prefs->SetPrefRect(rc.top, rc.bottom, rc.left, rc.right);
+        prefs->SetPrefRect(rc.top, rc.bottom, rc.left, rc.right,
+                           WinUtil::GetDPI(m_hWnd));
       } else { // maximized - mark as such for restore
         prefs->SetPrefRect(0, 0, 0, 0);
       }

--- a/src/ui/Windows/winutils.cpp
+++ b/src/ui/Windows/winutils.cpp
@@ -37,6 +37,7 @@
 typedef int (WINAPI* FP_GETDPI4SYSTEM) ();
 typedef int (WINAPI* FP_GETDPI4WINDOW) (HWND);
 typedef int (WINAPI* FP_GETSYSMETRICS4DPI) (int, UINT);
+typedef HRESULT (WINAPI* FP_GETDPI4MONITOR)(HMONITOR, int, UINT*, UINT*);
 typedef DPI_AWARENESS_CONTEXT (WINAPI* FP_SETTHREADDPIAWARENESSCONTEXT)(DPI_AWARENESS_CONTEXT);
 
 
@@ -293,6 +294,22 @@ UINT WinUtil::GetDPI(HWND hwnd)
     iss >> retval;
   }
   return retval;
+}
+
+UINT WinUtil::GetMonitorDPI(const RECT *prc)
+{
+  static FP_GETDPI4MONITOR fp = nullptr;
+  static bool inited = false;
+  if (!inited) {
+    auto hShcore = static_cast<HMODULE>(pws_os::LoadLibrary(L"Shcore.dll", pws_os::loadLibraryTypes::SYS));
+    if (hShcore != nullptr)
+      fp = FP_GETDPI4MONITOR(pws_os::GetFunction(hShcore, "GetDpiForMonitor"));
+    inited = true;
+  }
+  UINT dpiX = defDPI, dpiY = defDPI;
+  if (fp != nullptr)
+    fp(MonitorFromRect(prc, MONITOR_DEFAULTTONEAREST), 0 /*MDT_EFFECTIVE_DPI*/, &dpiX, &dpiY);
+  return dpiX;
 }
 
 void WinUtil::SetThreadDpiAwarenessContext()

--- a/src/ui/Windows/winutils.cpp
+++ b/src/ui/Windows/winutils.cpp
@@ -37,7 +37,6 @@
 typedef int (WINAPI* FP_GETDPI4SYSTEM) ();
 typedef int (WINAPI* FP_GETDPI4WINDOW) (HWND);
 typedef int (WINAPI* FP_GETSYSMETRICS4DPI) (int, UINT);
-typedef HRESULT(WINAPI* FP_GETDPI4MONITOR)(HMONITOR, int, UINT*, UINT*);
 typedef DPI_AWARENESS_CONTEXT (WINAPI* FP_SETTHREADDPIAWARENESSCONTEXT)(DPI_AWARENESS_CONTEXT);
 
 
@@ -265,7 +264,8 @@ exit:
 /**
  * Following started out as a way to test hi-resolution support without access to a hires monitor.
  * Now it's a wrapper to support pre-Windows 10 systems as well.
- * Since we're currently DPI unaware, this will always return 96. GetMonitorDPI() will return the scaled DPI in any case.
+ * Note: the value returned is virtualized to the calling thread's DPI awareness
+ * context (96 on a DPI-unaware thread, real DPI on a per-monitor-aware one).
  */
 UINT WinUtil::GetDPI(HWND hwnd)
 {
@@ -293,24 +293,6 @@ UINT WinUtil::GetDPI(HWND hwnd)
     iss >> retval;
   }
   return retval;
-}
-
-UINT WinUtil::GetMonitorDPI(HWND hwnd)
-{
-  static FP_GETDPI4MONITOR fp = nullptr;
-  static bool inited = false;
-  if (!inited) {
-    auto hShcore = static_cast<HMODULE>(pws_os::LoadLibrary(L"Shcore.dll", pws_os::loadLibraryTypes::SYS));
-    if (hShcore != nullptr)
-      fp = (FP_GETDPI4MONITOR)pws_os::GetFunction(hShcore, "GetDpiForMonitor");
-    inited = true;
-  }
-  UINT dpiX = defDPI, dpiY = defDPI;
-  if (fp != nullptr) {
-    HMONITOR hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-    fp(hMon, 0 /*MDT_EFFECTIVE_DPI*/, &dpiX, &dpiY);
-  }
-  return dpiX;
 }
 
 void WinUtil::SetThreadDpiAwarenessContext()

--- a/src/ui/Windows/winutils.h
+++ b/src/ui/Windows/winutils.h
@@ -24,7 +24,6 @@ namespace WinUtil {
   bool PerformConfigMigration();
   const UINT defDPI = 96;
   UINT GetDPI(HWND hwnd = nullptr); // wrapper for debugging and hiding Win10 compatibility breakage
-  UINT GetMonitorDPI(HWND hwnd = nullptr); // Gets DPI as affected by Scaling
   // Elevates the calling thread to per-monitor-V2 DPI awareness (Win10+ only; no-op
   // otherwise/if already elevated). Must be called before any DPI-dependent value
   // (e.g. Fonts::GetInstance()'s one-time DPI-scaled fonts) is computed, or that

--- a/src/ui/Windows/winutils.h
+++ b/src/ui/Windows/winutils.h
@@ -24,6 +24,7 @@ namespace WinUtil {
   bool PerformConfigMigration();
   const UINT defDPI = 96;
   UINT GetDPI(HWND hwnd = nullptr); // wrapper for debugging and hiding Win10 compatibility breakage
+  UINT GetMonitorDPI(const RECT *prc); // effective DPI of the monitor nearest the rect (defDPI if unavailable)
   // Elevates the calling thread to per-monitor-V2 DPI awareness (Win10+ only; no-op
   // otherwise/if already elevated). Must be called before any DPI-dependent value
   // (e.g. Fonts::GetInstance()'s one-time DPI-scaled fonts) is computed, or that


### PR DESCRIPTION
This reverts commit e6491bef3 ("Fix Windows scaling issue"), restoring the behavior of PR #1774, and removes the GetMonitorDPI() helper introduced by that commit (this was its only call site). Fixes the window position/size restore bug re-reported by @ColeBantam on 3.72.01 at 175% scale (see #1774 comments).

The saved rect is written verbatim from GetWindowRect() (OnMove/OnSize) and handed back verbatim to SetWindowPlacement(). Both calls run on the main GUI thread, and both run after that thread has been elevated to per-monitor-V2 (Fonts::GetInstance() -> tweakFontSizes() elevates before the master password dialog, which precedes any save or restore). So the physical pixel coordinate space the OS presents is the same on both ends, and the round-trip is correct by construction. 

e6491bef3's rationale is captured in the comment it added to GetDPI(): "Since we're currently DPI unaware, this will always return 96." That holds for the process manifest, but not at the call sites: by the time save/restore run, the thread has been elevated, so GetDpiForSystem() returns the real system DPI. This PR also corrects that GetDPI() comment (the returned value depends on the calling thread's DPI awareness context, not the manifest) and adds a comment at PlaceWindow() documenting the round-trip invariant, so the scaling doesn't get reintroduced a third time.

Verified: at 200% scale, a seeded Position rect round-trips through open -> exit unchanged with this fix; stock 3.72.1 restores it at 2x.

@ronys: since save and restore are symmetric, the verbatim restore in 3.72.0 can't itself have produced the misplacement you saw before e6491bef3: that was likely a different defect. I can perhaps track that down rather than have it patched here again. Also refining my earlier comment in #1774: I suggested the flip-flop came from save and restore running under different thread DPI contexts. On closer analysis they always run under the same context.