### PR TITLE
[wx] Fix runtime assert

### DIFF
--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -1018,7 +1018,7 @@ void TreeCtrl::OnGetToolTip( wxTreeEvent& evt )
   else if (ItemIsGroup(id)) { // we're on a group other than root, show number of entries including subgroups
     const size_t count = GetEntriesCount(id);
     if (count > 0) {
-      const wxString entries = wxString::Format(_("Number of entries: %d"), count);
+      const wxString entries = wxString::Format(_("Number of entries: %d"), static_cast<int>(count));
       evt.SetToolTip(entries);
     }
   }


### PR DESCRIPTION
The code that counts the entries in a group for display in a tooltip tries to format a size_t via %d, which isn't portable.

Assuming a sane number of entries under a group, casting to int is the simplest and most portable fix.