### PR TITLE
[wx] Fix a number of signed to unsigned comparisons

### DIFF
--- a/src/test/FileEncDecTest.cpp
+++ b/src/test/FileEncDecTest.cpp
@@ -97,7 +97,7 @@ TEST_F(FileEncDecTest, EmptyFile)
   // check decrypted file
   fp = pws_os::FOpen(emptyFile, L"r");
   ASSERT_TRUE(fp != nullptr);
-  EXPECT_EQ(pws_os::fileLength(fp), 0);
+  EXPECT_EQ(pws_os::fileLength(fp), 0u);
   res = pws_os::FClose(fp, true);
   ASSERT_TRUE(res == 0);
 

--- a/src/test/MRUListTest.cpp
+++ b/src/test/MRUListTest.cpp
@@ -47,24 +47,24 @@ TEST_F(MRUListTest, MRUList)
   prefs->PrepForUnitTests(false);
   is = prefs->SetMRUList(MRUFiles, 10);
   ig = prefs->GetMRUList(MRURet);
-  EXPECT_EQ(is, 0);
-  EXPECT_EQ(ig, 0);
-  EXPECT_EQ(MRURet.size(), 0);
+  EXPECT_EQ(is, 0u);
+  EXPECT_EQ(ig, 0u);
+  EXPECT_EQ(MRURet.size(), 0u);
   prefs->PrepForUnitTests(true);
 
   // Basic Set/Get
   prefs->SetPref(PWSprefs::MaxMRUItems, 10);
   is = prefs->SetMRUList(MRUFiles, 10);
   ig = prefs->GetMRUList(MRURet);
-  EXPECT_EQ(is, 5);
-  EXPECT_EQ(ig, 5);
+  EXPECT_EQ(is, 5u);
+  EXPECT_EQ(ig, 5u);
   EXPECT_EQ(MRUFiles, MRURet);
 
   // Test max_MRU parameter of SetMRUList
   is = prefs->SetMRUList(MRUFiles, 6);
   ig = prefs->GetMRUList(MRURet);
-  EXPECT_EQ(is, 5);
-  EXPECT_EQ(ig, 5);
+  EXPECT_EQ(is, 5u);
+  EXPECT_EQ(ig, 5u);
   EXPECT_EQ(MRUFiles, MRURet);
 
   v4 = MRUFiles;
@@ -72,30 +72,30 @@ TEST_F(MRUListTest, MRUList)
   v4.pop_back();
   is = prefs->SetMRUList(MRUFiles, 3);
   ig = prefs->GetMRUList(MRURet);
-  EXPECT_EQ(is, 3);
-  EXPECT_EQ(ig, 3);
+  EXPECT_EQ(is, 3u);
+  EXPECT_EQ(ig, 3u);
   EXPECT_EQ(v4, MRURet);
 
   v0.clear();
   is = prefs->SetMRUList(MRUFiles, 0);
   ig = prefs->GetMRUList(MRURet);
-  EXPECT_EQ(is, 0);
-  EXPECT_EQ(ig, 0);
+  EXPECT_EQ(is, 0u);
+  EXPECT_EQ(ig, 0u);
   EXPECT_EQ(v0, MRURet);
 
   // Test MaxMRUItems limit in GetMRUList
   prefs->SetPref(PWSprefs::MaxMRUItems, 3);
   is = prefs->SetMRUList(MRUFiles, 10);
   ig = prefs->GetMRUList(MRURet);
-  EXPECT_EQ(is, 5);
-  EXPECT_EQ(ig, 3);
+  EXPECT_EQ(is, 5u);
+  EXPECT_EQ(ig, 3u);
   EXPECT_EQ(v4, MRURet);
 
   prefs->SetPref(PWSprefs::MaxMRUItems, 0);
   is = prefs->SetMRUList(MRUFiles, 10);
   ig = prefs->GetMRUList(MRURet);
-  EXPECT_EQ(is, 5);
-  EXPECT_EQ(ig, 0);
+  EXPECT_EQ(is, 5u);
+  EXPECT_EQ(ig, 0u);
   EXPECT_EQ(v0, MRURet);
 
   // Test removing *.ibak from the list
@@ -107,8 +107,8 @@ TEST_F(MRUListTest, MRUList)
   MRUFiles.push_back(L"Filename.ibak~");
   is = prefs->SetMRUList(MRUFiles, 10);
   ig = prefs->GetMRUList(MRURet);
-  EXPECT_EQ(is, 5);
-  EXPECT_EQ(ig, 5);
+  EXPECT_EQ(is, 5u);
+  EXPECT_EQ(ig, 5u);
   EXPECT_EQ(v4, MRURet);
 }
 
@@ -160,13 +160,13 @@ TEST_F(RecentDBTest, RecentList)
   RecentDbList rdb;
   is = rdb.GetMaxFiles();
   EXPECT_EQ(is, 10);
-  EXPECT_EQ(rdb.GetCount(), 0);
+  EXPECT_EQ(rdb.GetCount(), 0u);
 
   // Load the list from PWSprefs and get the list of strings
   rdb.Load();
   rdb.GetAll(GotStrings);
-  EXPECT_EQ(rdb.GetCount(), 5);
-  EXPECT_EQ(GotStrings.size(), 5);
+  EXPECT_EQ(rdb.GetCount(), 5u);
+  EXPECT_EQ(GotStrings.size(), 5u);
   EXPECT_EQ(StrList, GotStrings);
 
   // Add a new name to the top of the list
@@ -175,8 +175,8 @@ TEST_F(RecentDBTest, RecentList)
 
   rdb.AddFileToHistory("NewFilename1");
   rdb.GetAll(GotStrings);
-  EXPECT_EQ(rdb.GetCount(), 6);
-  EXPECT_EQ(GotStrings.size(), 6);
+  EXPECT_EQ(rdb.GetCount(), 6u);
+  EXPECT_EQ(GotStrings.size(), 6u);
   EXPECT_EQ(StrList, GotStrings);
 
   // Remove a name from the list
@@ -185,8 +185,8 @@ TEST_F(RecentDBTest, RecentList)
 
   rdb.RemoveFile("filename1");
   rdb.GetAll(GotStrings);
-  EXPECT_EQ(rdb.GetCount(), 5);
-  EXPECT_EQ(GotStrings.size(), 5);
+  EXPECT_EQ(rdb.GetCount(), 5u);
+  EXPECT_EQ(GotStrings.size(), 5u);
   EXPECT_EQ(StrList, GotStrings);
 
   // Save the modified list to PWSprefs and check that it got there
@@ -203,13 +203,13 @@ TEST_F(RecentDBTest, RecentList)
   GotStrings.clear();
   rdb.Clear();
   rdb.GetAll(GotStrings);
-  EXPECT_EQ(rdb.GetCount(), 0);
-  EXPECT_EQ(GotStrings.size(), 0);
+  EXPECT_EQ(rdb.GetCount(), 0u);
+  EXPECT_EQ(GotStrings.size(), 0u);
 
   rdb.Save();
   ig = prefs->GetMRUList(MRURet);
   EXPECT_EQ(ig, 0);
-  EXPECT_EQ(MRURet.size(), 0);
+  EXPECT_EQ(MRURet.size(), 0u);
 }
 
 TEST_F(RecentDBTest, RecentListLimit)
@@ -231,8 +231,8 @@ TEST_F(RecentDBTest, RecentListLimit)
   GotStrings.clear();
   rdb.Load();
   rdb.GetAll(GotStrings);
-  EXPECT_EQ(rdb.GetCount(), 4);
-  EXPECT_EQ(GotStrings.size(), 4);
+  EXPECT_EQ(rdb.GetCount(), 4u);
+  EXPECT_EQ(GotStrings.size(), 4u);
   EXPECT_EQ(StrList, GotStrings);
 
   // Add to the top, remove from the bottom
@@ -242,8 +242,8 @@ TEST_F(RecentDBTest, RecentListLimit)
 
   rdb.AddFileToHistory("NewName1");
   rdb.GetAll(GotStrings);
-  EXPECT_EQ(rdb.GetCount(), 4);
-  EXPECT_EQ(GotStrings.size(), 4);
+  EXPECT_EQ(rdb.GetCount(), 4u);
+  EXPECT_EQ(GotStrings.size(), 4u);
   EXPECT_EQ(StrList, GotStrings);
 }
 
@@ -268,19 +268,19 @@ TEST_F(RecentDBTest, RecentListLimit0)
   GotStrings.clear();
   rdb.Load();
   rdb.GetAll(GotStrings);
-  EXPECT_EQ(rdb.GetCount(), 0);
-  EXPECT_EQ(GotStrings.size(), 0);
+  EXPECT_EQ(rdb.GetCount(), 0u);
+  EXPECT_EQ(GotStrings.size(), 0u);
 
   // Add should be sliently ignored
   GotStrings.clear();
   rdb.AddFileToHistory("NewName1");
   rdb.GetAll(GotStrings);
-  EXPECT_EQ(rdb.GetCount(), 0);
-  EXPECT_EQ(GotStrings.size(), 0);
+  EXPECT_EQ(rdb.GetCount(), 0u);
+  EXPECT_EQ(GotStrings.size(), 0u);
 
   rdb.Save();
   ig = prefs->GetMRUList(MRURet);
   EXPECT_EQ(ig, 0);
-  EXPECT_EQ(MRURet.size(), 0);
+  EXPECT_EQ(MRURet.size(), 0u);
 }
 #endif //WIN32

--- a/src/ui/cli/add-entry-test.cpp
+++ b/src/ui/cli/add-entry-test.cpp
@@ -17,7 +17,7 @@ TEST(AddEntryTest, AddEntryWithTitleOnly) {
   std::wostringstream os;
   int ret = AddEntryWithFields(core, {std::make_tuple(CItemData::TITLE, L"TitleOnlyItem")}, os);
   EXPECT_EQ(ret, PWScore::SUCCESS);
-  EXPECT_EQ(core.GetNumEntries(), 1);
+  EXPECT_EQ(core.GetNumEntries(), 1u);
   const CItemData &entry = core.GetEntryIter()->second;
   EXPECT_FALSE(entry.GetPassword().empty()) << "Password should be auto-generated";
 }
@@ -27,7 +27,7 @@ TEST(AddEntryTest, AddEntryWithoutTitle) {
   std::wostringstream os;
   int ret = AddEntryWithFields(core, {}, os);
   EXPECT_NE(ret, PWScore::SUCCESS);
-  EXPECT_EQ(core.GetNumEntries(), 0);
+  EXPECT_EQ(core.GetNumEntries(), 0u);
 }
 
 TEST(AddEntryTest, AddEntryWithPassword) {
@@ -36,7 +36,7 @@ TEST(AddEntryTest, AddEntryWithPassword) {
   int ret = AddEntryWithFields(core, {std::make_tuple(CItemData::TITLE, L"SomeTitle"),
                                       std::make_tuple(CItemData::PASSWORD, L"randompass")}, os);
   EXPECT_EQ(ret, PWScore::SUCCESS);
-  EXPECT_EQ(core.GetNumEntries(), 1);
+  EXPECT_EQ(core.GetNumEntries(), 1u);
   const CItemData &entry = core.GetEntryIter()->second;
   EXPECT_EQ(entry.GetPassword(), L"randompass") << "Password should NOT be auto-generated if specified";
 }
@@ -52,7 +52,7 @@ TEST(AddEntryTest, AddEntryWithFields) {
                                       std::make_tuple(CItemData::NOTES, L"Line1\nLine2\nLine3"),
                                       }, os);
   EXPECT_EQ(ret, PWScore::SUCCESS);
-  EXPECT_EQ(core.GetNumEntries(), 1);
+  EXPECT_EQ(core.GetNumEntries(), 1u);
   const CItemData &entry = core.GetEntryIter()->second;
   EXPECT_FALSE(entry.GetPassword().empty()) << "Password should be auto-generated even if other fields are specified";
   EXPECT_EQ(entry.GetGroup(), L"Example.Group");

--- a/src/ui/cli/arg-fields-test.cpp
+++ b/src/ui/cli/arg-fields-test.cpp
@@ -22,13 +22,13 @@ namespace {
 
 TEST(ParseFieldArgsTest, ParsesSingleField) {
   const CItemData::FieldBits fields = ParseFields( L"Group");
-  EXPECT_EQ(1, fields.count());
+  EXPECT_EQ(1u, fields.count());
   EXPECT_TRUE(fields.test(CItemData::GROUP));
 }
 
 TEST(ParseFieldArgsTest, ParsesAllFields) {
   const CItemData::FieldBits fields = ParseFields( L"Title,Username");
-  EXPECT_EQ(2, fields.count());
+  EXPECT_EQ(2u, fields.count());
   EXPECT_TRUE(fields.test(CItemData::TITLE));
   EXPECT_TRUE(fields.test(CItemData::USER));
 }
@@ -46,14 +46,14 @@ TEST(ParseFieldArgsTest, ThrowsOnInvalidField) {
 
 TEST(ParsesFieldValue, ParsesSingleFieldValue) {
   UserArgs::FieldUpdates upd = ParseFieldValues(L"Username=example");
-  EXPECT_EQ(upd.size(), 1);
+  EXPECT_EQ(upd.size(), 1u);
   EXPECT_EQ(std::get<0>(upd[0]), CItemData::USER);
   EXPECT_EQ(std::get<1>(upd[0]), L"example");
 }
 
 TEST(ParsesFieldValue, ParsesMultipleFieldValue) {
   UserArgs::FieldUpdates upd = ParseFieldValues(L"Group=NewGroup,URL=example.com,Username=example");
-  EXPECT_EQ(upd.size(), 3);
+  EXPECT_EQ(upd.size(), 3u);
   EXPECT_EQ(std::get<0>(upd[0]), CItemData::GROUP);
   EXPECT_EQ(std::get<1>(upd[0]), L"NewGroup");
   EXPECT_EQ(std::get<0>(upd[1]), CItemData::URL);
@@ -65,7 +65,7 @@ TEST(ParsesFieldValue, ParsesMultipleFieldValue) {
 TEST(ParsesFieldValue, ParsesSingleFieldValueWithSpacesAfterSeparator) {
   UserArgs::FieldUpdates upd;
   ASSERT_NO_THROW(upd = ParseFieldValues(L"Group= NewGroup"));
-  EXPECT_EQ(upd.size(), 1);
+  EXPECT_EQ(upd.size(), 1u);
   EXPECT_EQ(std::get<0>(upd[0]), CItemData::GROUP);
   EXPECT_EQ(std::get<1>(upd[0]), L" NewGroup");
 }
@@ -73,7 +73,7 @@ TEST(ParsesFieldValue, ParsesSingleFieldValueWithSpacesAfterSeparator) {
 TEST(ParsesFieldValue, ParsesSingleFieldValueWithSpacesBeforeSeparator) {
   UserArgs::FieldUpdates upd;
   ASSERT_NO_THROW(upd = ParseFieldValues(L"Group =NewGroup"));
-  EXPECT_EQ(upd.size(), 1);
+  EXPECT_EQ(upd.size(), 1u);
   EXPECT_EQ(std::get<0>(upd[0]), CItemData::GROUP);
   EXPECT_EQ(std::get<1>(upd[0]), L"NewGroup");
 }

--- a/src/ui/cli/search-test.cpp
+++ b/src/ui/cli/search-test.cpp
@@ -80,7 +80,7 @@ TEST_F(SearchTest, SearchAndDelete) {
 
   SearchInternal(core, ua, os);
 
-  EXPECT_EQ( core.GetNumEntries(), 0 );
+  EXPECT_EQ( core.GetNumEntries(), 0u );
 }
 
 TEST_F(SearchTest, SearchAndUpdate) {
@@ -96,7 +96,7 @@ TEST_F(SearchTest, SearchAndUpdate) {
 
   SearchInternal(core, ua, os);
 
-  EXPECT_EQ( core.GetNumEntries(), 1 );
+  EXPECT_EQ( core.GetNumEntries(), 1u );
   const CItemData &entry = core.GetEntryIter()->second;
   EXPECT_EQ( entry.GetEmail(), L"e-mail=somerandomenewemail@nosuchdomain.com" );
   EXPECT_EQ( entry.GetURL(), L"nowaysuchadomainexists.pwsafe" );
@@ -113,7 +113,7 @@ TEST_F(SearchTest, SearchAndClearFields) {
 
   SearchInternal(core, ua, os);
 
-  EXPECT_EQ( core.GetNumEntries(), 1 );
+  EXPECT_EQ( core.GetNumEntries(), 1u );
   const CItemData &entry = core.GetEntryIter()->second;
   EXPECT_TRUE( entry.IsNotesEmpty() );
 }
@@ -129,7 +129,7 @@ TEST_F(SearchTest, SearchAndChangePasswords) {
   const StringX before = core.GetEntryIter()->second.GetPassword();
   SearchInternal(core, ua, os);
 
-  EXPECT_EQ( core.GetNumEntries(), 1 );
+  EXPECT_EQ( core.GetNumEntries(), 1u );
   const StringX after = core.GetEntryIter()->second.GetPassword();
 
   EXPECT_NE( before, after );

--- a/src/ui/cli/split-test.cpp
+++ b/src/ui/cli/split-test.cpp
@@ -54,7 +54,7 @@ TEST_F(SplitTest, SplitsWithSingleCharSeparator) {
   Split( L"Hello, world!", L",", [&tokens](const wstring &s) {
     tokens.push_back(s);
   });
-  EXPECT_EQ(2, tokens.size());
+  EXPECT_EQ(2u, tokens.size());
   EXPECT_EQ(L"Hello", tokens[0]);
   EXPECT_EQ(L" world!", tokens[1]);
 }
@@ -64,7 +64,7 @@ TEST_F(SplitTest, ReturnEntireStringIfNoSeparatorMatch) {
   Split( L"Hello, world!", L";", [&tokens](const wstring &s) {
     tokens.push_back(s);
   });
-  EXPECT_EQ(1, tokens.size());
+  EXPECT_EQ(1u, tokens.size());
   EXPECT_EQ(L"Hello, world!", tokens[0]);
 }
 
@@ -73,7 +73,7 @@ TEST_F(SplitTest, IgnoreEmptyTokensBetweenSeparator) {
   Split( L"Hello,, world!", L",", [&tokens](const wstring &s) {
     tokens.push_back(s);
   });
-  EXPECT_EQ(2, tokens.size());
+  EXPECT_EQ(2u, tokens.size());
   EXPECT_EQ(L"Hello", tokens[0]);
   EXPECT_EQ(L" world!", tokens[1]);
 }
@@ -83,7 +83,7 @@ TEST_F(SplitTest, IgnoresEmptyTokensBeforeAndAfterSeparator) {
   Split( L",Hello, world!,", L",", [&tokens](const wstring &s) {
     tokens.push_back(s);
   });
-  EXPECT_EQ(2, tokens.size());
+  EXPECT_EQ(2u, tokens.size());
   EXPECT_EQ(L"Hello", tokens[0]);
   EXPECT_EQ(L" world!", tokens[1]);
 }


### PR DESCRIPTION
These warnings show-up in a template class used by the EXPECT_EQ macro, but only in Xcode 16.4 (clang 17) with the -Wextra option:

`/opt/homebrew/include/gtest/gtest.h:1394:11: warning: comparison of integers of different signs: 'const unsigned long' and 'const int' [-Wsign-compare]
`

In all cases, the 'int' was an integer constant, so I just added the 'u' suffix.
Thanks to @dskrvk for the pointer.