### PR TITLE
Add check on input length in PWSUtil::pull_time

### DIFF
--- a/src/core/Util.cpp
+++ b/src/core/Util.cpp
@@ -923,6 +923,9 @@ bool PWSUtil::pull_time(time_t &t, const unsigned char *data, size_t len)
     t = getInt<time_t>(buf);
   } else { // convert from 40 or 64 bit time to 32 bit
     unsigned char buf[sizeof(__time64_t)] = {0};
+    if (len > sizeof(buf)) {
+      ASSERT(0); return false;
+    }
     memcpy(buf, data, len); // not needed if len == 8, but no harm
     struct tm ts;
     const auto t64 = getInt<__time64_t>(buf);


### PR DESCRIPTION
Generated a warning on some compilers.