### PR TITLE
Fedora release

### DIFF
--- a/README.LINUX.md
+++ b/README.LINUX.md
@@ -23,7 +23,7 @@ To install it just use the following command.
 $ sudo apt install passwordsafe
 ```
 
-or 
+or
 
 1. Download the .deb file that corresponds to your distribution.
 2. Install it using dpkg:
@@ -45,8 +45,17 @@ To install it just use the following command.
    $ sudo dnf install passwordsafe
    ```
 
+or
+
+1. Download the .rpm file that corresponds to your distribution.
+2. Install it using dnf:
+
+   ```
+   $ sudo dnf install passwordsafe-*.rpm
+   ```
+
 ## Installation on Gentoo
-As usual there are USE flags to control the features of the package. 
+As usual there are USE flags to control the features of the package.
 On Gentoo, suport for Yubi keys and QR is disabled by default.
 
 ```
@@ -71,7 +80,7 @@ Finally, run
 ```
 $ sudo pacman -U passwordsafe-*.zst
 ```
-to install the package on your machine. 
+to install the package on your machine.
 
 For more details on building and installing packages on Arch, see https://wiki.archlinux.org/title/Arch_User_Repository
 
@@ -86,13 +95,13 @@ See https://flathub.org/setup to get started using flatpak.
 ## Enabling System Tray support in Password Safe
 Issue: Password Safe is running but not appearing in the System Tray.
 
-System Tray/Task Bar support in Linux is problematic, and the implementations for it are inconsistent or missing in many desktop environments. 
+System Tray/Task Bar support in Linux is problematic, and the implementations for it are inconsistent or missing in many desktop environments.
 Usually, this feature is not supported by the windowing system such as Wayland. You may also need to install a desktop environment extension to enable System Tray support.
-If Password Safe detects that the feature is not enabled at the system level, it is disabled in the program's Options. 
+If Password Safe detects that the feature is not enabled at the system level, it is disabled in the program's Options.
 
 Anyway, enabling this feature in many distros can be done by following these steps:
 
-1. GNOME, KDE Plasma, and others: Verify that the org.kde.StatusNotifierWatcher D-Bus interface that provides the System Tray is enabled. 
+1. GNOME, KDE Plasma, and others: Verify that the org.kde.StatusNotifierWatcher D-Bus interface that provides the System Tray is enabled.
    Note: some extensions don't register a D-Bus interface when installed.
    ```
    $ busctl --user list | grep StatusNotifierWatcher
@@ -109,7 +118,7 @@ Anyway, enabling this feature in many distros can be done by following these ste
 
    GNOME: Use the Extensions app to verify that the GNOME extension is installed and enabled.
 
-   If a GNOME extension cannot be installed via a web browser: 
+   If a GNOME extension cannot be installed via a web browser:
    - Download it as a ZIP file.
    - Install the extension using this command:
    ```

--- a/README.LINUX.md
+++ b/README.LINUX.md
@@ -16,7 +16,8 @@ Slackware is independently supported, see below.
 
 ## Installation on Debian or Ubuntu
 
-Password Safe is available as package (https://packages.debian.org/stable/passwordsafe). To install it just use the following command.
+Password Safe is available as a package (https://packages.debian.org/stable/passwordsafe).
+To install it just use the following command.
 
 ```
 $ sudo apt install passwordsafe
@@ -36,10 +37,12 @@ or
    ```
 
 ## Installation on Fedora
-1. Download the .rpm file that corresponds to your distribution.
-2. Install it using dnf:
+
+Password Safe is available as a package in the Fedora repositories.
+To install it just use the following command.
+
    ```
-   $ sudo dnf install passwordsafe-*.rpm
+   $ sudo dnf install passwordsafe
    ```
 
 ## Installation on Gentoo

--- a/src/core/ItemAtt.cpp
+++ b/src/core/ItemAtt.cpp
@@ -706,19 +706,19 @@ bool CItemAtt::DeSerializePlainText(const std::vector<char> &v)
       }
 
 #ifdef PWS_BIG_ENDIAN
-    unsigned char buf[len] = {0};
-        
     switch(type) {
       case ATTCTIME:
       case FILECTIME:
       case FILEMTIME:
       case FILEATIME:
-
-        memcpy(buf, &(*iter), len);
-        byteswap(buf, buf + len - 1);
-
-        if (!SetField(type, buf, len))
-          return false;
+        {
+          std::vector<char> buf(iter, iter+len);
+          unsigned char *begin = reinterpret_cast<unsigned char *>(buf.data());
+          unsigned char *end   = begin + len - 1;
+          byteswap(begin, end);
+          if (!SetField(type, begin, len))
+            return false;
+        }
         break;
 
       default:

--- a/src/core/ItemData.cpp
+++ b/src/core/ItemData.cpp
@@ -2309,9 +2309,6 @@ bool CItemData::DeSerializePlainText(const std::vector<char> &v)
     }
 
 #ifdef PWS_BIG_ENDIAN
-    unsigned char buf[len];
-    memset(buf, 0, len*sizeof(buf[0]));
-	  
     switch(type) {
       case CTIME:
       case PMTIME:
@@ -2323,11 +2320,14 @@ bool CItemData::DeSerializePlainText(const std::vector<char> &v)
       case KBSHORTCUT:
       case XTIME_INT:
       case DATA_ATT_MTIME:
-        memcpy(buf, &(*iter), len);
-        byteswap(buf, buf + len - 1);
-
-        if (!SetField(type, buf, len))
-          return false;
+        {
+          std::vector<char> buf(iter, iter+len);
+          unsigned char *begin = reinterpret_cast<unsigned char *>(buf.data());
+          unsigned char *end   = begin + len - 1;
+          byteswap(begin, end);
+          if (!SetField(type, begin, len))
+            return false;
+        }
         break;
 
       default:


### PR DESCRIPTION
Password safe is now in the Fedora repositories. However, the 1.25.0 build in S390 arch needs a patch, since the S390 C++ does not allow does not allow variable length arrays.