### PR TITLE
[wx] Fix unused variable compiler error in case of excluded QR-Code implementation

### DIFF
--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -44,7 +44,9 @@
 #include "PasswordSafeFrame.h"
 #include "PasswordSafeSearch.h"
 #include "PasswordSubsetDlg.h"
+#ifndef NO_QR
 #include "QRCodeDlg.h"
+#endif
 #include "TimedTaskChain.h"
 #include "TreeCtrl.h"
 #include "ViewAttachmentDlg.h"
@@ -1153,20 +1155,18 @@ void PasswordSafeFrame::OnPasswordSubset(wxCommandEvent &evt)
   }
 }
 
+#ifndef NO_QR
 void PasswordSafeFrame::OnPasswordQRCode(wxCommandEvent &evt)
 {
-  if ( /* constexpr */ HasQRCode() ) {
-    CItemData rueItem;
-    CItemData* item = GetSelectedEntry(evt, rueItem);
-    if (item != nullptr) {
-      CallAfter(&PasswordSafeFrame::DoPasswordQRCode, item);
-    }
+  CItemData rueItem;
+  CItemData* item = GetSelectedEntry(evt, rueItem);
+  if (item != nullptr) {
+    CallAfter(&PasswordSafeFrame::DoPasswordQRCode, item);
   }
 }
 
 void PasswordSafeFrame::DoPasswordQRCode(CItemData* item)
 {
-#ifndef NO_QR
   if (item) {
     auto gtu = item->GetTitle();
     if (!item->GetGroup().empty()) {
@@ -1183,8 +1183,8 @@ void PasswordSafeFrame::DoPasswordQRCode(CItemData* item)
     ShowModalAndGetResult<QRCodeDlg>(this, item->GetPassword(),
             _("Password of ") + towxstring(gtu));
   }
-#endif
 }
+#endif
 
 /*!
  * wxEVT_COMMAND_MENU_SELECTED event handler for ID_PROTECT

--- a/src/ui/wxWidgets/PasswordSafeFrame.cpp
+++ b/src/ui/wxWidgets/PasswordSafeFrame.cpp
@@ -48,7 +48,9 @@
 #include "PasswordSafeFrame.h"
 #include "PasswordSafeSearch.h"
 #include "PWSafeApp.h"
+#ifndef NO_QR
 #include "QRCodeDlg.h"
+#endif
 #include "SafeCombinationPromptDlg.h"
 #include "SetDatabaseIdDlg.h"
 #include "StatusBar.h"
@@ -310,7 +312,9 @@ BEGIN_EVENT_TABLE( PasswordSafeFrame, wxFrame )
 
   // Connect event handlers
   EVT_MENU( ID_PASSWORDSUBSET,          PasswordSafeFrame::OnPasswordSubset              )
+#ifndef NO_QR
   EVT_MENU( ID_PASSWORDQRCODE,          PasswordSafeFrame::OnPasswordQRCode              )
+#endif
   EVT_MENU( ID_COPYEMAIL,               PasswordSafeFrame::OnCopyEmailClick              )
   EVT_MENU( ID_COPYRUNCOMMAND,          PasswordSafeFrame::OnCopyRunCmd                  )
   EVT_MENU( ID_BROWSEURLPLUS,           PasswordSafeFrame::OnBrowseUrlAndAutotype        )
@@ -321,7 +325,9 @@ BEGIN_EVENT_TABLE( PasswordSafeFrame, wxFrame )
 
   // Update menu elements
   EVT_UPDATE_UI( ID_PASSWORDSUBSET,     PasswordSafeFrame::OnUpdateUI                    )
+#ifndef NO_QR
   EVT_UPDATE_UI( ID_PASSWORDQRCODE,     PasswordSafeFrame::OnUpdateUI                    )
+#endif
   EVT_UPDATE_UI( ID_COPYEMAIL,          PasswordSafeFrame::OnUpdateUI                    )
   EVT_UPDATE_UI( ID_BROWSEURLPLUS,      PasswordSafeFrame::OnUpdateUI                    )
   EVT_UPDATE_UI( ID_SENDEMAIL,          PasswordSafeFrame::OnUpdateUI                    )
@@ -641,9 +647,9 @@ void PasswordSafeFrame::CreateMenubar()
   menuEdit->Append(ID_COPYPASSWORD, _("&Copy Password to Clipboard\tCtrl+C"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_COPYUSERNAME, _("Copy &Username to Clipboard\tCtrl+U"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_PASSWORDSUBSET, _("Display subset of Password\tCtrl+B"), wxEmptyString, wxITEM_NORMAL);
-  if (HasQRCode()) {
-    menuEdit->Append(ID_PASSWORDQRCODE, _("Display Password as &QR code"), wxEmptyString, wxITEM_NORMAL);
-  }
+#ifndef NO_QR
+  menuEdit->Append(ID_PASSWORDQRCODE, _("Display Password as &QR code"), wxEmptyString, wxITEM_NORMAL);
+#endif
   menuEdit->Append(ID_COPYAUTHCODE, _("Copy Aut&h Code to Clipboard\tAlt+2"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_SHOWAUTHCODE, _("Display Auth Code\tAlt+Ctrl+2"), wxEmptyString, wxITEM_NORMAL);
   menuEdit->Append(ID_COPYNOTESFLD, _("Copy &Notes to Clipboard\tCtrl+G"), wxEmptyString, wxITEM_NORMAL);
@@ -1889,9 +1895,9 @@ void PasswordSafeFrame::OnContextMenu(const CItemData* item)
     itemEditMenu.Append(ID_COPYUSERNAME,   _("Copy &Username to Clipboard"));
     itemEditMenu.Append(ID_COPYPASSWORD,   _("&Copy Password to Clipboard"));
     itemEditMenu.Append(ID_PASSWORDSUBSET, _("Display subset of Password"));
-    if (HasQRCode()) {
-      itemEditMenu.Append(ID_PASSWORDQRCODE, _("Display Password as &QR code"));
-    }
+#ifndef NO_QR
+    itemEditMenu.Append(ID_PASSWORDQRCODE, _("Display Password as &QR code"));
+#endif
     itemEditMenu.Append(ID_COPYAUTHCODE,   _("Copy Aut&h Code to Clipboard"));
     itemEditMenu.Append(ID_SHOWAUTHCODE,   _("Display Auth Code"));
     itemEditMenu.Append(ID_COPYNOTESFLD,   _("Copy &Notes to Clipboard"));
@@ -2407,7 +2413,9 @@ void PasswordSafeFrame::OnUpdateUI(wxUpdateUIEvent& evt)
     case ID_EDIT:
     case ID_COPYPASSWORD:
     case ID_PASSWORDSUBSET:
+#ifndef NO_QR
     case ID_PASSWORDQRCODE:
+#endif
       evt.Enable(isUnlocked && !isTreeViewGroupSelected && pci);
       break;
 

--- a/src/ui/wxWidgets/PasswordSafeFrame.h
+++ b/src/ui/wxWidgets/PasswordSafeFrame.h
@@ -176,7 +176,9 @@ enum {
   ID_EDITMENU_FIND_NEXT,
   ID_EDITMENU_FIND_PREVIOUS,
   ID_PASSWORDSUBSET,
+#ifndef NO_QR
   ID_PASSWORDQRCODE,
+#endif
   ID_COPYEMAIL,
   ID_RUNCOMMAND,
   ID_COPYRUNCOMMAND,
@@ -548,7 +550,9 @@ public:
   void OnVisitWebsite(wxCommandEvent&);
 
   void OnPasswordSubset(wxCommandEvent& evt);
+#ifndef NO_QR
   void OnPasswordQRCode(wxCommandEvent& evt);
+#endif
 
 ////@begin PasswordSafeFrame member function declarations
 
@@ -803,7 +807,9 @@ private:
   void DoEditFilter();
   void DoGeneratePassword();
   void DoChangePassword();
+#ifndef NO_QR
   void DoPasswordQRCode(CItemData* item);
+#endif
   void DoPropertiesClick();
   void DoMergeAnotherSafe(wxString filename);
   void DoRestoreSafe();

--- a/src/ui/wxWidgets/QRCodeDlg.cpp
+++ b/src/ui/wxWidgets/QRCodeDlg.cpp
@@ -25,6 +25,7 @@
 
 #include "QREncode.h"
 #include "QRCodeDlg.h"
+
 #include "wxUtilities.h"
 
 #include <algorithm>

--- a/src/ui/wxWidgets/QRCodeDlg.h
+++ b/src/ui/wxWidgets/QRCodeDlg.h
@@ -58,12 +58,4 @@ protected:
   void OnInitDialog(wxInitDialogEvent &evt);
 };
 
-constexpr bool HasQRCode() {
-#ifndef NO_QR
-  return true;
-#else
-  return false;
-#endif
-}
-
 #endif // _QRCODEDLG_H_


### PR DESCRIPTION
Compiling the application with NO_QR=ON to disable the QR code functionality results in a compiler error due to an unused variable in PasswordSafeFrame::DoPasswordQRCode(CItemData* item).

This pull request more strictly excludes the QR code-related implementation to resolve the unused variable issue.