### PR TITLE
[wx] Sorting by date in grid view does not work on macOS

### DIFF
--- a/src/core/ItemData.h
+++ b/src/core/ItemData.h
@@ -162,6 +162,7 @@ public:
   StringX GetXTimeXML() const {return GetTime(XTIME, PWSUtil::TMC_XML);}  // V30
   StringX GetPMTimeXML() const {return GetTime(PMTIME, PWSUtil::TMC_XML);}  // V30
   StringX GetRMTimeXML() const {return GetTime(RMTIME, PWSUtil::TMC_XML);}  // V30
+  StringX GetTime(int whichtime, PWSUtil::TMC result_format, bool convert_epoch = false, bool utc_time = false) const; // V30
   //  These populate (and return) time_t instead of giving a character string
   time_t GetATime(time_t &t) const {CItem::GetTime(ATIME, t); return t;}  // V30
   time_t GetCTime(time_t &t) const {CItem::GetTime(CTIME, t); return t;}  // V30
@@ -422,9 +423,7 @@ private:
   EntryStatus m_entrystatus;
 
   // move from pre-2.0 name to post-2.0 title+user
-  void SplitName(const StringX &name,
-                 StringX &title, StringX &username);
-  StringX GetTime(int whichtime, PWSUtil::TMC result_format, bool convert_epoch = false, bool utc_time = false) const; // V30
+  void SplitName(const StringX &name, StringX &title, StringX &username);
   void SetTime(const int whichtime); // V30
   bool SetTime(const int whichtime, const stringT &time_str, bool utc_time = false); // V30
 

--- a/src/core/Util.cpp
+++ b/src/core/Util.cpp
@@ -547,11 +547,7 @@ StringX PWSUtil::ConvertToDateTimeString(const time_t &t, TMC result_format, boo
       is_error = !_tcsftime(datetime_str, sizeof(datetime_str) / sizeof(datetime_str[0]), _T("%Y-%m-%dT%H:%M:%S"), st);
       break;
     case TMC_LOCALE:
-#ifdef __APPLE__
-      is_error = !_tcsftime(datetime_str, sizeof(datetime_str) / sizeof(datetime_str[0]), _T("%a %d %b %Y %T %Z"), st);
-#else
       is_error = !_tcsftime(datetime_str, sizeof(datetime_str) / sizeof(datetime_str[0]), _T("%c"), st);
-#endif
       break;
     case TMC_LOCALE_SIMPLIFIED:
       is_error = !_tcsftime(datetime_str, sizeof(datetime_str) / sizeof(datetime_str[0]), _T("%F %T"), st);

--- a/src/core/Util.cpp
+++ b/src/core/Util.cpp
@@ -547,7 +547,11 @@ StringX PWSUtil::ConvertToDateTimeString(const time_t &t, TMC result_format, boo
       is_error = !_tcsftime(datetime_str, sizeof(datetime_str) / sizeof(datetime_str[0]), _T("%Y-%m-%dT%H:%M:%S"), st);
       break;
     case TMC_LOCALE:
+#ifdef __APPLE__
+      is_error = !_tcsftime(datetime_str, sizeof(datetime_str) / sizeof(datetime_str[0]), _T("%a %d %b %Y %T %Z"), st);
+#else
       is_error = !_tcsftime(datetime_str, sizeof(datetime_str) / sizeof(datetime_str[0]), _T("%c"), st);
+#endif
       break;
     case TMC_LOCALE_SIMPLIFIED:
       is_error = !_tcsftime(datetime_str, sizeof(datetime_str) / sizeof(datetime_str[0]), _T("%F %T"), st);

--- a/src/ui/wxWidgets/GridCtrl.cpp
+++ b/src/ui/wxWidgets/GridCtrl.cpp
@@ -749,10 +749,12 @@ void GridCtrl::RearrangeItemsDateTimeBased(ItemsCollection& collection, int colu
       // because localization is not taken into account and day-month detection algorithm is weak.
       // (e.g. 01.02.2026 -> Day=02 & Month=01; 02.01.2026 -> Day=01, Month=02)
       // See GitHub: https://github.com/wxWidgets/wxWidgets/issues/3049
+      // 2026-07-23 update: Now using YYYY-MM-DD format, so ParseDate() should be good.
       else if (dt.ParseDate(datetime, &end)) {
         collection.insert(std::pair<wxDateTime, const CItemData*>(dt, GetItem(row)));
-        pws_os::Trace(L"Warning - Sorting may be incorrect for date string: %ls ; day: %d ; month: %d ; year: %d",
-          datetime.wc_str(), dt.GetDay(), dt.GetMonth(), dt.GetYear());
+        // Note: GetMonth() return value range is 0..11
+        // pws_os::Trace(L"Warning - Sorting may be incorrect for date string: %ls ; day: %d ; month: %d ; year: %d",
+        //   datetime.wc_str(), dt.GetDay(), dt.GetMonth()+1, dt.GetYear());
       }
     }
     else {

--- a/src/ui/wxWidgets/GridCtrl.cpp
+++ b/src/ui/wxWidgets/GridCtrl.cpp
@@ -752,9 +752,6 @@ void GridCtrl::RearrangeItemsDateTimeBased(ItemsCollection& collection, int colu
       // 2026-07-23 update: Now using YYYY-MM-DD format, so ParseDate() should be good.
       else if (dt.ParseDate(datetime, &end)) {
         collection.insert(std::pair<wxDateTime, const CItemData*>(dt, GetItem(row)));
-        // Note: GetMonth() return value range is 0..11
-        // pws_os::Trace(L"Warning - Sorting may be incorrect for date string: %ls ; day: %d ; month: %d ; year: %d",
-        //   datetime.wc_str(), dt.GetDay(), dt.GetMonth()+1, dt.GetYear());
       }
     }
     else {

--- a/src/ui/wxWidgets/GridCtrl.cpp
+++ b/src/ui/wxWidgets/GridCtrl.cpp
@@ -713,12 +713,15 @@ template<typename ItemsCollection>
 void GridCtrl::RearrangeItemsDateTimeBased(ItemsCollection& collection, int column, bool dateOnly)
 {
   int row = 0;
-  struct tm tm;
   wxDateTime dt = wxDateTime::Today(); // initialize with valid date
   wxString datetime;
-  wxString dateFormat = wxGetApp().GetLocaleShortDateFormat();
   wxString::const_iterator end;
 
+  /*
+   This version of the code expects the date and time in the following format:
+   "YYYY-MM-DD HH:MM:SS" which is equivalent to "%F %T" format in strftime()
+   and is compatible with ISO 8601
+   */
   for (row = 0; row < GetNumberRows(); row++) {
     /*
       The items's date-time or date information.
@@ -740,19 +743,8 @@ void GridCtrl::RearrangeItemsDateTimeBased(ItemsCollection& collection, int colu
     /*
       The case if a date without a time is expected.
     */
-    else if (dateOnly) {
-      memset(&tm, 0, sizeof(tm)); // init / reset
-      if (!dateFormat.IsEmpty() && strptime(datetime.c_str(), dateFormat.c_str(), &tm)) {
-        collection.insert(std::pair<wxDateTime, const CItemData*>(wxDateTime(tm), GetItem(row)));
-      }
-      // Fallback to buggy version where day and month are in some cases swapped,
-      // because localization is not taken into account and day-month detection algorithm is weak.
-      // (e.g. 01.02.2026 -> Day=02 & Month=01; 02.01.2026 -> Day=01, Month=02)
-      // See GitHub: https://github.com/wxWidgets/wxWidgets/issues/3049
-      // 2026-07-23 update: Now using YYYY-MM-DD format, so ParseDate() should be good.
-      else if (dt.ParseDate(datetime, &end)) {
-        collection.insert(std::pair<wxDateTime, const CItemData*>(dt, GetItem(row)));
-      }
+    else if (dateOnly && dt.ParseDate(datetime, &end)) {
+      collection.insert(std::pair<wxDateTime, const CItemData*>(dt, GetItem(row)));
     }
     else {
       pws_os::Trace(L"Failed to parse item's date string: %ls ; using: %ls", datetime.wc_str(), wxDateTime::Today().FormatISOCombined().wc_str());

--- a/src/ui/wxWidgets/GridTable.cpp
+++ b/src/ui/wxWidgets/GridTable.cpp
@@ -122,20 +122,35 @@ wxString GridTable::GetColLabelValue(int col)
 
 wxString GridTable::GetValue(int row, int col)
 {
+  wxString ret = wxEmptyString;
+
   if (size_t(row) < m_pwsgrid->GetNumItems() &&
       size_t(col) < NumberOf(PWSGridCellData)) {
     const CItemData *pItem = m_pwsgrid->GetItem(row);
     if (pItem != nullptr) {
-      if (PWSGridCellData[col].ft != CItemData::POLICY) {
-        return towxstring(pItem->GetFieldValue(PWSGridCellData[col].ft));
-      } else {
-        PWPolicy pwp;
-        pItem->GetPWPolicy(pwp);
-        return towxstring(pwp.GetDisplayString());
+      switch (PWSGridCellData[col].ft) {
+      case CItemData::ATIME:
+      case CItemData::CTIME:
+      case CItemData::PMTIME:
+      case CItemData::RMTIME:
+        ret = towxstring(pItem->GetTime(PWSGridCellData[col].ft, PWSUtil::TMC_LOCALE_SIMPLIFIED));
+        break;
+
+      case CItemData::POLICY:
+        {
+          PWPolicy pwp;
+          pItem->GetPWPolicy(pwp);
+          ret = towxstring(pwp.GetDisplayString());
+        }
+        break;
+
+      default:
+        ret = towxstring(pItem->GetFieldValue(PWSGridCellData[col].ft));
+        break;
       }
     }
   }
-  return wxEmptyString;
+  return ret;
 }
 
 void GridTable::SetValue(int WXUNUSED(row), int WXUNUSED(col), const wxString& WXUNUSED(value))

--- a/src/ui/wxWidgets/GridTable.cpp
+++ b/src/ui/wxWidgets/GridTable.cpp
@@ -128,12 +128,23 @@ wxString GridTable::GetValue(int row, int col)
       size_t(col) < NumberOf(PWSGridCellData)) {
     const CItemData *pItem = m_pwsgrid->GetItem(row);
     if (pItem != nullptr) {
-      switch (PWSGridCellData[col].ft) {
+      const auto field = PWSGridCellData[col].ft;
+      switch (field) {
       case CItemData::ATIME:
       case CItemData::CTIME:
       case CItemData::PMTIME:
       case CItemData::RMTIME:
-        ret = towxstring(pItem->GetTime(PWSGridCellData[col].ft, PWSUtil::TMC_LOCALE_SIMPLIFIED));
+        ret = towxstring(pItem->GetTime(field, PWSUtil::TMC_LOCALE_SIMPLIFIED));
+        break;
+
+      case CItemData::XTIME:
+        if (pItem->IsExpiryDateSet()) {
+          time_t expTime;
+          ret = wxDateTime(pItem->GetXTime(expTime)).FormatISODate();
+          if (pItem->IsPasswordExpiryIntervalSet()) {
+            ret << L" *";
+          }
+        }
         break;
 
       case CItemData::POLICY:
@@ -145,7 +156,7 @@ wxString GridTable::GetValue(int row, int col)
         break;
 
       default:
-        ret = towxstring(pItem->GetFieldValue(PWSGridCellData[col].ft));
+        ret = towxstring(pItem->GetFieldValue(field));
         break;
       }
     }


### PR DESCRIPTION
Sorting the grid view by clicking on any date column has no effect.  Running in the debugger, I get a number of "Failed to parse item's date string:..." messages.  The crux of the problem seems to be that the strftime() %c format looks like this (with the year at the end):
`Wed Jul 22 10:29:44 2026`
This appears to be the one format that wxDateTIme::ParseDateTime() cannot parse.  ~This PR proposes to change the format string to look as follows~, which is more consistent with the %c result on Linux:
`Wed 22 Jul 2026 10:32:04 PDT`

~This affects the format in a few other places, such as the "Dates and Times" tab on the add/edit dialog and the password history, but that seems acceptable.~  An alternative might be to change the grid view to use the TMC_LOCALE_SIMPLIFIED ("%F %T"), which would be more consistent with Windows, but would be a change to all WX platforms.

Caveats:
1. I suspect the *BSDs may suffer the same issue, but I don't have an environment set-up to test them.
2. I don't know if the change in core will impact @huven project.  If so, I can use a different define symbol.

Tested on:
macOS M1Max 15.7.7 Sequoia, Xcode 16.4, wx 3.2.10, 3.2.11
Fedora 44 ARM64 VMware,  KDE/Wayland,   gcc 16.1.1, wx 3.2.9, GTK 3.24.52

