### PR TITLE
Misc: modernize mock-build.sh

### DIFF
--- a/Misc/mock-build.sh
+++ b/Misc/mock-build.sh
@@ -4,18 +4,76 @@
 # With no argument compiles for current system.
 # If added -r mock_arch, where mock_arch is a file name in /etc/mock without .cfg,
 # then rpm will be compiled on specified architecture.
-# Tested on Fedora-30 and CentOS-7
-# Build on or for CentOS-7 requires current mock* for devtoolset-7-gcc-c++ access.
-#
-# To install the resulting RPM on CentOS7, the https://fedoraproject.org/wiki/EPEL repository
-# should be installed.
+# Use -v WXVERSION to pin a specific wxGTK version instead of the latest.
+# Tested on Fedora
+
+usage() {
+    echo "Usage: $0 [-v WXVERSION] [mock options]" >&2
+    echo "  -v WXVERSION  Install this exact wxGTK version instead of the latest" >&2
+    exit 1
+}
+
+WANT_VERSION=""
+
+while getopts ":v:" opt; do
+    case $opt in
+        v) WANT_VERSION="$OPTARG" ;;
+        :) echo "ERROR: -$OPTARG requires an argument" >&2; usage ;;
+        \?) break ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CLONE_URL="https://github.com/pwsafe/pwsafe.git"
+CLONE_OPTS=""
+RPMDIR=$(rpm --eval '%_rpmdir')
+RPMARCH=$(rpm --eval '%_arch')
+DIST=$(rpm --eval '%{dist}' | sed 's/^\.//')
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+    UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null)
+    if [ -n "$UPSTREAM" ]; then
+        REMOTE=$(echo "$UPSTREAM" | cut -d/ -f1)
+        CLONE_URL=$(git remote get-url "$REMOTE")
+        CLONE_OPTS="--branch $BRANCH --single-branch"
+    fi
+fi
 
 mock --init "$@"
-if [ "$2" = epel-7-x86_64 -o \( -z "$2" -a $(readlink /etc/mock/default.cfg) = epel-7-x86_64.cfg \) ];then
-    mock "$@" install cmake gcc-c++ git gtest-devel libXt-devel libXtst-devel libcurl-devel libuuid-devel libyubikey-devel make openssl-devel wxGTK3-devel xerces-c-devel ykpers-devel qrencode-devel file-devel file-devel redhat-lsb-core devtoolset-7-gcc-c++
-    mock "$@" --enable-network --chroot 'su - mockbuild -c "git clone https://github.com/pwsafe/pwsafe.git; mkdir -p pwsafe/build; cd pwsafe/build; scl enable devtoolset-7 -- cmake -D wxWidgets_CONFIG_EXECUTABLE=/usr/libexec/wxGTK3/wx-config ..; scl enable devtoolset-7 -- cpack -G RPM"'
+mock "$@" install cmake dpkg gcc-c++ git libXt-devel libXtst-devel libcurl-devel libuuid-devel libyubikey-devel make openssl-devel wxGTK-devel xerces-c-devel ykpers-devel qrencode-devel file-devel ImageMagick libayatana-appindicator-gtk3-devel
+
+latest_rpm() {
+    ls -1v "$@" 2>/dev/null | tail -n1
+}
+
+if [ -n "$WANT_VERSION" ]; then
+    VER_GLOB="${WANT_VERSION}-*"
 else
-    mock "$@" install cmake gcc-c++ git gtest-devel libXt-devel libXtst-devel libcurl-devel libuuid-devel libyubikey-devel make openssl-devel wxGTK3-devel xerces-c-devel ykpers-devel qrencode-devel file-devel file-devel redhat-lsb-core
-    mock "$@" --enable-network --chroot 'su - mockbuild -c "git clone https://github.com/pwsafe/pwsafe.git; mkdir -p pwsafe/build; cd pwsafe/build; cmake ..; cpack -G RPM"'
+    VER_GLOB="[0-9]*"
 fi
+
+if ls "$RPMDIR/$RPMARCH"/wxGTK-${VER_GLOB}."$DIST.$RPMARCH.rpm" >/dev/null 2>&1; then
+    WXBASE=$(latest_rpm "$RPMDIR/$RPMARCH"/wxBase-${VER_GLOB}."$DIST.$RPMARCH.rpm")
+    WXBASE_DEVEL=$(latest_rpm "$RPMDIR/$RPMARCH"/wxBase-devel-${VER_GLOB}."$DIST.$RPMARCH.rpm")
+    WXGTK=$(latest_rpm "$RPMDIR/$RPMARCH"/wxGTK-${VER_GLOB}."$DIST.$RPMARCH.rpm")
+    WXGTK_DEVEL=$(latest_rpm "$RPMDIR/$RPMARCH"/wxGTK-devel-${VER_GLOB}."$DIST.$RPMARCH.rpm")
+    WXGTK_GL=$(latest_rpm "$RPMDIR/$RPMARCH"/wxGTK-gl-${VER_GLOB}."$DIST.$RPMARCH.rpm")
+    WXGTK_I18N=$(latest_rpm "$RPMDIR/noarch"/wxGTK-i18n-${VER_GLOB}."$DIST.noarch.rpm")
+    WXGTK_MEDIA=$(latest_rpm "$RPMDIR/$RPMARCH"/wxGTK-media-${VER_GLOB}."$DIST.$RPMARCH.rpm")
+    WXGTK_WEBVIEW=$(latest_rpm "$RPMDIR/$RPMARCH"/wxGTK-webview-${VER_GLOB}."$DIST.$RPMARCH.rpm")
+
+    mock "$@" --copyin \
+        "$WXBASE" \
+        "$WXBASE_DEVEL" \
+        "$WXGTK" \
+        "$WXGTK_DEVEL" \
+        "$WXGTK_GL" \
+        "$WXGTK_I18N" \
+        "$WXGTK_MEDIA" \
+        "$WXGTK_WEBVIEW" \
+        /tmp/
+    mock "$@" --chroot "rpm -Uvh --force /tmp/wxBase-3*.rpm /tmp/wxBase-devel*.rpm /tmp/wxGTK-3*.rpm /tmp/wxGTK-devel*.rpm /tmp/wxGTK-gl*.rpm /tmp/wxGTK-i18n*.rpm /tmp/wxGTK-media*.rpm /tmp/wxGTK-webview*.rpm"
+fi
+mock "$@" --enable-network --unpriv --chroot "cd /builddir && git clone $CLONE_OPTS $CLONE_URL && mkdir -p pwsafe/build && cd pwsafe/build && cmake .. -DNO_GTEST=ON && cmake --build . -j\$(nproc) && cpack -G RPM"
 mock "$@" --copyout '/builddir/pwsafe/build/passwordsafe*.rpm' .

--- a/Misc/mock-build.sh
+++ b/Misc/mock-build.sh
@@ -24,6 +24,16 @@ while getopts ":v:" opt; do
 done
 shift $((OPTIND - 1))
 
+# WANT_VERSION feeds into shell glob patterns (and RPM filenames) below;
+# restrict it to characters RPM versions/releases actually use.
+case "$WANT_VERSION" in
+    "") ;;
+    *[!A-Za-z0-9._+~-]*)
+        echo "ERROR: -v value '$WANT_VERSION' contains invalid characters (allowed: A-Z a-z 0-9 . _ + ~ -)" >&2
+        exit 1
+        ;;
+esac
+
 CLONE_URL="https://github.com/pwsafe/pwsafe.git"
 CLONE_OPTS=""
 RPMDIR=$(rpm --eval '%_rpmdir')
@@ -41,39 +51,77 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 mock --init "$@"
-mock "$@" install cmake dpkg gcc-c++ git libXt-devel libXtst-devel libcurl-devel libuuid-devel libyubikey-devel make openssl-devel wxGTK-devel xerces-c-devel ykpers-devel qrencode-devel file-devel ImageMagick libayatana-appindicator-gtk3-devel
+mock "$@" install \
+    cmake \
+    dpkg \
+    gcc-c++ \
+    git \
+    libXt-devel \
+    libXtst-devel \
+    libcurl-devel \
+    libuuid-devel \
+    libyubikey-devel \
+    make \
+    openssl-devel \
+    wxGTK-devel \
+    xerces-c-devel \
+    ykpers-devel \
+    qrencode-devel \
+    file-devel \
+    ImageMagick \
+    libayatana-appindicator-gtk3-devel
 
 latest_rpm() {
     ls -1v "$@" 2>/dev/null | tail -n1
 }
 
-if [ -n "$WANT_VERSION" ]; then
-    VER_GLOB="${WANT_VERSION}-*"
-else
-    VER_GLOB="[0-9]*"
-fi
+case "$WANT_VERSION" in
+    "") VER_GLOB="[0-9]*" ;;
+    *-*) VER_GLOB="$WANT_VERSION" ;;      # already version-release, e.g. 3.2.12-2.sni
+    *) VER_GLOB="${WANT_VERSION}-*" ;;    # bare version, e.g. 3.2.12: match any release
+esac
 
-if ls "$RPMDIR/$RPMARCH"/wxGTK-${VER_GLOB}."$DIST.$RPMARCH.rpm" >/dev/null 2>&1; then
-    WXBASE=$(latest_rpm "$RPMDIR/$RPMARCH"/wxBase-${VER_GLOB}."$DIST.$RPMARCH.rpm")
-    WXBASE_DEVEL=$(latest_rpm "$RPMDIR/$RPMARCH"/wxBase-devel-${VER_GLOB}."$DIST.$RPMARCH.rpm")
-    WXGTK=$(latest_rpm "$RPMDIR/$RPMARCH"/wxGTK-${VER_GLOB}."$DIST.$RPMARCH.rpm")
-    WXGTK_DEVEL=$(latest_rpm "$RPMDIR/$RPMARCH"/wxGTK-devel-${VER_GLOB}."$DIST.$RPMARCH.rpm")
-    WXGTK_GL=$(latest_rpm "$RPMDIR/$RPMARCH"/wxGTK-gl-${VER_GLOB}."$DIST.$RPMARCH.rpm")
-    WXGTK_I18N=$(latest_rpm "$RPMDIR/noarch"/wxGTK-i18n-${VER_GLOB}."$DIST.noarch.rpm")
-    WXGTK_MEDIA=$(latest_rpm "$RPMDIR/$RPMARCH"/wxGTK-media-${VER_GLOB}."$DIST.$RPMARCH.rpm")
-    WXGTK_WEBVIEW=$(latest_rpm "$RPMDIR/$RPMARCH"/wxGTK-webview-${VER_GLOB}."$DIST.$RPMARCH.rpm")
+wx_rpm_candidates() {
+    pkg="$1"
+    # $VER_GLOB may contain shell glob characters (e.g. "3.2.12-*" or "[0-9]*")
+    # and must stay unquoted here so the shell expands it.
+    { ls -1v "$RPMDIR/$RPMARCH"/${pkg}-${VER_GLOB}."$DIST.$RPMARCH.rpm" 2>/dev/null
+      ls -1v "$RPMDIR/noarch"/${pkg}-${VER_GLOB}."$DIST.noarch.rpm" 2>/dev/null; }
+}
 
-    mock "$@" --copyin \
-        "$WXBASE" \
-        "$WXBASE_DEVEL" \
-        "$WXGTK" \
-        "$WXGTK_DEVEL" \
-        "$WXGTK_GL" \
-        "$WXGTK_I18N" \
-        "$WXGTK_MEDIA" \
-        "$WXGTK_WEBVIEW" \
-        /tmp/
-    mock "$@" --chroot "rpm -Uvh --force /tmp/wxBase-3*.rpm /tmp/wxBase-devel*.rpm /tmp/wxGTK-3*.rpm /tmp/wxGTK-devel*.rpm /tmp/wxGTK-gl*.rpm /tmp/wxGTK-i18n*.rpm /tmp/wxGTK-media*.rpm /tmp/wxGTK-webview*.rpm"
+# Resolves pkg to a single matching RPM path. With -v, more than one match is
+# treated as an error (ambiguous pin) rather than silently picking the latest.
+wx_rpm_path() {
+    pkg="$1"
+    candidates=$(wx_rpm_candidates "$pkg")
+    count=$(printf '%s\n' "$candidates" | grep -c .)
+    if [ -n "$WANT_VERSION" ] && [ "$count" -gt 1 ]; then
+        echo "ERROR: -v $WANT_VERSION is ambiguous for $pkg, matches:" >&2
+        printf '%s\n' "$candidates" >&2
+        exit 1
+    fi
+    printf '%s\n' "$candidates" | tail -n1
+}
+
+# Only override wx* packages actually installed by the earlier `mock install`
+# (e.g. wxGTK-devel and whatever it pulled in), not every known wx subpackage.
+WX_PACKAGES=$(mock "$@" --quiet --chroot "rpm -qa --qf '%{NAME}\n' 'wx*'" 2>/dev/null | grep '^wx' | sort)
+
+WX_RPMS=""
+WX_TMP_RPMS=""
+for pkg in $WX_PACKAGES; do
+    rpm_path=$(wx_rpm_path "$pkg") || exit 1
+    if [ -z "$rpm_path" ]; then
+        echo "no ${VER_GLOB} rpm found for $pkg, leaving as installed" >&2
+        continue
+    fi
+    WX_RPMS="$WX_RPMS $rpm_path"
+    WX_TMP_RPMS="$WX_TMP_RPMS /tmp/$(basename "$rpm_path")"
+done
+
+if [ -n "$WX_RPMS" ]; then
+    mock "$@" --copyin $WX_RPMS /tmp/
+    mock "$@" --chroot "rpm -Uvh --force$WX_TMP_RPMS"
 fi
 mock "$@" --enable-network --unpriv --chroot "cd /builddir && git clone $CLONE_OPTS $CLONE_URL && mkdir -p pwsafe/build && cd pwsafe/build && cmake .. -DNO_GTEST=ON && cmake --build . -j\$(nproc) && cpack -G RPM"
 mock "$@" --copyout '/builddir/pwsafe/build/passwordsafe*.rpm' .


### PR DESCRIPTION
## Summary
- Drop CentOS-7/devtoolset-7 special-casing; target current Fedora only
- Add `-v WXVERSION` option to pin a specific installed wxGTK version instead of always using the latest, copying matching wx* RPMs into the mock chroot and force-installing them
- Clone from the current git remote/branch when run inside a repo, falling back to the upstream pwsafe.git otherwise
- Build with `cmake --build`/`cpack` directly instead of a fixed CentOS toolchain invocation; disable gtest in the mock build
- Add `libayatana-appindicator-gtk3-devel` to the installed build deps
- Mark the script executable

## Test plan
- Exercised the new features locally: ran the script both with and without `-v WXVERSION` to confirm version pinning picks up the matching wx* RPMs, and confirmed the git-remote-aware clone path picks up the current branch/remote when run from within a repo checkout.