### PR TITLE
Enable FreeBSD build on ARM64

### DIFF
--- a/src/core/PwsPlatform.h
+++ b/src/core/PwsPlatform.h
@@ -113,10 +113,10 @@
 #define PWS_BIG_ENDIAN
 #endif
 // **********************************************
-// * FreeBSD on Intel                           *
+// * FreeBSD on Intel and ARM64                 *
 // **********************************************
 #elif defined(__FreeBSD) || defined(__FreeBSD__)
-#if defined(__i386__) || defined(__amd64__)
+#if defined(__i386__) || defined(__amd64__) || defined(__aarch64__)
 #define PWS_LITTLE_ENDIAN
 #endif
 // **********************************************


### PR DESCRIPTION
Tested with 
FreeBSD 15.1 ARM64 VMware, KDE/X11, clang 19.1.7, wx 3.2.8.1, GTK 3.24.52
