### PR TITLE
mock-build.sh: don't touch %_rpmdir unless -v/-a is given

### DIFF
--- a/Misc/mock-build.sh
+++ b/Misc/mock-build.sh
@@ -1,4 +1,14 @@
 #! /bin/sh
+# Builds a pwsafe RPM, via mock, for an arbitrary Fedora or RHEL-clone
+# target - from master, or from whatever branch is checked out locally -
+# without needing a full pwsafe dev environment installed on this system,
+# only mock itself. Useful as a clean-room sanity build of a local dev
+# branch before pushing it.
+#
+# Can also optionally overlay newer wx*/libayatana-appindicator* packages
+# from a local rpmbuild tree into the mock chroot only (see -v/-a below);
+# this system's own installed packages are never touched either way.
+#
 # Following from https://github.com/pwsafe/pwsafe/issues/543 by ykne.
 # Mock can be installed via dnf or yum.
 # With no argument compiles for current system.
@@ -71,14 +81,12 @@ mock "$@" install \
     libcurl-devel \
     libuuid-devel \
     libyubikey-devel \
-    make \
     openssl-devel \
     wxGTK-devel \
     xerces-c-devel \
     ykpers-devel \
     qrencode-devel \
     file-devel \
-    ImageMagick \
     libayatana-appindicator-gtk3-devel
 
 # version -> glob against local RPM filenames, e.g. "3.2.12" -> "3.2.12-*",
@@ -114,24 +122,19 @@ local_rpm_path() {
     printf '%s\n' "$candidates" | tail -n1
 }
 
-# Collects RPM paths for packages matching $2 (an `rpm -qa` glob, e.g. 'wx*')
-# that are actually installed in the chroot, at local %_rpmdir build $1, into
-# the shared $OVERRIDE_RPMS/$OVERRIDE_TMP_RPMS accumulators below. Does
-# nothing at all if $1 is empty - no query, no accumulation.
-#
-# wxGTK's package Requires libayatana-appindicator-gtk3 >= 0.6.0, so if both
-# -v and -a are given, both families' RPMs must land in a single `rpm -Uvh`
-# transaction (see the combined install below) - installing wx by itself
-# first would fail that dependency against whatever stock appindicator is
-# still installed at that point.
+# Collects local-build RPM paths for installed packages whose name starts
+# with $2 into the shared OVERRIDE_RPMS/OVERRIDE_TMP_RPMS accumulators, later
+# installed together in one rpm -Uvh transaction (wxGTK depends on
+# libayatana-appindicator-gtk3, so mixing -v and -a needs both present at
+# once). No-op if $1 (the requested version) is empty.
 collect_local_build() {
-    wantver="$1" name_glob="$2" grep_anchor="$3"
-    shift 3
+    wantver="$1" name_base="$2"
+    shift 2
     # "$@" is now just the trailing mock options, for the mock call below.
     [ -n "$wantver" ] || return 0
 
     verglob=$(ver_glob_for "$wantver")
-    packages=$(mock "$@" --quiet --chroot "rpm -qa --qf '%{NAME}\n' '$name_glob'" 2>/dev/null | grep -E "$grep_anchor" | sort)
+    packages=$(mock "$@" --quiet --chroot "rpm -qa --qf '%{NAME}\n' '${name_base}*'" 2>/dev/null | grep -E "^${name_base}" | sort)
 
     for pkg in $packages; do
         rpm_path=$(local_rpm_path "$pkg" "$wantver" "$verglob") || exit 1
@@ -146,8 +149,8 @@ collect_local_build() {
 
 OVERRIDE_RPMS=""
 OVERRIDE_TMP_RPMS=""
-collect_local_build "$WANT_WX_VERSION" 'wx*' '^wx' "$@"
-collect_local_build "$WANT_APPINDICATOR_VERSION" 'libayatana-appindicator*' '^libayatana-appindicator' "$@"
+collect_local_build "$WANT_WX_VERSION" 'wx' "$@"
+collect_local_build "$WANT_APPINDICATOR_VERSION" 'libayatana-appindicator' "$@"
 
 if [ -n "$OVERRIDE_RPMS" ]; then
     mock "$@" --copyin $OVERRIDE_RPMS /tmp/

--- a/Misc/mock-build.sh
+++ b/Misc/mock-build.sh
@@ -136,8 +136,8 @@ collect_local_build() {
     for pkg in $packages; do
         rpm_path=$(local_rpm_path "$pkg" "$wantver" "$verglob") || exit 1
         if [ -z "$rpm_path" ]; then
-            echo "no $verglob rpm found for $pkg, leaving as installed" >&2
-            continue
+            echo "ERROR: no $verglob rpm found for $pkg" >&2
+            exit 1
         fi
         OVERRIDE_RPMS="$OVERRIDE_RPMS $rpm_path"
         OVERRIDE_TMP_RPMS="$OVERRIDE_TMP_RPMS /tmp/$(basename "$rpm_path")"

--- a/Misc/mock-build.sh
+++ b/Misc/mock-build.sh
@@ -151,7 +151,7 @@ collect_local_build "$WANT_APPINDICATOR_VERSION" 'libayatana-appindicator*' '^li
 
 if [ -n "$OVERRIDE_RPMS" ]; then
     mock "$@" --copyin $OVERRIDE_RPMS /tmp/
-    mock "$@" --chroot "rpm -Uvh --force$OVERRIDE_TMP_RPMS"
+    mock "$@" --chroot "rpm -Uvh --force ${OVERRIDE_TMP_RPMS# }"
 fi
 
 mock "$@" --enable-network --unpriv --chroot "cd /builddir && git clone $CLONE_OPTS $CLONE_URL && mkdir -p pwsafe/build && cd pwsafe/build && cmake .. -DNO_GTEST=ON && cmake --build . -j\$(nproc) && cpack -G RPM"

--- a/Misc/mock-build.sh
+++ b/Misc/mock-build.sh
@@ -4,35 +4,45 @@
 # With no argument compiles for current system.
 # If added -r mock_arch, where mock_arch is a file name in /etc/mock without .cfg,
 # then rpm will be compiled on specified architecture.
-# Use -v WXVERSION to pin a specific wxGTK version instead of the latest.
+# Use -v WXVERSION to override wx* packages with a local build from %_rpmdir
+# instead of whatever the mock chroot's repos provide.
+# Use -a APPINDICATORVERSION likewise for libayatana-appindicator* packages.
+# Neither is pinned by default - with no -v/-a, mock installs stock repo
+# packages for both and nothing under %_rpmdir is even looked at.
 # Tested on Fedora
 
 usage() {
-    echo "Usage: $0 [-v WXVERSION] [mock options]" >&2
-    echo "  -v WXVERSION  Install this exact wxGTK version instead of the latest" >&2
+    echo "Usage: $0 [-v WXVERSION] [-a APPINDICATORVERSION] [mock options]" >&2
+    echo "  -v WXVERSION            Override wx* packages with this local %_rpmdir build" >&2
+    echo "  -a APPINDICATORVERSION  Override libayatana-appindicator* packages with this local %_rpmdir build" >&2
     exit 1
 }
 
-WANT_VERSION=""
+WANT_WX_VERSION=""
+WANT_APPINDICATOR_VERSION=""
 
-while getopts ":v:" opt; do
+while getopts ":v:a:" opt; do
     case $opt in
-        v) WANT_VERSION="$OPTARG" ;;
+        v) WANT_WX_VERSION="$OPTARG" ;;
+        a) WANT_APPINDICATOR_VERSION="$OPTARG" ;;
         :) echo "ERROR: -$OPTARG requires an argument" >&2; usage ;;
         \?) break ;;
     esac
 done
 shift $((OPTIND - 1))
 
-# WANT_VERSION feeds into shell glob patterns (and RPM filenames) below;
-# restrict it to characters RPM versions/releases actually use.
-case "$WANT_VERSION" in
-    "") ;;
-    *[!A-Za-z0-9._+~-]*)
-        echo "ERROR: -v value '$WANT_VERSION' contains invalid characters (allowed: A-Z a-z 0-9 . _ + ~ -)" >&2
-        exit 1
-        ;;
-esac
+# Both values feed into shell glob patterns (and RPM filenames) below;
+# restrict them to characters RPM versions/releases actually use.
+for _v in "$WANT_WX_VERSION" "$WANT_APPINDICATOR_VERSION"; do
+    case "$_v" in
+        "") ;;
+        *[!A-Za-z0-9._+~-]*)
+            echo "ERROR: version '$_v' contains invalid characters (allowed: A-Z a-z 0-9 . _ + ~ -)" >&2
+            exit 1
+            ;;
+    esac
+done
+unset _v
 
 CLONE_URL="https://github.com/pwsafe/pwsafe.git"
 CLONE_OPTS=""
@@ -71,57 +81,78 @@ mock "$@" install \
     ImageMagick \
     libayatana-appindicator-gtk3-devel
 
-latest_rpm() {
-    ls -1v "$@" 2>/dev/null | tail -n1
+# version -> glob against local RPM filenames, e.g. "3.2.12" -> "3.2.12-*",
+# "3.2.12-2.sni" (already version-release) -> unchanged.
+ver_glob_for() {
+    case "$1" in
+        *-*) echo "$1" ;;
+        *) echo "$1-*" ;;
+    esac
 }
 
-case "$WANT_VERSION" in
-    "") VER_GLOB="[0-9]*" ;;
-    *-*) VER_GLOB="$WANT_VERSION" ;;      # already version-release, e.g. 3.2.12-2.sni
-    *) VER_GLOB="${WANT_VERSION}-*" ;;    # bare version, e.g. 3.2.12: match any release
-esac
-
-wx_rpm_candidates() {
-    pkg="$1"
-    # $VER_GLOB may contain shell glob characters (e.g. "3.2.12-*" or "[0-9]*")
-    # and must stay unquoted here so the shell expands it.
-    { ls -1v "$RPMDIR/$RPMARCH"/${pkg}-${VER_GLOB}."$DIST.$RPMARCH.rpm" 2>/dev/null
-      ls -1v "$RPMDIR/noarch"/${pkg}-${VER_GLOB}."$DIST.noarch.rpm" 2>/dev/null; }
+local_rpm_candidates() {
+    pkg="$1" verglob="$2"
+    # $verglob may contain shell glob characters (e.g. "3.2.12-*") and must
+    # stay unquoted here so the shell expands it.
+    { ls -1v "$RPMDIR/$RPMARCH"/${pkg}-${verglob}."$DIST.$RPMARCH.rpm" 2>/dev/null
+      ls -1v "$RPMDIR/noarch"/${pkg}-${verglob}."$DIST.noarch.rpm" 2>/dev/null; }
 }
 
-# Resolves pkg to a single matching RPM path. With -v, more than one match is
-# treated as an error (ambiguous pin) rather than silently picking the latest.
-wx_rpm_path() {
-    pkg="$1"
-    candidates=$(wx_rpm_candidates "$pkg")
+# Resolves pkg to a single matching RPM path. More than one match is always
+# treated as an error (ambiguous pin) - this is only ever called when a
+# version was explicitly requested, so there's no "just pick the latest"
+# fallback to silently paper over an ambiguous glob.
+local_rpm_path() {
+    pkg="$1" wantver="$2" verglob="$3"
+    candidates=$(local_rpm_candidates "$pkg" "$verglob")
     count=$(printf '%s\n' "$candidates" | grep -c .)
-    if [ -n "$WANT_VERSION" ] && [ "$count" -gt 1 ]; then
-        echo "ERROR: -v $WANT_VERSION is ambiguous for $pkg, matches:" >&2
+    if [ "$count" -gt 1 ]; then
+        echo "ERROR: -v/-a $wantver is ambiguous for $pkg, matches:" >&2
         printf '%s\n' "$candidates" >&2
         exit 1
     fi
     printf '%s\n' "$candidates" | tail -n1
 }
 
-# Only override wx* packages actually installed by the earlier `mock install`
-# (e.g. wxGTK-devel and whatever it pulled in), not every known wx subpackage.
-WX_PACKAGES=$(mock "$@" --quiet --chroot "rpm -qa --qf '%{NAME}\n' 'wx*'" 2>/dev/null | grep '^wx' | sort)
+# Collects RPM paths for packages matching $2 (an `rpm -qa` glob, e.g. 'wx*')
+# that are actually installed in the chroot, at local %_rpmdir build $1, into
+# the shared $OVERRIDE_RPMS/$OVERRIDE_TMP_RPMS accumulators below. Does
+# nothing at all if $1 is empty - no query, no accumulation.
+#
+# wxGTK's package Requires libayatana-appindicator-gtk3 >= 0.6.0, so if both
+# -v and -a are given, both families' RPMs must land in a single `rpm -Uvh`
+# transaction (see the combined install below) - installing wx by itself
+# first would fail that dependency against whatever stock appindicator is
+# still installed at that point.
+collect_local_build() {
+    wantver="$1" name_glob="$2" grep_anchor="$3"
+    shift 3
+    # "$@" is now just the trailing mock options, for the mock call below.
+    [ -n "$wantver" ] || return 0
 
-WX_RPMS=""
-WX_TMP_RPMS=""
-for pkg in $WX_PACKAGES; do
-    rpm_path=$(wx_rpm_path "$pkg") || exit 1
-    if [ -z "$rpm_path" ]; then
-        echo "no ${VER_GLOB} rpm found for $pkg, leaving as installed" >&2
-        continue
-    fi
-    WX_RPMS="$WX_RPMS $rpm_path"
-    WX_TMP_RPMS="$WX_TMP_RPMS /tmp/$(basename "$rpm_path")"
-done
+    verglob=$(ver_glob_for "$wantver")
+    packages=$(mock "$@" --quiet --chroot "rpm -qa --qf '%{NAME}\n' '$name_glob'" 2>/dev/null | grep -E "$grep_anchor" | sort)
 
-if [ -n "$WX_RPMS" ]; then
-    mock "$@" --copyin $WX_RPMS /tmp/
-    mock "$@" --chroot "rpm -Uvh --force$WX_TMP_RPMS"
+    for pkg in $packages; do
+        rpm_path=$(local_rpm_path "$pkg" "$wantver" "$verglob") || exit 1
+        if [ -z "$rpm_path" ]; then
+            echo "no $verglob rpm found for $pkg, leaving as installed" >&2
+            continue
+        fi
+        OVERRIDE_RPMS="$OVERRIDE_RPMS $rpm_path"
+        OVERRIDE_TMP_RPMS="$OVERRIDE_TMP_RPMS /tmp/$(basename "$rpm_path")"
+    done
+}
+
+OVERRIDE_RPMS=""
+OVERRIDE_TMP_RPMS=""
+collect_local_build "$WANT_WX_VERSION" 'wx*' '^wx' "$@"
+collect_local_build "$WANT_APPINDICATOR_VERSION" 'libayatana-appindicator*' '^libayatana-appindicator' "$@"
+
+if [ -n "$OVERRIDE_RPMS" ]; then
+    mock "$@" --copyin $OVERRIDE_RPMS /tmp/
+    mock "$@" --chroot "rpm -Uvh --force$OVERRIDE_TMP_RPMS"
 fi
+
 mock "$@" --enable-network --unpriv --chroot "cd /builddir && git clone $CLONE_OPTS $CLONE_URL && mkdir -p pwsafe/build && cd pwsafe/build && cmake .. -DNO_GTEST=ON && cmake --build . -j\$(nproc) && cpack -G RPM"
 mock "$@" --copyout '/builddir/pwsafe/build/passwordsafe*.rpm' .

--- a/Misc/mock-build.sh
+++ b/Misc/mock-build.sh
@@ -36,7 +36,11 @@ while getopts ":v:a:" opt; do
         v) WANT_WX_VERSION="$OPTARG" ;;
         a) WANT_APPINDICATOR_VERSION="$OPTARG" ;;
         :) echo "ERROR: -$OPTARG requires an argument" >&2; usage ;;
-        \?) break ;;
+        # An unrecognized flag (e.g. a mock option like -r) means option
+        # parsing is done; getopts has already advanced OPTIND past it, so
+        # back it up one or the shift below would swallow the flag itself
+        # and leave its value as a stray positional argument.
+        \?) OPTIND=$((OPTIND - 1)); break ;;
     esac
 done
 shift $((OPTIND - 1))
@@ -57,8 +61,6 @@ unset _v
 CLONE_URL="https://github.com/pwsafe/pwsafe.git"
 CLONE_OPTS=""
 RPMDIR=$(rpm --eval '%_rpmdir')
-RPMARCH=$(rpm --eval '%_arch')
-DIST=$(rpm --eval '%{dist}' | sed 's/^\.//')
 
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
@@ -71,6 +73,20 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 mock --init "$@"
+
+# Query the dist tag and arch from the mock chroot itself, not the host -
+# with -r targeting a different release or architecture (or a RHEL clone)
+# than this host runs, the host's own %{dist}/%_arch (e.g. "fc42"/"x86_64")
+# wouldn't match the local %_rpmdir build filenames for that target (e.g.
+# "...fc44.aarch64.rpm").
+DIST_ARCH=$(mock "$@" --quiet --chroot "rpm --eval '%{dist} %{_arch}'" 2>/dev/null)
+DIST=$(echo "$DIST_ARCH" | cut -d' ' -f1 | sed 's/^\.//')
+RPMARCH=$(echo "$DIST_ARCH" | cut -d' ' -f2)
+if [ -z "$DIST" ] || [ -z "$RPMARCH" ]; then
+    echo "ERROR: could not determine the dist tag/arch from the mock chroot" >&2
+    exit 1
+fi
+
 mock "$@" install \
     cmake \
     dpkg \


### PR DESCRIPTION
## Problem

`mock-build.sh` with no arguments is documented (and expected) to build against stock Fedora repo packages only. In practice, the default `VER_GLOB="[0-9]*"` matched *any* locally-built RPM under `%_rpmdir`, so if a developer had ever locally built a wx* package there (e.g. while working on the AppIndicator/SNI tray-icon patch from #1895), a plain no-argument run would silently force-install that local build over the repo package instead of leaving the repo package alone. Confirmed live: a no-arg run picked up a locally-built wxGTK 3.3.3 instead of Fedora 42's repo wxGTK-devel 3.2.8, and the pwsafe source failed to compile against wx 3.3's newer `_()` literal-only translation macro.

## Fix

Three small follow-ups to #1896 (already reviewed/merged), continuing on the same branch:

1. Add `-a APPINDICATORVERSION`, generalizing the existing `-v` override mechanism to also cover `libayatana-appindicator*` packages (needed since wxGTK's package now `Requires: libayatana-appindicator-gtk3 >= 0.6.0`, so pinning both families sometimes needs a single combined `rpm -Uvh` transaction).
2. Make the local-build lookup opt-in only: `collect_local_build()` now returns immediately unless a version was explicitly requested via `-v`/`-a`. With no arguments, nothing under `%_rpmdir` is queried or installed — mock's stock repo packages are used as-is. An unresolved `-v`/`-a` version is now a hard error instead of a silent "leave as installed" skip, since silently ignoring an explicit pin request would be more confusing than failing loudly.
3. Fix a missing separating space in the combined `rpm -Uvh --force` chroot command (previously worked by accident because the accumulator string happened to carry a leading space).

## Test plan

- [x] Ran `Misc/mock-build.sh` with no arguments on Fedora 42: confirmed no `--copyin`/`rpm -Uvh` override step ran, `cmake` picked up stock repo `wxGTK-devel-3.2.8`, and the build completed through `cpack -G RPM` producing `passwordsafe-fedora42-1.25-amd64.rpm`.