### PR TITLE
[win] Fixed regression introduced post 3.72.01

### DIFF
--- a/src/ui/Windows/AddEdit_Additional.cpp
+++ b/src/ui/Windows/AddEdit_Additional.cpp
@@ -334,19 +334,14 @@ void CAddEdit_Additional::SetupDCAComboBoxes(CComboBox *pcbox, bool isShift)
 }
 void CAddEdit_Additional::OnChanged()
 {
-  if (IsChangeIgnored())
-    return;
-
-  UpdateData(TRUE);
-  NotifyChanged();
+  if (TryUpdateData())
+    NotifyChanged();
 }
 
 void CAddEdit_Additional::OnHotKeyChanged()
 {
-  if (IsChangeIgnored())
+  if (!TryUpdateData())
     return;
-
-  UpdateData(TRUE);
 
   WORD wVirtualKeyCode, wHKModifiers, wPWSModifiers;
   m_KBShortcutCtrl.GetHotKey(wVirtualKeyCode, wHKModifiers);

--- a/src/ui/Windows/AddEdit_Additional.cpp
+++ b/src/ui/Windows/AddEdit_Additional.cpp
@@ -334,12 +334,18 @@ void CAddEdit_Additional::SetupDCAComboBoxes(CComboBox *pcbox, bool isShift)
 }
 void CAddEdit_Additional::OnChanged()
 {
+  if (IsChangeIgnored())
+    return;
+
   UpdateData(TRUE);
   NotifyChanged();
 }
 
 void CAddEdit_Additional::OnHotKeyChanged()
 {
+  if (IsChangeIgnored())
+    return;
+
   UpdateData(TRUE);
 
   WORD wVirtualKeyCode, wHKModifiers, wPWSModifiers;

--- a/src/ui/Windows/AddEdit_Attachment.cpp
+++ b/src/ui/Windows/AddEdit_Attachment.cpp
@@ -568,10 +568,9 @@ load_error:
 
 void CAddEdit_Attachment::OnAttNameChanged()
 {
-  if (IsChangeIgnored() || !M_attachment().HasContent())
+  if (!M_attachment().HasContent() || !TryUpdateData())
     return;
 
-  UpdateData(TRUE);
   M_attachment().SetTitle(m_AttName);
   NotifyChanged();
 }

--- a/src/ui/Windows/AddEdit_Attachment.cpp
+++ b/src/ui/Windows/AddEdit_Attachment.cpp
@@ -568,7 +568,7 @@ load_error:
 
 void CAddEdit_Attachment::OnAttNameChanged()
 {
-  if (!M_attachment().HasContent())
+  if (IsChangeIgnored() || !M_attachment().HasContent())
     return;
 
   UpdateData(TRUE);

--- a/src/ui/Windows/AddEdit_Basic.cpp
+++ b/src/ui/Windows/AddEdit_Basic.cpp
@@ -810,6 +810,9 @@ void CAddEdit_Basic::OnENSetFocusPassword2()
 
 void CAddEdit_Basic::OnENChangePassword()
 {
+  if (IsChangeIgnored())
+    return;
+
   UpdateData(TRUE);
   NotifyChanged();
   M_realpassword() = m_password;
@@ -916,12 +919,18 @@ void CAddEdit_Basic::OnGeneratePassword()
 
 void CAddEdit_Basic::OnGroupComboChanged()
 {
+  if (IsChangeIgnored())
+    return;
+
   UpdateData(TRUE);
   NotifyChanged();
 }
 
 void CAddEdit_Basic::OnChanged()
 {
+  if (IsChangeIgnored())
+    return;
+
   UpdateData(TRUE);
   NotifyChanged();
 }

--- a/src/ui/Windows/AddEdit_Basic.cpp
+++ b/src/ui/Windows/AddEdit_Basic.cpp
@@ -810,10 +810,9 @@ void CAddEdit_Basic::OnENSetFocusPassword2()
 
 void CAddEdit_Basic::OnENChangePassword()
 {
-  if (IsChangeIgnored())
+  if (!TryUpdateData())
     return;
 
-  UpdateData(TRUE);
   NotifyChanged();
   M_realpassword() = m_password;
   auto strength =  CPasswordCharPool::CalculatePasswordStrength(m_password);
@@ -919,20 +918,14 @@ void CAddEdit_Basic::OnGeneratePassword()
 
 void CAddEdit_Basic::OnGroupComboChanged()
 {
-  if (IsChangeIgnored())
-    return;
-
-  UpdateData(TRUE);
-  NotifyChanged();
+  if (TryUpdateData())
+    NotifyChanged();
 }
 
 void CAddEdit_Basic::OnChanged()
 {
-  if (IsChangeIgnored())
-    return;
-
-  UpdateData(TRUE);
-  NotifyChanged();
+  if (TryUpdateData())
+    NotifyChanged();
 }
 
 void CAddEdit_Basic::OnENChangeURL()

--- a/src/ui/Windows/AddEdit_PasswordPolicy.cpp
+++ b/src/ui/Windows/AddEdit_PasswordPolicy.cpp
@@ -276,6 +276,9 @@ BOOL CAddEdit_PasswordPolicy::OnInitDialog()
 
 void CAddEdit_PasswordPolicy::OnChanged()
 {
+  if (IsChangeIgnored())
+    return;
+
   UpdateData(TRUE);
   NotifyChanged();
 }

--- a/src/ui/Windows/AddEdit_PasswordPolicy.cpp
+++ b/src/ui/Windows/AddEdit_PasswordPolicy.cpp
@@ -276,11 +276,8 @@ BOOL CAddEdit_PasswordPolicy::OnInitDialog()
 
 void CAddEdit_PasswordPolicy::OnChanged()
 {
-  if (IsChangeIgnored())
-    return;
-
-  UpdateData(TRUE);
-  NotifyChanged();
+  if (TryUpdateData())
+    NotifyChanged();
 }
 
 void CAddEdit_PasswordPolicy::OnHelp()

--- a/src/ui/Windows/AddEdit_PropertyPage.cpp
+++ b/src/ui/Windows/AddEdit_PropertyPage.cpp
@@ -36,9 +36,14 @@ CAddEdit_PropertyPage::CAddEdit_PropertyPage(CWnd *pParent,
 {
 }
 
+bool CAddEdit_PropertyPage::IsChangeIgnored() const
+{
+  return !m_bInitdone || m_AEMD.uicaller == IDS_VIEWENTRY || m_AEMD.ucprotected != 0;
+}
+
 void CAddEdit_PropertyPage::NotifyChanged()
 {
-  if (!m_bInitdone || M_uicaller() == IDS_VIEWENTRY || M_protected() != 0)
+  if (IsChangeIgnored())
     return;
 
   m_ae_psh->SetChanged(true);

--- a/src/ui/Windows/AddEdit_PropertyPage.cpp
+++ b/src/ui/Windows/AddEdit_PropertyPage.cpp
@@ -49,6 +49,15 @@ void CAddEdit_PropertyPage::NotifyChanged()
   m_ae_psh->SetChanged(true);
 }
 
+bool CAddEdit_PropertyPage::TryUpdateData()
+{
+  if (IsChangeIgnored())
+    return false;
+
+  UpdateData(TRUE);
+  return true;
+}
+
 BOOL CAddEdit_PropertyPage::OnQueryCancel()
 {
   // Check whether there have been any changes in order to ask the user

--- a/src/ui/Windows/AddEdit_PropertyPage.h
+++ b/src/ui/Windows/AddEdit_PropertyPage.h
@@ -126,12 +126,16 @@ public:
   // user edit.
   void NotifyChanged();
 
-  // Check before UpdateData(TRUE) in change handlers, not just before
-  // marking the entry changed - control notifications can fire during
-  // OnInitDialog's own DoDataExchange, before real data is loaded.
+  // Guarded UpdateData(TRUE): a no-op returning false during initial data
+  // population, or for a view-only/protected entry. Call this instead of a
+  // bare UpdateData(TRUE) from any change handler.
+  bool TryUpdateData();
+
+protected:
+  // Shared by NotifyChanged() and TryUpdateData() - see NotifyChanged().
   bool IsChangeIgnored() const;
 
-
+public:
   static COLORREF crefGreen, crefWhite;
 
   DECLARE_DYNAMIC(CAddEdit_PropertyPage)

--- a/src/ui/Windows/AddEdit_PropertyPage.h
+++ b/src/ui/Windows/AddEdit_PropertyPage.h
@@ -126,6 +126,11 @@ public:
   // user edit.
   void NotifyChanged();
 
+  // Check before UpdateData(TRUE) in change handlers, not just before
+  // marking the entry changed - control notifications can fire during
+  // OnInitDialog's own DoDataExchange, before real data is loaded.
+  bool IsChangeIgnored() const;
+
 
   static COLORREF crefGreen, crefWhite;
 


### PR DESCRIPTION
Due to the way the Group listbox was populated in OnInitDialog(), the tweaks to the event loop processing caused this to be skipped, resulting in a blank group control even for an entry that's in a group.

This fixes the problem and adds some checks in other controls for consistency.