### PR TITLE
[wx] More unused variables

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -252,24 +252,6 @@ AddEditPropSheetDlg::AddEditPropSheetDlg(wxWindow *parent, PWScore &core,
   m_ItemTotp = m_Item; // The copy is used to show the TOTP on the 'Basic' tab
   m_IsNotesHidden = !PWSprefs::GetInstance()->GetPref(PWSprefs::ShowNotesDefault);
 
-  wxString dlgTitle;
-  if (caption == SYMBOL_AUTOPROPSHEETDLG_TITLE) {
-    switch(m_Type) {
-      case SheetType::ADD:
-        dlgTitle = SYMBOL_ADDPROPSHEETDLG_TITLE;
-        break;
-      case SheetType::EDIT:
-        dlgTitle = SYMBOL_EDITPROPSHEETDLG_TITLE;
-        break;
-      case SheetType::VIEW:
-        dlgTitle = SYMBOL_VIEWPROPSHEETDLG_TITLE;
-        break;
-      default:
-        dlgTitle = caption;
-        break;
-    }
-  }
-
 ////@begin AddEditPropSheetDlg creation
   SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY|wxWS_EX_BLOCK_EVENTS);
   wxPropertySheetDialog::Create( parent, id, caption, pos, size, style );

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -252,9 +252,27 @@ AddEditPropSheetDlg::AddEditPropSheetDlg(wxWindow *parent, PWScore &core,
   m_ItemTotp = m_Item; // The copy is used to show the TOTP on the 'Basic' tab
   m_IsNotesHidden = !PWSprefs::GetInstance()->GetPref(PWSprefs::ShowNotesDefault);
 
+  wxString dlgTitle;
+  if (caption == SYMBOL_AUTOPROPSHEETDLG_TITLE) {
+    switch(m_Type) {
+      case SheetType::ADD:
+        dlgTitle = SYMBOL_ADDPROPSHEETDLG_TITLE;
+        break;
+      case SheetType::EDIT:
+        dlgTitle = SYMBOL_EDITPROPSHEETDLG_TITLE;
+        break;
+      case SheetType::VIEW:
+        dlgTitle = SYMBOL_VIEWPROPSHEETDLG_TITLE;
+        break;
+      default:
+        dlgTitle = caption;
+        break;
+    }
+  }
+
 ////@begin AddEditPropSheetDlg creation
   SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY|wxWS_EX_BLOCK_EVENTS);
-  wxPropertySheetDialog::Create( parent, id, caption, pos, size, style );
+  wxPropertySheetDialog::Create( parent, id, dlgTitle, pos, size, style );
 
   int flags = (m_Type == SheetType::VIEW) ? (wxCLOSE|wxHELP) : (wxOK|wxCANCEL|wxHELP);
 

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.h
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.h
@@ -134,6 +134,9 @@ class wxNotebook;
 #define SYMBOL_ADDEDITPROPSHEETDLG_SIZE wxSize(400, 300)
 #define SYMBOL_ADDEDITPROPSHEETDLG_POSITION wxDefaultPosition
 ////@end control identifiers
+#define SYMBOL_ADDPROPSHEETDLG_TITLE _("Add Entry")
+#define SYMBOL_EDITPROPSHEETDLG_TITLE _("Edit Entry")
+#define SYMBOL_VIEWPROPSHEETDLG_TITLE _("View Entry")
 #define SYMBOL_AUTOPROPSHEETDLG_TITLE _("Add, Edit or View Entry")
 
 /*!

--- a/src/ui/wxWidgets/AddEditPropSheetDlg.h
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.h
@@ -134,9 +134,6 @@ class wxNotebook;
 #define SYMBOL_ADDEDITPROPSHEETDLG_SIZE wxSize(400, 300)
 #define SYMBOL_ADDEDITPROPSHEETDLG_POSITION wxDefaultPosition
 ////@end control identifiers
-#define SYMBOL_ADDPROPSHEETDLG_TITLE _("Add Entry")
-#define SYMBOL_EDITPROPSHEETDLG_TITLE _("Edit Entry")
-#define SYMBOL_VIEWPROPSHEETDLG_TITLE _("View Entry")
 #define SYMBOL_AUTOPROPSHEETDLG_TITLE _("Add, Edit or View Entry")
 
 /*!

--- a/src/ui/wxWidgets/GuiInfo.cpp
+++ b/src/ui/wxWidgets/GuiInfo.cpp
@@ -95,8 +95,7 @@ void GuiInfo::SaveTreeViewInfo(TreeCtrl* tree)
   if (selection.IsOk() && selection != tree->GetRootItem()) {
     if(tree->ItemIsGroup(selection)) {
       m_treeSelection = tree->GetItemGroup(selection);
-      const wxString selectionStr = m_treeSelection;
-      wxASSERT(!selectionStr.IsEmpty());
+      wxASSERT(!(static_cast<const wxString>(m_treeSelection)).IsEmpty());
     }
     else {
       CItemData* item = tree->GetItem(selection);


### PR DESCRIPTION
Removes a couple of unused variables that are only flagged some of the time.  In this case, when I build with wx 3.3.3.1 and PR #1852.
