### PR TITLE
[wx] Set wxDEBUG_LEVEL=0 in cmake release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,7 @@ endif(HAVE_YKPERS_H)
 if (NOT MSVC)
    # Following is because (a) -O3 breaks the test and application, and
    # (b) -O3 is the default for cmake
-   set (CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+   set (CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG -DwxDEBUG_LEVEL=0")
 endif (NOT MSVC)
 
 include(pws-version)

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -1059,10 +1059,8 @@ void PWSafeApp::OnHelp(wxCommandEvent& evt)
       wxHtmlModalHelp help(window, helpFileNamePath, itr->second, wxHF_DEFAULT_STYLE);
     }
     else {
-#if defined(_DEBUG) || defined(DEBUG)
       msg << _("Please inform the developers.");
       wxMessageBox(msg, _("Help Undefined"), wxOK | wxICON_EXCLAMATION);
-#endif
     } // keyName not found in map
   }
   else {

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -223,7 +223,7 @@ void PWSafeApp::Init()
   wxLocale::AddCatalogLookupPathPrefix(L"/usr/share/locale");
   wxLocale::AddCatalogLookupPathPrefix(L"/usr");
   wxLocale::AddCatalogLookupPathPrefix(L"/usr/local");
-#if defined(__WXDEBUG__) || defined(_DEBUG) || defined(DEBUG)
+#if defined(_DEBUG) || defined(DEBUG)
   wxLocale::AddCatalogLookupPathPrefix(L"../I18N/mos");
   wxLocale::AddCatalogLookupPathPrefix(L"src/ui/wxWidgets/I18N/mos"); // located in cmake's build directory
 #endif
@@ -232,7 +232,7 @@ void PWSafeApp::Init()
 ////@end PWSafeApp member initialisation
 }
 
-#ifdef __WXDEBUG__
+#if defined(_DEBUG) || defined(DEBUG)
 void PWSafeApp::OnAssertFailure(const wxChar *file, int line, const wxChar *func,
                 const wxChar *cond, const wxChar *msg)
 {
@@ -1059,7 +1059,7 @@ void PWSafeApp::OnHelp(wxCommandEvent& evt)
       wxHtmlModalHelp help(window, helpFileNamePath, itr->second, wxHF_DEFAULT_STYLE);
     }
     else {
-#ifdef __WXDEBUG__
+#if defined(_DEBUG) || defined(DEBUG)
       msg << _("Please inform the developers.");
       wxMessageBox(msg, _("Help Undefined"), wxOK | wxICON_EXCLAMATION);
 #endif

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -67,7 +67,7 @@ public:
   virtual bool OnInit() wxOVERRIDE;
 
   /// Handle asserts without showing the assert dialog until locale is initialized.
-#ifdef __WXDEBUG__
+#if defined(_DEBUG) || defined(DEBUG)
   virtual void OnAssertFailure(const wxChar *file, int line, const wxChar *func, const wxChar *cond, const wxChar *msg) wxOVERRIDE;
 #endif
   /// Called on exit


### PR DESCRIPTION
While working on something else, I discovered that `__WXDEBUG__` is always defined in Linux and FreeBSD builds.  The wxWidgets library build defaults to `wxDEBUG_LEVEL=1`, which cause `__WXDEBUG__` to be defined unless we compile with `wxDEBUG_LEVEL=0`.  The repo packages must have used the default build.

1. Add `wxDEBUG_LEVEL=0` to the CMakeLists.txt file for release builds.  The Xcode project already has this.
2. I only found `__WXDEBUG__` in a few places in PWSafeApp.cpp, so I replaced them with `DEBUG/_DEBUG`

Tested on:
macOS M1Max 15.7.9 Sequoia,                 Xcode 16.4, wx 3.2.10 and 3.2.11
Fedora 44 ARM64 VMware,      KDE/Wayland,   gcc 16.1.1, wx 3.2.9, GTK 3.24.52
FreeBSD 15.1 ARM64 VMware,   KDE/X11,       clang 19.1.7, wx 3.2.8.1, GTK 3.24.52
