### PR TITLE
Add cross-platform FFlush and separate it from FClose

### DIFF
--- a/src/core/ItemAtt.cpp
+++ b/src/core/ItemAtt.cpp
@@ -185,7 +185,7 @@ int CItemAtt::Import(const stringT &fname)
 
   auto flen = static_cast<size_t>(pws_os::fileLength(fhandle));
   if (flen > CItemAtt::MAX_SIZE) {
-    pws_os::FClose(fhandle, false);
+    pws_os::FClose(fhandle);
     return PWScore::MAX_SIZE_EXCEEDED;
   }
 
@@ -195,12 +195,12 @@ int CItemAtt::Import(const stringT &fname)
 
   size_t nread = fread(data, flen, 1, fhandle);
   if (nread != 1) {
-    pws_os::FClose(fhandle, false);
+    pws_os::FClose(fhandle);
     status = PWScore::READ_FAIL;
     goto done;
   }
 
-  if (pws_os::FClose(fhandle, true) != 0) {
+  if (pws_os::FClose(fhandle) != 0) {
     status = PWScore::READ_FAIL;
     goto done;
   }

--- a/src/core/PWSfile.cpp
+++ b/src/core/PWSfile.cpp
@@ -71,7 +71,7 @@ PWSfile *PWSfile::MakePWSfile(const StringX &a_filename, const StringX &passkey,
           status = CANT_OPEN_FILE;
           break;
         }
-        pws_os::FClose(fd, false);
+        pws_os::FClose(fd);
         [[fallthrough]];
       default:
         status = FAILURE;
@@ -158,7 +158,10 @@ int PWSfile::Close()
   int rc(SUCCESS);
 
   if (m_fd != nullptr) {
-    rc = pws_os::FClose(m_fd, m_rw == Write);
+    if (m_rw == Write)
+      rc = pws_os::FFlushAndClose(m_fd);
+    else
+      rc = pws_os::FClose(m_fd);
     m_fd = nullptr;
   }
 
@@ -415,7 +418,7 @@ bool PWSfile::Encrypt(const stringT &fn, const StringX &passwd, stringT &errmess
     goto exit;
   } // catch
 
-  status = (pws_os::FClose(out, true) == 0); out = nullptr;
+  status = (pws_os::FClose(out) == 0); out = nullptr;
 
  exit:
   if (!status)
@@ -423,8 +426,8 @@ bool PWSfile::Encrypt(const stringT &fn, const StringX &passwd, stringT &errmess
   delete fish;
   trashMemory(buf, BUFSIZ);
   delete[] ivthing;
-  pws_os::FClose(in, false);
-  pws_os::FClose(out, true);
+  pws_os::FClose(in);
+  pws_os::FClose(out);
   return status;
 }
 
@@ -451,7 +454,7 @@ bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess
   file_len = pws_os::fileLength(in);
 
   if (file_len < (8 + sizeof(randhash) + 8 + SaltLength)) {
-    pws_os::FClose(in, false);
+    pws_os::FClose(in);
     LoadAString(errmess, IDSC_FILE_TOO_SHORT);
     return false;
   }
@@ -474,7 +477,7 @@ bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess
 
   GenRandhash(passwd, randstuff, temphash);
   if (memcmp(reinterpret_cast<char *>(randhash), reinterpret_cast<char *>(temphash), SHA1::HASHLEN) != 0) {
-    pws_os::FClose(in, false);
+    pws_os::FClose(in);
     LoadAString(errmess, IDSC_BADPASSWORD);
     return false;
   }
@@ -558,8 +561,8 @@ bool PWSfile::Decrypt(const stringT &fn, const StringX &passwd, stringT &errmess
   delete[] ivthing;
   if (!status)
     errmess = ErrorMessages();
-  pws_os::FClose(in, false);
-  pws_os::FClose(out, true);
+  pws_os::FClose(in);
+  pws_os::FClose(out);
 
   return status;
 }

--- a/src/os/file.h
+++ b/src/os/file.h
@@ -32,7 +32,23 @@ namespace pws_os {
   extern void TryUnlockFile(const stringT &filename, HANDLE &lockFileHandle);
 
   extern std::FILE *FOpen(const stringT &filename, const TCHAR *mode);
-  extern int FClose(std::FILE *fd, const bool &bIsWrite);
+  // Flush stdio and OS buffers to storage. A null stream is a no-op.
+  // Returns zero on success and EOF on error.
+  extern int FFlush(std::FILE *fd);
+
+  inline int FClose(std::FILE *fd)
+  {
+    return fd != nullptr ? std::fclose(fd) : 0;
+  }
+
+  inline int FFlushAndClose(std::FILE *fd)
+  {
+    // Closing is unconditional, including when flushing fails.
+    const int flushResult = FFlush(fd);
+    const int closeResult = FClose(fd);
+    return flushResult == 0 && closeResult == 0 ? 0 : EOF;
+  }
+
   extern size_t fileLength(std::FILE *fp);
   extern bool GetFileTimes(const stringT &filename,
       time_t &ctime, time_t &mtime, time_t &atime);

--- a/src/os/mac/file.cpp
+++ b/src/os/mac/file.cpp
@@ -329,14 +329,9 @@ std::FILE *pws_os::FOpen(const stringT &filename, const TCHAR *mode)
   return retval;
 }
 
-int pws_os::FClose(std::FILE *fd, const bool &bIsWrite)
+int pws_os::FClose(std::FILE *fd, const bool &)
 {
   if (fd != NULL) {
-    if (bIsWrite) {
-      // Flush the data buffers
-      fflush(fd);
-    }
-    // Now close file
     return fclose(fd);
   }
   return 0;

--- a/src/os/mac/file.cpp
+++ b/src/os/mac/file.cpp
@@ -329,12 +329,19 @@ std::FILE *pws_os::FOpen(const stringT &filename, const TCHAR *mode)
   return retval;
 }
 
-int pws_os::FClose(std::FILE *fd, const bool &)
+int pws_os::FFlush(std::FILE *fd)
 {
-  if (fd != NULL) {
-    return fclose(fd);
-  }
-  return 0;
+  if (fd == nullptr)
+    return 0;
+
+  if (std::fflush(fd) != 0)
+    return EOF;
+
+  const int fileDescriptor = fileno(fd);
+  if (fileDescriptor == -1)
+    return EOF;
+
+  return fcntl(fileDescriptor, F_FULLFSYNC) == -1 ? EOF : 0;
 }
 
 size_t pws_os::fileLength(std::FILE *fp)

--- a/src/os/unix/file.cpp
+++ b/src/os/unix/file.cpp
@@ -406,17 +406,19 @@ std::FILE *pws_os::FOpen(const stringT &filename, const TCHAR *mode)
   return retval;
 }
 
-int pws_os::FClose(std::FILE *fd, const bool &bIsWrite)
+int pws_os::FFlush(std::FILE *fd)
 {
-  if (fd != nullptr) {
-    if (bIsWrite) {
-      // Flush the data buffers
-      fflush(fd);
-    }
-    // Now close file
-    return fclose(fd);
-  }
-  return 0;
+  if (fd == nullptr)
+    return 0;
+
+  if (std::fflush(fd) != 0)
+    return EOF;
+
+  const int fileDescriptor = fileno(fd);
+  if (fileDescriptor == -1)
+    return EOF;
+
+  return fsync(fileDescriptor) == -1 ? EOF : 0;
 }
 
 size_t pws_os::fileLength(std::FILE *fp)

--- a/src/os/windows/file.cpp
+++ b/src/os/windows/file.cpp
@@ -414,40 +414,28 @@ std::FILE *pws_os::FOpen(const stringT &filename, const TCHAR *mode)
   return fd;
 }
 
-int pws_os::FClose(std::FILE *fd, const bool &bIsWrite)
+int pws_os::FFlush(std::FILE *fd)
 {
-  if (fd != NULL) {
-    if (bIsWrite) {
-      // Flush the data buffers
-      // fflush returns 0 if the buffer was successfully flushed.
-      // A return value of EOF indicates an error.
-      int rc = fflush(fd);
-
-      // Don't bother trying FlushFileBuffers if fflush failed
-      if (rc == 0) {
-        // Windows FlushFileBuffers == Linux fsync
-        int ifileno = _fileno(fd);
-
-        if (ifileno != INVALID_FILE_DESCRIPTOR) {
-          intptr_t iosfhandle = _get_osfhandle(ifileno);
-
-          if ((HANDLE)iosfhandle != INVALID_HANDLE_VALUE) {
-            BOOL brc = FlushFileBuffers((HANDLE)iosfhandle);
-
-            if (brc == FALSE) {
-              pws_os::IssueError(_T("FlushFileBuffers on close of file on removable device"), false);
-            }
-          } // iosfhandle
-        } // ifileno
-      }  // fflush rc
-    }
-
-    // Now close file
-    // fclose returns 0 if the stream is successfully closed or EOF to indicate an error.
-    return fclose(fd);
-  } else {
+  if (fd == nullptr)
     return 0;
+
+  if (std::fflush(fd) != 0)
+    return EOF;
+
+  const int fileDescriptor = _fileno(fd);
+  if (fileDescriptor == INVALID_FILE_DESCRIPTOR)
+    return EOF;
+
+  const intptr_t osFileHandle = _get_osfhandle(fileDescriptor);
+  if ((HANDLE)osFileHandle == INVALID_HANDLE_VALUE)
+    return EOF;
+
+  if (FlushFileBuffers((HANDLE)osFileHandle) == FALSE) {
+    pws_os::IssueError(_T("FlushFileBuffers"), false);
+    return EOF;
   }
+
+  return 0;
 }
 
 size_t pws_os::fileLength(std::FILE *fp) {

--- a/src/test/FileEncDecTest.cpp
+++ b/src/test/FileEncDecTest.cpp
@@ -71,7 +71,7 @@ TEST_F(FileEncDecTest, EmptyFile)
   // create an empty file
   auto fp = pws_os::FOpen(emptyFile, L"w");
   ASSERT_TRUE(fp != nullptr);
-  auto res = pws_os::FClose(fp, true);
+  auto res = pws_os::FClose(fp);
   ASSERT_TRUE(res == 0);
 
   // decrypting an empty file should fail (too small)
@@ -98,7 +98,7 @@ TEST_F(FileEncDecTest, EmptyFile)
   fp = pws_os::FOpen(emptyFile, L"r");
   ASSERT_TRUE(fp != nullptr);
   EXPECT_EQ(pws_os::fileLength(fp), 0u);
-  res = pws_os::FClose(fp, true);
+  res = pws_os::FClose(fp);
   ASSERT_TRUE(res == 0);
 
 
@@ -157,7 +157,7 @@ void FileEncDecTest::TestFile(const stringT& testfile)
   auto len1 = pws_os::fileLength(fp);
   auto origBuf = new char[len1];
   ASSERT_EQ(len1, fread(origBuf, 1, len1, fp));
-  auto res = pws_os::FClose(fp, true);
+  auto res = pws_os::FClose(fp);
   ASSERT_TRUE(res == 0);
 
   fp = pws_os::FOpen(workTestFile, L"rb");
@@ -166,7 +166,7 @@ void FileEncDecTest::TestFile(const stringT& testfile)
   EXPECT_EQ(len1, len2);
   auto workBuf = new char[len2];
   ASSERT_EQ(len2, fread(workBuf, 1, len2, fp));
-  res = pws_os::FClose(fp, true);
+  res = pws_os::FClose(fp);
   ASSERT_TRUE(res == 0);
   ASSERT_EQ(memcmp(origBuf, workBuf, len1), 0);
 

--- a/src/test/ImportXmlTest.cpp
+++ b/src/test/ImportXmlTest.cpp
@@ -32,12 +32,12 @@ std::string readFileUtf8(const stringT &filename)
   const size_t length = pws_os::fileLength(fp);
   EXPECT_NE(length, static_cast<size_t>(-1));
   if (length == static_cast<size_t>(-1)) {
-    pws_os::FClose(fp, false);
+    pws_os::FClose(fp);
     return {};
   }
   std::vector<char> buffer(length);
   EXPECT_EQ(length, fread(buffer.data(), 1, length, fp));
-  pws_os::FClose(fp, false);
+  pws_os::FClose(fp);
   return std::string(buffer.begin(), buffer.end());
 }
 
@@ -46,7 +46,7 @@ void writeFileUtf8(const stringT &filename, const std::string &content)
   std::FILE *fp = pws_os::FOpen(filename, _T("wb"));
   ASSERT_NE(fp, nullptr);
   ASSERT_EQ(content.size(), fwrite(content.data(), 1, content.size(), fp));
-  ASSERT_EQ(0, pws_os::FClose(fp, true));
+  ASSERT_EQ(0, pws_os::FClose(fp));
 }
 
 void removeSensitiveElement(const stringT &filename)

--- a/src/test/OSTest.cpp
+++ b/src/test/OSTest.cpp
@@ -9,6 +9,13 @@
 
 #include "os/media.h"
 #include "os/dir.h"
+#include "os/file.h"
+
+#ifndef WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
 #include "gtest/gtest.h"
 
 TEST(OSTest, testMedia)
@@ -45,3 +52,29 @@ TEST(OSTest, testPath)
   out_path = pws_os::makepath(in_drive, in_dir, in_file, in_ext);
   EXPECT_EQ(in_path, out_path);
 }
+
+TEST(OSTest, testNullFileOperations)
+{
+  EXPECT_EQ(0, pws_os::FFlush(nullptr));
+  EXPECT_EQ(0, pws_os::FClose(nullptr));
+  EXPECT_EQ(0, pws_os::FFlushAndClose(nullptr));
+}
+
+#ifndef WIN32
+TEST(OSTest, testFlushAndCloseAfterFlushFailure)
+{
+  int pipeDescriptors[2];
+  ASSERT_EQ(0, pipe(pipeDescriptors));
+
+  std::FILE *fd = fdopen(pipeDescriptors[1], "w");
+  ASSERT_NE(nullptr, fd);
+  const int fileDescriptor = fileno(fd);
+  ASSERT_NE(-1, fileDescriptor);
+
+  ASSERT_EQ(1U, fwrite("x", 1, 1, fd));
+  EXPECT_EQ(EOF, pws_os::FFlushAndClose(fd));
+  EXPECT_EQ(-1, fcntl(fileDescriptor, F_GETFD));
+
+  close(pipeDescriptors[0]);
+}
+#endif

--- a/src/test/OSTest.cpp
+++ b/src/test/OSTest.cpp
@@ -72,6 +72,8 @@ TEST(OSTest, testFlushAndCloseAfterFlushFailure)
   ASSERT_NE(-1, fileDescriptor);
 
   ASSERT_EQ(1U, fwrite("x", 1, 1, fd));
+  // The stdio flush succeeds, but the OS-level sync fails because a pipe
+  // has no backing storage to synchronize.
   EXPECT_EQ(EOF, pws_os::FFlushAndClose(fd));
   EXPECT_EQ(-1, fcntl(fileDescriptor, F_GETFD));
 


### PR DESCRIPTION
## Summary

This supersedes the original macOS-only `FClose` change with consistent
cross-platform file-closing semantics.

- Add a platform-specific `FFlush()` that flushes stdio buffers and
  synchronizes data to storage:
  - macOS: `fflush()` followed by `F_FULLFSYNC`
  - Unix: `fflush()` followed by `fsync()`
  - Windows: `fflush()` followed by `FlushFileBuffers()`
- Move the platform-independent `FClose()` implementation into
  `os/file.h`.
- Add `FFlushAndClose()`, which always closes the stream and returns
  `EOF` if either operation fails.
- Use `FFlushAndClose()` when closing writable safe files.
- Update other callers to use the new `FClose()` signature.
- Add tests for null streams and for closing the descriptor after a
  flush failure.

This keeps ordinary closing separate from durable flushing while ensuring
that database writes explicitly request both operations.

## Testing

- `ninja test` on Linux
- 2/2 tests passed, including the new `fsync` failure-path test