### PR TITLE
Propagate database close failures

### DIFF
--- a/src/core/PWScore.cpp
+++ b/src/core/PWScore.cpp
@@ -648,8 +648,17 @@ int PWScore::WriteFile(const StringX &filename, PWSfile::VERSION version,
     return FAILURE;
   }
 
-  out->Close();
+  status = out->Close();
   delete out;
+
+  if (status != PWSfile::SUCCESS) {
+    PWS_LOGIT_ARGS("out->Close() failed, status: %d", status);
+
+    if (version < m_ReadFileVersion) // Exporting - restore saved header
+      m_hdr = saved_hdr;
+
+    return FAILURE;
+  }
 
   // Update info if we're saving or upgrading.
   if (version >= m_ReadFileVersion) {


### PR DESCRIPTION
## Summary

- Capture the result of the final `PWSfile::Close()` in
  `PWScore::WriteFile()`.
- Return `FAILURE` when closing a database fails.
- Restore the saved header when a failed close occurs during export.
- Avoid updating the file signature or marking the database clean after
  an unsuccessful close.

Previously, `PWScore::WriteFile()` discarded that result and returned
success unconditionally.

## Testing

- Compiled `PWScore.cpp` as C++17 with `-Wall`, `-Wextra`, `-Wpedantic`,
  and `-Werror`.
- `git diff --check` passes.

A regression test was not added because the current implementation has
no close-failure injection seam. Filesystem-based approaches would be
platform-specific and would depend on separate `FClose()` fixes.