### PR TITLE
[wx] Locale selection rework

### DIFF
--- a/Xcode/pwsafe-template.plist
+++ b/Xcode/pwsafe-template.plist
@@ -49,6 +49,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		578DF902302813A20045582C /* media.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2D181451C8FF86C0018AE03 /* media.cpp */; };
 		579BDA4F2C55F0A1004C727B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 579BDA4E2C55F0A1004C727B /* Assets.xcassets */; };
 		57BD7D042B19BEC2005C0123 /* helpEN.zip in Resources */ = {isa = PBXBuildFile; fileRef = E690B95612984B1D007EA508 /* helpEN.zip */; };
+		57D4306F303D3B1300867684 /* PWSLocale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57D4306E303D3B1300867684 /* PWSLocale.cpp */; };
 		57E951B42DE9377000DE9640 /* libcore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E6ADB80311956A93004E2BE5 /* libcore.a */; };
 		57E951B52DE9377500DE9640 /* libos.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E6ADB91C11956DD0004E2BE5 /* libos.a */; };
 		57E951B62DE937D200DE9640 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3A7B67C254824C000E780B8 /* AppKit.framework */; };
@@ -398,6 +399,7 @@
 		57C329E82A0715F500454292 /* ReleaseNotes.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = ReleaseNotes.md; path = ../docs/ReleaseNotes.md; sourceTree = "<group>"; };
 		57CC07053033D4FC005C4A29 /* PWSLocale.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PWSLocale.h; sourceTree = "<group>"; };
 		57D3F0072B782AF600E4A662 /* version.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = version.in; path = ../src/ui/wxWidgets/version.in; sourceTree = "<group>"; };
+		57D4306E303D3B1300867684 /* PWSLocale.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PWSLocale.cpp; sourceTree = "<group>"; };
 		57E9520A2DE93B7A00DE9640 /* AESTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AESTest.cpp; path = ../src/test/AESTest.cpp; sourceTree = SOURCE_ROOT; };
 		57E9520B2DE93B7A00DE9640 /* AliasShortcutTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AliasShortcutTest.cpp; path = ../src/test/AliasShortcutTest.cpp; sourceTree = SOURCE_ROOT; };
 		57E9520C2DE93B7A00DE9640 /* AuxParseTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AuxParseTest.cpp; path = ../src/test/AuxParseTest.cpp; sourceTree = SOURCE_ROOT; };
@@ -1635,6 +1637,7 @@
 				D3A1DCDC261B4AFC0014A300 /* PWFiltersTable.cpp */,
 				D364EC382632D0D800ECA59F /* PWFiltersTypeDlg.cpp */,
 				E6ADBA1B1195709A004E2BE5 /* PWSafeApp.cpp */,
+				57D4306E303D3B1300867684 /* PWSLocale.cpp */,
 				E6C94E911FA20593008F0072 /* QRCodeDlg.cpp */,
 				E6C94E951FA2075B008F0072 /* QREncode.mm */,
 				A6F2B3342832B0380096A7E4 /* QueryCancelDlg.cpp */,
@@ -2392,6 +2395,7 @@
 				D364EC3A2632D0D800ECA59F /* PWFiltersTypeDlg.cpp in Sources */,
 				E6DDC714138914B700F0C0D1 /* wxUtilities.cpp in Sources */,
 				E0C3C4502379CD8300715124 /* CryptKeyEntryDlg.cpp in Sources */,
+				57D4306F303D3B1300867684 /* PWSLocale.cpp in Sources */,
 				E66EE0B313921B30005C10C5 /* ComparisonGridTable.cpp in Sources */,
 				D31B027926384D29000EAA61 /* PWFiltersMediaDlg.cpp in Sources */,
 				E66FB84D13ACA5C3004DBB97 /* SizeRestrictedPanel.cpp in Sources */,

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -396,6 +396,7 @@
 		579BDA4E2C55F0A1004C727B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		57C329E72A070EFD00454292 /* ReleaseNotesWX.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = ReleaseNotesWX.md; path = ../docs/ReleaseNotesWX.md; sourceTree = "<group>"; };
 		57C329E82A0715F500454292 /* ReleaseNotes.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = ReleaseNotes.md; path = ../docs/ReleaseNotes.md; sourceTree = "<group>"; };
+		57CC07053033D4FC005C4A29 /* PWSLocale.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PWSLocale.h; sourceTree = "<group>"; };
 		57D3F0072B782AF600E4A662 /* version.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = version.in; path = ../src/ui/wxWidgets/version.in; sourceTree = "<group>"; };
 		57E9520A2DE93B7A00DE9640 /* AESTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AESTest.cpp; path = ../src/test/AESTest.cpp; sourceTree = SOURCE_ROOT; };
 		57E9520B2DE93B7A00DE9640 /* AliasShortcutTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AliasShortcutTest.cpp; path = ../src/test/AliasShortcutTest.cpp; sourceTree = SOURCE_ROOT; };
@@ -1709,6 +1710,7 @@
 				D3A1DCDD261B4AFC0014A300 /* PWFiltersTable.h */,
 				D364EC392632D0D800ECA59F /* PWFiltersTypeDlg.h */,
 				E6ADBA1C1195709A004E2BE5 /* PWSafeApp.h */,
+				57CC07053033D4FC005C4A29 /* PWSLocale.h */,
 				E6C94E921FA20593008F0072 /* QRCodeDlg.h */,
 				E6C94E941FA205E9008F0072 /* QREncode.h */,
 				A6F2B3352832B0380096A7E4 /* QueryCancelDlg.h */,

--- a/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
+++ b/Xcode/pwsafe-xcode6.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		5762BC2F2DE7E38800322CA5 /* searchaction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EBC8151D17165300AF61CD /* searchaction.cpp */; };
 		5762BC302DE7E38800322CA5 /* strutils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6EBC8181D17184F00AF61CD /* strutils.cpp */; };
 		57658D7E2FA3C2B100DD0972 /* run.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57658D7D2FA3C2B100DD0972 /* run.cpp */; };
+		578DF902302813A20045582C /* media.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2D181451C8FF86C0018AE03 /* media.cpp */; };
 		579BDA4F2C55F0A1004C727B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 579BDA4E2C55F0A1004C727B /* Assets.xcassets */; };
 		57BD7D042B19BEC2005C0123 /* helpEN.zip in Resources */ = {isa = PBXBuildFile; fileRef = E690B95612984B1D007EA508 /* helpEN.zip */; };
 		57E951B42DE9377000DE9640 /* libcore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E6ADB80311956A93004E2BE5 /* libcore.a */; };
@@ -77,7 +78,6 @@
 		6FF5D4A11DA14EE80032F5B6 /* PasswordSubsetDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF5D49D1DA14AB20032F5B6 /* PasswordSubsetDlg.cpp */; };
 		89A146668BFBBDB52F97EB58 /* TotpCore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8DA345B998C630600DF46F90 /* TotpCore.cpp */; };
 		8ED7E1C429D9F24C0012034B /* SetDatabaseIdDlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8ED7E1C329D9F24C0012034B /* SetDatabaseIdDlg.cpp */; };
-		A2D181461C8FF86C0018AE03 /* media.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2D181451C8FF86C0018AE03 /* media.cpp */; };
 		A2FE258D1C5ACF7500210C36 /* Item.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25811C5ACF7500210C36 /* Item.cpp */; };
 		A2FE258E1C5ACF7500210C36 /* ItemAtt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25831C5ACF7500210C36 /* ItemAtt.cpp */; };
 		A2FE25911C5ACF7500210C36 /* PWSfileHeader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2FE25891C5ACF7500210C36 /* PWSfileHeader.cpp */; };
@@ -1635,6 +1635,7 @@
 				D364EC382632D0D800ECA59F /* PWFiltersTypeDlg.cpp */,
 				E6ADBA1B1195709A004E2BE5 /* PWSafeApp.cpp */,
 				E6C94E911FA20593008F0072 /* QRCodeDlg.cpp */,
+				E6C94E951FA2075B008F0072 /* QREncode.mm */,
 				A6F2B3342832B0380096A7E4 /* QueryCancelDlg.cpp */,
 				E6ADBA271195709A004E2BE5 /* SafeCombinationChangeDlg.cpp */,
 				E6BA47831216DB9C00193879 /* SafeCombinationCtrl.cpp */,
@@ -1737,7 +1738,6 @@
 				E6ADBA361195709A004E2BE5 /* wxUtilities.h */,
 				5707816B2B0C4CED0082EB6E /* YubiCfgDlg.h */,
 				5707816D2B0C4CED0082EB6E /* YubiMixin.h */,
-				E6C94E951FA2075B008F0072 /* QREncode.mm */,
 			);
 			indentWidth = 2;
 			name = wxWidgets;
@@ -2267,7 +2267,6 @@
 				E6EE842F11E87E9800B01518 /* PWSprefs.cpp in Sources */,
 				E0C3C4422379B2C200715124 /* AES.cpp in Sources */,
 				B84A41C2A9CBBC9791F9B2DF /* base32.cpp in Sources */,
-				A2D181461C8FF86C0018AE03 /* media.cpp in Sources */,
 				E6EE843011E87E9800B01518 /* PWSrand.cpp in Sources */,
 				E0C3C4442379B2C200715124 /* KeyWrap.cpp in Sources */,
 				E0C3C4462379B2C200715124 /* sha1.cpp in Sources */,
@@ -2303,6 +2302,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				578DF902302813A20045582C /* media.cpp in Sources */,
 				570781742B0C4D330082EB6E /* PWYubi.cpp in Sources */,
 				E6889E021EE4640F0023E376 /* cleanup.cpp in Sources */,
 				57658D7E2FA3C2B100DD0972 /* run.cpp in Sources */,
@@ -2505,8 +2505,8 @@
 					DEBUG,
 					_DEBUG,
 					__WXMAC__,
-					__WXDEBUG__,
 					__WXOSX_COCOA__,
+					"wxDEBUG_LEVEL=1",
 					PUGIXML_WCHAR_MODE,
 					PUGIXML_NO_XPATH,
 				);
@@ -3139,8 +3139,8 @@
 					DEBUG,
 					_DEBUG,
 					__WXMAC__,
-					__WXDEBUG__,
 					__WXOSX_COCOA__,
+					"wxDEBUG_LEVEL=1",
 					PUGIXML_WCHAR_MODE,
 					PUGIXML_NO_XPATH,
 				);

--- a/docs/README.MAC.DEVELOPERS.md
+++ b/docs/README.MAC.DEVELOPERS.md
@@ -108,7 +108,7 @@ wxWidgets is the UI toolkit used by pwsafe for user-interface. There are two way
 ### Installing wxWidgets via Homebrew
 
 ```
-brew install wxwidgets
+brew install wxwidgets@3.2
 ```
 
 The problem with using Homebrew to install wxWidgets is that the version installed by Homebrew might
@@ -148,10 +148,10 @@ the tarball. My recommendation is to use the tarball. That's what I always do on
 
 
 ### Which Version of wxWidgets?
-Pwsafe code for macOS is no longer compatible with versions of wxWidgets older than 3.2.1.
+Pwsafe code for macOS is no longer compatible with versions of wxWidgets older than 3.2.2.
 There are a number of issues with version 3.0.5. For example, see
 [https://github.com/wxWidgets/wxWidgets/issues/19005](https://github.com/wxWidgets/wxWidgets/issues/19005).
-There are also Mac specific bugs in 3.2.1, 3.2.2.1 and 3.2.9.
+There are also Mac specific bugs in 3.2.2.1 and 3.2.9.
 
 **wxWidgets 3.2.10 is recommended.  3.2.4 and 3.2.8 are also known to work well.**
 

--- a/install/macosx/Makefile
+++ b/install/macosx/Makefile
@@ -75,6 +75,7 @@ lang: pwsI18N wxlocale
 		$(MDBIN) $(RESOURCES)/$$l.lproj ;	\
 		$(CPBIN) $$langPath/LC_MESSAGES/pwsafe.mo $(RESOURCES)/$$l.lproj;	\
 		$(CPBIN) $(WXDIR)/$$l.mo $(RESOURCES)/$$l.lproj/wxstd.mo;		\
+		plutil -insert CFBundleLocalizations -string $${l:0:2} -append $(RESOURCES)/../Info.plist; \
 	done
 
 dist: clean

--- a/install/macosx/Makefile
+++ b/install/macosx/Makefile
@@ -83,7 +83,7 @@ dist: clean
 	$(CPBIN) -R $(DOCS) $(SRCDIR)
 	$(CPBIN) -R $(RELDIR)/$(PWSAFE-APP) $(SRCDIR)
 	/usr/bin/codesign -v --force --sign - -o runtime --entitlements \
-		$(RELDIR)/../../Intermediates.noindex/pwsafe-xcode6.build/Release/pwsafe.build/pwsafe.app.xcent \
+		$(RELDIR)/../../Intermediates.noindex/pwsafe-xcode6.build/$(XCODE_CONFIG)/pwsafe.build/pwsafe.app.xcent \
 		--timestamp=none --generate-entitlement-der $(SRCDIR)/pwsafe.app
 	create-dmg \
 			--window-size 420 560 \

--- a/src/os/mac/utf8conv.cpp
+++ b/src/os/mac/utf8conv.cpp
@@ -31,6 +31,13 @@ using namespace std;
 class Startup {
 public:
   Startup() {
+    /*
+      All programs start in the "C" locale.
+      On macOS, a GUI app is typically started without any LANG/LC_* environment variables.
+      Therefore, the "" argumant treats the "system locale" as "C" and this doesn't actually change anything.
+      However, there are ways a power user can change that, so, maybe, this is worth doing.
+      It will be overridden very soon in PWSafeApp::OnInit(), anyway.
+    */
     char *sl = setlocale(LC_ALL, "");
     if (sl == NULL)
       throw "Couldn't initialize locale - bailing out";

--- a/src/os/mac/utf8conv.cpp
+++ b/src/os/mac/utf8conv.cpp
@@ -32,12 +32,12 @@ class Startup {
 public:
   Startup() {
     /*
-      All programs start in the "C" locale.
-      On macOS, a GUI app is typically started without any LANG/LC_* environment variables.
-      Therefore, the "" argumant treats the "system locale" as "C" and this doesn't actually change anything.
-      However, there are ways a power user can change that, so, maybe, this is worth doing.
-      It will be overridden very soon in PWSafeApp::OnInit(), anyway.
-    */
+     * All programs start in the "C" locale.
+     * On macOS, a GUI app is typically started without any LANG/LC_* environment variables.
+     * Therefore, the "" argumant treats the "system locale" as "C" and this doesn't actually change anything.
+     * However, there are ways a power user can change that, so, maybe, this is worth doing.
+     * It will be overridden very soon in PWSafeApp::OnInit(), anyway.
+     */
     char *sl = setlocale(LC_ALL, "");
     if (sl == NULL)
       throw "Couldn't initialize locale - bailing out";

--- a/src/ui/wxWidgets/CMakeLists.txt
+++ b/src/ui/wxWidgets/CMakeLists.txt
@@ -152,6 +152,7 @@ list(APPEND PWSAFE_SRC_LIST
     src/ui/wxWidgets/ManageFiltersTable.cpp
     src/ui/wxWidgets/QueryCancelDlg.cpp
     src/ui/wxWidgets/StrengthMeter.cpp
+    src/ui/wxWidgets/PWSLocale.cpp
     )
 
 if(HAVE_YKPERS_H)

--- a/src/ui/wxWidgets/CMakeLists.txt
+++ b/src/ui/wxWidgets/CMakeLists.txt
@@ -73,6 +73,7 @@ list(APPEND PWSAFE_HDR_LIST
     src/ui/wxWidgets/PWFiltersPasswordDlg.h
     src/ui/wxWidgets/ManageFiltersTable.h
     src/ui/wxWidgets/StrengthMeter.h
+    src/ui/wxWidgets/PWSLocale.h
     )
 
 

--- a/src/ui/wxWidgets/MenuManageHandlers.cpp
+++ b/src/ui/wxWidgets/MenuManageHandlers.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #include <wx/filename.h>
+#include <wx/uilocale.h>
 
 #include "core/PWSdirs.h"
 
@@ -333,7 +334,7 @@ void PasswordSafeFrame::OnLanguageClick(wxCommandEvent& evt)
   wxLanguage userLang=std::get<0>(m_languages[id]);
   if (wxGetApp().ActivateLanguage(userLang, false)) {
     m_selectedLanguage = id;
-    wxString userLangName=wxLocale::GetLanguageCanonicalName(userLang);
+    wxString userLangName=wxUILocale::GetLanguageCanonicalName(userLang);
     if (!userLangName.IsEmpty()){
       PWSprefs::GetInstance()->SetPref(PWSprefs::LanguageFile, tostringx(userLangName));
       pws_os::Trace(L"Saved user-preferred language: name= %ls\n", ToStr(userLangName));

--- a/src/ui/wxWidgets/MenuManageHandlers.cpp
+++ b/src/ui/wxWidgets/MenuManageHandlers.cpp
@@ -24,7 +24,6 @@
 #endif
 
 #include <wx/filename.h>
-#include <wx/uilocale.h>
 
 #include "core/PWSdirs.h"
 
@@ -334,7 +333,7 @@ void PasswordSafeFrame::OnLanguageClick(wxCommandEvent& evt)
   wxLanguage userLang=std::get<0>(m_languages[id]);
   if (wxGetApp().ActivateLanguage(userLang, false)) {
     m_selectedLanguage = id;
-    wxString userLangName=wxUILocale::GetLanguageCanonicalName(userLang);
+    wxString userLangName = PWSLocale::GetLanguageCanonicalName(userLang);
     if (!userLangName.IsEmpty()){
       PWSprefs::GetInstance()->SetPref(PWSprefs::LanguageFile, tostringx(userLangName));
       pws_os::Trace(L"Saved user-preferred language: name= %ls\n", ToStr(userLangName));

--- a/src/ui/wxWidgets/PWSLocale.cpp
+++ b/src/ui/wxWidgets/PWSLocale.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2003-2026 Rony Shapiro <ronys@pwsafe.org>.
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+
+/** \file PWSLocale.cpp
+*
+*/
+
+// For compilers that support precompilation, includes "wx/wx.h".
+#include <wx/wxprec.h>
+
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
+#include "os/debug.h"
+#include "PWSLocale.h"
+
+wxString PWSLocale::appendUTF8(const wxString& ev)
+{
+  if (ev.empty() || ev.EndsWith(".UTF-8")) return ev;
+  return ev + ".UTF-8";
+}
+
+#ifdef LOCALE_WX322
+
+bool PWSLocale::UseDefault()
+{
+  auto ret = wxUILocale::UseDefault();
+  setMacLocale(PWSGetCurrentName());
+  return ret;
+}
+
+/*
+ * Some languages have multiple locale variations.  (e.g. en_US, en_GB, etc.)
+ * Just using the two letter language identifier (e.g. en.UTF-8) does not work
+ * in some cases; there needs to be a region as well (e.g. en_US.UTF-8), not doing
+ * so causes some inconsistent results. Specifically, the date format seems to
+ * default to en_GB in WX but not in native macOS controls, such as the date picker.
+ * This checks the user environment setting, if the language matches, use the env locale.
+ * If not, use whatever WX guessed.
+ */
+void PWSLocale::ChooseLocale(wxLanguage language)
+{
+  const wxLanguageInfo *langInfo = GetLanguageInfo(language);
+  if (langInfo != nullptr) {
+    wxString envString;
+    wxLocaleIdent sysLocaleId = PWSLocale::GetSystemLocaleId();
+    if (langInfo->CanonicalName == sysLocaleId.GetLanguage() && !sysLocaleId.GetRegion().empty()) {
+      envString = sysLocaleId.GetName();
+
+    } else if (!langInfo->CanonicalRef.empty()) {
+      envString = langInfo->CanonicalRef;
+
+    } else {
+      envString = langInfo->CanonicalName;
+    }
+    wxString ev8 = appendUTF8(envString);
+    if ( !ev8.empty() ) {
+      wxUILocale::UseLocaleName(ev8);
+      setMacLocale(ev8);
+    }
+  }
+  pws_os::Trace(L"Current wx   locale is: %ls", static_cast<const wchar_t *>(PWSLocale::PWSGetCurrentName()));
+  pws_os::Trace(L"Current libc locale is: %s", setlocale(LC_ALL, NULL));
+}
+
+  #ifdef __WXMAC__
+  void PWSLocale::setMacLocale(const char *loc)
+  {
+    if (loc && !setlocale(LC_ALL, loc)) {
+      pws_os::Trace(L"Failed to set locale to: %s", loc);
+    }
+
+    // This value must be set for mac OS starting with version 11, but is no problem for earlier versions, see:
+    // https://trac.wxwidgets.org/ticket/19023
+    // https://docs.wxwidgets.org/3.2/classwx_locale.html
+    int major, minor;
+    wxGetOsVersion(&major, &minor);
+    if (major == 11 || (major == 12 && minor < 3)) {
+      setlocale(LC_NUMERIC, "C");
+    }
+  }
+  #else // __WXMAC__
+  void PWSLocale::setMacLocale(const char *) {}; // no-op if not macOS
+  #endif // __WXMAC__
+
+#else // LOCALE_WX322
+
+bool PWSLocale::UseDefault()
+{
+  // Because the old version did this, possibily as a problem work around.
+  setlocale(LC_CTYPE, "");
+  setlocale(LC_TIME, "");
+  return false;
+}
+
+void PWSLocale::ChooseLocale(wxLanguage language)
+{
+  const wxLanguageInfo *langInfo = GetLanguageInfo(language);
+  if (langInfo != nullptr) {
+    wxString ev8 = appendUTF8(langInfo->CanonicalName);
+    if ( !ev8.empty() ) {
+      setlocale(LC_CTYPE, ev8.c_str());
+      setlocale(LC_TIME, ev8.c_str());
+    }
+  }
+  if (m_pwslocale)
+    pws_os::Trace(L"Current wx   locale is: %ls", static_cast<const wchar_t *>(m_pwslocale->PWSGetCurrentName()));
+
+  pws_os::Trace(L"Current libc locale is: %s", setlocale(LC_ALL, NULL));
+}
+
+PWSLocale *PWSLocale::m_pwslocale = nullptr;
+
+#endif // LOCALE_WX322

--- a/src/ui/wxWidgets/PWSLocale.cpp
+++ b/src/ui/wxWidgets/PWSLocale.cpp
@@ -49,7 +49,7 @@ void PWSLocale::ChooseLocale(wxLanguage language)
   const wxLanguageInfo *langInfo = GetLanguageInfo(language);
   if (langInfo != nullptr) {
     wxString envString;
-    wxLocaleIdent sysLocaleId = PWSLocale::GetSystemLocaleId();
+    wxLocaleIdent sysLocaleId = GetSystemLocaleId();
     if (langInfo->CanonicalName == sysLocaleId.GetLanguage() && !sysLocaleId.GetRegion().empty()) {
       envString = sysLocaleId.GetName();
 
@@ -101,6 +101,10 @@ bool PWSLocale::UseDefault()
 
 void PWSLocale::ChooseLocale(wxLanguage language)
 {
+  // Don't do anything here until Init() has been called
+  if (m_pwslocale == nullptr)
+    return;
+
   const wxLanguageInfo *langInfo = GetLanguageInfo(language);
   if (langInfo != nullptr) {
     wxString ev8 = appendUTF8(langInfo->CanonicalName);
@@ -109,9 +113,7 @@ void PWSLocale::ChooseLocale(wxLanguage language)
       setlocale(LC_TIME, ev8.c_str());
     }
   }
-  if (m_pwslocale)
-    pws_os::Trace(L"Current wx   locale is: %ls", static_cast<const wchar_t *>(m_pwslocale->PWSGetCurrentName()));
-
+  pws_os::Trace(L"Current wx   locale is: %ls", static_cast<const wchar_t *>(m_pwslocale->PWSGetCurrentName()));
   pws_os::Trace(L"Current libc locale is: %s", setlocale(LC_ALL, NULL));
 }
 

--- a/src/ui/wxWidgets/PWSLocale.h
+++ b/src/ui/wxWidgets/PWSLocale.h
@@ -41,13 +41,18 @@
   public:
     PWSLocale() {};
     ~PWSLocale() { m_pwslocale = nullptr; }
-    static PWSLocale *m_pwslocale;
 
     static bool UseDefault();
     static void ChooseLocale(wxLanguage language);
     wxString PWSGetCurrentName() { return wxLocale::GetCanonicalName(); };
+    bool Init(wxLanguage lang)
+    {
+      if (m_pwslocale == nullptr) m_pwslocale = this;
+      return wxLocale::Init(lang);
+    }
 
   private:
+    static PWSLocale *m_pwslocale;
     static wxString appendUTF8(const wxString& ev);
   };
 #endif // LOCALE_WX322

--- a/src/ui/wxWidgets/PWSLocale.h
+++ b/src/ui/wxWidgets/PWSLocale.h
@@ -32,6 +32,11 @@ public:
   class PWSLocale : public wxUILocale, public PWSMacLocale
   {
   public:
+    static bool UseDefault() {
+      auto ret = wxUILocale::UseDefault();
+      setMacLocale(PWSGetCurrentName());
+      return ret;
+    }
     static wxString PWSGetCurrentName() { return wxUILocale::GetCurrent().GetName(); };
   };
 
@@ -42,7 +47,12 @@ public:
   {
   public:
     PWSLocale() {};
-    static bool UseDefault() { return false; }; //no-op for compatibility
+    static bool UseDefault() {
+      // Because the old version did this, possibily as problem work arounds.
+      setlocale(LC_CTYPE, "");
+      setlocale(LC_TIME, "");
+      return false;
+    };
     wxString PWSGetCurrentName() { return wxLocale::GetCanonicalName(); };
   };
 #endif // LOCALE_WX322

--- a/src/ui/wxWidgets/PWSLocale.h
+++ b/src/ui/wxWidgets/PWSLocale.h
@@ -1,0 +1,50 @@
+/*
+ * Initial version created by Richard Powell
+ *
+ * Copyright (c) 2003-2026 Rony Shapiro <ronys@pwsafe.org>.
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+
+#ifndef _PWSLOCALE_H_
+#define _PWSLOCALE_H_
+
+// wx3.2.2 and later can use wxUILocale and some improved logic
+#if wxCHECK_VERSION(3, 2, 2)
+#define LOCALE_WX322
+#endif
+
+class PWSMacLocale
+{
+public:
+#ifdef __WXMAC__
+  static void setMacLocale(const char *loc);
+#else
+  static void setMacLocale(const char *) {}; // no-op if not macOS
+#endif
+};
+
+#ifdef LOCALE_WX322
+#include <wx/uilocale.h>
+
+  class PWSLocale : public wxUILocale, public PWSMacLocale
+  {
+  public:
+    static wxString PWSGetCurrentName() { return wxUILocale::GetCurrent().GetName(); };
+  };
+
+#else // LOCALE_WX322
+
+  // Pre-wx3.2.2 compatible version
+  class PWSLocale : public wxLocale, public PWSMacLocale
+  {
+  public:
+    PWSLocale() {};
+    static bool UseDefault() { return false; }; //no-op for compatibility
+    wxString PWSGetCurrentName() { return wxLocale::GetCanonicalName(); };
+  };
+#endif // LOCALE_WX322
+
+#endif // _PWSLOCALE_H_

--- a/src/ui/wxWidgets/PWSLocale.h
+++ b/src/ui/wxWidgets/PWSLocale.h
@@ -12,24 +12,16 @@
 #define _PWSLOCALE_H_
 
 // wx3.2.2 and later can use wxUILocale and some improved logic
+// All supported macOS versions work best with wxWidgets 3.2.4 and above.
+// Unix/Linux is compatible as far back as wxWidgets 3.0.5
 #if wxCHECK_VERSION(3, 2, 2)
 #define LOCALE_WX322
 #endif
 
-class PWSMacLocale
-{
-public:
-#ifdef __WXMAC__
-  static void setMacLocale(const char *loc);
-#else
-  static void setMacLocale(const char *) {}; // no-op if not macOS
-#endif
-};
-
 #ifdef LOCALE_WX322
 #include <wx/uilocale.h>
 
-  class PWSLocale : public wxUILocale, public PWSMacLocale
+  class PWSLocale : public wxUILocale
   {
   public:
     static bool UseDefault() {
@@ -37,23 +29,68 @@ public:
       setMacLocale(PWSGetCurrentName());
       return ret;
     }
+    static void UseLocaleName(const wxString& envString) {
+      wxString ev8 = setUTF8(envString);
+      if ( !ev8.empty() ) {
+        wxUILocale::UseLocaleName(ev8);
+        setMacLocale(ev8);
+      }
+    }
     static wxString PWSGetCurrentName() { return wxUILocale::GetCurrent().GetName(); };
+
+  private:
+    static wxString setUTF8(const wxString& ev) {
+      if (ev.empty() || ev.EndsWith(".UTF-8")) return ev;
+      return ev + ".UTF-8";
+    }
+
+  #ifdef __WXMAC__
+    static void setMacLocale(const char *loc) {
+      if (loc && !setlocale(LC_ALL, loc)) {
+        pws_os::Trace(L"Failed to set locale to: %s", loc);
+      }
+
+      // This value must be set for mac OS starting with version 11, but is no problem for earlier versions, see:
+      // https://trac.wxwidgets.org/ticket/19023
+      // https://docs.wxwidgets.org/3.2/classwx_locale.html
+      int major, minor;
+      wxGetOsVersion(&major, &minor);
+      if (major == 11 || (major == 12 && minor < 3)) {
+        setlocale(LC_NUMERIC, "C");
+      }
+    }
+  #else // __WXMAC__
+    static void setMacLocale(const char *) {}; // no-op if not macOS
+  #endif // __WXMAC__
   };
 
 #else // LOCALE_WX322
 
   // Pre-wx3.2.2 compatible version
-  class PWSLocale : public wxLocale, public PWSMacLocale
+  class PWSLocale : public wxLocale
   {
   public:
     PWSLocale() {};
     static bool UseDefault() {
-      // Because the old version did this, possibily as problem work arounds.
+      // Because the old version did this, possibily as a problem work around.
       setlocale(LC_CTYPE, "");
       setlocale(LC_TIME, "");
       return false;
-    };
+    }
+    static void UseLocaleName(const wxString& envString) {
+      wxString ev8 = setUTF8(envString);
+      if ( !ev8.empty() ) {
+        setlocale(LC_CTYPE, ev8.c_str());
+        setlocale(LC_TIME, ev8.c_str());
+      }
+    }
     wxString PWSGetCurrentName() { return wxLocale::GetCanonicalName(); };
+
+  private:
+    static wxString setUTF8(const wxString& ev) {
+      if (ev.empty() || ev.EndsWith(".UTF-8")) return ev;
+      return ev + ".UTF-8";
+    }
   };
 #endif // LOCALE_WX322
 

--- a/src/ui/wxWidgets/PWSLocale.h
+++ b/src/ui/wxWidgets/PWSLocale.h
@@ -24,44 +24,13 @@
   class PWSLocale : public wxUILocale
   {
   public:
-    static bool UseDefault() {
-      auto ret = wxUILocale::UseDefault();
-      setMacLocale(PWSGetCurrentName());
-      return ret;
-    }
-    static void UseLocaleName(const wxString& envString) {
-      wxString ev8 = setUTF8(envString);
-      if ( !ev8.empty() ) {
-        wxUILocale::UseLocaleName(ev8);
-        setMacLocale(ev8);
-      }
-    }
+    static bool UseDefault();
+    static void ChooseLocale(wxLanguage language);
     static wxString PWSGetCurrentName() { return wxUILocale::GetCurrent().GetName(); };
 
   private:
-    static wxString setUTF8(const wxString& ev) {
-      if (ev.empty() || ev.EndsWith(".UTF-8")) return ev;
-      return ev + ".UTF-8";
-    }
-
-  #ifdef __WXMAC__
-    static void setMacLocale(const char *loc) {
-      if (loc && !setlocale(LC_ALL, loc)) {
-        pws_os::Trace(L"Failed to set locale to: %s", loc);
-      }
-
-      // This value must be set for mac OS starting with version 11, but is no problem for earlier versions, see:
-      // https://trac.wxwidgets.org/ticket/19023
-      // https://docs.wxwidgets.org/3.2/classwx_locale.html
-      int major, minor;
-      wxGetOsVersion(&major, &minor);
-      if (major == 11 || (major == 12 && minor < 3)) {
-        setlocale(LC_NUMERIC, "C");
-      }
-    }
-  #else // __WXMAC__
-    static void setMacLocale(const char *) {}; // no-op if not macOS
-  #endif // __WXMAC__
+    static wxString appendUTF8(const wxString& ev);
+    static void setMacLocale(const char *loc);
   };
 
 #else // LOCALE_WX322
@@ -71,26 +40,15 @@
   {
   public:
     PWSLocale() {};
-    static bool UseDefault() {
-      // Because the old version did this, possibily as a problem work around.
-      setlocale(LC_CTYPE, "");
-      setlocale(LC_TIME, "");
-      return false;
-    }
-    static void UseLocaleName(const wxString& envString) {
-      wxString ev8 = setUTF8(envString);
-      if ( !ev8.empty() ) {
-        setlocale(LC_CTYPE, ev8.c_str());
-        setlocale(LC_TIME, ev8.c_str());
-      }
-    }
+    ~PWSLocale() { m_pwslocale = nullptr; }
+    static PWSLocale *m_pwslocale;
+
+    static bool UseDefault();
+    static void ChooseLocale(wxLanguage language);
     wxString PWSGetCurrentName() { return wxLocale::GetCanonicalName(); };
 
   private:
-    static wxString setUTF8(const wxString& ev) {
-      if (ev.empty() || ev.EndsWith(".UTF-8")) return ev;
-      return ev + ".UTF-8";
-    }
+    static wxString appendUTF8(const wxString& ev);
   };
 #endif // LOCALE_WX322
 

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -35,6 +35,8 @@
 
 #if wxCHECK_VERSION(3, 1, 6)
 #include <wx/uilocale.h>
+#else
+#  error "This build requires wxWidgets 3.1.6 or above for wxUILocale"
 #endif
 
 #if wxCHECK_VERSION(2,9,2)
@@ -695,6 +697,7 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
       setMacLocale(envString);
 #endif // __WXMAC__
 #else // wxCHECK_VERSION
+#warning "Improved locale logic requires wxWidgets 3.2.2 or above"
       wxString envString = langInfo->CanonicalRef;
       if (envString.empty()) {
         envString = langInfo->CanonicalName;

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -33,12 +33,6 @@
 #include <wx/tokenzr.h>
 #include <wx/spinctrl.h>
 
-#if wxCHECK_VERSION(3, 1, 6)
-#include <wx/uilocale.h>
-#else
-#  error "This build requires wxWidgets 3.1.6 or above for wxUILocale"
-#endif
-
 #if wxCHECK_VERSION(2,9,2)
 #include <wx/richmsgdlg.h>
 #endif
@@ -209,6 +203,8 @@ PWSafeApp::~PWSafeApp()
   PWSrand::DeleteInstance();
   PWSLog::DeleteLog();
   Clipboard::DeleteInstance();
+
+  delete m_locale;
 }
 
 /*!
@@ -219,6 +215,9 @@ void PWSafeApp::Init()
 {
   pws_os::install_cleanup_handler(cleanup_handler, &m_core);
 
+#ifndef LOCALE_WX322
+  m_locale = new PWSLocale;
+#endif
 #if defined(__UNIX__) && !defined(__WXMAC__)
   wxFileTranslationsLoader::AddCatalogLookupPathPrefix(L"/usr/share/locale");
   wxFileTranslationsLoader::AddCatalogLookupPathPrefix(L"/usr/local/share/locale");
@@ -239,7 +238,7 @@ void PWSafeApp::Init()
 void PWSafeApp::OnAssertFailure(const wxChar *file, int line, const wxChar *func,
                 const wxChar *cond, const wxChar *msg)
 {
-  if (m_wxUILocaleIsSet)
+  if (m_PWSLocaleIsSet)
     wxApp::OnAssertFailure(file, line, func, cond, msg);
   else
       std::wcerr << file << L'(' << line << L"):"
@@ -253,7 +252,7 @@ void PWSafeApp::OnAssertFailure(const wxChar *file, int line, const wxChar *func
 */
 bool PWSafeApp::ActivateHelp(wxLanguage language) {
   wxString fileNameBase = L"help", fileExt=L".zip", defaultSuffix=L"EN"+fileExt;
-  wxString langSuffix = wxUILocale::GetLanguageCanonicalName(language);
+  wxString langSuffix = PWSLocale::GetLanguageCanonicalName(language);
   // Get only two letters
   if (langSuffix.length() >= 2) {
     langSuffix = langSuffix.substr(0, 2).Upper() + fileExt;
@@ -285,12 +284,14 @@ bool PWSafeApp::ActivateHelp(wxLanguage language) {
 
 bool PWSafeApp::OnInit()
 {
-  // Initialize the WX UI locale to the desktop configured default.
-  // According to the wx documentation, this also calls setlocale() on
-  // Unix/Linux wxGTK platforms, but not on macOS.
-  // This should suffice until we set the users' preferred language a bit later....
-  wxUILocale::UseDefault();
-  m_wxUILocaleIsSet = true;
+  /*
+   * In LOCALE_WX322, this initializes the WX UI locale to the desktop
+   * configured default. According to the wx documentation, this also calls
+   * setlocale() on Unix/Linux wxGTK platforms, but not on macOS.
+   * In old locale it just returns false, wxLocale::Init happens later.
+   * This should suffice until we set the user's preferred language a bit later....
+   */
+  m_PWSLocaleIsSet = PWSLocale::UseDefault();
 
   //Used by help subsystem
   wxFileSystem::AddHandler(new wxArchiveFSHandler);
@@ -385,6 +386,10 @@ bool PWSafeApp::OnInit()
   // Only initialize the locale with a language PasswordSafe can really activate.
   // Otherwise fall back to English before touching the locale.
   wxLanguage effectiveLang = ActivateLanguage(selectedLang, true) ? selectedLang : wxLANGUAGE_ENGLISH;
+
+#ifndef LOCALE_WX322
+  m_PWSLocaleIsSet = m_locale->Init(effectiveLang);
+#endif
 
   ActivateLanguage(effectiveLang, false);
 
@@ -593,7 +598,7 @@ void PWSafeApp::FinishInit() {
  */
 wxLanguage PWSafeApp::GetSystemLanguage()
 {
-  return static_cast<wxLanguage>(wxUILocale::GetSystemLanguage());
+  return static_cast<wxLanguage>(PWSLocale::GetSystemLanguage());
 }
 
 /* Get selected language (user preference or system) */
@@ -604,10 +609,10 @@ wxLanguage PWSafeApp::GetSelectedLanguage()
   const wxLanguageInfo *langInfo = nullptr;
 
   if (sxUserLang.empty()) {
-    langInfo = wxUILocale::GetLanguageInfo(wxLANGUAGE_DEFAULT);
+    langInfo = PWSLocale::GetLanguageInfo(wxLANGUAGE_DEFAULT);
   }
   else {
-    langInfo = wxUILocale::FindLanguageInfo(towxstring(sxUserLang));
+    langInfo = PWSLocale::FindLanguageInfo(towxstring(sxUserLang));
   }
 
   if (langInfo && ActivateLanguage(static_cast<wxLanguage>(langInfo->Language), true)) {
@@ -649,11 +654,11 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
 
   if (language != wxLANGUAGE_ENGLISH) {
     if ( !translations->AddStdCatalog() ) {
-      pws_os::Trace(L"Couldn't load default language catalog for %ls\n", ToStr(wxUILocale::GetLanguageName(language)));
+      pws_os::Trace(L"Couldn't load default language catalog for %ls\n", ToStr(PWSLocale::GetLanguageName(language)));
     }
 
     if ( !translations->AddCatalog(DOMAIN_) ) {
-      pws_os::Trace(L"Couldn't load %ls language catalog for %ls\n", ToStr(DOMAIN_), ToStr(wxUILocale::GetLanguageName(language)));
+      pws_os::Trace(L"Couldn't load %ls language catalog for %ls\n", ToStr(DOMAIN_), ToStr(PWSLocale::GetLanguageName(language)));
       translations->SetLanguage(wxLANGUAGE_ENGLISH);
       language = wxLANGUAGE_ENGLISH; // Back to default language english
     }
@@ -669,19 +674,21 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
     isHelpActivated = ActivateHelp(language);
 
     const wxLanguageInfo *langInfo = nullptr;
-    langInfo = wxUILocale::GetLanguageInfo(language);
+    langInfo = PWSLocale::GetLanguageInfo(language);
     if(langInfo) {
 
-#if wxCHECK_VERSION(3, 2, 2)
-      // Some languages have multiple locale variations.  (e.g. en_US, en_GB, etc.)
-      // Just using the two letter language identifier (e.g. en.UTF-8) does not work
-      // in some cases; there needs to be a region as well (e.g. en_US.UTF-8), not doing
-      // so causes some inconsistent results. Specifically, the date format seems to
-      // default to en_GB in WX but not in native macOS controls, such as the date picker.
-      // This checks the user environment setting, if the language matches, use the env locale.
-      // If not, use whatever WX guessed.
+#ifdef LOCALE_WX322
+      /*
+       * Some languages have multiple locale variations.  (e.g. en_US, en_GB, etc.)
+       * Just using the two letter language identifier (e.g. en.UTF-8) does not work
+       * in some cases; there needs to be a region as well (e.g. en_US.UTF-8), not doing
+       * so causes some inconsistent results. Specifically, the date format seems to
+       * default to en_GB in WX but not in native macOS controls, such as the date picker.
+       * This checks the user environment setting, if the language matches, use the env locale.
+       * If not, use whatever WX guessed.
+       */
       wxString envString;
-      wxLocaleIdent sysLocaleId = wxUILocale::GetSystemLocaleId();
+      wxLocaleIdent sysLocaleId = PWSLocale::GetSystemLocaleId();
       if (langInfo->CanonicalName == sysLocaleId.GetLanguage() && !sysLocaleId.GetRegion().empty()) {
         envString = sysLocaleId.GetName();
 
@@ -692,19 +699,17 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
         envString = langInfo->CanonicalName;
       }
       envString += ".UTF-8";
-      wxUILocale::UseLocaleName(envString);
-      
-#ifdef __WXMAC__
-      setMacLocale(envString);
-#endif // __WXMAC__
+      PWSLocale::UseLocaleName(envString);
+      PWSLocale::setMacLocale(envString);
+      pws_os::Trace(L"Current wx   locale is: %ls", static_cast<const wchar_t *>(PWSLocale::PWSGetCurrentName()));
 
-#else // wxCHECK_VERSION
-      wxString envString = langInfo->CanonicalRef;
-      if (envString.empty()) {
-        envString = langInfo->CanonicalName;
-      }
-      wxUILocale::UseLocaleName(envString + ".UTF-8");
-#endif // wxCHECK_VERSION
+#else // LOCALE_WX322
+      wxString envString = langInfo->CanonicalName + ".UTF-8";
+      setlocale(LC_CTYPE, envString.c_str());
+      setlocale(LC_TIME, envString.c_str());
+      PWSLocale::setMacLocale(envString);
+      pws_os::Trace(L"Current wx   locale is: %ls", static_cast<const wchar_t *>(m_locale->PWSGetCurrentName()));
+#endif // LOCALE_WX322
       pws_os::Trace(L"Current libc locale is: %s", setlocale(LC_ALL, NULL));
     }
   }
@@ -714,11 +719,13 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
 #ifdef __WXMAC__
 // macOS specific functions for UI interactions...
 
-void PWSafeApp::setMacLocale(const char *loc)
+void PWSMacLocale::setMacLocale([[maybe_unused]] const char *loc)
 {
+#ifdef LOCALE_WX322
   if (loc && !setlocale(LC_ALL, loc)) {
     pws_os::Trace(L"Failed to set locale to: %s", loc);
   }
+#endif // LOCALE_WX322
 
   // This value must be set for mac OS starting with version 11, but is no problem for earlier versions, see:
   // https://trac.wxwidgets.org/ticket/19023

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -698,16 +698,12 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
       } else {
         envString = langInfo->CanonicalName;
       }
-      envString += ".UTF-8";
       PWSLocale::UseLocaleName(envString);
-      PWSLocale::setMacLocale(envString);
       pws_os::Trace(L"Current wx   locale is: %ls", static_cast<const wchar_t *>(PWSLocale::PWSGetCurrentName()));
 
 #else // LOCALE_WX322
-      wxString envString = langInfo->CanonicalName + ".UTF-8";
-      setlocale(LC_CTYPE, envString.c_str());
-      setlocale(LC_TIME, envString.c_str());
-      PWSLocale::setMacLocale(envString);
+      wxString envString = langInfo->CanonicalName;
+      PWSLocale::UseLocaleName(envString);
       pws_os::Trace(L"Current wx   locale is: %ls", static_cast<const wchar_t *>(m_locale->PWSGetCurrentName()));
 #endif // LOCALE_WX322
       pws_os::Trace(L"Current libc locale is: %s", setlocale(LC_ALL, NULL));
@@ -718,24 +714,6 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
 
 #ifdef __WXMAC__
 // macOS specific functions for UI interactions...
-
-void PWSMacLocale::setMacLocale([[maybe_unused]] const char *loc)
-{
-#ifdef LOCALE_WX322
-  if (loc && !setlocale(LC_ALL, loc)) {
-    pws_os::Trace(L"Failed to set locale to: %s", loc);
-  }
-#endif // LOCALE_WX322
-
-  // This value must be set for mac OS starting with version 11, but is no problem for earlier versions, see:
-  // https://trac.wxwidgets.org/ticket/19023
-  // https://docs.wxwidgets.org/3.2/classwx_locale.html
-  int major, minor;
-  wxGetOsVersion(&major, &minor);
-  if (major == 11 || (major == 12 && minor < 3)) {
-    setlocale(LC_NUMERIC, "C");
-  }
-}
 
 // This enables file unlock and UI restore upon left-click of the dock icon.
 // Not to be confused with the system tray (menu bar) icon.

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -216,7 +216,7 @@ void PWSafeApp::Init()
   pws_os::install_cleanup_handler(cleanup_handler, &m_core);
 
 #ifndef LOCALE_WX322
-  m_locale = PWSLocale::m_pwslocale = new PWSLocale;
+  m_locale = new PWSLocale;
 #endif
 #if defined(__UNIX__) && !defined(__WXMAC__)
   wxFileTranslationsLoader::AddCatalogLookupPathPrefix(L"/usr/share/locale");
@@ -592,9 +592,9 @@ void PWSafeApp::FinishInit() {
 }
 
 /*!
- * Initializing the language support means currently
- * to determine the system default language and
- * activate this one for the application.
+ * Initializing the language support means
+ * to activate the user's selected language
+ * or the system default.
  */
 wxLanguage PWSafeApp::GetSystemLanguage()
 {

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -246,7 +246,7 @@ void PWSafeApp::OnAssertFailure(const wxChar *file, int line, const wxChar *func
 */
 bool PWSafeApp::ActivateHelp(wxLanguage language) {
   wxString fileNameBase = L"help", fileExt=L".zip", defaultSuffix=L"EN"+fileExt;
-  wxString langSuffix = wxLocale::GetLanguageCanonicalName(language);
+  wxString langSuffix = wxUILocale::GetLanguageCanonicalName(language);
   // Get only two letters
   if (langSuffix.length() >= 2) {
     langSuffix = langSuffix.substr(0, 2).Upper() + fileExt;
@@ -602,10 +602,10 @@ wxLanguage PWSafeApp::GetSelectedLanguage()
   const wxLanguageInfo *langInfo = nullptr;
 
   if (sxUserLang.empty()) {
-    langInfo = wxLocale::GetLanguageInfo(wxLANGUAGE_DEFAULT);
+    langInfo = wxUILocale::GetLanguageInfo(wxLANGUAGE_DEFAULT);
   }
   else {
-    langInfo = wxLocale::FindLanguageInfo(towxstring(sxUserLang));
+    langInfo = wxUILocale::FindLanguageInfo(towxstring(sxUserLang));
   }
 
   if (langInfo && ActivateLanguage(static_cast<wxLanguage>(langInfo->Language), true)) {
@@ -647,11 +647,11 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
 
   if (language != wxLANGUAGE_ENGLISH) {
     if ( !translations->AddStdCatalog() ) {
-      pws_os::Trace(L"Couldn't load default language catalog for %ls\n", ToStr(wxLocale::GetLanguageName(language)));
+      pws_os::Trace(L"Couldn't load default language catalog for %ls\n", ToStr(wxUILocale::GetLanguageName(language)));
     }
 
     if ( !translations->AddCatalog(DOMAIN_) ) {
-      pws_os::Trace(L"Couldn't load %ls language catalog for %ls\n", ToStr(DOMAIN_), ToStr(wxLocale::GetLanguageName(language)));
+      pws_os::Trace(L"Couldn't load %ls language catalog for %ls\n", ToStr(DOMAIN_), ToStr(wxUILocale::GetLanguageName(language)));
       translations->SetLanguage(wxLANGUAGE_ENGLISH);
       language = wxLANGUAGE_ENGLISH; // Back to default language english
     }
@@ -667,7 +667,7 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
     isHelpActivated = ActivateHelp(language);
 
     const wxLanguageInfo *langInfo = nullptr;
-    langInfo = wxLocale::GetLanguageInfo(language);
+    langInfo = wxUILocale::GetLanguageInfo(language);
     if(langInfo) {
 
 #if wxCHECK_VERSION(3, 2, 2)

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -216,7 +216,7 @@ void PWSafeApp::Init()
   pws_os::install_cleanup_handler(cleanup_handler, &m_core);
 
 #ifndef LOCALE_WX322
-  m_locale = new PWSLocale;
+  m_locale = PWSLocale::m_pwslocale = new PWSLocale;
 #endif
 #if defined(__UNIX__) && !defined(__WXMAC__)
   wxFileTranslationsLoader::AddCatalogLookupPathPrefix(L"/usr/share/locale");
@@ -673,41 +673,7 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
     wxTranslations::Set(translations);
     isHelpActivated = ActivateHelp(language);
 
-    const wxLanguageInfo *langInfo = nullptr;
-    langInfo = PWSLocale::GetLanguageInfo(language);
-    if(langInfo) {
-
-#ifdef LOCALE_WX322
-      /*
-       * Some languages have multiple locale variations.  (e.g. en_US, en_GB, etc.)
-       * Just using the two letter language identifier (e.g. en.UTF-8) does not work
-       * in some cases; there needs to be a region as well (e.g. en_US.UTF-8), not doing
-       * so causes some inconsistent results. Specifically, the date format seems to
-       * default to en_GB in WX but not in native macOS controls, such as the date picker.
-       * This checks the user environment setting, if the language matches, use the env locale.
-       * If not, use whatever WX guessed.
-       */
-      wxString envString;
-      wxLocaleIdent sysLocaleId = PWSLocale::GetSystemLocaleId();
-      if (langInfo->CanonicalName == sysLocaleId.GetLanguage() && !sysLocaleId.GetRegion().empty()) {
-        envString = sysLocaleId.GetName();
-
-      } else if (!langInfo->CanonicalRef.empty()) {
-        envString = langInfo->CanonicalRef;
-
-      } else {
-        envString = langInfo->CanonicalName;
-      }
-      PWSLocale::UseLocaleName(envString);
-      pws_os::Trace(L"Current wx   locale is: %ls", static_cast<const wchar_t *>(PWSLocale::PWSGetCurrentName()));
-
-#else // LOCALE_WX322
-      wxString envString = langInfo->CanonicalName;
-      PWSLocale::UseLocaleName(envString);
-      pws_os::Trace(L"Current wx   locale is: %ls", static_cast<const wchar_t *>(m_locale->PWSGetCurrentName()));
-#endif // LOCALE_WX322
-      pws_os::Trace(L"Current libc locale is: %s", setlocale(LC_ALL, NULL));
-    }
+    PWSLocale::ChooseLocale(language);
   }
   return bRes;
 }

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -190,8 +190,7 @@ IMPLEMENT_CLASS( PWSafeApp, wxApp )
  */
 
 PWSafeApp::PWSafeApp() : m_idleTimer(new wxTimer(this, IDLE_TIMER_ID)),
-                         m_frame(nullptr), m_recentDatabases(nullptr),
-                         m_locale(nullptr)
+                         m_frame(nullptr), m_recentDatabases(nullptr)
 {
   Init();
 }
@@ -208,8 +207,6 @@ PWSafeApp::~PWSafeApp()
   PWSrand::DeleteInstance();
   PWSLog::DeleteLog();
   Clipboard::DeleteInstance();
-
-  delete m_locale;
 }
 
 /*!
@@ -219,7 +216,6 @@ PWSafeApp::~PWSafeApp()
 void PWSafeApp::Init()
 {
   pws_os::install_cleanup_handler(cleanup_handler, &m_core);
-  m_locale = new wxLocale;
   wxLocale::AddCatalogLookupPathPrefix(L"/usr/share/locale");
   wxLocale::AddCatalogLookupPathPrefix(L"/usr");
   wxLocale::AddCatalogLookupPathPrefix(L"/usr/local");
@@ -236,7 +232,7 @@ void PWSafeApp::Init()
 void PWSafeApp::OnAssertFailure(const wxChar *file, int line, const wxChar *func,
                 const wxChar *cond, const wxChar *msg)
 {
-  if (m_locale)
+  if (m_wxUILocaleIsSet)
     wxApp::OnAssertFailure(file, line, func, cond, msg);
   else
       std::wcerr << file << L'(' << line << L"):"
@@ -282,32 +278,17 @@ bool PWSafeApp::ActivateHelp(wxLanguage language) {
 
 bool PWSafeApp::OnInit()
 {
-  // Get the locale environment variable 'LC_CTYPE' specified by the environment
-  // For instance, the behavior of function 'wcstombs' depends on the LC_CTYPE 
-  // category of the selected C locale.
-#if defined(__WXMAC__)
-  const char *lcCType = setlocale(LC_CTYPE, NULL);
+  // Initialize the WX UI locale to the desktop configured default.
+  // According to the wx documentation, this also calls setlocale() on
+  // Unix/Linux wxGTK platforms...
+  wxUILocale::UseDefault();
+  m_wxUILocaleIsSet = true;
 
-  if (lcCType && strcmp(lcCType, "UTF-8")) { // MAC OS only have UTF-8 as default, but conversion with this string is not running well
-    setlocale(LC_CTYPE, "");
-  }
-  else {
-    const char *env_lc_cType = std::getenv("LC_CTYPE");
-    
-    if(env_lc_cType) {
-      setlocale(LC_CTYPE, env_lc_cType);
-    }
-    else {
-      setlocale(LC_CTYPE, "en_US.UTF-8");
-    }
-  }
-  // This value must be set for mac OS starting with version 11, but is no problem for earlier versions, see
-  // https://trac.wxwidgets.org/ticket/19023
-  setlocale(LC_NUMERIC, "C");
-#else
-  setlocale(LC_CTYPE, "");
+  // ...but not on macOS.  This should be good enough until we set the
+  // users' preferred language a bit later....
+#if defined(__WXMAC__)
+  setMacLocale("");
 #endif
-  setlocale(LC_TIME, "");
 
   //Used by help subsystem
   wxFileSystem::AddHandler(new wxArchiveFSHandler);
@@ -399,17 +380,13 @@ bool PWSafeApp::OnInit()
   // will ignore config file parameter
   wxLanguage selectedLang = GetSelectedLanguage();
 
-  // Only initialize wxLocale with a language PasswordSafe can really activate.
-  // Otherwise fall back to English before touching wxLocale.
-  wxLanguage effectiveLang =
-    wxGetApp().ActivateLanguage(selectedLang, true)
-      ? selectedLang
-      : wxLANGUAGE_ENGLISH;
+  // Only initialize the locale with a language PasswordSafe can really activate.
+  // Otherwise fall back to English before touching the locale.
+  wxLanguage effectiveLang = ActivateLanguage(selectedLang, true) ? selectedLang : wxLANGUAGE_ENGLISH;
 
-  m_locale->Init(effectiveLang);
   ActivateLanguage(effectiveLang, false);
 
- // Process encryption/decryption command line arguments
+  // Process encryption/decryption command line arguments
   // Note that this is done after language is set, addressing GH1572
   if ((cmd_encrypt || cmd_decrypt) && !cmd_filename.IsEmpty()) {
 
@@ -614,31 +591,7 @@ void PWSafeApp::FinishInit() {
  */
 wxLanguage PWSafeApp::GetSystemLanguage()
 {
-  int language = wxLocale::GetSystemLanguage();
-
-#if defined(__UNIX__) && !defined(__WXMAC__) && wxCHECK_VERSION( 2, 8, 0 )
-  // Workaround for wx bug 15006 that has been fixed in wxWidgets 2.8
-  if (language == wxLANGUAGE_UNKNOWN) {
-    std::wcerr << L"Couldn't detect locale. Trying to skip empty env. variables." << std::endl;
-    // Undefine empty environment variables and try again
-    wxString langFull;
-    if (wxGetEnv(wxT("LC_ALL"), &langFull) && !langFull) {
-      wxUnsetEnv(wxT("LC_ALL"));
-      std::wcerr << L"Empty LC_ALL variable was dropped" << std::endl;
-    }
-    if (wxGetEnv(wxT("LC_MESSAGES"), &langFull) && !langFull) {
-      wxUnsetEnv(wxT("LC_MESSAGES"));
-      std::wcerr << L"Empty LC_MESSAGES variable was dropped" << std::endl;
-    }
-    if (wxGetEnv(wxT("LANG"), &langFull) && !langFull) {
-      wxUnsetEnv(wxT("LANG"));
-      std::wcerr << L"Empty LANG variable was dropped" << std::endl;
-    }
-    language = wxLocale::GetSystemLanguage();
-  }
-#endif
-
-  return static_cast<wxLanguage>(language);
+  return static_cast<wxLanguage>(wxUILocale::GetSystemLanguage());
 }
 
 /* Get selected language (user preference or system) */
@@ -664,6 +617,8 @@ wxLanguage PWSafeApp::GetSelectedLanguage()
 #ifdef DEBUG
     if (langInfo) {
       pws_os::Trace(L"User-preferred language can't be activated: id= %d, name= %ls\n", langInfo->Language, sxUserLang.c_str());
+    } else {
+      pws_os::Trace(L"Unknown language in config file: name= %ls\n", sxUserLang.c_str());
     }
 #endif
     return GetSystemLanguage();
@@ -715,13 +670,14 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
     langInfo = wxLocale::GetLanguageInfo(language);
     if(langInfo) {
 
-#if defined(__WXMAC__)
 #if wxCHECK_VERSION(3, 2, 2)
       // Some languages have multiple locale variations.  (e.g. en_US, en_GB, etc.)
-      // Just using the two letter languane identifier (e.g. en.UTF-8) does not work
-      // on macOS, there needs to be a region as well (e.g. en_US.UTF-8), not doing
+      // Just using the two letter language identifier (e.g. en.UTF-8) does not work
+      // in some cases; there needs to be a region as well (e.g. en_US.UTF-8), not doing
       // so causes some inconsistent results. Specifically, the date format seems to
       // default to en_GB in WX but not in native macOS controls, such as the date picker.
+      // This checks the user environment setting, if the language matches, use the env locale.
+      // If not, use whatever WX guessed.
       wxString envString;
       wxLocaleIdent sysLocaleId = wxUILocale::GetSystemLocaleId();
       if (langInfo->CanonicalName == sysLocaleId.GetLanguage() && !sysLocaleId.GetRegion().empty()) {
@@ -729,23 +685,22 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
 
       } else if (!langInfo->CanonicalRef.empty()) {
         envString = langInfo->CanonicalRef;
-      }
-      if (!envString.empty()) {
-        envString += ".UTF-8";
-        setlocale(LC_CTYPE, envString.c_str());
-        setlocale(LC_TIME, envString.c_str());
-      }
-#endif // wxCHECK_VERSION
-      // This value must be set for mac OS starting with version 11, but is no problem for earlier versions, see
-      // https://github.com/wxWidgets/wxWidgets/issues/19023
-      // https://docs.wxwidgets.org/3.2/classwx_locale.html
-      setlocale(LC_NUMERIC, "C");
-#else // __WXMAC__
-      wxString envString = langInfo->CanonicalName + ".UTF-8";
-      setlocale(LC_CTYPE, envString.c_str());
-      setlocale(LC_TIME, envString.c_str());
-#endif // __WXMAC__
 
+      } else {
+        envString = langInfo->CanonicalName;
+      }
+      envString += ".UTF-8";
+      wxUILocale::UseLocaleName(envString);
+#ifdef __WXMAC__
+      setMacLocale(envString);
+#endif // __WXMAC__
+#else // wxCHECK_VERSION
+      wxString envString = langInfo->CanonicalRef;
+      if (envString.empty()) {
+        envString = langInfo->CanonicalName;
+      }
+      wxUILocale::UseLocaleName(envString + ".UTF-8");
+#endif // wxCHECK_VERSION
     }
   }
   return bRes;
@@ -753,6 +708,23 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
 
 #ifdef __WXMAC__
 // macOS specific functions for UI interactions...
+
+void PWSafeApp::setMacLocale(const char *loc)
+{
+  if (loc && !setlocale(LC_ALL, loc)) {
+    pws_os::Trace(L"Failed to set locale to: %s", loc);
+  }
+
+  // This value must be set for mac OS starting with version 11, but is no problem for earlier versions, see:
+  // https://trac.wxwidgets.org/ticket/19023
+  // https://docs.wxwidgets.org/3.2/classwx_locale.html
+  int major, minor;
+  wxGetOsVersion(&major, &minor);
+  if (major == 11 || (major == 12 && minor < 3)) {
+    setlocale(LC_NUMERIC, "C");
+  }
+  pws_os::Trace(L"Current locale is: %s", setlocale(LC_ALL, NULL));
+}
 
 // This enables file unlock and UI restore upon left-click of the dock icon.
 // Not to be confused with the system tray (menu bar) icon.

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -218,12 +218,17 @@ PWSafeApp::~PWSafeApp()
 void PWSafeApp::Init()
 {
   pws_os::install_cleanup_handler(cleanup_handler, &m_core);
-  wxLocale::AddCatalogLookupPathPrefix(L"/usr/share/locale");
-  wxLocale::AddCatalogLookupPathPrefix(L"/usr");
-  wxLocale::AddCatalogLookupPathPrefix(L"/usr/local");
+
+#if defined(__UNIX__) && !defined(__WXMAC__)
+  wxFileTranslationsLoader::AddCatalogLookupPathPrefix(L"/usr/share/locale");
+  wxFileTranslationsLoader::AddCatalogLookupPathPrefix(L"/usr/local/share/locale");
+#endif
 #if defined(_DEBUG) || defined(DEBUG)
-  wxLocale::AddCatalogLookupPathPrefix(L"../I18N/mos");
-  wxLocale::AddCatalogLookupPathPrefix(L"src/ui/wxWidgets/I18N/mos"); // located in cmake's build directory
+  wxFileTranslationsLoader::AddCatalogLookupPathPrefix(L"../I18N/mos");
+  wxFileTranslationsLoader::AddCatalogLookupPathPrefix(L"src/ui/wxWidgets/I18N/mos"); // located in cmake's build directory
+#else
+  // Don't allow this in release builds
+  unsetenv("LC_PATH");
 #endif
 
 ////@begin PWSafeApp member initialisation
@@ -282,15 +287,10 @@ bool PWSafeApp::OnInit()
 {
   // Initialize the WX UI locale to the desktop configured default.
   // According to the wx documentation, this also calls setlocale() on
-  // Unix/Linux wxGTK platforms...
+  // Unix/Linux wxGTK platforms, but not on macOS.
+  // This should suffice until we set the users' preferred language a bit later....
   wxUILocale::UseDefault();
   m_wxUILocaleIsSet = true;
-
-  // ...but not on macOS.  This should be good enough until we set the
-  // users' preferred language a bit later....
-#if defined(__WXMAC__)
-  setMacLocale("");
-#endif
 
   //Used by help subsystem
   wxFileSystem::AddHandler(new wxArchiveFSHandler);
@@ -693,17 +693,19 @@ bool PWSafeApp::ActivateLanguage(wxLanguage language, bool tryOnly)
       }
       envString += ".UTF-8";
       wxUILocale::UseLocaleName(envString);
+      
 #ifdef __WXMAC__
       setMacLocale(envString);
 #endif // __WXMAC__
+
 #else // wxCHECK_VERSION
-#warning "Improved locale logic requires wxWidgets 3.2.2 or above"
       wxString envString = langInfo->CanonicalRef;
       if (envString.empty()) {
         envString = langInfo->CanonicalName;
       }
       wxUILocale::UseLocaleName(envString + ".UTF-8");
 #endif // wxCHECK_VERSION
+      pws_os::Trace(L"Current libc locale is: %s", setlocale(LC_ALL, NULL));
     }
   }
   return bRes;
@@ -726,7 +728,6 @@ void PWSafeApp::setMacLocale(const char *loc)
   if (major == 11 || (major == 12 && minor < 3)) {
     setlocale(LC_NUMERIC, "C");
   }
-  pws_os::Trace(L"Current locale is: %s", setlocale(LC_ALL, NULL));
 }
 
 // This enables file unlock and UI restore upon left-click of the dock icon.

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -234,7 +234,7 @@ void PWSafeApp::Init()
 ////@end PWSafeApp member initialisation
 }
 
-#if defined(_DEBUG) || defined(DEBUG)
+#if defined(__WXDEBUG__)
 void PWSafeApp::OnAssertFailure(const wxChar *file, int line, const wxChar *func,
                 const wxChar *cond, const wxChar *msg)
 {

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -288,7 +288,7 @@ bool PWSafeApp::OnInit()
    * In LOCALE_WX322, this initializes the WX UI locale to the desktop
    * configured default. According to the wx documentation, this also calls
    * setlocale() on Unix/Linux wxGTK platforms, but not on macOS.
-   * In old locale it just returns false, wxLocale::Init happens later.
+   * In old locale mode it always returns false; wxLocale::Init happens later.
    * This should suffice until we set the user's preferred language a bit later....
    */
   m_PWSLocaleIsSet = PWSLocale::UseDefault();

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -36,7 +36,6 @@
 ////@end forward declarations
 class wxTimer;
 class PasswordSafeFrame;
-class wxLocale;
 
 /*!
  * Control identifiers
@@ -75,6 +74,7 @@ public:
 
 ////@begin PWSafeApp event handler declarations
 #ifdef __WXMAC__
+  void setMacLocale(const char *loc);
   virtual void MacReopenApp() wxOVERRIDE;
   virtual void MacNewFile() wxOVERRIDE;
   virtual void MacOpenFiles(const wxArrayString& fileNames) wxOVERRIDE;
@@ -118,7 +118,6 @@ private:
   WX_DECLARE_STRING_HASH_MAP(wxString, StringToStringMap);
   StringToStringMap &GetHelpMap();
   wxIconBundle m_appIcons;
-  wxLocale *m_locale; // set in Init(), deleted in d'tor, unused elsewhere
   wxString helpFileNamePath;
   bool isHelpActivated;
   bool ActivateHelp(wxLanguage language);
@@ -128,6 +127,7 @@ private:
   bool m_cmd_minimized;
   bool m_file_in_cmd = false;
   bool m_initComplete = false;
+  bool m_wxUILocaleIsSet = false;
   void FinishInit();
 
 public:
@@ -138,7 +138,6 @@ public:
   wxLanguage GetSystemLanguage();
   wxLanguage GetSelectedLanguage();
   PasswordSafeFrame* GetPasswordSafeFrame() { return m_frame; }
-  wxString GetLocaleShortDateFormat() const { return m_locale ? m_locale->GetInfo(wxLOCALE_SHORT_DATE_FMT) : wxString(); }
 };
 
 /*!

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -67,7 +67,7 @@ public:
   virtual bool OnInit() wxOVERRIDE;
 
   /// Handle asserts without showing the assert dialog until locale is initialized.
-#if defined(_DEBUG) || defined(DEBUG)
+#if defined(__WXDEBUG__)
   virtual void OnAssertFailure(const wxChar *file, int line, const wxChar *func, const wxChar *cond, const wxChar *msg) wxOVERRIDE;
 #endif
   /// Called on exit

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -26,7 +26,8 @@
 #include "SafeCombinationEntryDlg.h"
 ////@end includes
 #include "core/PWScore.h"
-#include "./RecentDbList.h"
+#include "RecentDbList.h"
+#include "PWSLocale.h"
 
 /*!
  * Forward declarations
@@ -43,42 +44,6 @@ class PasswordSafeFrame;
 
 ////@begin control identifiers
 ////@end control identifiers
-
-// wx3.2.2 and later can use wxUILocale and some improved logic
-#if wxCHECK_VERSION(3, 2, 2)
-#define LOCALE_WX322
-#endif
-
-class PWSMacLocale
-{
-public:
-#ifdef __WXMAC__
-  static void setMacLocale(const char *loc);
-#else
-  static void setMacLocale([[maybe_unused]] const char *loc) {}; // no-op if not macOS
-#endif
-};
-
-#ifdef LOCALE_WX322
-#include <wx/uilocale.h>
-
-  class PWSLocale : public wxUILocale, public PWSMacLocale
-  {
-  public:
-    static wxString PWSGetCurrentName() { return wxUILocale::GetCurrent().GetName(); };
-  };
-
-#else // wxCHECK_VERSION
-
-  // Pre-wx3.2.2 compatible version
-  class PWSLocale : public wxLocale, public PWSMacLocale
-  {
-  public:
-    PWSLocale() {};
-    static bool UseDefault() { return false; }; //no-op for compatibility
-    wxString PWSGetCurrentName() { return wxLocale::GetCanonicalName(); };
-  };
-#endif // wxCHECK_VERSION
 
 /*!
  * PWSafeApp class declaration

--- a/src/ui/wxWidgets/PWSafeApp.h
+++ b/src/ui/wxWidgets/PWSafeApp.h
@@ -44,6 +44,42 @@ class PasswordSafeFrame;
 ////@begin control identifiers
 ////@end control identifiers
 
+// wx3.2.2 and later can use wxUILocale and some improved logic
+#if wxCHECK_VERSION(3, 2, 2)
+#define LOCALE_WX322
+#endif
+
+class PWSMacLocale
+{
+public:
+#ifdef __WXMAC__
+  static void setMacLocale(const char *loc);
+#else
+  static void setMacLocale([[maybe_unused]] const char *loc) {}; // no-op if not macOS
+#endif
+};
+
+#ifdef LOCALE_WX322
+#include <wx/uilocale.h>
+
+  class PWSLocale : public wxUILocale, public PWSMacLocale
+  {
+  public:
+    static wxString PWSGetCurrentName() { return wxUILocale::GetCurrent().GetName(); };
+  };
+
+#else // wxCHECK_VERSION
+
+  // Pre-wx3.2.2 compatible version
+  class PWSLocale : public wxLocale, public PWSMacLocale
+  {
+  public:
+    PWSLocale() {};
+    static bool UseDefault() { return false; }; //no-op for compatibility
+    wxString PWSGetCurrentName() { return wxLocale::GetCanonicalName(); };
+  };
+#endif // wxCHECK_VERSION
+
 /*!
  * PWSafeApp class declaration
  */
@@ -74,7 +110,6 @@ public:
 
 ////@begin PWSafeApp event handler declarations
 #ifdef __WXMAC__
-  void setMacLocale(const char *loc);
   virtual void MacReopenApp() wxOVERRIDE;
   virtual void MacNewFile() wxOVERRIDE;
   virtual void MacOpenFiles(const wxArrayString& fileNames) wxOVERRIDE;
@@ -127,7 +162,8 @@ private:
   bool m_cmd_minimized;
   bool m_file_in_cmd = false;
   bool m_initComplete = false;
-  bool m_wxUILocaleIsSet = false;
+  bool m_PWSLocaleIsSet = false;
+  PWSLocale *m_locale = nullptr;
   void FinishInit();
 
 public:


### PR DESCRIPTION
Resolves #1711
Related to #1712

I’m posting this as a draft in the hope of getting more testing, especially in non-english locales and unusual language/locale combinations.

This is a re-work of the locale selection code.  Per current recommendations it replaces wxLocale with wxUILocale which separates language selection from locale selection.  (The use of wxTranslations to select the language is largely unchanged.)  It also tries to keep the WX UI and C library locales in sync.  This is particularly problematic on macOS, but applies to Unix/Linux as well.  Also addresses a date format problem seen while testing with wx3.3.x on macOS (it always used d/m/y format)

Some of the trouble stems from pwsafe setting the language (e.g. en, fr, etc.) then wxLocale chooses a default locale for it (en_GB for English), which may not be what the user wants, especially the date format.  This code will use the user’s system configured locale (region code e.g. US or GB), provided the language part matches (en).

wxUILocale first appeared in wx3.1.6 and some of the logic requires 3.2.2.  Pwsafe still supports some older distros that have 3.0.5 (e.g. Ubuntu 22).  As it happens, most of the work is done with static class member functions that are the same between the two classes.  That allows for an implementation that defines a new class, PWSLocale, that is derived from either wxLocale or wxUILocale, depending on the WX version used for the build, thus allowing compatibility with the “old style” while minimizing the use of ifdef’s in the code.  Builds using a WX version prior to 3.2.2 should behave the same as before.

A few highlights:
- Existing macOS code to select an appropriate locale based on the selected language, system settings, and environment variables now applies to all platforms with wx3.2.2 or newer.
- As a side effect, this resolved an issue of German language dialogs in older versions of macOS. Issue #1711
- Disabled the ability to use the LC_PATH environment variable to locate language catalog files in Release builds
- Revised some Xcode project debug settings

macOS known issue:
- Per the wxWidgets documentation: wxUILocale and setlocale do not affect macOS native controls, e.g. date picker, and the system locale cannot be changed by the application.  If necessary, a Mac user can set the system settings as desired or use the defaults command to set the locale specifically for pwsafe.  Note, the language part needs to match the pwsafe language selection.  For example, to use Pwsafe in French, but with Canadian date format, while the system is set to en_US, use the following two commands: 
```
defaults write org.pwsafe.pwsafe AppleLocale fr_CA.   # The CA region is used 
defaults write org.pwsafe.pwsafe AppleLanguages '("fr-CA”)’   # (- instead of _) The fr language is used 
```

Then, within Pwsafe, select French for the language.

Tested on:
```
macOS M1Max 15.7.9 Sequoia,                 Xcode 16.4, wx 3.2.10, 3.2.11, and 3.3.3.1
FreeBSD 15.1 ARM64 VMware,   KDE/X11,       clang 19.1.7, wx 3.2.8.1, GTK 3.24.52
Fedora 44 ARM64 VMware,      KDE/Wayland,   gcc 16.1.1, wx 3.2.9, GTK 3.24.52
Ubuntu 24.04.4 ARM64 VMware, Gnome/Wayland, gcc 13.3.0, wx 3.2.4, GTK 3.24.41

```