### PR TITLE
Linux: repaint tray icon on next interaction after a transient IsAvailable() drop

### DIFF
--- a/src/ui/wxWidgets/SystemTray.cpp
+++ b/src/ui/wxWidgets/SystemTray.cpp
@@ -90,12 +90,13 @@ SystemTray::SystemTray(PasswordSafeFrame* frame) : m_TrayIconWithOverlay(false),
 
 void SystemTray::SetTrayStatus(TrayStatus status)
 {
+  if (m_inSetTrayStatus)
+    return;
+  m_inSetTrayStatus = true;
+
   m_status = status;
 
-  if (!IsTaskBarIconAvailable())
-    return;
-
-  if (PWSprefs::GetInstance()->GetPref(PWSprefs::UseSystemTray)) {
+  if (IsTaskBarIconAvailable() && PWSprefs::GetInstance()->GetPref(PWSprefs::UseSystemTray)) {
      switch(status) {
        case TrayStatus::CLOSED:
          SetIcon(m_IconClosed, wxTheApp->GetAppName());
@@ -113,6 +114,8 @@ void SystemTray::SetTrayStatus(TrayStatus status)
          break;
      }
   }
+
+  m_inSetTrayStatus = false;
 }
 
 wxMenu* SystemTray::RepopulateMenu(wxMenu* menu)
@@ -203,10 +206,12 @@ wxMenu* SystemTray::GetPopupMenu()
   // Also deliberately does not re-run SetTrayStatus() the way the other
   // handlers do to self-heal a stale icon: this is called *from inside*
   // SetIcon() itself (via SetTrayStatus() -> SetIcon() -> here), so doing
-  // so would recurse. It's also moot here either way - opening the menu
-  // under this backend never reaches this method in the first place (the
-  // shell renders it from a one-time D-Bus export, with no callback into
-  // the app), so there's no interaction to catch.
+  // so would recurse (m_inSetTrayStatus guards against that actually
+  // happening, but it's not a reason to add the call - see below). It's
+  // also moot here either way - opening the menu under this backend never
+  // reaches this method in the first place (the shell renders it from a
+  // one-time D-Bus export, with no callback into the app), so there's no
+  // interaction to catch.
   m_sniMenu = RepopulateMenu(m_sniMenu);
   return m_sniMenu;
 }

--- a/src/ui/wxWidgets/SystemTray.cpp
+++ b/src/ui/wxWidgets/SystemTray.cpp
@@ -264,6 +264,13 @@ void SystemTray::OnSysTrayMenuItem(wxCommandEvent& evt)
 {
   EventHandlerDisabler ehd(this);
 
+  // IsTaskBarIconAvailable() can transiently report false (e.g. while the
+  // screen is DPMS-blanked), which makes SetTrayStatus() skip SetIcon()
+  // and leave the icon/menu stale once availability returns, since nothing
+  // else re-triggers a repaint. Re-run it here so the icon self-heals the
+  // next time the user actually interacts with it, without polling.
+  SetTrayStatus(m_status);
+
   const int id = evt.GetId();
   if (IsRUECommand(id)) {
     RUEOperation opn = GetRUEOperation(id);
@@ -363,5 +370,8 @@ void SystemTray::ProcessSysTrayMenuItem(int itemId)
 
 void SystemTray::OnTaskBarLeftDoubleClick(wxTaskBarIconEvent& WXUNUSED(evt))
 {
+  // See the comment in OnSysTrayMenuItem() re: self-healing a stale icon.
+  SetTrayStatus(m_status);
+
   wxTheApp->CallAfter([this](){ ProcessSysTrayMenuItem(ID_SYSTRAY_RESTORE); });
 }

--- a/src/ui/wxWidgets/SystemTray.cpp
+++ b/src/ui/wxWidgets/SystemTray.cpp
@@ -169,6 +169,13 @@ wxMenu* SystemTray::RepopulateMenu(wxMenu* menu)
 //virtual
 wxMenu* SystemTray::CreatePopupMenu()
 {
+  // Reached on right-click when there's no AppIndicator/SNI backend (e.g.
+  // wxUSE_APPINDICATOR isn't even compiled in, as on stock Fedora 42's
+  // wx 3.2). See the comment in OnSysTrayMenuItem() re: self-healing a
+  // stale icon; safe here since, unlike GetPopupMenu(), this isn't also
+  // called internally by SetIcon() on every SetTrayStatus().
+  SetTrayStatus(m_status);
+
   wxMenu* menu = RepopulateMenu(nullptr);
 
   // whe there are active modal dialogs, we need to reparent menu, so it could process context menu events
@@ -192,6 +199,14 @@ wxMenu* SystemTray::GetPopupMenu()
   // the same instance reused/repopulated rather than a fresh one each
   // time. Deliberately does not go through CreatePopupMenu(), whose
   // reparent-and-display-now logic exists only for actual click handling.
+  //
+  // Also deliberately does not re-run SetTrayStatus() the way the other
+  // handlers do to self-heal a stale icon: this is called *from inside*
+  // SetIcon() itself (via SetTrayStatus() -> SetIcon() -> here), so doing
+  // so would recurse. It's also moot here either way - opening the menu
+  // under this backend never reaches this method in the first place (the
+  // shell renders it from a one-time D-Bus export, with no callback into
+  // the app), so there's no interaction to catch.
   m_sniMenu = RepopulateMenu(m_sniMenu);
   return m_sniMenu;
 }

--- a/src/ui/wxWidgets/SystemTray.h
+++ b/src/ui/wxWidgets/SystemTray.h
@@ -66,6 +66,11 @@ class SystemTray : public wxTaskBarIcon
     wxIcon m_IconUnlockedWithID, m_IconLockedWithID;
     PasswordSafeFrame* m_frame;
     TrayStatus m_status;
+    // Guards against SetTrayStatus() recursing into itself - e.g. if it
+    // were ever called from within GetPopupMenu(), which SetTrayStatus()
+    // can itself trigger via SetIcon(). Not currently reachable, but cheap
+    // insurance against a future change accidentally introducing it.
+    bool m_inSetTrayStatus = false;
 #if wxUSE_APPINDICATOR
     // Kept alive for wx's AppIndicator backend (GetPopupMenu()'s contract:
     // the returned menu is never destroyed by wx). Deliberately not deleted


### PR DESCRIPTION
## Summary
Fixes #1905. `SetTrayStatus()` re-checks `IsTaskBarIconAvailable()` on
every call but skips `SetIcon()` when it's false, and never gets called
again once availability returns (since the tracked status itself didn't
change) — leaving the tray icon showing stale state, e.g. after the
screen is DPMS-blanked during idle-timeout auto-lock.

Per the discussion on the issue, this implements the "repaint on next
natural event" option: `SetTrayStatus(m_status)` is re-run at the top of
the handlers that only fire when the user actually interacts with the
tray icon, so the icon self-heals without caching `IsAvailable()`'s
result (which risks the crash `77c1814a2` fixed) or adding a recurring
polling timer.

Which handlers are reachable depends on the backend:
- `OnTaskBarLeftDoubleClick()` and `OnSysTrayMenuItem()` cover
  double-click and menu-item selection on every backend.
- `CreatePopupMenu()` additionally covers right-click, but only when
  there's no AppIndicator/SNI backend in play — e.g. stock Fedora 42's
  wx 3.2, which doesn't compile in `wxUSE_APPINDICATOR` at all. On that
  path, `wxTaskBarIconBase::OnRightButtonDown()` falls back to
  `CreatePopupMenu()` since `GetPopupMenu()` isn't overridden.

Right-click can *not* be caught this way under the AppIndicator/SNI
backend itself (e.g. wx 3.3 on Wayland): the menu is exported once via
a one-time D-Bus dump inside `app_indicator_set_menu()`, and the shell
renders it from that without ever calling back into the app —
`GetPopupMenu()` is only invoked internally by `SetIcon()`, never by an
actual click. So on that backend, a stale icon only self-heals via
double-click or by actually selecting a menu item, not by merely
opening the menu with a right-click. (The AppIndicator/StatusNotifierItem
protocol has no hover/mouse-move signal at all either — only
`Activate`/`SecondaryActivate`/`Scroll` — so there's no better hook
available there.)

## Test plan
- [x] Clean mock build against stock Fedora 42 repo packages
- [x] Clean mock build overlaying wx 3.3.4-4 + libayatana-appindicator 0.6.0-1
- [x] Manual repro on Wayland (wx 3.3/AppIndicator): locked DB via
      idle-timeout while screen was DPMS-blanked, woke the screen,
      confirmed the icon stayed stale until double-clicking, at which
      point it repainted correctly
- [x] Manual repro on Fedora 42 (no AppIndicator): confirmed left-click
      and right-click (opening the menu) both repaint a stale icon