### PR TITLE
[wx] Fix warnings from FreeBSD

### DIFF
--- a/src/os/unix/KeySend.cpp
+++ b/src/os/unix/KeySend.cpp
@@ -38,7 +38,7 @@ static Ret GetPref(PrefEnum pref) {
   return PWSprefs::GetInstance()->GetPref(pref);
 }
 
-static pws_os::AutotypeMethod DefaultAutytypeMethod() {
+static pws_os::AutotypeMethod DefaultAutotypeMethod() {
   return GetPref(PWSprefs::UseAltAutoType)? pws_os::ATMETHOD_XTEST: pws_os::ATMETHOD_XSENDKEYS;
 }
 
@@ -46,7 +46,7 @@ static pws_os::AutotypeMethod DefaultAutytypeMethod() {
 // CKeySend - The generic implementation
 CKeySend::CKeySend(bool, unsigned defaultDelay)
   : m_delayMS(defaultDelay),
-    m_impl(new CKeySendImpl(DefaultAutytypeMethod()))
+    m_impl(new CKeySendImpl(DefaultAutotypeMethod()))
 {
 }
 

--- a/src/os/unix/KeySend.cpp
+++ b/src/os/unix/KeySend.cpp
@@ -16,7 +16,7 @@
 #include "../../core/PWSprefs.h"
 
 template <typename EnumType>
-class PrefT;
+struct PrefT;
 
 template <>
 struct PrefT<PWSprefs::BoolPrefs> {

--- a/src/ui/wxWidgets/QREncode.cpp
+++ b/src/ui/wxWidgets/QREncode.cpp
@@ -65,7 +65,7 @@ wxBitmap QRCodeBitmap( const StringX &data )
 
 	// This converts a line of QR data to a line of scaled-up pixels
 	// The last bit of QR byte, if 0 => white, else black
-	auto qr2xbmp = [&qc, scale](int line) {
+	auto qr2xbmp = [&qc](int line) {
 		vector<char> pixels(qc->width*scale/8);
 		auto fill_index = pixels.begin();
 		auto from = qc->data + line*qc->width;


### PR DESCRIPTION
This fixes two warnings that I only see when I compile on FreeBSD:
`FreeBSD 15.1 ARM64 VMware, KDE/X11, clang 19.1.7, wx 3.2.8.1, GTK 3.24.52`

```
pwsafe/src/os/unix/KeySend.cpp:22:1: warning: 'PrefT' defined as a struct template here but previously declared as a class template; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
   22 | struct PrefT<PWSprefs::BoolPrefs> {
      | ^
pwsafe/src/os/unix/KeySend.cpp:19:1: note: did you mean struct here?
   19 | class PrefT;
      | ^~~~~
      | struct

```

```
pwsafe/src/ui/wxWidgets/QREncode.cpp:68:23: warning: lambda capture 'scale' is not required to be captured for this use [-Wunused-lambda-capture]
   68 |         auto qr2xbmp = [&qc, scale](int line) {
      |                            ~~^~~~~

```