### PR TITLE
[wx] Release build fails on macOS with Yubikey disabled

### DIFF
--- a/src/ui/wxWidgets/DbSelectionPanel.h
+++ b/src/ui/wxWidgets/DbSelectionPanel.h
@@ -79,7 +79,7 @@ private:
   SafeCombinationCtrl* m_sc;
   bool m_bAutoValidate;
   PWScore* m_core;
-  int m_confirmationButtonId;
+  [[maybe_unused]] int m_confirmationButtonId;
   StringX m_yubiCombination; // needed to adjust TransferDataFromWindow()
 };
 

--- a/src/ui/wxWidgets/DbSelectionPanel.h
+++ b/src/ui/wxWidgets/DbSelectionPanel.h
@@ -79,7 +79,13 @@ private:
   SafeCombinationCtrl* m_sc;
   bool m_bAutoValidate;
   PWScore* m_core;
+#if defined(__clang__)
   [[maybe_unused]] int m_confirmationButtonId;
+#elif defined(__GNUC__)
+  int m_confirmationButtonId;
+#else
+  int m_confirmationButtonId;
+#endif
   StringX m_yubiCombination; // needed to adjust TransferDataFromWindow()
 };
 

--- a/src/ui/wxWidgets/DbSelectionPanel.h
+++ b/src/ui/wxWidgets/DbSelectionPanel.h
@@ -81,8 +81,6 @@ private:
   PWScore* m_core;
 #if defined(__clang__)
   [[maybe_unused]] int m_confirmationButtonId;
-#elif defined(__GNUC__)
-  int m_confirmationButtonId;
 #else
   int m_confirmationButtonId;
 #endif


### PR DESCRIPTION
This PR provides a fix that allows the build to compile successfully on macOS with Yubikey support disabled (Release configuration).

macOS (Release configuration) - fails with an error

% xcodebuild -project pwsafe-xcode6.xcodeproj -scheme pwsafe -configuration Release
...
In file included from /Users/ja/Documents/pwsafe/src/ui/wxWidgets/DbSelectionPanel.cpp:28:
/Users/ja/Documents/pwsafe/src/ui/wxWidgets/DbSelectionPanel.h:82:7: error: private field 'm_confirmationButtonId' is not used
      [-Werror,-Wunused-private-field]
   82 |   int m_confirmationButtonId;
      |       ^
**1 error generated.**

macOS (Debug-no-yubi configuration), FreeBSD and OpenBSD - succeeds with warning

Example - FreeBSD:
$ cmake -D wxWidgets_CONFIG_EXECUTABLE=/usr/local/bin/wxgtk3u-3.2-config -D NO_YUBI=ON ..
$ gmake
/home/ja/Documents/pwsafe/src/ui/wxWidgets/DbSelectionPanel.h:82:7: warning: private field 'm_confirmationButtonId' is not used [-Wunused-private-field]
   82 |   int m_confirmationButtonId;
      |       ^
1 warning generated.
