### PR TITLE
[help] Various fixes

### DIFF
--- a/help/default/html/display_tab.html
+++ b/help/default/html/display_tab.html
@@ -35,7 +35,7 @@ what other window may have focus.</p>
 in environments where passers-by can view the monitor.</i></p>
 
 <h3>Show Notes as ToolTips in Tree &amp; List Views</h3>
-<p>If checked, the notes of an hovered item will be shown.</p>
+<p>If checked, the notes of a hovered item will be shown.</p>
 
 <h3>Show password in Add &amp; Edit</h3>
 

--- a/help/default/html/preferences.html
+++ b/help/default/html/preferences.html
@@ -381,6 +381,7 @@ These preferences apply to all databases on a given machine by a given user.</p>
 changes to it</td>
 </tr>
 
+<tr>
 <td>ClearClipboardOnExit</td>
 <td>true</td>
 <td>Clear the clipboard of <b>Password Safe</b> information when <b>Password Safe</b>
@@ -392,7 +393,6 @@ ends</td>
 <td>true</td>
 <td>Clear the clipboard of <b>Password Safe</b> information on minimize</td>
 </tr>
-<tr>
 
 <tr>
 <td>DatabaseClear</td>

--- a/help/default_wx/html/display_tab.html
+++ b/help/default_wx/html/display_tab.html
@@ -19,8 +19,8 @@ and password items are displayed.</p>
 
 <h3>Always keep Password Safe on top</h3>
 
-<p>If checked, maximized <b>Password Safe</b> will
-always be the top most window displayed in the monitor, regardless of
+<p>If checked, <b>Password Safe</b> will
+always be the topmost window displayed in the monitor, regardless of
 what other window may have focus.</p>
 
 <h3>Show Username in Tree View</h3>
@@ -31,11 +31,11 @@ what other window may have focus.</p>
 <h3>Show Password in Tree View</h3>
 
 <p>If checked, passwords will be displayed in curly braces following the user's name in the
-<b>Nested Tree</b> view. <i>However, this option is <b>strongly</b> discouraged
+<b>Nested Tree</b> view. <i>This option is <b>strongly</b> discouraged
 in environments where passers-by can view the monitor.</i></p>
 
 <h3>Show Notes as ToolTips in Tree &amp; List Views</h3>
-<p>If checked, notes to an hovered item will be shown.</p>
+<p>If checked, the notes of an hovered item will be shown.</p>
 
 <h3>Show password in Add &amp; Edit</h3>
 
@@ -51,8 +51,8 @@ there.</p>
 
 <h3>Word Wrap Notes in Add &amp; Edit</h3>
 
-<p>If checked, the words will automatically be wrapped in the window, without an horizontal scroll bar. 
-If not checked, an horizontal scroll bar will appear, if necessary.</p>
+<p>If checked, the words will automatically be wrapped in the window, without a horizontal scroll bar. 
+If not checked, a horizontal scroll bar will appear, if necessary.</p>
 
 <h3>Put Groups first in Tree View</h3>
 
@@ -74,6 +74,10 @@ expiration date is <i>N</i> days or less from the current date.</p>
 <h3>Show Text in Toolbar</h3>
 
 <p>If checked, labels for Toolbar icons are shown.</p>
+
+<h3>Show Alias Selection in Add &amp; Edit</h3>
+
+<p>If checked, the Alias To... button is displayed on the Basic tab of the dialog window, which allows one entry to reference another entry's password instead of duplicating the same password.</p>
 
 <h3>Initial tree view</h3>
 

--- a/help/default_wx/html/display_tab.html
+++ b/help/default_wx/html/display_tab.html
@@ -35,7 +35,7 @@ what other window may have focus.</p>
 in environments where passers-by can view the monitor.</i></p>
 
 <h3>Show Notes as ToolTips in Tree &amp; List Views</h3>
-<p>If checked, the notes of an hovered item will be shown.</p>
+<p>If checked, the notes of a hovered item will be shown.</p>
 
 <h3>Show password in Add &amp; Edit</h3>
 

--- a/help/default_wx/html/misc_tab.html
+++ b/help/default_wx/html/misc_tab.html
@@ -36,7 +36,7 @@ viewed, etc.). The time is stored with the entry, and may be viewed in the entry
 when no entry was edited. This means you may be prompted to save the
 database upon exit, even though you didn't explicitly change anything.</li>
 
-<li>When the database is opened in read-only mode, access times are
+<li>When the database is opened in read-only mode, this setting is ignored, and access times are
 <b>not</b> updated.</li>
 </ul>
 </small>
@@ -45,15 +45,15 @@ database upon exit, even though you didn't explicitly change anything.</li>
 
 <p>When checked, <b>Esc</b> can be used to close <b>Password Safe</b>
 when the program is maximized. Note that if the System Tray is enabled
-(via the Put Icon in System Tray option), then <b>Esc</b> just closes
+(via the Put Icon in System Tray option on the System tab), then <b>Esc</b> just closes
 the main window, which can be re-opened by double-clicking on the icon
 in the System Tray.</p>
 
-<h3>Double click action</h3>
+<h3>Double click and Shift double click action</h3>
 
 <p>This allows you to define what action <b>Password Safe</b> will take when
-you double-click on an entry. The default is to copy the entry's
-password to the clipboard. &nbsp;The available actions are:</p>
+you double-click (shift+double-click) on an entry. The default is to copy the entry's
+password to the clipboard. The available actions are:</p>
 
 <ul>
 <li>AutoType</li>
@@ -99,7 +99,6 @@ default. Of course, you can edit it if needed.<br></p>
 if your default browser is Firefox, and you wish to access a website that works best with Google Chrome. 
 Or, on Linux with Wayland, you may specify a startup sequence that enables the Xwayland backend for the default browser, 
 allowing Autotype to work (such as "env MOZ_ENABLE_WAYLAND=0 firefox" for Firefox).</p>
-
 
 <p>You can specify command line options to the browser via the Browser
 command line parameters field. Do <b>not</b> enclose this value in single or

--- a/help/default_wx/html/preferences.html
+++ b/help/default_wx/html/preferences.html
@@ -357,6 +357,7 @@ These preferences apply to all databases on a given machine by a given user.</p>
 changes to it</td>
 </tr>
 
+<tr>
 <td>ClearClipboardOnExit</td>
 <td>true</td>
 <td>Clear the clipboard of <b>Password Safe</b> information when <b>Password Safe</b>
@@ -368,7 +369,6 @@ ends</td>
 <td>true</td>
 <td>Clear the clipboard of <b>Password Safe</b> information on minimize</td>
 </tr>
-<tr>
 
 <tr>
 <td>DatabaseClear</td>

--- a/help/pwsafeRU/html/preferences.html
+++ b/help/pwsafeRU/html/preferences.html
@@ -338,6 +338,7 @@
 <td>Создавать резервные копии при сохранении контейнера</td>
 </tr>
 
+<tr>
 <td>ClearClipboardOnExit</td>
 <td>true</td>
 <td>Очищать буфер обмена при завершении работы <b>Password Safe</b><b></b></td>
@@ -348,7 +349,6 @@
 <td>true</td>
 <td>Очищать буфер обмена при сворачивании <b>Password Safe</b></td>
 </tr>
-<tr>
 
 <tr>
 <td>DatabaseClear</td>

--- a/help/pwsafeSK/html/misc_tab.html
+++ b/help/pwsafeSK/html/misc_tab.html
@@ -41,7 +41,7 @@ To znamená, že pri ukončení aplikácie sa môže zobraziť výzva na uložen
 <h3>Kláves Esc ukončí aplikáciu</h3>
 
 <p>Ak je začiarknuté, kláves <b>Esc</b> sa dá použiť na zatvorenie aplikácie keď je maximalizovaná. 
-Avšak, ak je zapnutý System Tray (prostredníctvom nastavenia "Pridať ikonu na panel úloh" na karte "Systém"), 
+Avšak, ak je zapnutý System Tray (prostredníctvom nastavenia "Pridať ikonu do systémovej lišty" na karte "Systém"), 
 potom kláves <b>Esc</b> iba zatvorí hlavné okno, a je možné ho znova otvoriť dvojitým kliknutím na ikonu v systémovej lište.</p>
 
 <h3>Akcia pri dvojkliku</h3>

--- a/help/pwsafeSK/html/preferences.html
+++ b/help/pwsafeSK/html/preferences.html
@@ -361,6 +361,7 @@ Tieto predvoľby sa vzťahujú na všetky databázy na danom počítači a pre d
 <td>Pred uložením akýchkoľvek zmien v databáze premenuje aktuálnu databázu podľa nastavení záloh</td>
 </tr>
 
+<tr>
 <td>ClearClipboardOnExit</td>
 <td>true</td>
 <td>Vymazať schránku informácií z <b>Password Safe</b> pri končení programu</b>
@@ -372,7 +373,6 @@ ends</td>
 <td>true</td>
 <td>Vymazať schránku informácií z <b>Password Safe</b> pri minimalizácii programu</td>
 </tr>
-<tr>
 
 <tr>
 <td>DatabaseClear</td>

--- a/help/pwsafeSK_wx/html/display_tab.html
+++ b/help/pwsafeSK_wx/html/display_tab.html
@@ -20,7 +20,7 @@
 
 <h3>Ponechať okno programu vždy navrchu</h3>
 
-<p>Ak je začiarknuté, maximalizované <b>Password Safe</b> bude
+<p>Ak je začiarknuté, okno <b>Password Safe</b> bude
 vždy najvyššie zobrazené okno na monitore, bez ohľadu na to
 ktoré iné okno môže byť vybraté.</p>
 
@@ -60,13 +60,17 @@ Keď je táto možnosť vybratá, všetky skupiny sa zobrazia ako prvé (v abece
 
 <h3>Upozorniť <i>N</i> dní pred vypršaním platnosti hesla</h3>
 
-<p>Ak je zaškrtnuté, <b>Password Safe</b> bude pri čítaní databázy skenovať všetky záznamy
+<p>Ak je začiarknuté, <b>Password Safe</b> bude pri čítaní databázy skenovať všetky záznamy
 (zvyčajne pri spustení) a zobrazí zoznam záznamov, ktorých
 dátum vypršania platnosti je <i>N</i> dní alebo menej od aktuálneho dátumu.</p>
 
 <h3>Zobraziť text v paneli nástrojov</h3>
 
 <p>Ak je začiarknuté, tak ikony na paneli nástrojov majú názvy s popisom činnosti.</p>
+
+<h3>Zobraziť výber aliasu pri zobrazení záznamu</h3>
+
+<p>Ak je začiarknuté, na karte Základné v dialógovom okne "Pridať, upraviť alebo zobraziť záznam" sa zobrazí tlačidlo Alias ​​pre... ktoré umožní inému záznamu odkazovať sa na heslo iného záznamu namiesto duplikovania toho istého hesla.</p>
 
 <h3>Počiatočný vzhľad stromu</h3>
 

--- a/help/pwsafeSK_wx/html/images.html
+++ b/help/pwsafeSK_wx/html/images.html
@@ -32,20 +32,20 @@
 <p class="indented"><img src="images/normal.png"/>&nbsp;Normálny záznam</p>
 <p class="indented"><img src="images/abase.png"/>&nbsp;Normálny záznam s aliasmi</p>
 <p class="indented"><img src="images/sbase.png"/>&nbsp;Normálny záznam s odkazmi</p>
-<p class="indented"><img src="images/alias.png"/>Alias</p>
-<p class="indented"><img src="images/shortcut.png"/>Odkaz</p>
+<p class="indented"><img src="images/alias.png"/>&nbsp;Alias</p>
+<p class="indented"><img src="images/shortcut.png"/>&nbsp;Odkaz</p>
 
 <p>Okrem toho môže mať normálny záznam k heslu zadaný dátum vypršania platnosti. Ak používateľ zadá interval upozornenia, tak napr. 5 dní pred vypršaním platnosti hesla sa zobrazený obrázok zmení na čiastočne fialový.</p>
 
-<p class="indented"><img src="images/normal_warn.png"/>Normálny záznam - platnosť hesla vyprší v rámci používateľom zadaného intervalu</p>
-<p class="indented"><img src="images/abase_warn.png"/>Normálny záznam s aliasmi - platnosť hesla vyprší v rámci používateľom zadaného intervalu</p>
-<p class="indented"><img src="images/sbase_warn.png"/>Normálny záznam s odkazmi - platnosť hesla vyprší v rámci používateľom zadaného intervalu</p>
+<p class="indented"><img src="images/normal_warn.png"/>&nbsp;Normálny záznam - platnosť hesla vyprší v rámci používateľom zadaného intervalu</p>
+<p class="indented"><img src="images/abase_warn.png"/>&nbsp;Normálny záznam s aliasmi - platnosť hesla vyprší v rámci používateľom zadaného intervalu</p>
+<p class="indented"><img src="images/sbase_warn.png"/>&nbsp;Normálny záznam s odkazmi - platnosť hesla vyprší v rámci používateľom zadaného intervalu</p>
 
 <p>Po vypršaní platnosti bude celé fialové.<p>
 
-<p class="indented"><img src="images/normal_exp.png"/>Normálny záznam - platnosť hesla vypršala</p>
-<p class="indented"><img src="images/abase_exp.png"/>Normálny záznam s aliasmi - platnosť hesla vypršala</p>
-<p class="indented"><img src="images/sbase_exp.png"/>Normálny záznam s odkazmi - platnosť hesla vypršala</p>
+<p class="indented"><img src="images/normal_exp.png"/>&nbsp;Normálny záznam - platnosť hesla vypršala</p>
+<p class="indented"><img src="images/abase_exp.png"/>&nbsp;Normálny záznam s aliasmi - platnosť hesla vypršala</p>
+<p class="indented"><img src="images/sbase_exp.png"/>&nbsp;Normálny záznam s odkazmi - platnosť hesla vypršala</p>
 
 <!-- Added some white space at the bottom for natural scrolling -->
 <br>

--- a/help/pwsafeSK_wx/html/misc_tab.html
+++ b/help/pwsafeSK_wx/html/misc_tab.html
@@ -41,7 +41,7 @@ To znamená, že pri ukončení aplikácie sa môže zobraziť výzva na uložen
 <h3>Kláves Esc ukončí aplikáciu</h3>
 
 <p>Ak je začiarknuté, kláves <b>Esc</b> sa dá použiť na zatvorenie aplikácie keď je maximalizovaná. 
-Avšak, ak je zapnutý System Tray (prostredníctvom nastavenia "Pridať ikonu na panel úloh" na karte "Systém"), 
+Avšak, ak je zapnutý System Tray (prostredníctvom nastavenia "Pridať ikonu do systémovej lišty" na karte "Systém"), 
 potom kláves <b>Esc</b> iba zatvorí hlavné okno, a je možné ho znova otvoriť dvojitým kliknutím na ikonu v systémovej lište.</p>
 
 <h3>Akcia pri dvojkliku</h3>

--- a/help/pwsafeSK_wx/html/preferences.html
+++ b/help/pwsafeSK_wx/html/preferences.html
@@ -344,6 +344,7 @@ Tieto predvoľby sa vzťahujú na všetky databázy na danom počítači a pre d
 <td>Pred uložením akýchkoľvek zmien v databáze premenuje aktuálnu databázu podľa nastavení záloh</td>
 </tr>
 
+<tr>
 <td>ClearClipboardOnExit</td>
 <td>true</td>
 <td>Vymazať schránku informácií z <b>Password Safe</b> pri končení programu</b>
@@ -355,7 +356,6 @@ ends</td>
 <td>true</td>
 <td>Vymazať schránku informácií z <b>Password Safe</b> pri minimalizácii programu</td>
 </tr>
-<tr>
 
 <tr>
 <td>DatabaseClear</td>


### PR DESCRIPTION
This PR is to modify Help for both Windows and wx versions.

Changes:
-Fixed unclosed and missing tags (preferences.html)
-Fixed translation to be aligned with the GUI (Slovak - misc_tab.html)
-Synced wx Help with the Windows version (display_tab.html and misc_tab.html)
-Added text describing Linux specific features (Show Alias Selection in display_tab.html)
-Added missing non-breaking space lost in translation (Slovak - images.html)

Unclosed and missing tags in preferences.html are visible only in the wx version. On Windows, the browser engine seems to ignore these errors, so the issue went unnoticed for so long.

<img width="2814" height="1678" alt="pwsafe_1 25-wxWidgets-bug-Help-prefs_table-01" src="https://github.com/user-attachments/assets/cfcac937-449b-4eba-b7b8-12159ce114e5" />

