### PR TITLE
[wx] Fix for assertions during drag-and-drop operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ endif(HAVE_YKPERS_H)
 if (NOT MSVC)
    # Following is because (a) -O3 breaks the test and application, and
    # (b) -O3 is the default for cmake
-   set (CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG -DwxDEBUG_LEVEL=0")
+   set (CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 endif (NOT MSVC)
 
 include(pws-version)


### PR DESCRIPTION
Resolves issue #1923, related to PR #1907.

According to the wxWidgets documentation (e.g. https://docs.wxwidgets.org/3.2/group__group__funcmacro__debug.html):
Starting with wxWidgets 2.9.1, debugging support in wxWidgets is always compiled in by default, you need to explicitly define wxDEBUG_LEVEL as 0 to disable it completely. However, by default debugging macros are dormant in the release builds. 

My understanding is that wxDEBUG_LEVEL=0 can only be set when both wxWidgets and Password Safe are built together, which is true only in some cases, such as during the Flatpak build or building a package on macOS.