### PR TITLE
[wx] Release mouse before DoDragDrop

### DIFF
--- a/src/ui/wxWidgets/DragBarCtrl.cpp
+++ b/src/ui/wxWidgets/DragBarCtrl.cpp
@@ -278,6 +278,8 @@ void DragBarCtrl::OnDrag(wxAuiToolBarEvent& event)
 {
   auto toolId = event.GetToolId();
 
+  ReleaseMouse();
+  
   if (toolId == ID_DRAGBAR_DND) {
 #if wxUSE_DRAG_AND_DROP && (wxVERSION_NUMBER != 3104) // 3.1.4 is crashing in Drop, use 3.1.5 instead
     auto mainFrame = wxGetApp().GetPasswordSafeFrame();


### PR DESCRIPTION
Loosely related to #1923.

The assert message in the screenshot happens in a debug build when the very next left-click, following a drag operation, is on one of the drag bar icons.  Apparently, the mouse is left in a "captured" state following a drag operation.  When the next LeftDown event is on a drag bar button, it tries to capture the mouse again resulting in the assert message.  In a release build, the assert is disabled, but the sequence can result in erratic behavior.

To reproduce the problem:

1. Launch a debug build of pwsafe and open a safe.
2. Display the drag bar, if not already visible
3. Select an entry
4. Select one of the DB icons and drag it somewhere*
5. Important: The very next click must be on any of the DB icons
6. Observe the assert message

* You don't need to do the full DnD, just start to drag, so the icon changes, then release.

I have reproduced the problem on macOS and Fedora, but oddly not on FreeBSD.

```
macOS M1Max 15.7.9 Sequoia,                 Xcode 16.4, wx 3.2.10 (local build)
FreeBSD 15.1 ARM64 VMware,   KDE/X11,       clang 19.1.7, wx 3.2.8.1, GTK 3.24.52
Fedora 44 ARM64 VMware,      KDE/Wayland,   gcc 16.1.1, wx 3.2.9, GTK 3.24.52

```

<img width="704" height="345" alt="Screenshot 2026-08-22 at 11 14 18 AM" src="https://github.com/user-attachments/assets/5209fbdf-88c5-468e-a75e-d706449a6eaa" />
