### PR TITLE
[wx] Fix assertion during Tree DnD on Linux

### DIFF
--- a/src/ui/wxWidgets/TreeCtrl.cpp
+++ b/src/ui/wxWidgets/TreeCtrl.cpp
@@ -1407,7 +1407,7 @@ void TreeCtrl::OnBeginDrag(wxTreeEvent& evt)
       wxPoint mousePt = ScreenToClient(wxGetMousePosition());
       wxRect rect;
       GetBoundingRect(item, rect, true);
-      if(! m_drag_image->BeginDrag(mousePt - rect.GetLeftTop(), this, true)) {
+      if(! m_drag_image->BeginDrag(mousePt - rect.GetLeftTop(), this, false)) {
         pws_os::Trace(L"BeginDrag failed");
         wxDELETE(m_drag_image);
       }


### PR DESCRIPTION
Resolves issue #1923 - the problem of moving items within wxTree.
The other problems were fixed in PR #1925.

Issue (on Linux):
Gtk-CRITICAL **: gtk_widget_queue_draw: assertion 'GTK_IS_WIDGET (widget)' failed
The assert (invalid dc for wxOverlay) is a GTK‑side failure: it happens when wxGenericDragImage tries to create an overlay on a window whose underlying GDK surface cannot provide a valid Cairo context.

Fix:
Turn off the "full‑window" overlay.
The "fullScreen" parameter set to true in BeginDrag() forces an overlay over the full screen, or over as much of the screen as is specified by rect. On GTK that's exactly where the assertion comes from.
false (the default value) - This keeps the drag image local to the control and avoids the overlay path.

Tested on:
Ubuntu 22.04 + wxWidgets 3.0.5
Debian 13 (GNOME) + wxWidgets 3.2.8
macOS 15 + wxWidgets 3.2.9
FreeBSD 14.3 (KDE) + wxWidgets 3.2.8
