### PR TITLE
[wx] Fix for Help not found on FreeBSD and OpenBSD

### DIFF
--- a/src/os/unix/dir.cpp
+++ b/src/os/unix/dir.cpp
@@ -207,8 +207,8 @@ stringT pws_os::getxmldir(void)
 {
    stringT xmldir = pws_os::getenv("PWS_XMLDIR", true);
   if (xmldir.empty()) {
-#ifdef __FreeBSD__
-  xmldir = _T("/usr/local/share/pwsafe/xml/");
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+  xmldir = _T("/usr/local/share/passwordsafe/xml/");
 #else
   xmldir = _T("/usr/share/passwordsafe/xml/");
 #endif
@@ -220,8 +220,8 @@ stringT pws_os::gethelpdir(void)
 {
   stringT helpdir = pws_os::getenv("PWS_HELPDIR", true);
   if (helpdir.empty()) {
-#if defined( __FreeBSD__) || defined(__OpenBSD)
-    helpdir = _T("/usr/local/share/doc/passwordsafe/help/");
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+    helpdir = _T("/usr/local/share/passwordsafe/help/");
 #else
     helpdir = _T("/usr/share/passwordsafe/help/");
 #endif


### PR DESCRIPTION
When the CPack packaging tool is used on BSD, the paths to the Help and XML files do not match the locations expected by the functions that look for them.
This PR fixes the issue.

Example for FreeBSD:
$ cpack -G FREEBSD ..
CPack: Create package using FREEBSD
CPack: Install projects
CPack: - Run preinstall target for: passwordsafe
CPack: - Install project: passwordsafe []
CPack: Create package
CPack: Executing post-build script: CMakeModules/PostBuild.cmake
CPack: - package: passwordsafe-freebsd-1.25-amd64.pkg generated.

\# pkg add -f passwordsafe-freebsd-1.25-amd64.pkg
Installing passwordsafe-1.25...
Extracting passwordsafe-1.25: 100%
==> Running trigger: gtk-update-icon-cache.ucl
Generating GTK icon cache for /usr/local/share/icons/hicolor
==> Running trigger: desktop-file-utils.ucl
Building cache database of MIME types

Tested on:
FreeBSD 14.3 (KDE) + wxWidgets 3.2.8
OpenBSD 7.7 (GNOME) + wxWidgets 3.2.7

Attached you can find some screenshots.
<img width="1025" height="783" alt="pwsafe_1 25-wxWidgets-bug-BSD-Help_XML-01" src="https://github.com/user-attachments/assets/530baa55-a807-47bc-8417-5497cd815c72" />

Main menu > File > Import From > XML format

<img width="1033" height="787" alt="pwsafe_1 25-wxWidgets-bug-BSD-Help_XML-02" src="https://github.com/user-attachments/assets/399f396d-d27c-4b84-9663-192d696f9b16" />

