### PR TITLE
Fix missing XML schema error when reading filter files

### DIFF
--- a/src/core/PWSFilters.cpp
+++ b/src/core/PWSFilters.cpp
@@ -53,6 +53,8 @@ static const char * szentry[] = {"normal",
 static const char * szstatus[] = {"clean", "added", "modified", 
                                   "deleted"};
 
+const stringT PWSFilters::schema_filename = L"pwsafe_filter.xsd";
+
 static void GetFilterTestXML(const st_FilterRow &st_fldata,
                              ostringstream &oss, bool bFile)
 {
@@ -677,7 +679,8 @@ std::string PWSFilters::GetFilterXMLHeader(const StringX &currentfile,
     oss << "Database_uuid=\"" << huuid << "\"" << endl;
   }
   oss << "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" << endl;
-  oss << "xsi:noNamespaceSchemaLocation=\"pwsafe_filter.xsd\">" << endl;
+  utf8conv.ToUTF8(schema_filename.c_str(), utf8, utf8Len);
+  oss << "xsi:noNamespaceSchemaLocation=\"" << utf8 << "\">" << endl;
   oss << endl;
 
   return oss.str().c_str();

--- a/src/core/PWSFilters.h
+++ b/src/core/PWSFilters.h
@@ -371,6 +371,8 @@ class PWScore;
 
 class PWSFilters : public std::map<st_Filterkey, st_filters, ltfk> {
  public:
+  static const stringT schema_filename;
+
   typedef std::pair<st_Filterkey, st_filters> Pair;
   
   int WriteFilterXMLFile(const StringX &filename, const PWSfileHeader &hdr,

--- a/src/core/PWSfileV3.cpp
+++ b/src/core/PWSfileV3.cpp
@@ -797,15 +797,15 @@ int PWSfileV3::ReadHeader()
         if (utf8Len > 0) {
           stringT strErrors;
 #if !defined(USE_XML_LIBRARY) || (!defined(_WIN32) && USE_XML_LIBRARY == MSXML)
-          // Using PUGI XML we do not need XDS File
+          // Using PUGI XML we do not need XSD File
           stringT XSDFilename = _T("");
 #else
-          stringT XSDFilename = PWSdirs::GetXMLDir() + _T("pwsafe_filter.xsd");
+          stringT XSDFilename = PWSdirs::GetXMLDir() + PWSFilters::schema_filename;
           if (!pws_os::FileExists(XSDFilename)) {
             // No filter schema => user won't be able to access stored filters
             // Inform her of the fact (probably an installation problem).
             stringT message, message2;
-            Format(message, IDSC_MISSINGXSD, L"pwsafe_filter.xsd");
+            Format(message, IDSC_MISSINGXSD, PWSFilters::schema_filename.c_str());
             LoadAString(message2, IDSC_FILTERSKEPT);
             message += stringT(_T("\n\n")) + message2;
             if (m_pReporter != nullptr)

--- a/src/core/PWSfileV4.cpp
+++ b/src/core/PWSfileV4.cpp
@@ -1129,15 +1129,15 @@ int PWSfileV4::ReadHeader()
       if (utf8Len > 0) {
         stringT strErrors;
 #if !defined(USE_XML_LIBRARY) || (!defined(_WIN32) && USE_XML_LIBRARY == MSXML)
-        // Using PUGI XML we do not need XDS File
+        // Using PUGI XML we do not need XSD File
         stringT XSDFilename = _T("");
 #else
-        stringT XSDFilename = PWSdirs::GetXMLDir() + _T("pwsafe_filter.xsd");
+        stringT XSDFilename = PWSdirs::GetXMLDir() + PWSFilters::schema_filename;
         if (!pws_os::FileExists(XSDFilename)) {
           // No filter schema => user won't be able to access stored filters
           // Inform her of the fact (probably an installation problem).
           stringT message, message2;
-          Format(message, IDSC_MISSINGXSD, _T("pwsafe_filter.xsd"));
+          Format(message, IDSC_MISSINGXSD, PWSFilters::schema_filename.c_str());
           LoadAString(message2, IDSC_FILTERSKEPT);
           message += stringT(_T("\n\n")) + message2;
           if (m_pReporter != nullptr)

--- a/src/core/XML/Xerces/XFilterXMLProcessor.cpp
+++ b/src/core/XML/Xerces/XFilterXMLProcessor.cpp
@@ -121,11 +121,6 @@ bool XFilterXMLProcessor::Process(const bool &bvalidation,
   pSAX2Parser->setContentHandler(pSAX2Handler);
   pSAX2Parser->setErrorHandler(pSAX2Handler);
 
-  // Workaround/bypass until Xerces supports retrieving version from the
-  // <xs:schema ...> statement!
-  // Set 'dummy' schema version to arbitrary value > 1
-  pSAX2Handler->SetSchemaVersion(99);
-
   pSAX2Handler->SetVariables(m_pAsker, &m_MapXMLFilters, m_FPool, m_bValidation);
 
   // instantiate converter out of if/else to be sure that string will be valid

--- a/src/ui/Windows/DboxMain.cpp
+++ b/src/ui/Windows/DboxMain.cpp
@@ -943,12 +943,12 @@ void DboxMain::InitPasswordSafe()
 
       if (pws_os::FileExists(wsAutoLoad)) {
           std::wstring strErrors;
-          std::wstring XSDFilename = PWSdirs::GetXMLDir() + L"pwsafe_filter.xsd";
+          std::wstring XSDFilename = PWSdirs::GetXMLDir() + PWSFilters::schema_filename;
 
           if (!pws_os::FileExists(XSDFilename)) {
               CGeneralMsgBox gmb;
               CString cs_title, cs_msg, cs_temp;
-              cs_temp.Format(IDSC_MISSINGXSD, L"pwsafe_filter.xsd");
+              cs_temp.Format(IDSC_MISSINGXSD, PWSFilters::schema_filename.c_str());
               cs_msg.Format(IDS_CANTAUTOIMPORTFILTERS, static_cast<LPCWSTR>(cs_temp));
               cs_title.LoadString(IDSC_CANTVALIDATEXML);
               gmb.MessageBox(cs_msg, cs_title, MB_OK | MB_ICONSTOP);

--- a/src/ui/Windows/MainFilters.cpp
+++ b/src/ui/Windows/MainFilters.cpp
@@ -384,12 +384,11 @@ void DboxMain::ImportFilters()
 {
   CString cs_title, cs_temp, cs_text;
   cs_text.LoadString(IDS_PICKXMLFILE);
-  const std::wstring XSDfn(L"pwsafe_filter.xsd");
-  std::wstring XSDFilename = PWSdirs::GetXMLDir() + XSDfn;
+  std::wstring XSDFilename = PWSdirs::GetXMLDir() + PWSFilters::schema_filename;
 
   if (!pws_os::FileExists(XSDFilename)) {
     CGeneralMsgBox gmb;
-    cs_temp.Format(IDSC_MISSINGXSD, static_cast<LPCWSTR>(XSDfn.c_str()));
+    cs_temp.Format(IDSC_MISSINGXSD, static_cast<LPCWSTR>(PWSFilters::schema_filename.c_str()));
     cs_title.LoadString(IDSC_CANTVALIDATEXML);
     gmb.MessageBox(cs_temp, cs_title, MB_OK | MB_ICONSTOP);
     return;

--- a/src/ui/wxWidgets/ManageFiltersDlg.cpp
+++ b/src/ui/wxWidgets/ManageFiltersDlg.cpp
@@ -10,6 +10,7 @@
 * 
 */
 // For compilers that support precompilation, includes "wx/wx.h".
+#include "PWSdirs.h"
 #include "wx/wxprec.h"
 
 #ifdef __BORLANDC__
@@ -1045,8 +1046,10 @@ void ManageFiltersDlg::OnImportClick(wxCommandEvent& WXUNUSED(event))
   if (fd.ShowModal() == wxID_OK) {
     wxString filename = fd.GetPath();
     stringT strErrors = L"";
-    
-    int rc = m_pMapAllFilters->ImportFilterXMLFile(FPOOL_IMPORTED, L"", tostdstring(filename), L"", strErrors, &asker, nullptr);
+    stringT XSDFilename = PWSdirs::GetXMLDir() + PWSFilters::schema_filename;
+    int rc = m_pMapAllFilters->ImportFilterXMLFile(FPOOL_IMPORTED, L"",
+                                                   tostdstring(filename), XSDFilename,
+                                                   strErrors, &asker, nullptr);
     
     if (rc != PWScore::SUCCESS) {
       stringT cs_error;

--- a/src/ui/wxWidgets/PWSafeApp.cpp
+++ b/src/ui/wxWidgets/PWSafeApp.cpp
@@ -549,8 +549,9 @@ void PWSafeApp::FinishInit() {
   
   if (pws_os::FileExists(wsAutoLoad)) {
     stringT strErrors = L"";
+    stringT XSDFilename = PWSdirs::GetXMLDir() + PWSFilters::schema_filename;
     int rc = m_frame->ImportFilterXMLFile(FPOOL_AUTOLOAD, L"", wsAutoLoad,
-                                          L"", strErrors, &anAsker, nullptr); // Only summary will be reported
+                                          XSDFilename, strErrors, &anAsker, nullptr); // Only summary will be reported
     if (rc != PWScore::SUCCESS) {
       wxMessageBox(towxstring(strErrors), _("Unable to import \"autoload_filters.xml\""), wxOK | wxICON_ERROR);
     }


### PR DESCRIPTION
It's possible these calls relied on some defaults, but on my system they
 result in an XML "schema not found" error.
Changed them to align with existing calls that specify the schema explicitly.
Also, remove an obsolete version workaround.

The original support was added in https://github.com/pwsafe/pwsafe/pull/746 - perhaps it only covered pugi?

## Testing

Linux only (xercesc 3.2.4, wxwidgets 3.2.10), I don't have access to Win/Mac:

* Import/export XML filters
* Import/export pwsafe files as XML
* Autoload filters load when a file is opened