### PR TITLE
[flatpak] Add hint when Autotype fails

### DIFF
--- a/src/ui/wxWidgets/MenuEditHandlers.cpp
+++ b/src/ui/wxWidgets/MenuEditHandlers.cpp
@@ -785,8 +785,14 @@ void PasswordSafeFrame::MaybeRestoreUI(bool autotype_err, const wxString &autoty
       m_guiInfo->Restore(this);
     }
   }
-  if (autotype_err)
-    wxMessageBox(_("There was an error autotyping.  ") + autotype_err_msg, _("Autotype error"), wxOK|wxICON_ERROR, this);
+  if (autotype_err) {
+    if (IsRunningInFlatpak() && wxUtilities::WhatWindowSystem() == wxUtilities::Wayland) {
+      wxMessageBox(_("There was an error autotyping. Full X11 access may be required for this action to work properly. Make sure the '--nosocket=fallback-x11 --socket=x11' permissions are granted to the Flatpak application (the order matters).\nError: ") + autotype_err_msg, _("Autotype error"), wxOK|wxICON_ERROR, this);
+    }
+    else {
+      wxMessageBox(_("There was an error autotyping.  ") + autotype_err_msg, _("Autotype error"), wxOK|wxICON_ERROR, this);
+    }
+  }
 }
 
 /*


### PR DESCRIPTION
Issue:
The AutoType/Browse+AutoType feature was recently fixed on Linux under Wayland in native versions of pwsafe.
Autotype under Wayland works toward target apps such as web browsers using the XWayland backend.
However, with the Flatpak version, users receive the following error: "There was an error autotyping: Could not open X display."

Reason:
Flatpak improves security by isolating applications from one another through sandboxing, which limits Flatpak applications' access to the host environment and other apps.
This includes the standard "--socket=fallback-x11" permission combined with "--socket=wayland" that limits pwsafe when interacting with other apps, for example, when performing Autotype.
The "--socket=x11" permission needs to be used instead of "--socket=fallback-x11" to provide full X11 access, however it is not allowed by default in the Flathub repo. Building the Flatpak package then fails with the following validate-manifest job error: 'finish-args-contains-both-x11-and-wayland' error found in linter manifest check.
An exception can be requested to allow this combination to be ignored, but Flathub exceptions are granted on a case-by-case basis and may be revoked in the future.
The criteria state that an exception is granted only if the application crashes, fails to launch, or is unusable without both permissions, and the issue cannot be solved otherwise.

Proposed change:
This PR provides users with information about the issue and instructions on how to manually override the sandbox restrictions.
In most cases, this is as simple as modifying the Flatpak app's shortcut properties and adding additional arguments to the startup command (for example, using the Menu Editor in KDE).

Notes:
On some systems (possibly with older versions of Flatpak), the "--nosocket=fallback-x11" and "--socket=x11" permissions must be used together.
On some systems, the order matters; "--socket=x11 --nosocket=fallback-x11" does not work.
On some systems, only the "--socket=x11" permission is needed.
On all tested systems, "--nosocket=fallback-x11 --socket=x11" worked.

Tested on:
Debian 13 (X11/Wayland), Kubuntu 26.04, Ubuntu 22.04 (X11/Wayland), Fedora 44, Mint 22.2 (X11/Wayland).

Attached you can find some screenshots.
<img width="916" height="707" alt="pwsafe_1 25-wxWidgets-flatpak-Autotype-01" src="https://github.com/user-attachments/assets/c0471279-cba5-4a4d-ad05-a76ccbc23441" />
<img width="1000" height="712" alt="pwsafe_1 25-wxWidgets-flatpak-Autotype-02" src="https://github.com/user-attachments/assets/feea1b1a-6cca-4715-8ca2-9592e793551a" />
<img width="1352" height="863" alt="pwsafe_1 25-wxWidgets-flatpak-Autotype-03" src="https://github.com/user-attachments/assets/fc3954ed-1320-4d92-8af0-45816e47926f" />
<img width="1352" height="1056" alt="pwsafe_1 25-wxWidgets-flatpak-Autotype-04" src="https://github.com/user-attachments/assets/03ea55bd-a24e-4a87-b02a-4dc9b9e48ef8" />


